### PR TITLE
fix(editing): enable video trim on S3-backed storage (#671)

### DIFF
--- a/.github/workflows/storage-migration-tests.yml
+++ b/.github/workflows/storage-migration-tests.yml
@@ -90,6 +90,9 @@ jobs:
       - name: 'Phase: user-delete-s3-orphans'
         run: pnpm tsx src/storage-migration.ts user-delete-s3-orphans
 
+      - name: 'Phase: video-trim-s3'
+        run: pnpm tsx src/storage-migration.ts video-trim-s3
+
       - name: 'Phase: no-files'
         run: pnpm tsx src/storage-migration.ts no-files
 

--- a/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-1.md
+++ b/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-1.md
@@ -22,11 +22,13 @@
 ### Task 1: Add the `video-trim-s3` phase and observe the expected RED
 
 **Files:**
+
 - Modify: `e2e/src/storage-migration.ts` (add `phaseVideoTrimS3` before `main()`; add a `case` in the `main()` switch and to the "Valid phases" error string)
 
 **Interfaces:**
 
 Consumes (all already exported from the same file):
+
 - `api(method: string, path: string, opts?: { body?: unknown; formData?: FormData; token?: string }): Promise<any>`
 - `loginAdmin(): Promise<string>`
 - `uploadAsset(token: string, filename: string, data: Buffer, sidecar?: Buffer, extraFields?: Record<string,string>): Promise<{ id: string; status: number }>`
@@ -119,7 +121,10 @@ async function phaseVideoTrimS3(): Promise<void> {
       `SELECT path, type FROM asset_file WHERE "assetId" = $1 AND "isEdited" = true ORDER BY type`,
       [assetId],
     );
-    assert.ok(editedRows.length >= 3, `Expected >= 3 edited asset_file rows (video+preview+thumbnail), got ${editedRows.length}`);
+    assert.ok(
+      editedRows.length >= 3,
+      `Expected >= 3 edited asset_file rows (video+preview+thumbnail), got ${editedRows.length}`,
+    );
 
     for (const row of editedRows) {
       assert.ok(!row.path.startsWith('/'), `Edited ${row.type} path must be an S3 key, got ${row.path}`);

--- a/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-1.md
+++ b/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-1.md
@@ -1,0 +1,284 @@
+# Video Trim on S3 — Slice 1: Reproduce on real S3 (e2e phase, unwired)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `video-trim-s3` phase to the MinIO storage-migration e2e harness that exercises a video trim on an S3-backed server, and observe it fail against unfixed code — proving the phase can detect #671.
+
+**Architecture:** The phase is a new exported `async function phaseVideoTrimS3()` in `e2e/src/storage-migration.ts` plus one `case` in the `main()` switch. It is deliberately **not** added to `storage-migration.sh`'s full-workflow sequence or to `.github/workflows/storage-migration-tests.yml` — both run an explicit phase list, so an unwired phase never runs in CI and cannot redden the branch while the fix is in progress. Slice 7 wires it in.
+
+**Tech Stack:** TypeScript run via `tsx` on the host; a real Immich server container (`immich-e2e-server`, port 2285) with `IMMICH_STORAGE_BACKEND=s3`; MinIO (bucket `immich-test`); Postgres on 5435; `node:assert/strict`.
+
+## Global Constraints
+
+- The phase must leave suite state as it found it: `migrate-to-disk` runs later in the same CI job and has never seen `encoded-video` rows.
+- No binary fixture may be committed. Generate the test video with ffmpeg inside the server container.
+- The video must be **at least 3 seconds** long: `AssetService.editAsset` rejects trims on videos under 2 seconds (`server/src/services/asset.service.ts:753`).
+- Do not wire the phase into `storage-migration.sh` or the CI workflow in this slice.
+- `dockerExec` has a 30s timeout and returns trimmed stdout.
+- Spec: `docs/superpowers/specs/2026-07-12-video-trim-s3-design.md`, Slice 1.
+
+---
+
+### Task 1: Add the `video-trim-s3` phase and observe the expected RED
+
+**Files:**
+- Modify: `e2e/src/storage-migration.ts` (add `phaseVideoTrimS3` before `main()`; add a `case` in the `main()` switch and to the "Valid phases" error string)
+
+**Interfaces:**
+
+Consumes (all already exported from the same file):
+- `api(method: string, path: string, opts?: { body?: unknown; formData?: FormData; token?: string }): Promise<any>`
+- `loginAdmin(): Promise<string>`
+- `uploadAsset(token: string, filename: string, data: Buffer, sidecar?: Buffer, extraFields?: Record<string,string>): Promise<{ id: string; status: number }>`
+- `waitForProcessing(token: string, timeoutMs?: number): Promise<void>`
+- `queryDb<T>(sql: string, params?: unknown[]): Promise<T[]>`
+- `dockerExec(service: string, cmd: string): string`
+- `minioFileExists(key: string): boolean`
+- `diskFileExists(path: string): boolean`
+- `sleep(ms: number): Promise<void>`
+- `MEDIA_LOCATION` (module const, `/usr/src/app/upload`)
+
+Produces: `phaseVideoTrimS3(): Promise<void>` — invoked only via `pnpm tsx src/storage-migration.ts video-trim-s3`.
+
+- [ ] **Step 1: Write the phase**
+
+Add this function immediately before `async function main()` in `e2e/src/storage-migration.ts`:
+
+```ts
+// ---------------------------------------------------------------------------
+// Phase: video-trim-s3
+//
+// Covers gh#671. Trims a video on an S3-backed server and asserts every output
+// (edited encoded video + edited thumbnails) is persisted to MinIO as a relative
+// key, that the non-edited encoded object is not overwritten, and that nothing is
+// left behind on the pod's local disk.
+//
+// Runs with the server in s3 write mode. Leaves suite state as it found it.
+// ---------------------------------------------------------------------------
+async function phaseVideoTrimS3(): Promise<void> {
+  console.log('=== Phase: video-trim-s3 ===');
+  const token = await loginAdmin();
+
+  // --- Arrange: force transcoding so a NON-edited EncodedVideo exists in S3.
+  // That object is the trim job's preferred input and is what makes gh#671's
+  // defect 3 (S3 key handed to ffmpeg) reachable.
+  const originalConfig = await api('GET', '/system-config', { token });
+  const trimConfig = JSON.parse(JSON.stringify(originalConfig));
+  trimConfig.ffmpeg.transcode = 'all';
+  await api('PUT', '/system-config', { body: trimConfig, token });
+  console.log('  ffmpeg.transcode = all');
+
+  try {
+    // 4s test video, tiny frame size. Must be >= 2s or editAsset rejects the trim.
+    const base64 = dockerExec(
+      'immich-server',
+      'ffmpeg -y -loglevel error -f lavfi -i testsrc=duration=4:size=192x144:rate=10 ' +
+        '-c:v libx264 -pix_fmt yuv420p /tmp/trim-src.mp4 && base64 /tmp/trim-src.mp4 | tr -d "\\n"',
+    );
+    const video = Buffer.from(base64, 'base64');
+    assert.ok(video.length > 1000, `Generated video looks too small: ${video.length} bytes`);
+    console.log(`  Generated test video (${video.length} bytes)`);
+
+    const { id: assetId } = await uploadAsset(token, 'trim-s3.mp4', video);
+    console.log(`  Uploaded asset ${assetId}`);
+    await waitForProcessing(token, 120_000);
+
+    // Precondition 1: duration was probed (editAsset needs it).
+    const assetRows = await queryDb<{ ownerId: string; duration: string | null; originalPath: string }>(
+      'SELECT "ownerId", duration, "originalPath" FROM asset WHERE id = $1',
+      [assetId],
+    );
+    assert.ok(assetRows[0], `Asset ${assetId} not found`);
+    const { ownerId, originalPath } = assetRows[0];
+    assert.ok(assetRows[0].duration, 'Asset duration was not probed — editAsset would reject the trim');
+    assert.ok(!originalPath.startsWith('/'), `Expected S3 (relative) originalPath, got ${originalPath}`);
+
+    // Precondition 2: a NON-edited EncodedVideo exists in S3.
+    // NB: the asset_file.type enum value is 'encoded_video' (snake_case), not 'encodedVideo'.
+    const encodedRows = await queryDb<{ path: string }>(
+      `SELECT path FROM asset_file WHERE "assetId" = $1 AND type = 'encoded_video' AND "isEdited" = false`,
+      [assetId],
+    );
+    assert.equal(encodedRows.length, 1, `Expected 1 non-edited encodedVideo row, got ${encodedRows.length}`);
+    const nonEditedKey = encodedRows[0].path;
+    assert.ok(!nonEditedKey.startsWith('/'), `Expected relative encodedVideo path, got ${nonEditedKey}`);
+    assert.ok(minioFileExists(nonEditedKey), `Non-edited encoded video missing from MinIO: ${nonEditedKey}`);
+    const nonEditedStatBefore = dockerExec('minio', `mc stat local/immich-test/${nonEditedKey}`);
+    console.log(`  Precondition OK: transcoded video in S3 at ${nonEditedKey}`);
+
+    // --- Act: trim 1s..3s of the 4s video.
+    await api('PUT', `/assets/${assetId}/edits`, {
+      token,
+      body: { edits: [{ action: 'trim', parameters: { startTime: 1, endTime: 3 } }] },
+    });
+    console.log('  Trim edit submitted');
+    await waitForProcessing(token, 120_000);
+
+    // --- Assert
+    const editedRows = await queryDb<{ path: string; type: string }>(
+      `SELECT path, type FROM asset_file WHERE "assetId" = $1 AND "isEdited" = true ORDER BY type`,
+      [assetId],
+    );
+    assert.ok(editedRows.length >= 3, `Expected >= 3 edited asset_file rows (video+preview+thumbnail), got ${editedRows.length}`);
+
+    for (const row of editedRows) {
+      assert.ok(!row.path.startsWith('/'), `Edited ${row.type} path must be an S3 key, got ${row.path}`);
+      assert.ok(minioFileExists(row.path), `Edited ${row.type} missing from MinIO: ${row.path}`);
+    }
+
+    const editedVideo = editedRows.find((r) => r.type === 'encoded_video');
+    assert.ok(editedVideo, 'No edited encodedVideo row');
+    const expectedKey = `encoded-video/${ownerId}/${assetId.slice(0, 2)}/${assetId.slice(2, 4)}/${assetId}_edited.mp4`;
+    assert.equal(editedVideo.path, expectedKey, 'Edited encoded video key mismatch');
+    assert.notEqual(editedVideo.path, nonEditedKey, 'Edited video must not reuse the non-edited key');
+
+    for (const row of editedRows.filter((r) => r.type !== 'encoded_video')) {
+      assert.ok(row.path.includes('_edited'), `Edited ${row.type} key must carry _edited: ${row.path}`);
+    }
+
+    // Collision guard: the transcoded original must be untouched.
+    assert.ok(minioFileExists(nonEditedKey), 'Non-edited encoded video disappeared');
+    const nonEditedStatAfter = dockerExec('minio', `mc stat local/immich-test/${nonEditedKey}`);
+    assert.equal(nonEditedStatAfter, nonEditedStatBefore, 'Non-edited encoded video was overwritten by the trim');
+
+    // No local leftovers: persistFile must upload AND unlink.
+    const localEditedPath = `${MEDIA_LOCATION}/encoded-video/${ownerId}/${assetId.slice(0, 2)}/${assetId.slice(2, 4)}/${assetId}_edited.mp4`;
+    assert.ok(!diskFileExists(localEditedPath), `Trimmed video left on local disk: ${localEditedPath}`);
+
+    // Duration reflects the trim (2s), not the original (4s).
+    const trimmedRows = await queryDb<{ duration: string | null }>('SELECT duration FROM asset WHERE id = $1', [
+      assetId,
+    ]);
+    const durationMs = Number(trimmedRows[0].duration);
+    assert.ok(
+      durationMs >= 1500 && durationMs <= 2500,
+      `Expected trimmed duration ~2000ms, got ${trimmedRows[0].duration}`,
+    );
+
+    // Playback serves the trimmed video from S3.
+    const playbackRes = await fetch(`${BASE_URL}/assets/${assetId}/video/playback`, {
+      headers: { Authorization: `Bearer ${token}` },
+      redirect: 'follow',
+    });
+    assert.equal(playbackRes.status, 200, `Expected 200 from playback, got ${playbackRes.status}`);
+    await playbackRes.arrayBuffer();
+    console.log('  Trim persisted to S3 and served');
+
+    // --- Undo: edited objects must be removed from the bucket.
+    const editedKeys = editedRows.map((r) => r.path);
+    await api('DELETE', `/assets/${assetId}/edits`, { token });
+    await waitForProcessing(token, 120_000);
+
+    for (const key of editedKeys) {
+      assert.ok(!minioFileExists(key), `Undo left an edited object in MinIO: ${key}`);
+    }
+
+    const undoRes = await fetch(`${BASE_URL}/assets/${assetId}/video/playback`, {
+      headers: { Authorization: `Bearer ${token}` },
+      redirect: 'follow',
+    });
+    assert.equal(undoRes.status, 200, `Expected 200 from playback after undo, got ${undoRes.status}`);
+    await undoRes.arrayBuffer();
+    console.log('  Undo removed edited objects from S3');
+
+    // --- Teardown: leave no trace for migrate-to-disk.
+    await api('DELETE', '/assets', { token, body: { ids: [assetId], force: true } });
+    console.log('  Asset deleted');
+  } finally {
+    await api('PUT', '/system-config', { body: originalConfig, token });
+    console.log('  ffmpeg config restored');
+  }
+
+  console.log('  video-trim-s3 PASSED');
+}
+```
+
+- [ ] **Step 2: Wire the phase into the switch (only)**
+
+In `main()`'s `switch (phase)`, add before the `default:` case:
+
+```ts
+      case 'video-trim-s3': {
+        await phaseVideoTrimS3();
+        break;
+      }
+```
+
+And append `, video-trim-s3` to the `Valid phases:` list in the `default:` branch's error message.
+
+Do **not** touch `e2e/storage-migration.sh` or `.github/workflows/storage-migration-tests.yml` in this slice.
+
+- [ ] **Step 3: Bring the stack up in S3 mode**
+
+The stack was started with `IMMICH_STORAGE_BACKEND=disk`. The phase needs the server in **s3** write mode, and the bucket must exist.
+
+Run from `e2e/`:
+
+```bash
+export COMPOSE_FILE=docker-compose.yml:docker-compose.storage-migration.yml
+docker compose exec -T minio sh -c "mc alias set local http://localhost:9000 minioadmin minioadmin && mc mb local/immich-test --ignore-existing"
+pnpm tsx src/storage-migration.ts setup                      # creates the admin user
+IMMICH_STORAGE_BACKEND=s3 docker compose up -d --no-deps --force-recreate --wait --wait-timeout 180 immich-server
+```
+
+Expected: the bucket is created (or already exists), `setup` passes, and the server restarts healthy in s3 mode.
+
+- [ ] **Step 4: Run the phase and observe the RED**
+
+Run from `e2e/`:
+
+```bash
+COMPOSE_FILE=docker-compose.yml:docker-compose.storage-migration.yml pnpm tsx src/storage-migration.ts video-trim-s3
+```
+
+**Expected RED:** the run fails at the `PUT /assets/{id}/edits` call with:
+
+```
+API PUT /assets/<id>/edits failed: 400 {"message":"Video trimming is not available for cloud-stored videos", ...}
+```
+
+That is the Layer-1 guard in `asset.service.ts:729`, which Slice 2 removes.
+
+**The preconditions must have passed first.** The console must show `Generated test video`, `Uploaded asset`, and `Precondition OK: transcoded video in S3 at encoded-video/...` before the 400. If it fails earlier:
+
+- No `duration` → metadata extraction did not run; raise the `waitForProcessing` timeout.
+- `Expected 1 non-edited encodedVideo row, got 0` → the transcode did not run. Check that `ffmpeg.transcode = 'all'` was accepted (the `PUT /system-config` body must be the full config object, mutated) and that the video-conversion queue drained.
+- `ffmpeg: not found` / empty base64 → adjust the `dockerExec` command; the server image is Debian-based and has both `ffmpeg` and `base64`.
+
+Do **not** proceed to Slice 2 until the phase reaches the 400. A phase that fails before the trim call does not reproduce #671.
+
+- [ ] **Step 5: Confirm the phase does not disturb the rest of the suite**
+
+The phase deletes its asset and restores the config, so `migrate-to-disk` must still pass after it. Run from `e2e/` (server is currently in s3 mode, so flip it back to disk first, as `storage-migration.sh` does):
+
+```bash
+export COMPOSE_FILE=docker-compose.yml:docker-compose.storage-migration.yml
+IMMICH_STORAGE_BACKEND=s3 docker compose up -d --no-deps --force-recreate --wait --wait-timeout 180 immich-server
+pnpm tsx src/storage-migration.ts migrate-to-s3
+IMMICH_STORAGE_BACKEND=disk docker compose up -d --no-deps --force-recreate --wait --wait-timeout 180 immich-server
+pnpm tsx src/storage-migration.ts migrate-to-disk
+```
+
+Expected: both phases pass. (They pass on `main` today; the point is that the trim phase's leftovers — none, if teardown works — do not break them.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add e2e/src/storage-migration.ts docs/superpowers/plans/2026-07-12-video-trim-s3-slice-1.md
+git commit -m "test(e2e): add video-trim-s3 phase reproducing #671 on MinIO (unwired)
+
+The phase fails today at PUT /assets/:id/edits with 400 'Video trimming is
+not available for cloud-stored videos' — the API guard that fences trim off
+on S3. Wired into the phase switch only, not into storage-migration.sh or
+the CI workflow, so CI stays green until the fix lands (slice 7 wires it)."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** every Slice 1 assertion in the spec appears in Step 1 — relative paths, edited key shape, thumbnails carrying `_edited`, MinIO existence, non-edited object unchanged (`mc stat` before/after), playback 200, trimmed duration, no local leftover, undo removing objects, teardown restoring state. The "no `FFmpeg trim failed` / ENOENT in logs" assertion from the spec is **intentionally dropped**: `assertNoMoveEnoent` exists for the migration phases, and here the DB/MinIO assertions already prove the job succeeded — a log scrape would add flakiness (log capture windows) without adding signal. This is a deliberate simplification, recorded here rather than silently omitted.
+
+**Placeholders:** none. Every step has a runnable command or complete code.
+
+**Type consistency:** `asset_file.type` values are the DB enum strings (`encodedVideo`, `preview`, `thumbnail`, `fullsize`); `queryDb` returns `duration` as a string or null (Postgres bigint via `pg`), hence `Number(...)`. `MEDIA_LOCATION` and `BASE_URL` are module-level consts already defined in the file.

--- a/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-2.md
+++ b/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-2.md
@@ -1,0 +1,391 @@
+# Video Trim on S3 — Slice 2: Enable trim on S3 at the API (Layer 1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the API rejecting video trims on S3-backed assets, and give the pre-flight audio-only probe an input it can read without downloading the whole video.
+
+**Architecture:** Two changes. (1) The guard in `AssetService.editAsset` currently rejects any non-`isImmichPath` original, which includes every S3 relative key; it becomes a check that rejects only *absolute* paths outside the media location (external libraries). (2) The pre-flight `probe(asset.originalPath)` runs inside the HTTP request, so instead of downloading the object we add `getReadableUrl(key)` to the `StorageBackend` interface — the disk backend returns a local path, the S3 backend returns a presigned URL that ffprobe reads directly, fetching only the header it needs. `BaseService.getProbeInput` picks between them.
+
+**Tech Stack:** NestJS, vitest, `@aws-sdk/s3-request-presigner` (already a dependency, already mocked in the S3 backend spec).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-12-video-trim-s3-design.md`, Slice 2 (design §1 and §2).
+- Slice 1 is complete (commit `a510ecfde2`): the e2e phase `video-trim-s3` exists and currently fails with the 400 this slice removes.
+- **Do not touch `media.service.ts` or `storage.core.ts`** — those are Slices 3–6.
+- The media location under unit tests is `/data`, set at import time by `server/test/repositories/storage.repository.mock.ts:47`. So `/data/library/x.mp4` is an Immich path, `/mnt/external/x.mp4` is external, `upload/admin/ab/cd/x.mp4` is an S3 key.
+- Run tests from `server/`: `pnpm test -- --run src/services/asset.service.spec.ts` (and the backend specs by path).
+- Every test must be seen failing. RED tests must fail with the named reason before implementation. The one GUARD test (E4) passes on arrival and must be proved with the named mutation.
+- `asset.service.ts` already imports `isAbsolute` from `node:path` (line 5). `base.service.ts` already imports it too (line 6). No new imports needed for those two files.
+
+---
+
+### Task 1: `getReadableUrl` on both storage backends
+
+**Files:**
+- Modify: `server/src/interfaces/storage-backend.interface.ts`
+- Modify: `server/src/backends/disk-storage.backend.ts`
+- Modify: `server/src/backends/s3-storage.backend.ts`
+- Test: `server/src/backends/disk-storage.backend.spec.ts`, `server/src/backends/s3-storage.backend.spec.ts`
+
+**Interfaces:**
+- Consumes: `DiskStorageBackend.resolvePath(key)` (private, existing — returns absolute paths as-is, else `join(this.mediaLocation, key)`); `S3StorageBackend.presignedUrlExpiry`, `this.client`, `this.bucket`; `getSignedUrl` from `@aws-sdk/s3-request-presigner` (already imported at line 11).
+- Produces: `StorageBackend.getReadableUrl(key: string): Promise<string>` — a path or URL that ffmpeg/ffprobe can read directly, without downloading. Consumed by `BaseService.getProbeInput` in Task 2.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `describe('DiskStorageBackend', ...)` block in `server/src/backends/disk-storage.backend.spec.ts`:
+
+```ts
+  describe('getReadableUrl', () => {
+    it('returns the resolved local path for a relative key', async () => {
+      await expect(backend.getReadableUrl('upload/admin/ab/cd/video.mp4')).resolves.toBe(
+        join(testDir, 'upload/admin/ab/cd/video.mp4'),
+      );
+    });
+
+    it('returns absolute paths unchanged', async () => {
+      await expect(backend.getReadableUrl('/data/library/video.mp4')).resolves.toBe('/data/library/video.mp4');
+    });
+  });
+```
+
+Append to `server/src/backends/s3-storage.backend.spec.ts`, inside the top-level `describe('S3StorageBackend', ...)` block (the file already mocks `@aws-sdk/s3-request-presigner` with `getSignedUrl` resolving to `'https://bucket.s3.amazonaws.com/key?X-Amz-Signature=abc123'`):
+
+```ts
+  describe('getReadableUrl', () => {
+    it('returns a presigned GET url for the key', async () => {
+      const url = await backend.getReadableUrl('upload/admin/ab/cd/video.mp4');
+
+      expect(url).toBe('https://bucket.s3.amazonaws.com/key?X-Amz-Signature=abc123');
+      expect(GetObjectCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ Key: 'upload/admin/ab/cd/video.mp4' }),
+      );
+    });
+  });
+```
+
+If `GetObjectCommand` is not already imported in that spec, add it to the existing `@aws-sdk/client-s3` import. Match the existing spec's `backend` construction in its `beforeEach`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd server
+pnpm test -- --run src/backends/disk-storage.backend.spec.ts src/backends/s3-storage.backend.spec.ts
+```
+
+Expected: FAIL — `backend.getReadableUrl is not a function` (E5, E6).
+
+- [ ] **Step 3: Implement `getReadableUrl`**
+
+In `server/src/interfaces/storage-backend.interface.ts`, add to the `StorageBackend` interface (after `getServeStrategy`):
+
+```ts
+  /**
+   * A path or URL that external tools (ffmpeg/ffprobe) can read directly,
+   * without downloading the object first. Disk returns a filesystem path;
+   * S3 returns a presigned URL.
+   */
+  getReadableUrl(key: string): Promise<string>;
+```
+
+In `server/src/backends/disk-storage.backend.ts`:
+
+```ts
+  getReadableUrl(key: string): Promise<string> {
+    return Promise.resolve(this.resolvePath(key));
+  }
+```
+
+In `server/src/backends/s3-storage.backend.ts`:
+
+```ts
+  async getReadableUrl(key: string): Promise<string> {
+    return getSignedUrl(this.client, new GetObjectCommand({ Bucket: this.bucket, Key: key }), {
+      expiresIn: this.presignedUrlExpiry,
+    });
+  }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+pnpm test -- --run src/backends/disk-storage.backend.spec.ts src/backends/s3-storage.backend.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/interfaces/storage-backend.interface.ts server/src/backends/
+git commit -m "feat(storage): add StorageBackend.getReadableUrl for download-free probing"
+```
+
+---
+
+### Task 2: `BaseService.getProbeInput`
+
+**Files:**
+- Modify: `server/src/services/base.service.ts` (add next to `ensureLocalFile`, around line 398)
+
+**Interfaces:**
+- Consumes: `StorageBackend.getReadableUrl` (Task 1); `StorageService.resolveBackendForKey(key)` (existing static).
+- Produces: `protected async getProbeInput(filePath: string): Promise<string>` — consumed by `AssetService.editAsset` in Task 3.
+
+- [ ] **Step 1: Implement (covered by Task 3's tests — no separate test)**
+
+This is a two-line delegation with no behaviour of its own; Task 3's E1/E3/E4 exercise both of its branches through `editAsset`. Add immediately after `ensureLocalFile` in `server/src/services/base.service.ts`:
+
+```ts
+  /**
+   * Returns something ffmpeg/ffprobe can read directly: an absolute path as-is,
+   * or a presigned URL for a storage-backend key. Unlike ensureLocalFile this
+   * does NOT download the object, so it is safe to call inside a request handler.
+   */
+  protected async getProbeInput(filePath: string): Promise<string> {
+    if (isAbsolute(filePath)) {
+      return filePath;
+    }
+    // lazy import to avoid circular dependency (StorageService extends BaseService)
+    const { StorageService } = await import('./storage.service.js');
+    return StorageService.resolveBackendForKey(filePath).getReadableUrl(filePath);
+  }
+```
+
+- [ ] **Step 2: Commit with Task 3** (this alone changes no behaviour)
+
+---
+
+### Task 3: Lift the guard and probe via `getProbeInput`
+
+**Files:**
+- Modify: `server/src/services/asset.service.ts:728-737`
+- Test: `server/src/services/asset.service.spec.ts` (rewrite the test at line ~2301, add three more)
+
+**Interfaces:**
+- Consumes: `BaseService.getProbeInput` (Task 2).
+- Produces: no new exports. Behaviour change: `PUT /assets/:id/edits` with a Trim now accepts S3-backed assets.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `server/src/services/asset.service.spec.ts`, **replace** the existing test `'should reject trim on cloud-stored videos'` (line ~2301) — it encodes the old behaviour and must go — with the following four tests. Keep the surrounding `describe` block and its existing setup.
+
+```ts
+    it('should accept trim on S3-backed videos and probe via a presigned url', async () => {
+      const assetId = newUuid();
+      const getReadableUrl = vi.fn().mockResolvedValue('https://bucket.s3/key?X-Amz-Signature=abc');
+      const { StorageService } = await import('src/services/storage.service.js');
+      vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue({ getReadableUrl } as any);
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
+      mocks.asset.getForEdit.mockResolvedValue({
+        type: AssetType.Video,
+        livePhotoVideoId: null,
+        originalPath: 'upload/admin/ab/cd/video.mp4',
+        originalFileName: 'video.mp4',
+        duration: 30_000,
+        exifImageWidth: 1920,
+        exifImageHeight: 1080,
+        orientation: null,
+        projectionType: null,
+      } as any);
+      mocks.assetEdit.getAll.mockResolvedValue([]);
+      mocks.assetEdit.replaceAll.mockResolvedValue([] as any);
+      mocks.media.probe.mockResolvedValue({
+        videoStreams: [{}],
+        audioStreams: [{}],
+        format: {},
+      } as any);
+
+      await sut.editAsset(authStub.admin, assetId, {
+        edits: [{ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } }],
+      });
+
+      expect(getReadableUrl).toHaveBeenCalledWith('upload/admin/ab/cd/video.mp4');
+      expect(mocks.media.probe).toHaveBeenCalledWith('https://bucket.s3/key?X-Amz-Signature=abc');
+      expect(mocks.assetEdit.replaceAll).toHaveBeenCalled();
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.AssetEditThumbnailGeneration,
+        data: { id: assetId },
+      });
+
+      vi.restoreAllMocks();
+    });
+
+    it('should reject trim on external library videos', async () => {
+      const assetId = newUuid();
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
+      mocks.asset.getForEdit.mockResolvedValue({
+        type: AssetType.Video,
+        livePhotoVideoId: null,
+        originalPath: '/mnt/external/video.mp4',
+        originalFileName: 'video.mp4',
+        duration: 30_000,
+        exifImageWidth: 1920,
+        exifImageHeight: 1080,
+        orientation: null,
+        projectionType: null,
+      } as any);
+
+      await expect(
+        sut.editAsset(authStub.admin, assetId, {
+          edits: [{ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } }],
+        }),
+      ).rejects.toThrow('Video trimming is not available for external library videos');
+    });
+
+    it('should reject trim on audio-only S3 files', async () => {
+      const assetId = newUuid();
+      const getReadableUrl = vi.fn().mockResolvedValue('https://bucket.s3/key?X-Amz-Signature=abc');
+      const { StorageService } = await import('src/services/storage.service.js');
+      vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue({ getReadableUrl } as any);
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
+      mocks.asset.getForEdit.mockResolvedValue({
+        type: AssetType.Video,
+        livePhotoVideoId: null,
+        originalPath: 'upload/admin/ab/cd/audio.m4a',
+        originalFileName: 'audio.m4a',
+        duration: 180_000,
+        exifImageWidth: null,
+        exifImageHeight: null,
+        orientation: null,
+        projectionType: null,
+      } as any);
+      mocks.assetEdit.getAll.mockResolvedValue([]);
+      mocks.media.probe.mockResolvedValue({ videoStreams: [], audioStreams: [{}], format: {} } as any);
+
+      await expect(
+        sut.editAsset(authStub.admin, assetId, {
+          edits: [{ action: AssetEditAction.Trim, parameters: { startTime: 10, endTime: 60 } }],
+        }),
+      ).rejects.toThrow('Cannot trim audio-only files');
+
+      vi.restoreAllMocks();
+    });
+
+    it('should probe disk-backed videos by absolute path, without presigning', async () => {
+      const assetId = newUuid();
+      const { StorageService } = await import('src/services/storage.service.js');
+      const resolveSpy = vi.spyOn(StorageService, 'resolveBackendForKey');
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
+      mocks.asset.getForEdit.mockResolvedValue({
+        type: AssetType.Video,
+        livePhotoVideoId: null,
+        originalPath: '/data/library/video.mp4',
+        originalFileName: 'video.mp4',
+        duration: 30_000,
+        exifImageWidth: 1920,
+        exifImageHeight: 1080,
+        orientation: null,
+        projectionType: null,
+      } as any);
+      mocks.assetEdit.getAll.mockResolvedValue([]);
+      mocks.assetEdit.replaceAll.mockResolvedValue([] as any);
+      mocks.media.probe.mockResolvedValue({ videoStreams: [{}], audioStreams: [{}], format: {} } as any);
+
+      await sut.editAsset(authStub.admin, assetId, {
+        edits: [{ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } }],
+      });
+
+      expect(mocks.media.probe).toHaveBeenCalledWith('/data/library/video.mp4');
+      expect(resolveSpy).not.toHaveBeenCalled();
+
+      vi.restoreAllMocks();
+    });
+```
+
+Check the top of the spec for the imports these need (`vi`, `JobName`, `AssetEditAction`, `AssetType`, `newUuid`, `authStub`) and add only what is missing.
+
+- [ ] **Step 2: Run the tests to verify they fail with the named reasons**
+
+```bash
+cd server
+pnpm test -- --run src/services/asset.service.spec.ts
+```
+
+Expected reds:
+- "should accept trim on S3-backed videos…" → FAILS: throws `Video trimming is not available for cloud-stored videos` (E1).
+- "should reject trim on external library videos" → FAILS: message is `…not available for cloud-stored videos`, not `…external library videos` (E2).
+- "should reject trim on audio-only S3 files" → FAILS: the cloud-stored guard throws before the probe (E3).
+- "should probe disk-backed videos by absolute path…" → **PASSES already** (E4). This is the GUARD; its mutation proof is Step 5.
+
+- [ ] **Step 3: Implement the guard replacement and the probe input**
+
+In `server/src/services/asset.service.ts`, replace lines 728–737 (the `// S3/cloud storage check` block through the `probe` call and its audio-only check) with:
+
+```ts
+      // Block external-library videos: absolute paths outside the media location.
+      // S3-backed originals are relative keys, resolved through the storage backend.
+      if (isAbsolute(asset.originalPath) && !StorageCore.isImmichPath(asset.originalPath)) {
+        throw new BadRequestException('Video trimming is not available for external library videos');
+      }
+
+      // Audio-only file check. getProbeInput hands ffprobe an absolute path (disk) or a
+      // presigned URL (S3) — it does NOT download the video, which matters here because
+      // this runs inside the request.
+      const probeResult = await this.mediaRepository.probe(await this.getProbeInput(asset.originalPath));
+      if (!probeResult.videoStreams || probeResult.videoStreams.length === 0) {
+        throw new BadRequestException('Cannot trim audio-only files');
+      }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+pnpm test -- --run src/services/asset.service.spec.ts
+```
+
+Expected: PASS, all four, and every other test in the file still green.
+
+- [ ] **Step 5: Mutation-prove the E4 guard**
+
+E4 passed before the implementation, so prove it has teeth. Temporarily change `getProbeInput` in `base.service.ts` to always presign:
+
+```ts
+  protected async getProbeInput(filePath: string): Promise<string> {
+    const { StorageService } = await import('./storage.service.js');
+    return StorageService.resolveBackendForKey(filePath).getReadableUrl(filePath);
+  }
+```
+
+Run `pnpm test -- --run src/services/asset.service.spec.ts`.
+
+Expected: "should probe disk-backed videos by absolute path, without presigning" **FAILS** (`resolveSpy` was called). Then **revert the mutation** and confirm the suite is green again. If the test still passes under the mutation, the test is broken — fix it before continuing.
+
+- [ ] **Step 6: Run the full server unit suite**
+
+```bash
+pnpm test -- --run
+```
+
+Expected: green. `getProbeInput` is new and `editAsset` is the only caller, so the blast radius is small — but confirm.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/services/asset.service.ts server/src/services/base.service.ts server/src/services/asset.service.spec.ts
+git commit -m "feat(editing): allow video trim on S3-backed assets (#671)
+
+The API guard rejected any non-isImmichPath original, which includes every S3
+relative key, so trim was fenced off entirely on S3 installs. It now rejects
+only absolute paths outside the media location (external libraries).
+
+The pre-flight audio-only probe runs inside the request, so it resolves its
+input via the new BaseService.getProbeInput: an absolute path on disk, a
+presigned URL on S3. ffprobe reads the header without downloading the video."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** E1 (accept S3 trim + presigned probe), E2 (external library still rejected, new message), E3 (audio-only on S3), E4 (disk guard, mutation-proved), E5 (S3 `getReadableUrl`), E6 (disk `getReadableUrl`), and the rewrite of the obsolete `asset.service.spec.ts:2301` test — all present.
+
+**Placeholders:** none; every step has complete code or a runnable command.
+
+**Type consistency:** `getReadableUrl(key: string): Promise<string>` is identical in the interface, both backends, the `getProbeInput` call site, and the test doubles. `mocks.assetEdit` matches `server/test/utils.ts:234`. `mocks.job.queue` and `JobName.AssetEditThumbnailGeneration` match `asset.service.ts:811`.
+
+**Not in this slice:** `media.service.ts`, `storage.core.ts`, the e2e wiring. The e2e phase will still fail after this slice — but deeper, inside the trim job with ENOENT, which is the Slice 2 "done when" signal and the proof that Layer 2 is real.

--- a/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-2.md
+++ b/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-2.md
@@ -4,7 +4,7 @@
 
 **Goal:** Stop the API rejecting video trims on S3-backed assets, and give the pre-flight audio-only probe an input it can read without downloading the whole video.
 
-**Architecture:** Two changes. (1) The guard in `AssetService.editAsset` currently rejects any non-`isImmichPath` original, which includes every S3 relative key; it becomes a check that rejects only *absolute* paths outside the media location (external libraries). (2) The pre-flight `probe(asset.originalPath)` runs inside the HTTP request, so instead of downloading the object we add `getReadableUrl(key)` to the `StorageBackend` interface — the disk backend returns a local path, the S3 backend returns a presigned URL that ffprobe reads directly, fetching only the header it needs. `BaseService.getProbeInput` picks between them.
+**Architecture:** Two changes. (1) The guard in `AssetService.editAsset` currently rejects any non-`isImmichPath` original, which includes every S3 relative key; it becomes a check that rejects only _absolute_ paths outside the media location (external libraries). (2) The pre-flight `probe(asset.originalPath)` runs inside the HTTP request, so instead of downloading the object we add `getReadableUrl(key)` to the `StorageBackend` interface — the disk backend returns a local path, the S3 backend returns a presigned URL that ffprobe reads directly, fetching only the header it needs. `BaseService.getProbeInput` picks between them.
 
 **Tech Stack:** NestJS, vitest, `@aws-sdk/s3-request-presigner` (already a dependency, already mocked in the S3 backend spec).
 
@@ -23,12 +23,14 @@
 ### Task 1: `getReadableUrl` on both storage backends
 
 **Files:**
+
 - Modify: `server/src/interfaces/storage-backend.interface.ts`
 - Modify: `server/src/backends/disk-storage.backend.ts`
 - Modify: `server/src/backends/s3-storage.backend.ts`
 - Test: `server/src/backends/disk-storage.backend.spec.ts`, `server/src/backends/s3-storage.backend.spec.ts`
 
 **Interfaces:**
+
 - Consumes: `DiskStorageBackend.resolvePath(key)` (private, existing — returns absolute paths as-is, else `join(this.mediaLocation, key)`); `S3StorageBackend.presignedUrlExpiry`, `this.client`, `this.bucket`; `getSignedUrl` from `@aws-sdk/s3-request-presigner` (already imported at line 11).
 - Produces: `StorageBackend.getReadableUrl(key: string): Promise<string>` — a path or URL that ffmpeg/ffprobe can read directly, without downloading. Consumed by `BaseService.getProbeInput` in Task 2.
 
@@ -37,32 +39,30 @@
 Append to the `describe('DiskStorageBackend', ...)` block in `server/src/backends/disk-storage.backend.spec.ts`:
 
 ```ts
-  describe('getReadableUrl', () => {
-    it('returns the resolved local path for a relative key', async () => {
-      await expect(backend.getReadableUrl('upload/admin/ab/cd/video.mp4')).resolves.toBe(
-        join(testDir, 'upload/admin/ab/cd/video.mp4'),
-      );
-    });
-
-    it('returns absolute paths unchanged', async () => {
-      await expect(backend.getReadableUrl('/data/library/video.mp4')).resolves.toBe('/data/library/video.mp4');
-    });
+describe('getReadableUrl', () => {
+  it('returns the resolved local path for a relative key', async () => {
+    await expect(backend.getReadableUrl('upload/admin/ab/cd/video.mp4')).resolves.toBe(
+      join(testDir, 'upload/admin/ab/cd/video.mp4'),
+    );
   });
+
+  it('returns absolute paths unchanged', async () => {
+    await expect(backend.getReadableUrl('/data/library/video.mp4')).resolves.toBe('/data/library/video.mp4');
+  });
+});
 ```
 
 Append to `server/src/backends/s3-storage.backend.spec.ts`, inside the top-level `describe('S3StorageBackend', ...)` block (the file already mocks `@aws-sdk/s3-request-presigner` with `getSignedUrl` resolving to `'https://bucket.s3.amazonaws.com/key?X-Amz-Signature=abc123'`):
 
 ```ts
-  describe('getReadableUrl', () => {
-    it('returns a presigned GET url for the key', async () => {
-      const url = await backend.getReadableUrl('upload/admin/ab/cd/video.mp4');
+describe('getReadableUrl', () => {
+  it('returns a presigned GET url for the key', async () => {
+    const url = await backend.getReadableUrl('upload/admin/ab/cd/video.mp4');
 
-      expect(url).toBe('https://bucket.s3.amazonaws.com/key?X-Amz-Signature=abc123');
-      expect(GetObjectCommand).toHaveBeenCalledWith(
-        expect.objectContaining({ Key: 'upload/admin/ab/cd/video.mp4' }),
-      );
-    });
+    expect(url).toBe('https://bucket.s3.amazonaws.com/key?X-Amz-Signature=abc123');
+    expect(GetObjectCommand).toHaveBeenCalledWith(expect.objectContaining({ Key: 'upload/admin/ab/cd/video.mp4' }));
   });
+});
 ```
 
 If `GetObjectCommand` is not already imported in that spec, add it to the existing `@aws-sdk/client-s3` import. Match the existing spec's `backend` construction in its `beforeEach`.
@@ -127,9 +127,11 @@ git commit -m "feat(storage): add StorageBackend.getReadableUrl for download-fre
 ### Task 2: `BaseService.getProbeInput`
 
 **Files:**
+
 - Modify: `server/src/services/base.service.ts` (add next to `ensureLocalFile`, around line 398)
 
 **Interfaces:**
+
 - Consumes: `StorageBackend.getReadableUrl` (Task 1); `StorageService.resolveBackendForKey(key)` (existing static).
 - Produces: `protected async getProbeInput(filePath: string): Promise<string>` — consumed by `AssetService.editAsset` in Task 3.
 
@@ -160,10 +162,12 @@ This is a two-line delegation with no behaviour of its own; Task 3's E1/E3/E4 ex
 ### Task 3: Lift the guard and probe via `getProbeInput`
 
 **Files:**
+
 - Modify: `server/src/services/asset.service.ts:728-737`
 - Test: `server/src/services/asset.service.spec.ts` (rewrite the test at line ~2301, add three more)
 
 **Interfaces:**
+
 - Consumes: `BaseService.getProbeInput` (Task 2).
 - Produces: no new exports. Behaviour change: `PUT /assets/:id/edits` with a Trim now accepts S3-backed assets.
 
@@ -172,129 +176,129 @@ This is a two-line delegation with no behaviour of its own; Task 3's E1/E3/E4 ex
 In `server/src/services/asset.service.spec.ts`, **replace** the existing test `'should reject trim on cloud-stored videos'` (line ~2301) — it encodes the old behaviour and must go — with the following four tests. Keep the surrounding `describe` block and its existing setup.
 
 ```ts
-    it('should accept trim on S3-backed videos and probe via a presigned url', async () => {
-      const assetId = newUuid();
-      const getReadableUrl = vi.fn().mockResolvedValue('https://bucket.s3/key?X-Amz-Signature=abc');
-      const { StorageService } = await import('src/services/storage.service.js');
-      vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue({ getReadableUrl } as any);
+it('should accept trim on S3-backed videos and probe via a presigned url', async () => {
+  const assetId = newUuid();
+  const getReadableUrl = vi.fn().mockResolvedValue('https://bucket.s3/key?X-Amz-Signature=abc');
+  const { StorageService } = await import('src/services/storage.service.js');
+  vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue({ getReadableUrl } as any);
 
-      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
-      mocks.asset.getForEdit.mockResolvedValue({
-        type: AssetType.Video,
-        livePhotoVideoId: null,
-        originalPath: 'upload/admin/ab/cd/video.mp4',
-        originalFileName: 'video.mp4',
-        duration: 30_000,
-        exifImageWidth: 1920,
-        exifImageHeight: 1080,
-        orientation: null,
-        projectionType: null,
-      } as any);
-      mocks.assetEdit.getAll.mockResolvedValue([]);
-      mocks.assetEdit.replaceAll.mockResolvedValue([] as any);
-      mocks.media.probe.mockResolvedValue({
-        videoStreams: [{}],
-        audioStreams: [{}],
-        format: {},
-      } as any);
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
+  mocks.asset.getForEdit.mockResolvedValue({
+    type: AssetType.Video,
+    livePhotoVideoId: null,
+    originalPath: 'upload/admin/ab/cd/video.mp4',
+    originalFileName: 'video.mp4',
+    duration: 30_000,
+    exifImageWidth: 1920,
+    exifImageHeight: 1080,
+    orientation: null,
+    projectionType: null,
+  } as any);
+  mocks.assetEdit.getAll.mockResolvedValue([]);
+  mocks.assetEdit.replaceAll.mockResolvedValue([] as any);
+  mocks.media.probe.mockResolvedValue({
+    videoStreams: [{}],
+    audioStreams: [{}],
+    format: {},
+  } as any);
 
-      await sut.editAsset(authStub.admin, assetId, {
-        edits: [{ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } }],
-      });
+  await sut.editAsset(authStub.admin, assetId, {
+    edits: [{ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } }],
+  });
 
-      expect(getReadableUrl).toHaveBeenCalledWith('upload/admin/ab/cd/video.mp4');
-      expect(mocks.media.probe).toHaveBeenCalledWith('https://bucket.s3/key?X-Amz-Signature=abc');
-      expect(mocks.assetEdit.replaceAll).toHaveBeenCalled();
-      expect(mocks.job.queue).toHaveBeenCalledWith({
-        name: JobName.AssetEditThumbnailGeneration,
-        data: { id: assetId },
-      });
+  expect(getReadableUrl).toHaveBeenCalledWith('upload/admin/ab/cd/video.mp4');
+  expect(mocks.media.probe).toHaveBeenCalledWith('https://bucket.s3/key?X-Amz-Signature=abc');
+  expect(mocks.assetEdit.replaceAll).toHaveBeenCalled();
+  expect(mocks.job.queue).toHaveBeenCalledWith({
+    name: JobName.AssetEditThumbnailGeneration,
+    data: { id: assetId },
+  });
 
-      vi.restoreAllMocks();
-    });
+  vi.restoreAllMocks();
+});
 
-    it('should reject trim on external library videos', async () => {
-      const assetId = newUuid();
-      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
-      mocks.asset.getForEdit.mockResolvedValue({
-        type: AssetType.Video,
-        livePhotoVideoId: null,
-        originalPath: '/mnt/external/video.mp4',
-        originalFileName: 'video.mp4',
-        duration: 30_000,
-        exifImageWidth: 1920,
-        exifImageHeight: 1080,
-        orientation: null,
-        projectionType: null,
-      } as any);
+it('should reject trim on external library videos', async () => {
+  const assetId = newUuid();
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
+  mocks.asset.getForEdit.mockResolvedValue({
+    type: AssetType.Video,
+    livePhotoVideoId: null,
+    originalPath: '/mnt/external/video.mp4',
+    originalFileName: 'video.mp4',
+    duration: 30_000,
+    exifImageWidth: 1920,
+    exifImageHeight: 1080,
+    orientation: null,
+    projectionType: null,
+  } as any);
 
-      await expect(
-        sut.editAsset(authStub.admin, assetId, {
-          edits: [{ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } }],
-        }),
-      ).rejects.toThrow('Video trimming is not available for external library videos');
-    });
+  await expect(
+    sut.editAsset(authStub.admin, assetId, {
+      edits: [{ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } }],
+    }),
+  ).rejects.toThrow('Video trimming is not available for external library videos');
+});
 
-    it('should reject trim on audio-only S3 files', async () => {
-      const assetId = newUuid();
-      const getReadableUrl = vi.fn().mockResolvedValue('https://bucket.s3/key?X-Amz-Signature=abc');
-      const { StorageService } = await import('src/services/storage.service.js');
-      vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue({ getReadableUrl } as any);
+it('should reject trim on audio-only S3 files', async () => {
+  const assetId = newUuid();
+  const getReadableUrl = vi.fn().mockResolvedValue('https://bucket.s3/key?X-Amz-Signature=abc');
+  const { StorageService } = await import('src/services/storage.service.js');
+  vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue({ getReadableUrl } as any);
 
-      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
-      mocks.asset.getForEdit.mockResolvedValue({
-        type: AssetType.Video,
-        livePhotoVideoId: null,
-        originalPath: 'upload/admin/ab/cd/audio.m4a',
-        originalFileName: 'audio.m4a',
-        duration: 180_000,
-        exifImageWidth: null,
-        exifImageHeight: null,
-        orientation: null,
-        projectionType: null,
-      } as any);
-      mocks.assetEdit.getAll.mockResolvedValue([]);
-      mocks.media.probe.mockResolvedValue({ videoStreams: [], audioStreams: [{}], format: {} } as any);
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
+  mocks.asset.getForEdit.mockResolvedValue({
+    type: AssetType.Video,
+    livePhotoVideoId: null,
+    originalPath: 'upload/admin/ab/cd/audio.m4a',
+    originalFileName: 'audio.m4a',
+    duration: 180_000,
+    exifImageWidth: null,
+    exifImageHeight: null,
+    orientation: null,
+    projectionType: null,
+  } as any);
+  mocks.assetEdit.getAll.mockResolvedValue([]);
+  mocks.media.probe.mockResolvedValue({ videoStreams: [], audioStreams: [{}], format: {} } as any);
 
-      await expect(
-        sut.editAsset(authStub.admin, assetId, {
-          edits: [{ action: AssetEditAction.Trim, parameters: { startTime: 10, endTime: 60 } }],
-        }),
-      ).rejects.toThrow('Cannot trim audio-only files');
+  await expect(
+    sut.editAsset(authStub.admin, assetId, {
+      edits: [{ action: AssetEditAction.Trim, parameters: { startTime: 10, endTime: 60 } }],
+    }),
+  ).rejects.toThrow('Cannot trim audio-only files');
 
-      vi.restoreAllMocks();
-    });
+  vi.restoreAllMocks();
+});
 
-    it('should probe disk-backed videos by absolute path, without presigning', async () => {
-      const assetId = newUuid();
-      const { StorageService } = await import('src/services/storage.service.js');
-      const resolveSpy = vi.spyOn(StorageService, 'resolveBackendForKey');
+it('should probe disk-backed videos by absolute path, without presigning', async () => {
+  const assetId = newUuid();
+  const { StorageService } = await import('src/services/storage.service.js');
+  const resolveSpy = vi.spyOn(StorageService, 'resolveBackendForKey');
 
-      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
-      mocks.asset.getForEdit.mockResolvedValue({
-        type: AssetType.Video,
-        livePhotoVideoId: null,
-        originalPath: '/data/library/video.mp4',
-        originalFileName: 'video.mp4',
-        duration: 30_000,
-        exifImageWidth: 1920,
-        exifImageHeight: 1080,
-        orientation: null,
-        projectionType: null,
-      } as any);
-      mocks.assetEdit.getAll.mockResolvedValue([]);
-      mocks.assetEdit.replaceAll.mockResolvedValue([] as any);
-      mocks.media.probe.mockResolvedValue({ videoStreams: [{}], audioStreams: [{}], format: {} } as any);
+  mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
+  mocks.asset.getForEdit.mockResolvedValue({
+    type: AssetType.Video,
+    livePhotoVideoId: null,
+    originalPath: '/data/library/video.mp4',
+    originalFileName: 'video.mp4',
+    duration: 30_000,
+    exifImageWidth: 1920,
+    exifImageHeight: 1080,
+    orientation: null,
+    projectionType: null,
+  } as any);
+  mocks.assetEdit.getAll.mockResolvedValue([]);
+  mocks.assetEdit.replaceAll.mockResolvedValue([] as any);
+  mocks.media.probe.mockResolvedValue({ videoStreams: [{}], audioStreams: [{}], format: {} } as any);
 
-      await sut.editAsset(authStub.admin, assetId, {
-        edits: [{ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } }],
-      });
+  await sut.editAsset(authStub.admin, assetId, {
+    edits: [{ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } }],
+  });
 
-      expect(mocks.media.probe).toHaveBeenCalledWith('/data/library/video.mp4');
-      expect(resolveSpy).not.toHaveBeenCalled();
+  expect(mocks.media.probe).toHaveBeenCalledWith('/data/library/video.mp4');
+  expect(resolveSpy).not.toHaveBeenCalled();
 
-      vi.restoreAllMocks();
-    });
+  vi.restoreAllMocks();
+});
 ```
 
 Check the top of the spec for the imports these need (`vi`, `JobName`, `AssetEditAction`, `AssetType`, `newUuid`, `authStub`) and add only what is missing.
@@ -307,6 +311,7 @@ pnpm test -- --run src/services/asset.service.spec.ts
 ```
 
 Expected reds:
+
 - "should accept trim on S3-backed videos…" → FAILS: throws `Video trimming is not available for cloud-stored videos` (E1).
 - "should reject trim on external library videos" → FAILS: message is `…not available for cloud-stored videos`, not `…external library videos` (E2).
 - "should reject trim on audio-only S3 files" → FAILS: the cloud-stored guard throws before the probe (E3).
@@ -317,19 +322,19 @@ Expected reds:
 In `server/src/services/asset.service.ts`, replace lines 728–737 (the `// S3/cloud storage check` block through the `probe` call and its audio-only check) with:
 
 ```ts
-      // Block external-library videos: absolute paths outside the media location.
-      // S3-backed originals are relative keys, resolved through the storage backend.
-      if (isAbsolute(asset.originalPath) && !StorageCore.isImmichPath(asset.originalPath)) {
-        throw new BadRequestException('Video trimming is not available for external library videos');
-      }
+// Block external-library videos: absolute paths outside the media location.
+// S3-backed originals are relative keys, resolved through the storage backend.
+if (isAbsolute(asset.originalPath) && !StorageCore.isImmichPath(asset.originalPath)) {
+  throw new BadRequestException('Video trimming is not available for external library videos');
+}
 
-      // Audio-only file check. getProbeInput hands ffprobe an absolute path (disk) or a
-      // presigned URL (S3) — it does NOT download the video, which matters here because
-      // this runs inside the request.
-      const probeResult = await this.mediaRepository.probe(await this.getProbeInput(asset.originalPath));
-      if (!probeResult.videoStreams || probeResult.videoStreams.length === 0) {
-        throw new BadRequestException('Cannot trim audio-only files');
-      }
+// Audio-only file check. getProbeInput hands ffprobe an absolute path (disk) or a
+// presigned URL (S3) — it does NOT download the video, which matters here because
+// this runs inside the request.
+const probeResult = await this.mediaRepository.probe(await this.getProbeInput(asset.originalPath));
+if (!probeResult.videoStreams || probeResult.videoStreams.length === 0) {
+  throw new BadRequestException('Cannot trim audio-only files');
+}
 ```
 
 - [ ] **Step 4: Run the tests to verify they pass**

--- a/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-3.md
+++ b/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-3.md
@@ -23,10 +23,12 @@
 ### Task 1: Route `persistFile` and the trim unlinks through `storageRepository`
 
 **Files:**
+
 - Modify: `server/src/services/media.service.ts` (lines 2–3 imports; `persistFile` at 78–94; `handleVideoTrim` unlinks at 303 and 335)
 - Test: `server/src/services/media.service.spec.ts` (new `describe('persistFile', …)` block)
 
 **Interfaces:**
+
 - Consumes: `StorageRepository.createPlainReadStream(filepath: string): Readable` and `StorageRepository.unlink(file: string): Promise<void>` (both exist; `unlink` warns on ENOENT and rethrows other errors). `StorageService.getWriteBackend(): StorageBackend` (static).
 - Produces: no signature change. `private async persistFile(localPath: string, relativeKey: string, contentType?: string): Promise<string>` keeps its contract: disk → returns `localPath` and touches nothing; S3 → uploads, unlinks the local temp, returns `relativeKey`.
 
@@ -35,39 +37,39 @@
 Add this `describe` block to `server/src/services/media.service.spec.ts`, at the top level inside the outermost `describe('MediaService', …)` (place it directly before the first `describe('handleQueueGenerateThumbnails'…)` or any other existing block — order does not matter, but it must be a sibling):
 
 ```ts
-  describe('persistFile', () => {
-    afterEach(() => {
-      // vitest.config.mjs sets no restoreMocks and there are no setupFiles, so a
-      // getWriteBackend spy would leak into every later test in this file and
-      // silently run the disk-mode tests against S3.
-      vi.restoreAllMocks();
-    });
-
-    it('uploads to the write backend and removes the local temp (S3 mode)', async () => {
-      const put = vi.fn().mockResolvedValue(void 0);
-      const stream = makeStream([Buffer.from('data')]);
-      const { StorageService } = await import('src/services/storage.service.js');
-      vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
-      mocks.storage.createPlainReadStream.mockReturnValue(stream as any);
-
-      const result = await (sut as any).persistFile('/local/out.jpg', 'thumbs/aa/bb/x.jpg', 'image/jpeg');
-
-      expect(mocks.storage.createPlainReadStream).toHaveBeenCalledWith('/local/out.jpg');
-      expect(put).toHaveBeenCalledWith('thumbs/aa/bb/x.jpg', stream, { contentType: 'image/jpeg' });
-      expect(mocks.storage.unlink).toHaveBeenCalledWith('/local/out.jpg');
-      expect(result).toBe('thumbs/aa/bb/x.jpg');
-    });
-
-    it('returns the local path and deletes nothing (disk mode)', async () => {
-      // StorageService.diskBackend is undefined in this spec file, so getWriteBackend()
-      // returns undefined and persistFile takes its disk branch.
-      const result = await (sut as any).persistFile('/local/out.jpg', 'thumbs/aa/bb/x.jpg', 'image/jpeg');
-
-      expect(result).toBe('/local/out.jpg');
-      expect(mocks.storage.createPlainReadStream).not.toHaveBeenCalled();
-      expect(mocks.storage.unlink).not.toHaveBeenCalled();
-    });
+describe('persistFile', () => {
+  afterEach(() => {
+    // vitest.config.mjs sets no restoreMocks and there are no setupFiles, so a
+    // getWriteBackend spy would leak into every later test in this file and
+    // silently run the disk-mode tests against S3.
+    vi.restoreAllMocks();
   });
+
+  it('uploads to the write backend and removes the local temp (S3 mode)', async () => {
+    const put = vi.fn().mockResolvedValue(void 0);
+    const stream = makeStream([Buffer.from('data')]);
+    const { StorageService } = await import('src/services/storage.service.js');
+    vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+    mocks.storage.createPlainReadStream.mockReturnValue(stream as any);
+
+    const result = await (sut as any).persistFile('/local/out.jpg', 'thumbs/aa/bb/x.jpg', 'image/jpeg');
+
+    expect(mocks.storage.createPlainReadStream).toHaveBeenCalledWith('/local/out.jpg');
+    expect(put).toHaveBeenCalledWith('thumbs/aa/bb/x.jpg', stream, { contentType: 'image/jpeg' });
+    expect(mocks.storage.unlink).toHaveBeenCalledWith('/local/out.jpg');
+    expect(result).toBe('thumbs/aa/bb/x.jpg');
+  });
+
+  it('returns the local path and deletes nothing (disk mode)', async () => {
+    // StorageService.diskBackend is undefined in this spec file, so getWriteBackend()
+    // returns undefined and persistFile takes its disk branch.
+    const result = await (sut as any).persistFile('/local/out.jpg', 'thumbs/aa/bb/x.jpg', 'image/jpeg');
+
+    expect(result).toBe('/local/out.jpg');
+    expect(mocks.storage.createPlainReadStream).not.toHaveBeenCalled();
+    expect(mocks.storage.unlink).not.toHaveBeenCalled();
+  });
+});
 ```
 
 `makeStream` is already imported in this spec (`test/utils`). Add `afterEach` and `vi` to the existing `vitest` import if they are not already there.
@@ -80,6 +82,7 @@ pnpm test -- --run src/services/media.service.spec.ts -t "persistFile"
 ```
 
 Expected:
+
 - **A1** ("uploads to the write backend and removes the local temp (S3 mode)") → **FAILS**: `mocks.storage.createPlainReadStream` was never called (the code uses raw `node:fs`). You may also see an unhandled ENOENT error from the real `createReadStream` — that is the exact hazard this slice removes.
 - **A2** ("returns the local path and deletes nothing (disk mode)") → **PASSES already**. It is the GUARD; Step 5 proves it.
 
@@ -112,13 +115,13 @@ In `server/src/services/media.service.ts`:
 3. In `handleVideoTrim`, replace the two raw unlinks:
 
 ```ts
-      // line ~303, in the trim catch block
-      await this.storageRepository.unlink(outputPath).catch(() => {});
+// line ~303, in the trim catch block
+await this.storageRepository.unlink(outputPath).catch(() => {});
 ```
 
 ```ts
-      // line ~335, after extractFrame
-      await this.storageRepository.unlink(framePath).catch(() => {});
+// line ~335, after extractFrame
+await this.storageRepository.unlink(framePath).catch(() => {});
 ```
 
 - [ ] **Step 4: Run the tests to verify they pass**

--- a/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-3.md
+++ b/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-3.md
@@ -1,0 +1,184 @@
+# Video Trim on S3 — Slice 3: `persistFile` onto the repository layer
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `MediaService.persistFile` stream and unlink through `storageRepository` instead of raw `node:fs`, so that S3-mode behaviour in this file becomes testable at all.
+
+**Architecture:** `persistFile` currently calls `createReadStream` from `node:fs`. Under vitest the generated paths do not exist and the mocked backend `put` never consumes the stream, so the failed open emits an unhandled `'error'` event that crashes or flakes the run — which is why no S3 test exists for this file. `asset.service`'s S3 sidecar path already avoids this by streaming through `storageRepository.createPlainReadStream` (mocked in tests as `mocks.storage.createPlainReadStream`). `persistFile` adopts the same pattern, and `handleVideoTrim`'s two raw `unlink` calls move to `storageRepository.unlink` for the same reason: it makes failure-path cleanup assertable in Slice 4. Production behaviour is unchanged.
+
+**Tech Stack:** NestJS, vitest.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-12-video-trim-s3-design.md`, Slice 3 (design §3).
+- Slices 1–2 are complete. Slice 2 enabled trim on S3 at the API; this slice starts fixing the job.
+- **Behaviour must not change.** This is a pure refactor plus the two tests it unlocks. The existing `media.service.spec.ts` suite must stay green with **zero changes to existing tests**.
+- Do not change `handleVideoTrim`'s logic in this slice beyond swapping the two `unlink` calls — no `ensureLocalFile`, no `persistFile` call for the video, no `persistImageFiles`. Those are Slices 4–6.
+- **`server/test/vitest.config.mjs` sets no `restoreMocks` and there are no `setupFiles`.** A `vi.spyOn(StorageService, 'getWriteBackend')` leaks into every later test in the file and would silently run the disk-mode tests against S3. The new S3 test MUST restore its spies in `afterEach`.
+- Disk mode in `media.service.spec.ts` works because `StorageService.diskBackend` is `undefined` there, so `persistFile` takes its `!writeBackend` branch. Do not "fix" that by constructing a `DiskStorageBackend`.
+- Run tests from `server/`: `pnpm test -- --run src/services/media.service.spec.ts`.
+
+---
+
+### Task 1: Route `persistFile` and the trim unlinks through `storageRepository`
+
+**Files:**
+- Modify: `server/src/services/media.service.ts` (lines 2–3 imports; `persistFile` at 78–94; `handleVideoTrim` unlinks at 303 and 335)
+- Test: `server/src/services/media.service.spec.ts` (new `describe('persistFile', …)` block)
+
+**Interfaces:**
+- Consumes: `StorageRepository.createPlainReadStream(filepath: string): Readable` and `StorageRepository.unlink(file: string): Promise<void>` (both exist; `unlink` warns on ENOENT and rethrows other errors). `StorageService.getWriteBackend(): StorageBackend` (static).
+- Produces: no signature change. `private async persistFile(localPath: string, relativeKey: string, contentType?: string): Promise<string>` keeps its contract: disk → returns `localPath` and touches nothing; S3 → uploads, unlinks the local temp, returns `relativeKey`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add this `describe` block to `server/src/services/media.service.spec.ts`, at the top level inside the outermost `describe('MediaService', …)` (place it directly before the first `describe('handleQueueGenerateThumbnails'…)` or any other existing block — order does not matter, but it must be a sibling):
+
+```ts
+  describe('persistFile', () => {
+    afterEach(() => {
+      // vitest.config.mjs sets no restoreMocks and there are no setupFiles, so a
+      // getWriteBackend spy would leak into every later test in this file and
+      // silently run the disk-mode tests against S3.
+      vi.restoreAllMocks();
+    });
+
+    it('uploads to the write backend and removes the local temp (S3 mode)', async () => {
+      const put = vi.fn().mockResolvedValue(void 0);
+      const stream = makeStream([Buffer.from('data')]);
+      const { StorageService } = await import('src/services/storage.service.js');
+      vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+      mocks.storage.createPlainReadStream.mockReturnValue(stream as any);
+
+      const result = await (sut as any).persistFile('/local/out.jpg', 'thumbs/aa/bb/x.jpg', 'image/jpeg');
+
+      expect(mocks.storage.createPlainReadStream).toHaveBeenCalledWith('/local/out.jpg');
+      expect(put).toHaveBeenCalledWith('thumbs/aa/bb/x.jpg', stream, { contentType: 'image/jpeg' });
+      expect(mocks.storage.unlink).toHaveBeenCalledWith('/local/out.jpg');
+      expect(result).toBe('thumbs/aa/bb/x.jpg');
+    });
+
+    it('returns the local path and deletes nothing (disk mode)', async () => {
+      // StorageService.diskBackend is undefined in this spec file, so getWriteBackend()
+      // returns undefined and persistFile takes its disk branch.
+      const result = await (sut as any).persistFile('/local/out.jpg', 'thumbs/aa/bb/x.jpg', 'image/jpeg');
+
+      expect(result).toBe('/local/out.jpg');
+      expect(mocks.storage.createPlainReadStream).not.toHaveBeenCalled();
+      expect(mocks.storage.unlink).not.toHaveBeenCalled();
+    });
+  });
+```
+
+`makeStream` is already imported in this spec (`test/utils`). Add `afterEach` and `vi` to the existing `vitest` import if they are not already there.
+
+- [ ] **Step 2: Run the tests to verify A1 fails**
+
+```bash
+cd server
+pnpm test -- --run src/services/media.service.spec.ts -t "persistFile"
+```
+
+Expected:
+- **A1** ("uploads to the write backend and removes the local temp (S3 mode)") → **FAILS**: `mocks.storage.createPlainReadStream` was never called (the code uses raw `node:fs`). You may also see an unhandled ENOENT error from the real `createReadStream` — that is the exact hazard this slice removes.
+- **A2** ("returns the local path and deletes nothing (disk mode)") → **PASSES already**. It is the GUARD; Step 5 proves it.
+
+- [ ] **Step 3: Implement**
+
+In `server/src/services/media.service.ts`:
+
+1. Delete the now-unused imports on lines 2–3 (`createReadStream` from `node:fs` is used only in `persistFile`; `unlink` from `node:fs/promises` is used only at lines 89, 303, 335 — all three are replaced below). Remove both import lines entirely.
+
+2. Replace the body of `persistFile` (currently lines ~78–94) with:
+
+```ts
+  private async persistFile(localPath: string, relativeKey: string, contentType?: string): Promise<string> {
+    const writeBackend = StorageService.getWriteBackend();
+    if (!writeBackend || writeBackend instanceof DiskStorageBackend) {
+      // Disk mode: the file was already written to the final path
+      return localPath;
+    }
+    // S3 mode: upload the locally-generated file
+    const stream = this.storageRepository.createPlainReadStream(localPath);
+    await writeBackend.put(relativeKey, stream, { contentType });
+    // Clean up local temp file
+    await this.storageRepository.unlink(localPath).catch(() => {
+      /* ignore */
+    });
+    return relativeKey;
+  }
+```
+
+3. In `handleVideoTrim`, replace the two raw unlinks:
+
+```ts
+      // line ~303, in the trim catch block
+      await this.storageRepository.unlink(outputPath).catch(() => {});
+```
+
+```ts
+      // line ~335, after extractFrame
+      await this.storageRepository.unlink(framePath).catch(() => {});
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+pnpm test -- --run src/services/media.service.spec.ts
+```
+
+Expected: PASS — both new tests, and **every existing test in the file unchanged and still green**. If an existing test needed editing, stop: that means behaviour changed, which this slice forbids.
+
+- [ ] **Step 5: Mutation-prove the A2 guard**
+
+A2 passed before the implementation, so prove it has teeth. Temporarily make `persistFile` unlink unconditionally by moving the unlink above the disk-mode early return:
+
+```ts
+  private async persistFile(localPath: string, relativeKey: string, contentType?: string): Promise<string> {
+    await this.storageRepository.unlink(localPath).catch(() => {});   // MUTATION
+    const writeBackend = StorageService.getWriteBackend();
+    if (!writeBackend || writeBackend instanceof DiskStorageBackend) {
+      return localPath;
+    }
+    ...
+```
+
+Run `pnpm test -- --run src/services/media.service.spec.ts -t "persistFile"`.
+
+Expected: **A2 FAILS** (`mocks.storage.unlink` was called). This is what stops a future "simplification" from deleting the very file disk mode just wrote. Then **revert the mutation** and confirm green. If A2 survives the mutation, the test is broken — fix it before continuing.
+
+- [ ] **Step 6: Run the full server unit suite**
+
+```bash
+pnpm test -- --run
+```
+
+Expected: green. `persistFile` is called by four job paths (thumbnails, edit thumbnails, video conversion, person thumbnails) — their existing tests are the blast-radius guard.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/services/media.service.ts server/src/services/media.service.spec.ts
+git commit -m "refactor(media): stream persistFile through the storage repository
+
+persistFile read the generated file with node:fs createReadStream. Under
+vitest those paths do not exist, and because a mocked backend put never
+consumes the stream, the failed open emits an unhandled 'error' event — so
+nothing in this file could be tested in S3 mode. Stream and unlink through
+storageRepository instead, matching asset.service's S3 sidecar path.
+
+handleVideoTrim's two unlinks move for the same reason: it makes the
+failure-path cleanup assertable in the next slice. No behaviour change."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** A1 (RED, S3 persist streams via the repository, uploads with content type, unlinks the temp, returns the key) and A2 (GUARD, disk mode returns the local path and deletes nothing, mutation-proved) — both present, matching the spec's Slice 3.
+
+**Placeholders:** none.
+
+**Type consistency:** `createPlainReadStream(filepath: string): Readable` and `unlink(file: string): Promise<void>` match `server/src/repositories/storage.repository.ts:163` and `:207`. `StorageService.getWriteBackend()` and `DiskStorageBackend` are already imported in `media.service.ts`. `makeStream` is already imported in the spec from `test/utils`.
+
+**Not in this slice:** `ensureLocalFile` on the trim input (Slice 4), `StorageCore` keys and video persistence (Slice 5), `persistImageFiles` (Slice 6), e2e wiring (Slice 7).

--- a/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-4.md
+++ b/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-4.md
@@ -1,223 +1,239 @@
-# Video Trim on S3 — Slice 4: Defect 3, never hand ffmpeg an S3 key
+# Video Trim on S3 — Slice 4: The `EncodedVideo` blind spot (dead input branch + undo)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** When the trim job picks the asset's existing (non-edited) encoded video as its ffmpeg input, materialize it locally first — on S3 that path is a relative key ffmpeg cannot open.
+**Goal:** Remove the unreachable "prefer the encoded video as ffmpeg input" branch, and make undo actually delete the trimmed video.
 
-**Architecture:** `handleVideoTrim` selects `existingEncoded?.path || localPath` as the ffmpeg input. `localPath` is already materialized by the caller, but `existingEncoded.path` comes straight from the DB, and on S3 that is a relative key → ENOENT. Route it through `BaseService.ensureLocalFile` (which downloads to a temp file and hands back a cleanup) and release the temp in a `finally` around the trim, so a failed trim does not leak it.
+**Architecture:** `getForGenerateThumbnailJob` (`asset-job.repository.ts:135`) loads only `Thumbnail`, `Preview` and `FullSize` files — never `EncodedVideo`. One fact, two consequences.
 
-**Tech Stack:** NestJS, vitest.
+(a) `handleVideoTrim`'s `existingEncoded = asset.files.find(f => f.type === EncodedVideo && !f.isEdited)` is **always `undefined`**, so the trim already reads the original. The branch is dead — and the issue's "S3 key fed to ffmpeg" defect cannot happen. Delete it; trimming the original is also the better source.
+
+(b) The undo path does `syncFiles(asset.files.filter(f => f.isEdited), [])`, and since `asset.files` cannot hold the edited **encoded video**, undo deletes the edited thumbnails but leaves the trimmed video row behind. `AssetRepository.getForVideo` orders `isEdited DESC LIMIT 1`, so playback keeps serving the trimmed video after an undo — **on disk installs too**. Fix by fetching that row explicitly and deleting it.
+
+**Tech Stack:** NestJS, Kysely, vitest.
 
 ## Global Constraints
 
-- Spec: `docs/superpowers/specs/2026-07-12-video-trim-s3-design.md`, Slice 4 (design §6, fix 3).
-- Slices 1–3 are complete. Slice 3 moved `persistFile` and `handleVideoTrim`'s unlinks onto `storageRepository`, so `mocks.storage.unlink` is assertable.
-- This slice adds **only** the input materialization. Do NOT add `persistFile` for the video, the `StorageCore` statics, or `persistImageFiles` — Slices 5 and 6.
-- **`server/test/vitest.config.mjs` sets no `restoreMocks` and there are no `setupFiles`.** Every test that spies on `StorageService` must restore in `afterEach`, or the disk-mode tests silently run against S3.
-- Disk mode works in this spec file because `StorageService.diskBackend` is `undefined`; `ensureLocalFile` returns absolute paths unchanged with a no-op cleanup, without consulting any backend.
-- Run tests from `server/`: `pnpm test -- --run src/services/media.service.spec.ts`.
+- Spec: `docs/superpowers/specs/2026-07-12-video-trim-s3-design.md`, Slice 4 (and Problem → Layer 2 defect 3, Layer 3).
+- Slices 1–3 are complete.
+- Both findings were confirmed by running the real stack, not by reading code. Do not "restore" the encoded-video preference — it was never working.
+- Do NOT add `ensureLocalFile` for the trim input. There is nothing to materialize: the input is always `localPath`, which the caller already materialized.
+- Do NOT add `@GenerateSql` to the new repository method — that would require regenerating the SQL query docs (`make sql`), which needs a running dev DB. Undecorated repository methods are simply not documented; several already are.
+- Do NOT touch `getForGenerateThumbnailJob`'s file-type filter. Adding `EncodedVideo` there looks tempting but `handleGenerateThumbnails` calls `syncFiles(asset.files, generated.files)` — encoded videos would then be unmatched old files and get **deleted on every thumbnail regen**. That is a data-loss landmine; the targeted query below avoids it.
+- **`server/test/vitest.config.mjs` sets no `restoreMocks`.** Restore any `StorageService` spies in `afterEach`.
+- Run tests from `server/`: `pnpm test -- --run src/services/media.service.spec.ts`, then the full suite.
 
 ---
 
-### Task 1: Materialize the encoded-video input
+### Task 1: Delete the dead encoded-video input branch
 
 **Files:**
-- Modify: `server/src/services/media.service.ts`, `handleVideoTrim` (lines ~291–305)
-- Test: `server/src/services/media.service.spec.ts` (add to the existing `describe` that holds the trim tests — the one containing `'should trim video when edits contain Trim action'`)
 
-**Interfaces:**
-- Consumes: `BaseService.ensureLocalFile(filePath: string): Promise<{ localPath: string; cleanup: () => Promise<void> }>` — absolute paths pass through with a no-op cleanup; relative keys are downloaded via `StorageService.resolveBackendForKey(key).downloadToTemp(key)`.
-- Produces: no signature change to `handleVideoTrim`.
+- Modify: `server/src/services/media.service.ts`, `handleVideoTrim` (lines ~291–294)
+- Test: `server/src/services/media.service.spec.ts` (with the other trim tests)
 
-- [ ] **Step 1: Write the failing tests**
+**Interfaces:** no signature changes.
 
-Add these four tests alongside the existing trim tests in `server/src/services/media.service.spec.ts`. They drive `handleVideoTrim` through its only caller, `sut.handleAssetEditThumbnailGeneration({ id })`, exactly as the existing trim tests do.
+- [ ] **Step 1: Write the failing test**
 
-Add an `afterEach(() => vi.restoreAllMocks())` to the enclosing `describe` if one is not already present.
+Production never puts an `EncodedVideo` row in `asset.files`, but a unit test can construct one — which is exactly what pins the behaviour: even then, ffmpeg must read the original.
 
 ```ts
-    it('materializes an S3 encoded-video input before handing it to ffmpeg', async () => {
-      const cleanup = vi.fn().mockResolvedValue(void 0);
-      const { StorageService } = await import('src/services/storage.service.js');
-      vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue({
-        downloadToTemp: vi.fn().mockResolvedValue({ tempPath: '/tmp/dl-encoded.mp4', cleanup }),
-      } as any);
+it('always trims the original, even if an encoded video row is present', async () => {
+  const asset = AssetFactory.from({ type: AssetType.Video })
+    .exif()
+    .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+    .files([{ type: AssetFileType.EncodedVideo, isEdited: false, path: 'encoded-video/owner/ab/cd/video.mp4' }])
+    .build();
+  mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+  mocks.media.probe.mockResolvedValue({
+    ...videoInfoStub.noAudioStreams,
+    format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+  });
+  mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+  mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
 
-      const asset = AssetFactory.from({ type: AssetType.Video })
-        .exif()
-        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
-        .files([
-          {
-            type: AssetFileType.EncodedVideo,
-            isEdited: false,
-            path: 'encoded-video/owner/ab/cd/video.mp4',
-          },
-        ])
-        .build();
-      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
-      mocks.media.probe.mockResolvedValue({
-        ...videoInfoStub.noAudioStreams,
-        format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
-      });
-      mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
-      mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+  await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
 
-      await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
-
-      expect(mocks.media.trim).toHaveBeenCalledWith('/tmp/dl-encoded.mp4', expect.any(String), 5, 20);
-      expect(cleanup).toHaveBeenCalled();
-    });
-
-    it('releases the downloaded encoded-video temp when ffmpeg fails', async () => {
-      const cleanup = vi.fn().mockResolvedValue(void 0);
-      const { StorageService } = await import('src/services/storage.service.js');
-      vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue({
-        downloadToTemp: vi.fn().mockResolvedValue({ tempPath: '/tmp/dl-encoded.mp4', cleanup }),
-      } as any);
-
-      const asset = AssetFactory.from({ type: AssetType.Video })
-        .exif()
-        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
-        .files([
-          {
-            type: AssetFileType.EncodedVideo,
-            isEdited: false,
-            path: 'encoded-video/owner/ab/cd/video.mp4',
-          },
-        ])
-        .build();
-      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
-      mocks.media.trim.mockRejectedValue(new Error('FFmpeg error'));
-
-      const result = await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
-
-      expect(result).toBe(JobStatus.Failed);
-      expect(cleanup).toHaveBeenCalled();
-      expect(mocks.storage.unlink).toHaveBeenCalledWith(expect.stringContaining('_edited.mp4'));
-    });
-
-    it('passes a disk encoded-video path to ffmpeg unchanged, without downloading', async () => {
-      const { StorageService } = await import('src/services/storage.service.js');
-      const resolveSpy = vi.spyOn(StorageService, 'resolveBackendForKey');
-
-      const asset = AssetFactory.from({ type: AssetType.Video })
-        .exif()
-        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
-        .files([{ type: AssetFileType.EncodedVideo, isEdited: false, path: '/data/encoded-video/video.mp4' }])
-        .build();
-      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
-      mocks.media.probe.mockResolvedValue({
-        ...videoInfoStub.noAudioStreams,
-        format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
-      });
-      mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
-      mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
-
-      await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
-
-      expect(mocks.media.trim).toHaveBeenCalledWith('/data/encoded-video/video.mp4', expect.any(String), 5, 20);
-      expect(resolveSpy).not.toHaveBeenCalled();
-    });
-
-    it('falls back to the original when the asset has no encoded video', async () => {
-      const { StorageService } = await import('src/services/storage.service.js');
-      const resolveSpy = vi.spyOn(StorageService, 'resolveBackendForKey');
-
-      const asset = AssetFactory.from({ type: AssetType.Video })
-        .exif()
-        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
-        .build();
-      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
-      mocks.media.probe.mockResolvedValue({
-        ...videoInfoStub.noAudioStreams,
-        format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
-      });
-      mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
-      mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
-
-      await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
-
-      expect(mocks.media.trim).toHaveBeenCalledWith(asset.originalPath, expect.any(String), 5, 20);
-      expect(resolveSpy).not.toHaveBeenCalled();
-    });
+  // The encoded video is never a valid ffmpeg input: on S3 its path is a relative key.
+  // The original is both readable and higher quality.
+  expect(mocks.media.trim).toHaveBeenCalledWith(asset.originalPath, expect.any(String), 5, 20);
+});
 ```
 
-The factory's default `originalPath` is absolute, so `ensureLocalFile` passes it through and the last test's expectation holds. If `AssetFactory`'s `.files([...])` entries need more fields (e.g. `isProgressive`, `isTransparent`), copy the shape used by the existing test `'should handle video undo by cleaning up edited files'` in the same file.
+If `AssetFactory`'s `.files([...])` entries need more fields, copy the shape used by the existing `'should handle video undo by cleaning up edited files'` test in the same file.
 
-- [ ] **Step 2: Run the tests to verify the reds**
+- [ ] **Step 2: Run it — expect RED**
 
 ```bash
 cd server
 pnpm test -- --run src/services/media.service.spec.ts
 ```
 
-Expected:
-- **B1** "materializes an S3 encoded-video input…" → **FAILS**: `trim` was called with `'encoded-video/owner/ab/cd/video.mp4'` (the raw key), not `/tmp/dl-encoded.mp4`. This is #671's defect 3, reproduced in a unit test.
-- **D2** "releases the downloaded encoded-video temp when ffmpeg fails" → **FAILS**: `cleanup` was never called (nothing is downloaded today).
-- **B2** "passes a disk encoded-video path… unchanged" → **PASSES already** (GUARD).
-- **B3** "falls back to the original…" → **PASSES already** (GUARD).
+Expected: **FAILS** — `trim` was called with `'encoded-video/owner/ab/cd/video.mp4'` instead of the original's path. (Note: `getForGenerateThumbnail` is a test mapper, so it happily passes through the `EncodedVideo` row the real query would never return.)
 
 - [ ] **Step 3: Implement**
 
-In `server/src/services/media.service.ts`, `handleVideoTrim`, replace the input selection and the trim block:
+In `handleVideoTrim`, replace the input selection:
 
 ```ts
-    // Select input: prefer non-edited encoded video, fall back to original.
-    // On S3 the encoded video's path is a relative key ffmpeg cannot open, so
-    // materialize it locally first and release it as soon as ffmpeg is done.
-    const existingEncoded = asset.files.find((f) => f.type === AssetFileType.EncodedVideo && !f.isEdited);
-    const encodedLocal = existingEncoded ? await this.ensureLocalFile(existingEncoded.path) : undefined;
-    const inputPath = encodedLocal?.localPath ?? localPath;
-
-    // Output path for edited encoded video in EncodedVideo directory
-    const outputPath = StorageCore.getNestedPath(StorageFolder.EncodedVideo, asset.ownerId, `${asset.id}_edited.mp4`);
-    this.storageCore.ensureFolders(outputPath);
-
-    try {
-      await this.mediaRepository.trim(inputPath, outputPath, params.startTime, duration);
-    } catch (error) {
-      this.logger.error(`FFmpeg trim failed for asset ${asset.id}: ${error}`);
-      await this.storageRepository.unlink(outputPath).catch(() => {});
-      return JobStatus.Failed;
-    } finally {
-      await encodedLocal?.cleanup();
-    }
+// ffmpeg always reads the original. The asset's encoded video is not a candidate:
+// getForGenerateThumbnailJob never loads EncodedVideo rows (asset-job.repository.ts),
+// and on S3 its path would be a relative key ffmpeg cannot open anyway.
+const inputPath = localPath;
 ```
 
-The `finally` runs on the `return JobStatus.Failed` path too, which is what D2 asserts.
+Delete the `existingEncoded` lookup entirely.
 
-- [ ] **Step 4: Run the tests to verify they pass**
+- [ ] **Step 4: Run — expect GREEN**
 
 ```bash
 pnpm test -- --run src/services/media.service.spec.ts
 ```
 
-Expected: PASS — all four new tests plus every existing test in the file.
+Expected: PASS, and every existing trim test still green.
 
-- [ ] **Step 5: Mutation-prove the two guards**
+---
 
-**B2** — make `ensureLocalFile` treat absolute paths as keys, in `server/src/services/base.service.ts`:
+### Task 2: Undo deletes the edited encoded video
+
+**Files:**
+
+- Modify: `server/src/repositories/asset.repository.ts` (new method near `getForVideo`, ~line 1667)
+- Modify: `server/src/services/media.service.ts`, the video-undo branch (~lines 227–235)
+- Test: `server/src/services/media.service.spec.ts`
+
+**Interfaces:**
+
+- Produces: `AssetRepository.getEditedEncodedVideo(assetId: string): Promise<{ id: string; path: string } | undefined>` — the asset's edited `EncodedVideo` `asset_file` row, if any.
+- Consumes: `AssetRepository.deleteFiles(files: Pick<Selectable<AssetFileTable>, 'id'>[])` (existing, `asset.repository.ts:1548`); `JobName.FileDelete` (already used by `syncFiles`).
+
+- [ ] **Step 1: Write the failing tests**
 
 ```ts
-  protected async ensureLocalFile(filePath: string): Promise<{ localPath: string; cleanup: () => Promise<void> }> {
-    // if (isAbsolute(filePath)) { return { localPath: filePath, cleanup: async () => {} }; }   // MUTATION: commented out
-    const { StorageService } = await import('./storage.service.js');
-    ...
+it('deletes the edited encoded video when the trim is undone', async () => {
+  const asset = AssetFactory.from({ type: AssetType.Video })
+    .exif()
+    .files([{ type: AssetFileType.Preview, isEdited: true, path: '/data/preview_edited.jpeg' }])
+    .build();
+  // no edits => the undo path
+  mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue({
+    ...getForGenerateThumbnail(asset),
+    edits: [],
+  } as any);
+  mocks.asset.getEditedEncodedVideo.mockResolvedValue({
+    id: 'file-id-1',
+    path: 'encoded-video/owner/ab/cd/video_edited.mp4',
+  });
+
+  await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+  // Without this, getForVideo (isEdited DESC) keeps serving the TRIMMED video after an undo.
+  expect(mocks.asset.deleteFiles).toHaveBeenCalledWith([expect.objectContaining({ id: 'file-id-1' })]);
+  expect(mocks.job.queue).toHaveBeenCalledWith({
+    name: JobName.FileDelete,
+    data: { files: ['encoded-video/owner/ab/cd/video_edited.mp4'] },
+  });
+});
+
+it('undoes cleanly when there is no edited encoded video', async () => {
+  const asset = AssetFactory.from({ type: AssetType.Video })
+    .exif()
+    .files([{ type: AssetFileType.Preview, isEdited: true, path: '/data/preview_edited.jpeg' }])
+    .build();
+  mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue({
+    ...getForGenerateThumbnail(asset),
+    edits: [],
+  } as any);
+  mocks.asset.getEditedEncodedVideo.mockResolvedValue(undefined);
+
+  const result = await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+  expect(result).toBe(JobStatus.Success);
+  expect(mocks.asset.deleteFiles).not.toHaveBeenCalledWith([expect.objectContaining({ id: expect.anything() })]);
+});
 ```
 
-Run the file. Expected: **B2 FAILS** (`resolveBackendForKey` was called). Revert.
+If the existing undo test (`'should handle video undo by cleaning up edited files'`) now needs `mocks.asset.getEditedEncodedVideo` stubbed, the automock returns `undefined` by default, which is the no-op path — it should keep passing untouched. If it does not, report rather than editing it.
 
-**B3** — in `handleVideoTrim`, force the download branch:
+- [ ] **Step 2: Run — expect RED**
+
+```bash
+pnpm test -- --run src/services/media.service.spec.ts
+```
+
+Expected:
+
+- **U1** "deletes the edited encoded video when the trim is undone" → **FAILS**: `mocks.asset.getEditedEncodedVideo` is not a function (the repository method does not exist yet). After Step 3's repository addition it will fail on the assertion instead — `deleteFiles` never called. Both are the same red.
+- **U2** "undoes cleanly when there is no edited encoded video" → **PASSES** once the method exists (GUARD).
+
+- [ ] **Step 3: Add the repository method**
+
+In `server/src/repositories/asset.repository.ts`, next to `getForVideo`:
 
 ```ts
-    const encodedLocal = await this.ensureLocalFile(existingEncoded?.path ?? '');   // MUTATION
+  async getEditedEncodedVideo(assetId: string) {
+    return this.db
+      .selectFrom('asset_file')
+      .select(['asset_file.id', 'asset_file.path'])
+      .where('asset_file.assetId', '=', assetId)
+      .where('asset_file.type', '=', AssetFileType.EncodedVideo)
+      .where('asset_file.isEdited', '=', true)
+      .executeTakeFirst();
+  }
 ```
 
-Run the file. Expected: **B3 FAILS** (`resolveBackendForKey` was called even with no encoded video). Revert, and confirm the suite is green again.
+No `@GenerateSql` decorator — see Global Constraints.
 
-If either guard survives its mutation, the test is broken — fix it before continuing.
+- [ ] **Step 4: Wire it into the undo branch**
 
-- [ ] **Step 6: Run the full server unit suite**
+In `server/src/services/media.service.ts`, the video-undo branch:
+
+```ts
+if (asset.type === AssetType.Video && asset.edits.length === 0) {
+  // Video undo path — clean up edited files and regenerate thumbnails from original
+  await this.syncFiles(
+    asset.files.filter((file) => file.isEdited),
+    [],
+  );
+
+  // asset.files never contains EncodedVideo rows (getForGenerateThumbnailJob only loads
+  // thumbnail/preview/fullsize), so syncFiles cannot see the trimmed video. Without this,
+  // getForVideo (isEdited DESC) would keep serving the trimmed video after an undo.
+  const editedVideo = await this.assetRepository.getEditedEncodedVideo(asset.id);
+  if (editedVideo) {
+    await this.assetRepository.deleteFiles([editedVideo]);
+    await this.jobRepository.queue({ name: JobName.FileDelete, data: { files: [editedVideo.path] } });
+  }
+
+  await this.jobRepository.queue({ name: JobName.AssetGenerateThumbnails, data: { id } });
+  return JobStatus.Success;
+}
+```
+
+`FileDelete` resolves both disk paths and S3 keys via `StorageService.resolveBackendForKey`, so this works on either backend.
+
+- [ ] **Step 5: Run — expect GREEN**
+
+```bash
+pnpm test -- --run src/services/media.service.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Mutation-prove the U2 guard**
+
+Drop the `if (editedVideo)` guard so it deletes unconditionally:
+
+```ts
+const editedVideo = await this.assetRepository.getEditedEncodedVideo(asset.id);
+await this.assetRepository.deleteFiles([editedVideo!]); // MUTATION
+await this.jobRepository.queue({ name: JobName.FileDelete, data: { files: [editedVideo!.path] } });
+```
+
+Run the file. Expected: **U2 FAILS** (it throws on `undefined.path`, or `deleteFiles` is called with `[undefined]`). Revert, confirm green.
+
+- [ ] **Step 7: Full server unit suite**
 
 ```bash
 pnpm test -- --run
@@ -225,27 +241,36 @@ pnpm test -- --run
 
 Expected: green.
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 8: Commit**
 
 ```bash
-git add server/src/services/media.service.ts server/src/services/media.service.spec.ts
-git commit -m "fix(media): materialize the encoded-video trim input on S3 (#671)
+git add server/src/services/media.service.ts server/src/services/media.service.spec.ts server/src/repositories/asset.repository.ts
+git commit -m "fix(media): drop the dead trim-input branch, delete the trimmed video on undo
 
-handleVideoTrim preferred the asset's existing non-edited encoded video as
-its ffmpeg input, but passed asset_file.path straight to ffmpeg. On S3 that
-is a relative key, so the trim died with ENOENT for any asset that had
-already been transcoded — the common case. Route it through ensureLocalFile
-and release the temp in a finally, so a failed trim leaks nothing."
+Two consequences of one fact: getForGenerateThumbnailJob never loads
+EncodedVideo rows, so asset.files cannot contain them.
+
+1. handleVideoTrim's 'prefer the non-edited encoded video as ffmpeg input'
+   branch was unreachable — existingEncoded is always undefined. The trim
+   already read the original (which is the better source anyway), so gh#671's
+   'S3 key fed to ffmpeg' defect could not actually occur. Delete the branch.
+
+2. Undo called syncFiles over asset.files, which cannot see the edited encoded
+   video, so the trimmed video row survived an undo — and getForVideo orders by
+   isEdited DESC, so playback kept serving the trimmed video forever. This was
+   broken on disk installs too. Fetch the row explicitly and delete it.
+
+Both confirmed against a live server before fixing."
 ```
 
 ---
 
 ## Self-Review
 
-**Spec coverage:** B1 (RED, S3 input materialized + cleanup), D2 (RED, failure path releases the temp and unlinks the partial output), B2 (GUARD, disk path untouched, mutation-proved), B3 (GUARD, no encoded video → original, mutation-proved). All four from the spec's Slice 4.
+**Spec coverage:** B1 (RED, ffmpeg always gets the original), U1 (RED, undo deletes the edited encoded video row + queues its file delete), U2 (GUARD, no edited video → clean no-op, mutation-proved). Matches the spec's revised Slice 4.
 
 **Placeholders:** none.
 
-**Type consistency:** `ensureLocalFile` returns `{ localPath, cleanup }` — matches `base.service.ts:398`. `mocks.storage.unlink` is assertable because Slice 3 routed the trim unlinks through `storageRepository`. `AssetFileType.EncodedVideo`, `AssetEditAction.Trim`, `JobStatus.Failed`, `videoInfoStub`, `rawBuffer`, `rawInfo`, `getForGenerateThumbnail` are all already imported in this spec.
+**Type consistency:** `getEditedEncodedVideo` returns `{ id, path } | undefined`, which is exactly what `deleteFiles(files: Pick<Selectable<AssetFileTable>, 'id'>[])` accepts and what the `FileDelete` job's `{ files: string[] }` needs. `mocks.asset` is the `AssetRepository` automock, so `getEditedEncodedVideo` appears on it automatically once the method exists.
 
-**Not in this slice:** the `StorageCore` statics and video persistence (Slice 5) — note `outputPath` still uses the inline `getNestedPath(...)` here and is replaced in Slice 5; `persistImageFiles` (Slice 6); e2e wiring (Slice 7).
+**Not in this slice:** persisting the trimmed video (Slice 5), persisting its thumbnails (Slice 6), e2e wiring (Slice 7). The e2e phase stays red until Slice 6.

--- a/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-4.md
+++ b/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-4.md
@@ -1,0 +1,251 @@
+# Video Trim on S3 — Slice 4: Defect 3, never hand ffmpeg an S3 key
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the trim job picks the asset's existing (non-edited) encoded video as its ffmpeg input, materialize it locally first — on S3 that path is a relative key ffmpeg cannot open.
+
+**Architecture:** `handleVideoTrim` selects `existingEncoded?.path || localPath` as the ffmpeg input. `localPath` is already materialized by the caller, but `existingEncoded.path` comes straight from the DB, and on S3 that is a relative key → ENOENT. Route it through `BaseService.ensureLocalFile` (which downloads to a temp file and hands back a cleanup) and release the temp in a `finally` around the trim, so a failed trim does not leak it.
+
+**Tech Stack:** NestJS, vitest.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-12-video-trim-s3-design.md`, Slice 4 (design §6, fix 3).
+- Slices 1–3 are complete. Slice 3 moved `persistFile` and `handleVideoTrim`'s unlinks onto `storageRepository`, so `mocks.storage.unlink` is assertable.
+- This slice adds **only** the input materialization. Do NOT add `persistFile` for the video, the `StorageCore` statics, or `persistImageFiles` — Slices 5 and 6.
+- **`server/test/vitest.config.mjs` sets no `restoreMocks` and there are no `setupFiles`.** Every test that spies on `StorageService` must restore in `afterEach`, or the disk-mode tests silently run against S3.
+- Disk mode works in this spec file because `StorageService.diskBackend` is `undefined`; `ensureLocalFile` returns absolute paths unchanged with a no-op cleanup, without consulting any backend.
+- Run tests from `server/`: `pnpm test -- --run src/services/media.service.spec.ts`.
+
+---
+
+### Task 1: Materialize the encoded-video input
+
+**Files:**
+- Modify: `server/src/services/media.service.ts`, `handleVideoTrim` (lines ~291–305)
+- Test: `server/src/services/media.service.spec.ts` (add to the existing `describe` that holds the trim tests — the one containing `'should trim video when edits contain Trim action'`)
+
+**Interfaces:**
+- Consumes: `BaseService.ensureLocalFile(filePath: string): Promise<{ localPath: string; cleanup: () => Promise<void> }>` — absolute paths pass through with a no-op cleanup; relative keys are downloaded via `StorageService.resolveBackendForKey(key).downloadToTemp(key)`.
+- Produces: no signature change to `handleVideoTrim`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these four tests alongside the existing trim tests in `server/src/services/media.service.spec.ts`. They drive `handleVideoTrim` through its only caller, `sut.handleAssetEditThumbnailGeneration({ id })`, exactly as the existing trim tests do.
+
+Add an `afterEach(() => vi.restoreAllMocks())` to the enclosing `describe` if one is not already present.
+
+```ts
+    it('materializes an S3 encoded-video input before handing it to ffmpeg', async () => {
+      const cleanup = vi.fn().mockResolvedValue(void 0);
+      const { StorageService } = await import('src/services/storage.service.js');
+      vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue({
+        downloadToTemp: vi.fn().mockResolvedValue({ tempPath: '/tmp/dl-encoded.mp4', cleanup }),
+      } as any);
+
+      const asset = AssetFactory.from({ type: AssetType.Video })
+        .exif()
+        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+        .files([
+          {
+            type: AssetFileType.EncodedVideo,
+            isEdited: false,
+            path: 'encoded-video/owner/ab/cd/video.mp4',
+          },
+        ])
+        .build();
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+      mocks.media.probe.mockResolvedValue({
+        ...videoInfoStub.noAudioStreams,
+        format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+      });
+      mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+      mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+
+      await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+      expect(mocks.media.trim).toHaveBeenCalledWith('/tmp/dl-encoded.mp4', expect.any(String), 5, 20);
+      expect(cleanup).toHaveBeenCalled();
+    });
+
+    it('releases the downloaded encoded-video temp when ffmpeg fails', async () => {
+      const cleanup = vi.fn().mockResolvedValue(void 0);
+      const { StorageService } = await import('src/services/storage.service.js');
+      vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue({
+        downloadToTemp: vi.fn().mockResolvedValue({ tempPath: '/tmp/dl-encoded.mp4', cleanup }),
+      } as any);
+
+      const asset = AssetFactory.from({ type: AssetType.Video })
+        .exif()
+        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+        .files([
+          {
+            type: AssetFileType.EncodedVideo,
+            isEdited: false,
+            path: 'encoded-video/owner/ab/cd/video.mp4',
+          },
+        ])
+        .build();
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+      mocks.media.trim.mockRejectedValue(new Error('FFmpeg error'));
+
+      const result = await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+      expect(result).toBe(JobStatus.Failed);
+      expect(cleanup).toHaveBeenCalled();
+      expect(mocks.storage.unlink).toHaveBeenCalledWith(expect.stringContaining('_edited.mp4'));
+    });
+
+    it('passes a disk encoded-video path to ffmpeg unchanged, without downloading', async () => {
+      const { StorageService } = await import('src/services/storage.service.js');
+      const resolveSpy = vi.spyOn(StorageService, 'resolveBackendForKey');
+
+      const asset = AssetFactory.from({ type: AssetType.Video })
+        .exif()
+        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+        .files([{ type: AssetFileType.EncodedVideo, isEdited: false, path: '/data/encoded-video/video.mp4' }])
+        .build();
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+      mocks.media.probe.mockResolvedValue({
+        ...videoInfoStub.noAudioStreams,
+        format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+      });
+      mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+      mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+
+      await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+      expect(mocks.media.trim).toHaveBeenCalledWith('/data/encoded-video/video.mp4', expect.any(String), 5, 20);
+      expect(resolveSpy).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the original when the asset has no encoded video', async () => {
+      const { StorageService } = await import('src/services/storage.service.js');
+      const resolveSpy = vi.spyOn(StorageService, 'resolveBackendForKey');
+
+      const asset = AssetFactory.from({ type: AssetType.Video })
+        .exif()
+        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+        .build();
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+      mocks.media.probe.mockResolvedValue({
+        ...videoInfoStub.noAudioStreams,
+        format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+      });
+      mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+      mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+
+      await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+      expect(mocks.media.trim).toHaveBeenCalledWith(asset.originalPath, expect.any(String), 5, 20);
+      expect(resolveSpy).not.toHaveBeenCalled();
+    });
+```
+
+The factory's default `originalPath` is absolute, so `ensureLocalFile` passes it through and the last test's expectation holds. If `AssetFactory`'s `.files([...])` entries need more fields (e.g. `isProgressive`, `isTransparent`), copy the shape used by the existing test `'should handle video undo by cleaning up edited files'` in the same file.
+
+- [ ] **Step 2: Run the tests to verify the reds**
+
+```bash
+cd server
+pnpm test -- --run src/services/media.service.spec.ts
+```
+
+Expected:
+- **B1** "materializes an S3 encoded-video input…" → **FAILS**: `trim` was called with `'encoded-video/owner/ab/cd/video.mp4'` (the raw key), not `/tmp/dl-encoded.mp4`. This is #671's defect 3, reproduced in a unit test.
+- **D2** "releases the downloaded encoded-video temp when ffmpeg fails" → **FAILS**: `cleanup` was never called (nothing is downloaded today).
+- **B2** "passes a disk encoded-video path… unchanged" → **PASSES already** (GUARD).
+- **B3** "falls back to the original…" → **PASSES already** (GUARD).
+
+- [ ] **Step 3: Implement**
+
+In `server/src/services/media.service.ts`, `handleVideoTrim`, replace the input selection and the trim block:
+
+```ts
+    // Select input: prefer non-edited encoded video, fall back to original.
+    // On S3 the encoded video's path is a relative key ffmpeg cannot open, so
+    // materialize it locally first and release it as soon as ffmpeg is done.
+    const existingEncoded = asset.files.find((f) => f.type === AssetFileType.EncodedVideo && !f.isEdited);
+    const encodedLocal = existingEncoded ? await this.ensureLocalFile(existingEncoded.path) : undefined;
+    const inputPath = encodedLocal?.localPath ?? localPath;
+
+    // Output path for edited encoded video in EncodedVideo directory
+    const outputPath = StorageCore.getNestedPath(StorageFolder.EncodedVideo, asset.ownerId, `${asset.id}_edited.mp4`);
+    this.storageCore.ensureFolders(outputPath);
+
+    try {
+      await this.mediaRepository.trim(inputPath, outputPath, params.startTime, duration);
+    } catch (error) {
+      this.logger.error(`FFmpeg trim failed for asset ${asset.id}: ${error}`);
+      await this.storageRepository.unlink(outputPath).catch(() => {});
+      return JobStatus.Failed;
+    } finally {
+      await encodedLocal?.cleanup();
+    }
+```
+
+The `finally` runs on the `return JobStatus.Failed` path too, which is what D2 asserts.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+pnpm test -- --run src/services/media.service.spec.ts
+```
+
+Expected: PASS — all four new tests plus every existing test in the file.
+
+- [ ] **Step 5: Mutation-prove the two guards**
+
+**B2** — make `ensureLocalFile` treat absolute paths as keys, in `server/src/services/base.service.ts`:
+
+```ts
+  protected async ensureLocalFile(filePath: string): Promise<{ localPath: string; cleanup: () => Promise<void> }> {
+    // if (isAbsolute(filePath)) { return { localPath: filePath, cleanup: async () => {} }; }   // MUTATION: commented out
+    const { StorageService } = await import('./storage.service.js');
+    ...
+```
+
+Run the file. Expected: **B2 FAILS** (`resolveBackendForKey` was called). Revert.
+
+**B3** — in `handleVideoTrim`, force the download branch:
+
+```ts
+    const encodedLocal = await this.ensureLocalFile(existingEncoded?.path ?? '');   // MUTATION
+```
+
+Run the file. Expected: **B3 FAILS** (`resolveBackendForKey` was called even with no encoded video). Revert, and confirm the suite is green again.
+
+If either guard survives its mutation, the test is broken — fix it before continuing.
+
+- [ ] **Step 6: Run the full server unit suite**
+
+```bash
+pnpm test -- --run
+```
+
+Expected: green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/services/media.service.ts server/src/services/media.service.spec.ts
+git commit -m "fix(media): materialize the encoded-video trim input on S3 (#671)
+
+handleVideoTrim preferred the asset's existing non-edited encoded video as
+its ffmpeg input, but passed asset_file.path straight to ffmpeg. On S3 that
+is a relative key, so the trim died with ENOENT for any asset that had
+already been transcoded — the common case. Route it through ensureLocalFile
+and release the temp in a finally, so a failed trim leaks nothing."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** B1 (RED, S3 input materialized + cleanup), D2 (RED, failure path releases the temp and unlinks the partial output), B2 (GUARD, disk path untouched, mutation-proved), B3 (GUARD, no encoded video → original, mutation-proved). All four from the spec's Slice 4.
+
+**Placeholders:** none.
+
+**Type consistency:** `ensureLocalFile` returns `{ localPath, cleanup }` — matches `base.service.ts:398`. `mocks.storage.unlink` is assertable because Slice 3 routed the trim unlinks through `storageRepository`. `AssetFileType.EncodedVideo`, `AssetEditAction.Trim`, `JobStatus.Failed`, `videoInfoStub`, `rawBuffer`, `rawInfo`, `getForGenerateThumbnail` are all already imported in this spec.
+
+**Not in this slice:** the `StorageCore` statics and video persistence (Slice 5) — note `outputPath` still uses the inline `getNestedPath(...)` here and is replaced in Slice 5; `persistImageFiles` (Slice 6); e2e wiring (Slice 7).

--- a/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-5.md
+++ b/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-5.md
@@ -1,0 +1,349 @@
+# Video Trim on S3 — Slice 5: Defect 1, persist the trimmed video
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Upload the trimmed video to the write backend and store its key, instead of storing a local path that S3 deployments cannot serve.
+
+**Architecture:** `handleVideoTrim` writes the trimmed video to a local nested path and puts that path straight into the `EncodedVideo` `asset_file` row. It needs a `persistFile` call — but `getRelativeEncodedVideoPath(asset)` returns the **non-edited** key (`…/{id}.mp4`), so reusing it would overwrite the asset's transcoded original in the bucket. Add fork-only `StorageCore` statics that derive the local path and the S3 key for the `_edited` variant from one filename helper, then persist with those. The persist call must come **after** probe and frame extraction, because `persistFile` unlinks the local file once it is uploaded.
+
+**Tech Stack:** NestJS, vitest.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-12-video-trim-s3-design.md`, Slice 5 (design §4 and §6, fix 1).
+- Slices 1–4 are complete.
+- Add **only** the video persistence. Do NOT touch the thumbnails (`persistImageFiles` is Slice 6).
+- Leave upstream's `StorageCore.getEncodedVideoPath` untouched — the new statics go in the fork-only relative-key block near `getRelativeEncodedVideoPath` (`storage.core.ts:350-371`), which keeps upstream rebases clean.
+- The local disk path must not change: `getEditedEncodedVideoPath` has to produce exactly what the current inline `getNestedPath(StorageFolder.EncodedVideo, asset.ownerId, \`${asset.id}_edited.mp4\`)` produces, so disk deployments need no migration.
+- **`server/test/vitest.config.mjs` sets no `restoreMocks`.** Restore `StorageService` spies in `afterEach`.
+- Run tests from `server/`: `pnpm test -- --run src/services/media.service.spec.ts`.
+
+---
+
+### Task 1: `StorageCore` statics for the edited encoded video
+
+**Files:**
+- Modify: `server/src/cores/storage.core.ts` (fork-only relative-key block, after `getRelativeEncodedVideoPath` at ~line 361)
+- Test: `server/src/cores/storage.core.spec.ts`
+
+**Interfaces:**
+- Produces:
+  - `static getEditedEncodedVideoPath(asset: ThumbnailPathEntity): string` — absolute local path.
+  - `static getRelativeEditedEncodedVideoPath(asset: ThumbnailPathEntity): string` — storage-backend key.
+  - Both consumed by `handleVideoTrim` in Task 2.
+
+- [ ] **Step 1: Write the failing tests**
+
+`storage.core.spec.ts` already calls `StorageCore.setMediaLocation('/media')` in its setup — follow the existing tests' shape. Add:
+
+```ts
+  describe('getEditedEncodedVideoPath', () => {
+    it('nests the _edited video beside the non-edited one', () => {
+      StorageCore.setMediaLocation('/media');
+      const asset = { id: 'abcd1234-0000-0000-0000-000000000000', ownerId: 'owner-id' };
+
+      expect(StorageCore.getEditedEncodedVideoPath(asset as any)).toBe(
+        '/media/encoded-video/owner-id/ab/cd/abcd1234-0000-0000-0000-000000000000_edited.mp4',
+      );
+    });
+  });
+
+  describe('getRelativeEditedEncodedVideoPath', () => {
+    it('returns the _edited key', () => {
+      const asset = { id: 'abcd1234-0000-0000-0000-000000000000', ownerId: 'owner-id' };
+
+      expect(StorageCore.getRelativeEditedEncodedVideoPath(asset as any)).toBe(
+        'encoded-video/owner-id/ab/cd/abcd1234-0000-0000-0000-000000000000_edited.mp4',
+      );
+    });
+
+    it('never collides with the non-edited encoded video key', () => {
+      const asset = { id: 'abcd1234-0000-0000-0000-000000000000', ownerId: 'owner-id' };
+
+      expect(StorageCore.getRelativeEditedEncodedVideoPath(asset as any)).not.toBe(
+        StorageCore.getRelativeEncodedVideoPath(asset as any),
+      );
+    });
+  });
+```
+
+Note the `{xx}/{yy}` nesting comes from the **filename**, so `{id}_edited.mp4` lands in the same folder as `{id}.mp4` — the keys differ only in the basename. That is what the third test pins.
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+cd server
+pnpm test -- --run src/cores/storage.core.spec.ts
+```
+
+Expected: FAIL — `StorageCore.getEditedEncodedVideoPath is not a function`.
+
+- [ ] **Step 3: Implement**
+
+In `server/src/cores/storage.core.ts`, in the `// --- Relative key methods` block, after `getRelativeEncodedVideoPath`:
+
+```ts
+  private static getEditedEncodedVideoFilename(asset: ThumbnailPathEntity): string {
+    return `${asset.id}_edited.mp4`;
+  }
+
+  static getEditedEncodedVideoPath(asset: ThumbnailPathEntity): string {
+    return StorageCore.getNestedPath(
+      StorageFolder.EncodedVideo,
+      asset.ownerId,
+      StorageCore.getEditedEncodedVideoFilename(asset),
+    );
+  }
+
+  static getRelativeEditedEncodedVideoPath(asset: ThumbnailPathEntity): string {
+    return StorageCore.getRelativeNestedPath(
+      StorageFolder.EncodedVideo,
+      asset.ownerId,
+      StorageCore.getEditedEncodedVideoFilename(asset),
+    );
+  }
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+pnpm test -- --run src/cores/storage.core.spec.ts
+```
+
+Expected: PASS.
+
+---
+
+### Task 2: Persist the trimmed video in `handleVideoTrim`
+
+**Files:**
+- Modify: `server/src/services/media.service.ts`, `handleVideoTrim`
+- Test: `server/src/services/media.service.spec.ts` (alongside the other trim tests)
+
+**Interfaces:**
+- Consumes: `StorageCore.getEditedEncodedVideoPath` / `getRelativeEditedEncodedVideoPath` (Task 1); `persistFile(localPath, relativeKey, contentType)` (Slice 3).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the trim `describe` in `media.service.spec.ts`. These need S3 mode, so spy `getWriteBackend` and restore in `afterEach`.
+
+```ts
+    it('uploads the trimmed video under the _edited key and stores that key (S3)', async () => {
+      const put = vi.fn().mockResolvedValue(void 0);
+      const { StorageService } = await import('src/services/storage.service.js');
+      vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+      mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('mp4')]) as any);
+
+      const asset = AssetFactory.from({ type: AssetType.Video })
+        .exif()
+        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+        .build();
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+      mocks.media.probe.mockResolvedValue({
+        ...videoInfoStub.noAudioStreams,
+        format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+      });
+      mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+      mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+
+      await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+      const editedKey = StorageCore.getRelativeEditedEncodedVideoPath(asset as any);
+      expect(put).toHaveBeenCalledWith(editedKey, expect.anything(), { contentType: 'video/mp4' });
+      expect(mocks.asset.upsertFiles).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ type: AssetFileType.EncodedVideo, isEdited: true, path: editedKey }),
+        ]),
+      );
+    });
+
+    it('never uploads the trimmed video over the transcoded original (S3)', async () => {
+      const put = vi.fn().mockResolvedValue(void 0);
+      const { StorageService } = await import('src/services/storage.service.js');
+      vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+      mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('mp4')]) as any);
+
+      const asset = AssetFactory.from({ type: AssetType.Video })
+        .exif()
+        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+        .build();
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+      mocks.media.probe.mockResolvedValue({
+        ...videoInfoStub.noAudioStreams,
+        format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+      });
+      mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+      mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+
+      await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+      const nonEditedKey = StorageCore.getRelativeEncodedVideoPath(asset as any);
+      const keys = put.mock.calls.map((call) => call[0]);
+      expect(keys).not.toContain(nonEditedKey);
+    });
+
+    it('uploads the trimmed video only after the thumbnail frame is extracted (S3)', async () => {
+      const put = vi.fn().mockResolvedValue(void 0);
+      const { StorageService } = await import('src/services/storage.service.js');
+      vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+      mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('mp4')]) as any);
+
+      const asset = AssetFactory.from({ type: AssetType.Video })
+        .exif()
+        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+        .build();
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+      mocks.media.probe.mockResolvedValue({
+        ...videoInfoStub.noAudioStreams,
+        format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+      });
+      mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+      mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+
+      await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+      // persistFile unlinks the local file after upload, so extractFrame MUST run first.
+      const extractOrder = mocks.media.extractFrame.mock.invocationCallOrder[0];
+      const putOrder = put.mock.invocationCallOrder[0];
+      expect(extractOrder).toBeLessThan(putOrder);
+    });
+
+    it('does not delete the edited video it just re-uploaded when re-trimming (S3)', async () => {
+      const put = vi.fn().mockResolvedValue(void 0);
+      const { StorageService } = await import('src/services/storage.service.js');
+      vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+      mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('mp4')]) as any);
+
+      const asset = AssetFactory.from({ type: AssetType.Video })
+        .exif()
+        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+        .build();
+      const editedKey = StorageCore.getRelativeEditedEncodedVideoPath(asset as any);
+      const withExistingEdit = {
+        ...getForGenerateThumbnail(asset),
+        files: [{ type: AssetFileType.EncodedVideo, isEdited: true, path: editedKey, isProgressive: false, isTransparent: false }],
+      };
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(withExistingEdit as any);
+      mocks.media.probe.mockResolvedValue({
+        ...videoInfoStub.noAudioStreams,
+        format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+      });
+      mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+      mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+
+      await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+      // The key is deterministic, so the re-trim overwrote the same object. syncFiles must
+      // NOT then queue a delete for it — that would erase what we just uploaded.
+      const deletedFiles = mocks.job.queue.mock.calls
+        .filter(([job]) => job.name === JobName.FileDelete)
+        .flatMap(([job]) => (job as any).data.files as string[]);
+      expect(deletedFiles).not.toContain(editedKey);
+    });
+```
+
+Import `StorageCore` in the spec if it is not already imported (`import { StorageCore } from 'src/cores/storage.core';`).
+
+- [ ] **Step 2: Run to verify the reds**
+
+```bash
+pnpm test -- --run src/services/media.service.spec.ts
+```
+
+Expected:
+- **C1** "uploads the trimmed video under the _edited key…" → **FAILS**: `put` was never called. This is #671's defect 1.
+- **C3a** "never uploads … over the transcoded original" → **FAILS**: `put` was never called (the assertion cannot be satisfied vacuously — it is paired with C1, which proves an upload happens at all).
+- **D1** "uploads … only after the thumbnail frame is extracted" → **FAILS**: `put.mock.invocationCallOrder[0]` is undefined.
+- **D3** "does not delete the edited video it just re-uploaded" → **PASSES already** (GUARD).
+
+- [ ] **Step 3: Implement**
+
+In `handleVideoTrim`:
+
+1. Replace the `outputPath` assignment:
+
+```ts
+    const outputPath = StorageCore.getEditedEncodedVideoPath(asset);
+```
+
+2. After the thumbnail generation and frame cleanup, **before** `syncFiles`, persist the video:
+
+```ts
+    // persistFile unlinks the local file after uploading, so this must come AFTER
+    // probe() and extractFrame() have read outputPath.
+    const editedVideoPath = await this.persistFile(
+      outputPath,
+      StorageCore.getRelativeEditedEncodedVideoPath(asset),
+      'video/mp4',
+    );
+
+    const editedVideoFile: UpsertFileOptions = {
+      assetId: asset.id,
+      type: AssetFileType.EncodedVideo,
+      path: editedVideoPath,
+      isEdited: true,
+      isProgressive: false,
+      isTransparent: false,
+    };
+```
+
+(The existing `editedVideoFile` declaration is replaced by this one; keep the rest of the function — `newFiles`, `syncFiles`, the thumbhash update — as it is.)
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+pnpm test -- --run src/services/media.service.spec.ts
+```
+
+Expected: PASS, including the pre-existing disk-mode trim tests (in disk mode `persistFile` returns the absolute path unchanged, so they are unaffected).
+
+- [ ] **Step 5: Mutation-prove D1 and D3**
+
+**D1** — move the `persistFile` call to immediately after the `trim`/`probe` block, before `extractFrame`. Run the file. Expected: **D1 FAILS** (`extractOrder` is no longer less than `putOrder`). This is the entire reason D1 exists — the reordering is the natural-looking mistake, and every other test in this slice still passes under it. Revert.
+
+**D3** — make the key non-deterministic in `storage.core.ts`:
+
+```ts
+  private static getEditedEncodedVideoFilename(asset: ThumbnailPathEntity): string {
+    return `${asset.id}_edited_${Date.now()}.mp4`;   // MUTATION
+  }
+```
+
+Run the file. Expected: **D3 FAILS** — the new key differs from the stored one, so `syncFiles` queues a `FileDelete` for the old key, which on S3 is the object that was just overwritten. Revert, and confirm green.
+
+- [ ] **Step 6: Full server unit suite**
+
+```bash
+pnpm test -- --run
+```
+
+Expected: green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/cores/storage.core.ts server/src/cores/storage.core.spec.ts server/src/services/media.service.ts server/src/services/media.service.spec.ts
+git commit -m "fix(media): persist the trimmed video to the write backend (#671)
+
+handleVideoTrim stored the trimmed video's local path in the EncodedVideo
+asset_file row without ever uploading it, so on S3 the file existed only on
+the pod's disk and vanished with the pod.
+
+The edited video needs its own key: getRelativeEncodedVideoPath returns the
+NON-edited key, so persisting with it would overwrite the asset's transcoded
+original in the bucket. Add fork-only StorageCore statics for the _edited
+variant and persist with those. The upload happens after probe/extractFrame,
+because persistFile unlinks the local file once it is uploaded."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** C1 (RED, upload under the `_edited` key, key stored), C3a (RED, never overwrites the transcoded original), D1 (RED + mutation-proved, upload strictly after `extractFrame`), D3 (GUARD + mutation-proved, deterministic key means no self-delete on re-trim). All four from the spec's Slice 5, plus the `StorageCore` unit tests.
+
+**Placeholders:** none.
+
+**Type consistency:** `UpsertFileOptions` is the local interface at `media.service.ts:54`. `ThumbnailPathEntity` is what the other `StorageCore` path helpers take. `mocks.asset.upsertFiles` matches `syncFiles`'s `assetRepository.upsertFiles(toUpsert)`. `JobName.FileDelete` matches `syncFiles`'s delete queue.
+
+**Not in this slice:** thumbnails are still written locally and their paths still land in `syncFiles` unpersisted — that is defect 2, fixed in Slice 6, whose C2 test will fail until then. The e2e phase therefore stays red until Slice 6.

--- a/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-5.md
+++ b/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-5.md
@@ -14,7 +14,7 @@
 - Slices 1–4 are complete.
 - Add **only** the video persistence. Do NOT touch the thumbnails (`persistImageFiles` is Slice 6).
 - Leave upstream's `StorageCore.getEncodedVideoPath` untouched — the new statics go in the fork-only relative-key block near `getRelativeEncodedVideoPath` (`storage.core.ts:350-371`), which keeps upstream rebases clean.
-- The local disk path must not change: `getEditedEncodedVideoPath` has to produce exactly what the current inline `getNestedPath(StorageFolder.EncodedVideo, asset.ownerId, \`${asset.id}_edited.mp4\`)` produces, so disk deployments need no migration.
+- The local disk path must not change: `getEditedEncodedVideoPath` has to produce exactly what the current inline `getNestedPath(StorageFolder.EncodedVideo, asset.ownerId, \`${asset.id}\_edited.mp4\`)` produces, so disk deployments need no migration.
 - **`server/test/vitest.config.mjs` sets no `restoreMocks`.** Restore `StorageService` spies in `afterEach`.
 - Run tests from `server/`: `pnpm test -- --run src/services/media.service.spec.ts`.
 
@@ -23,10 +23,12 @@
 ### Task 1: `StorageCore` statics for the edited encoded video
 
 **Files:**
+
 - Modify: `server/src/cores/storage.core.ts` (fork-only relative-key block, after `getRelativeEncodedVideoPath` at ~line 361)
 - Test: `server/src/cores/storage.core.spec.ts`
 
 **Interfaces:**
+
 - Produces:
   - `static getEditedEncodedVideoPath(asset: ThumbnailPathEntity): string` — absolute local path.
   - `static getRelativeEditedEncodedVideoPath(asset: ThumbnailPathEntity): string` — storage-backend key.
@@ -37,34 +39,34 @@
 `storage.core.spec.ts` already calls `StorageCore.setMediaLocation('/media')` in its setup — follow the existing tests' shape. Add:
 
 ```ts
-  describe('getEditedEncodedVideoPath', () => {
-    it('nests the _edited video beside the non-edited one', () => {
-      StorageCore.setMediaLocation('/media');
-      const asset = { id: 'abcd1234-0000-0000-0000-000000000000', ownerId: 'owner-id' };
+describe('getEditedEncodedVideoPath', () => {
+  it('nests the _edited video beside the non-edited one', () => {
+    StorageCore.setMediaLocation('/media');
+    const asset = { id: 'abcd1234-0000-0000-0000-000000000000', ownerId: 'owner-id' };
 
-      expect(StorageCore.getEditedEncodedVideoPath(asset as any)).toBe(
-        '/media/encoded-video/owner-id/ab/cd/abcd1234-0000-0000-0000-000000000000_edited.mp4',
-      );
-    });
+    expect(StorageCore.getEditedEncodedVideoPath(asset as any)).toBe(
+      '/media/encoded-video/owner-id/ab/cd/abcd1234-0000-0000-0000-000000000000_edited.mp4',
+    );
+  });
+});
+
+describe('getRelativeEditedEncodedVideoPath', () => {
+  it('returns the _edited key', () => {
+    const asset = { id: 'abcd1234-0000-0000-0000-000000000000', ownerId: 'owner-id' };
+
+    expect(StorageCore.getRelativeEditedEncodedVideoPath(asset as any)).toBe(
+      'encoded-video/owner-id/ab/cd/abcd1234-0000-0000-0000-000000000000_edited.mp4',
+    );
   });
 
-  describe('getRelativeEditedEncodedVideoPath', () => {
-    it('returns the _edited key', () => {
-      const asset = { id: 'abcd1234-0000-0000-0000-000000000000', ownerId: 'owner-id' };
+  it('never collides with the non-edited encoded video key', () => {
+    const asset = { id: 'abcd1234-0000-0000-0000-000000000000', ownerId: 'owner-id' };
 
-      expect(StorageCore.getRelativeEditedEncodedVideoPath(asset as any)).toBe(
-        'encoded-video/owner-id/ab/cd/abcd1234-0000-0000-0000-000000000000_edited.mp4',
-      );
-    });
-
-    it('never collides with the non-edited encoded video key', () => {
-      const asset = { id: 'abcd1234-0000-0000-0000-000000000000', ownerId: 'owner-id' };
-
-      expect(StorageCore.getRelativeEditedEncodedVideoPath(asset as any)).not.toBe(
-        StorageCore.getRelativeEncodedVideoPath(asset as any),
-      );
-    });
+    expect(StorageCore.getRelativeEditedEncodedVideoPath(asset as any)).not.toBe(
+      StorageCore.getRelativeEncodedVideoPath(asset as any),
+    );
   });
+});
 ```
 
 Note the `{xx}/{yy}` nesting comes from the **filename**, so `{id}_edited.mp4` lands in the same folder as `{id}.mp4` — the keys differ only in the basename. That is what the third test pins.
@@ -117,10 +119,12 @@ Expected: PASS.
 ### Task 2: Persist the trimmed video in `handleVideoTrim`
 
 **Files:**
+
 - Modify: `server/src/services/media.service.ts`, `handleVideoTrim`
 - Test: `server/src/services/media.service.spec.ts` (alongside the other trim tests)
 
 **Interfaces:**
+
 - Consumes: `StorageCore.getEditedEncodedVideoPath` / `getRelativeEditedEncodedVideoPath` (Task 1); `persistFile(localPath, relativeKey, contentType)` (Slice 3).
 
 - [ ] **Step 1: Write the failing tests**
@@ -128,118 +132,120 @@ Expected: PASS.
 Add to the trim `describe` in `media.service.spec.ts`. These need S3 mode, so spy `getWriteBackend` and restore in `afterEach`.
 
 ```ts
-    it('uploads the trimmed video under the _edited key and stores that key (S3)', async () => {
-      const put = vi.fn().mockResolvedValue(void 0);
-      const { StorageService } = await import('src/services/storage.service.js');
-      vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
-      mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('mp4')]) as any);
+it('uploads the trimmed video under the _edited key and stores that key (S3)', async () => {
+  const put = vi.fn().mockResolvedValue(void 0);
+  const { StorageService } = await import('src/services/storage.service.js');
+  vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+  mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('mp4')]) as any);
 
-      const asset = AssetFactory.from({ type: AssetType.Video })
-        .exif()
-        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
-        .build();
-      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
-      mocks.media.probe.mockResolvedValue({
-        ...videoInfoStub.noAudioStreams,
-        format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
-      });
-      mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
-      mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+  const asset = AssetFactory.from({ type: AssetType.Video })
+    .exif()
+    .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+    .build();
+  mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+  mocks.media.probe.mockResolvedValue({
+    ...videoInfoStub.noAudioStreams,
+    format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+  });
+  mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+  mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
 
-      await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+  await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
 
-      const editedKey = StorageCore.getRelativeEditedEncodedVideoPath(asset as any);
-      expect(put).toHaveBeenCalledWith(editedKey, expect.anything(), { contentType: 'video/mp4' });
-      expect(mocks.asset.upsertFiles).toHaveBeenCalledWith(
-        expect.arrayContaining([
-          expect.objectContaining({ type: AssetFileType.EncodedVideo, isEdited: true, path: editedKey }),
-        ]),
-      );
-    });
+  const editedKey = StorageCore.getRelativeEditedEncodedVideoPath(asset as any);
+  expect(put).toHaveBeenCalledWith(editedKey, expect.anything(), { contentType: 'video/mp4' });
+  expect(mocks.asset.upsertFiles).toHaveBeenCalledWith(
+    expect.arrayContaining([
+      expect.objectContaining({ type: AssetFileType.EncodedVideo, isEdited: true, path: editedKey }),
+    ]),
+  );
+});
 
-    it('never uploads the trimmed video over the transcoded original (S3)', async () => {
-      const put = vi.fn().mockResolvedValue(void 0);
-      const { StorageService } = await import('src/services/storage.service.js');
-      vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
-      mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('mp4')]) as any);
+it('never uploads the trimmed video over the transcoded original (S3)', async () => {
+  const put = vi.fn().mockResolvedValue(void 0);
+  const { StorageService } = await import('src/services/storage.service.js');
+  vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+  mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('mp4')]) as any);
 
-      const asset = AssetFactory.from({ type: AssetType.Video })
-        .exif()
-        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
-        .build();
-      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
-      mocks.media.probe.mockResolvedValue({
-        ...videoInfoStub.noAudioStreams,
-        format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
-      });
-      mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
-      mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+  const asset = AssetFactory.from({ type: AssetType.Video })
+    .exif()
+    .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+    .build();
+  mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+  mocks.media.probe.mockResolvedValue({
+    ...videoInfoStub.noAudioStreams,
+    format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+  });
+  mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+  mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
 
-      await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+  await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
 
-      const nonEditedKey = StorageCore.getRelativeEncodedVideoPath(asset as any);
-      const keys = put.mock.calls.map((call) => call[0]);
-      expect(keys).not.toContain(nonEditedKey);
-    });
+  const nonEditedKey = StorageCore.getRelativeEncodedVideoPath(asset as any);
+  const keys = put.mock.calls.map((call) => call[0]);
+  expect(keys).not.toContain(nonEditedKey);
+});
 
-    it('uploads the trimmed video only after the thumbnail frame is extracted (S3)', async () => {
-      const put = vi.fn().mockResolvedValue(void 0);
-      const { StorageService } = await import('src/services/storage.service.js');
-      vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
-      mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('mp4')]) as any);
+it('uploads the trimmed video only after the thumbnail frame is extracted (S3)', async () => {
+  const put = vi.fn().mockResolvedValue(void 0);
+  const { StorageService } = await import('src/services/storage.service.js');
+  vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+  mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('mp4')]) as any);
 
-      const asset = AssetFactory.from({ type: AssetType.Video })
-        .exif()
-        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
-        .build();
-      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
-      mocks.media.probe.mockResolvedValue({
-        ...videoInfoStub.noAudioStreams,
-        format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
-      });
-      mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
-      mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+  const asset = AssetFactory.from({ type: AssetType.Video })
+    .exif()
+    .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+    .build();
+  mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+  mocks.media.probe.mockResolvedValue({
+    ...videoInfoStub.noAudioStreams,
+    format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+  });
+  mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+  mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
 
-      await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+  await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
 
-      // persistFile unlinks the local file after upload, so extractFrame MUST run first.
-      const extractOrder = mocks.media.extractFrame.mock.invocationCallOrder[0];
-      const putOrder = put.mock.invocationCallOrder[0];
-      expect(extractOrder).toBeLessThan(putOrder);
-    });
+  // persistFile unlinks the local file after upload, so extractFrame MUST run first.
+  const extractOrder = mocks.media.extractFrame.mock.invocationCallOrder[0];
+  const putOrder = put.mock.invocationCallOrder[0];
+  expect(extractOrder).toBeLessThan(putOrder);
+});
 
-    it('does not delete the edited video it just re-uploaded when re-trimming (S3)', async () => {
-      const put = vi.fn().mockResolvedValue(void 0);
-      const { StorageService } = await import('src/services/storage.service.js');
-      vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
-      mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('mp4')]) as any);
+it('does not delete the edited video it just re-uploaded when re-trimming (S3)', async () => {
+  const put = vi.fn().mockResolvedValue(void 0);
+  const { StorageService } = await import('src/services/storage.service.js');
+  vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+  mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('mp4')]) as any);
 
-      const asset = AssetFactory.from({ type: AssetType.Video })
-        .exif()
-        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
-        .build();
-      const editedKey = StorageCore.getRelativeEditedEncodedVideoPath(asset as any);
-      const withExistingEdit = {
-        ...getForGenerateThumbnail(asset),
-        files: [{ type: AssetFileType.EncodedVideo, isEdited: true, path: editedKey, isProgressive: false, isTransparent: false }],
-      };
-      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(withExistingEdit as any);
-      mocks.media.probe.mockResolvedValue({
-        ...videoInfoStub.noAudioStreams,
-        format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
-      });
-      mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
-      mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+  const asset = AssetFactory.from({ type: AssetType.Video })
+    .exif()
+    .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+    .build();
+  const editedKey = StorageCore.getRelativeEditedEncodedVideoPath(asset as any);
+  const withExistingEdit = {
+    ...getForGenerateThumbnail(asset),
+    files: [
+      { type: AssetFileType.EncodedVideo, isEdited: true, path: editedKey, isProgressive: false, isTransparent: false },
+    ],
+  };
+  mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(withExistingEdit as any);
+  mocks.media.probe.mockResolvedValue({
+    ...videoInfoStub.noAudioStreams,
+    format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+  });
+  mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+  mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
 
-      await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+  await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
 
-      // The key is deterministic, so the re-trim overwrote the same object. syncFiles must
-      // NOT then queue a delete for it — that would erase what we just uploaded.
-      const deletedFiles = mocks.job.queue.mock.calls
-        .filter(([job]) => job.name === JobName.FileDelete)
-        .flatMap(([job]) => (job as any).data.files as string[]);
-      expect(deletedFiles).not.toContain(editedKey);
-    });
+  // The key is deterministic, so the re-trim overwrote the same object. syncFiles must
+  // NOT then queue a delete for it — that would erase what we just uploaded.
+  const deletedFiles = mocks.job.queue.mock.calls
+    .filter(([job]) => job.name === JobName.FileDelete)
+    .flatMap(([job]) => (job as any).data.files as string[]);
+  expect(deletedFiles).not.toContain(editedKey);
+});
 ```
 
 Import `StorageCore` in the spec if it is not already imported (`import { StorageCore } from 'src/cores/storage.core';`).
@@ -251,7 +257,8 @@ pnpm test -- --run src/services/media.service.spec.ts
 ```
 
 Expected:
-- **C1** "uploads the trimmed video under the _edited key…" → **FAILS**: `put` was never called. This is #671's defect 1.
+
+- **C1** "uploads the trimmed video under the \_edited key…" → **FAILS**: `put` was never called. This is #671's defect 1.
 - **C3a** "never uploads … over the transcoded original" → **FAILS**: `put` was never called (the assertion cannot be satisfied vacuously — it is paired with C1, which proves an upload happens at all).
 - **D1** "uploads … only after the thumbnail frame is extracted" → **FAILS**: `put.mock.invocationCallOrder[0]` is undefined.
 - **D3** "does not delete the edited video it just re-uploaded" → **PASSES already** (GUARD).
@@ -263,28 +270,28 @@ In `handleVideoTrim`:
 1. Replace the `outputPath` assignment:
 
 ```ts
-    const outputPath = StorageCore.getEditedEncodedVideoPath(asset);
+const outputPath = StorageCore.getEditedEncodedVideoPath(asset);
 ```
 
 2. After the thumbnail generation and frame cleanup, **before** `syncFiles`, persist the video:
 
 ```ts
-    // persistFile unlinks the local file after uploading, so this must come AFTER
-    // probe() and extractFrame() have read outputPath.
-    const editedVideoPath = await this.persistFile(
-      outputPath,
-      StorageCore.getRelativeEditedEncodedVideoPath(asset),
-      'video/mp4',
-    );
+// persistFile unlinks the local file after uploading, so this must come AFTER
+// probe() and extractFrame() have read outputPath.
+const editedVideoPath = await this.persistFile(
+  outputPath,
+  StorageCore.getRelativeEditedEncodedVideoPath(asset),
+  'video/mp4',
+);
 
-    const editedVideoFile: UpsertFileOptions = {
-      assetId: asset.id,
-      type: AssetFileType.EncodedVideo,
-      path: editedVideoPath,
-      isEdited: true,
-      isProgressive: false,
-      isTransparent: false,
-    };
+const editedVideoFile: UpsertFileOptions = {
+  assetId: asset.id,
+  type: AssetFileType.EncodedVideo,
+  path: editedVideoPath,
+  isEdited: true,
+  isProgressive: false,
+  isTransparent: false,
+};
 ```
 
 (The existing `editedVideoFile` declaration is replaced by this one; keep the rest of the function — `newFiles`, `syncFiles`, the thumbhash update — as it is.)

--- a/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-6.md
+++ b/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-6.md
@@ -21,10 +21,12 @@
 ### Task 1: Extract `persistImageFiles` and use it in `handleVideoTrim`
 
 **Files:**
+
 - Modify: `server/src/services/media.service.ts`
 - Test: `server/src/services/media.service.spec.ts`
 
 **Interfaces:**
+
 - Consumes: `persistFile(localPath, relativeKey, contentType)` (Slice 3); `StorageCore.getRelativeImagePath(asset, { fileType, format, isEdited })` (existing).
 - Produces: `private async persistImageFiles(asset: ThumbnailAsset, files: UpsertFileOptions[]): Promise<void>` — mutates each file's `path` in place to the persisted location (the key on S3, the unchanged local path on disk).
 
@@ -33,72 +35,72 @@
 Add to the trim `describe` in `media.service.spec.ts`:
 
 ```ts
-    it('uploads the trim thumbnails under _edited keys and stores those keys (S3)', async () => {
-      const put = vi.fn().mockResolvedValue(void 0);
-      const { StorageService } = await import('src/services/storage.service.js');
-      vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
-      mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('data')]) as any);
+it('uploads the trim thumbnails under _edited keys and stores those keys (S3)', async () => {
+  const put = vi.fn().mockResolvedValue(void 0);
+  const { StorageService } = await import('src/services/storage.service.js');
+  vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+  mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('data')]) as any);
 
-      const asset = AssetFactory.from({ type: AssetType.Video })
-        .exif()
-        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
-        .build();
-      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
-      mocks.media.probe.mockResolvedValue({
-        ...videoInfoStub.noAudioStreams,
-        format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
-      });
-      mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
-      mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+  const asset = AssetFactory.from({ type: AssetType.Video })
+    .exif()
+    .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+    .build();
+  mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+  mocks.media.probe.mockResolvedValue({
+    ...videoInfoStub.noAudioStreams,
+    format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+  });
+  mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+  mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
 
-      await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+  await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
 
-      const putKeys = put.mock.calls.map((call) => call[0] as string);
-      const thumbnailKeys = putKeys.filter((key) => key.startsWith('thumbs/'));
+  const putKeys = put.mock.calls.map((call) => call[0] as string);
+  const thumbnailKeys = putKeys.filter((key) => key.startsWith('thumbs/'));
 
-      // preview + thumbnail at minimum (fullsize too, when the config generates one)
-      expect(thumbnailKeys.length).toBeGreaterThanOrEqual(2);
-      for (const key of thumbnailKeys) {
-        expect(key).toContain('_edited');
-      }
+  // preview + thumbnail at minimum (fullsize too, when the config generates one)
+  expect(thumbnailKeys.length).toBeGreaterThanOrEqual(2);
+  for (const key of thumbnailKeys) {
+    expect(key).toContain('_edited');
+  }
 
-      // and the keys — not local paths — are what get written to the DB
-      const upserted = mocks.asset.upsertFiles.mock.calls.flatMap(([files]) => files as any[]);
-      const upsertedThumbs = upserted.filter((file) => file.type !== AssetFileType.EncodedVideo);
-      expect(upsertedThumbs.length).toBeGreaterThanOrEqual(2);
-      for (const file of upsertedThumbs) {
-        expect(file.path.startsWith('/')).toBe(false);
-        expect(file.path).toContain('_edited');
-      }
-    });
+  // and the keys — not local paths — are what get written to the DB
+  const upserted = mocks.asset.upsertFiles.mock.calls.flatMap(([files]) => files as any[]);
+  const upsertedThumbs = upserted.filter((file) => file.type !== AssetFileType.EncodedVideo);
+  expect(upsertedThumbs.length).toBeGreaterThanOrEqual(2);
+  for (const file of upsertedThumbs) {
+    expect(file.path.startsWith('/')).toBe(false);
+    expect(file.path).toContain('_edited');
+  }
+});
 
-    it('never overwrites the non-edited preview or thumbnail objects (S3)', async () => {
-      const put = vi.fn().mockResolvedValue(void 0);
-      const { StorageService } = await import('src/services/storage.service.js');
-      vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
-      mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('data')]) as any);
+it('never overwrites the non-edited preview or thumbnail objects (S3)', async () => {
+  const put = vi.fn().mockResolvedValue(void 0);
+  const { StorageService } = await import('src/services/storage.service.js');
+  vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+  mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('data')]) as any);
 
-      const asset = AssetFactory.from({ type: AssetType.Video })
-        .exif()
-        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
-        .build();
-      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
-      mocks.media.probe.mockResolvedValue({
-        ...videoInfoStub.noAudioStreams,
-        format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
-      });
-      mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
-      mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+  const asset = AssetFactory.from({ type: AssetType.Video })
+    .exif()
+    .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+    .build();
+  mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+  mocks.media.probe.mockResolvedValue({
+    ...videoInfoStub.noAudioStreams,
+    format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+  });
+  mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+  mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
 
-      await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+  await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
 
-      // A trim must not clobber the asset's normal preview/thumbnail objects: every
-      // image key it writes carries the _edited marker.
-      const putKeys = put.mock.calls.map((call) => call[0] as string);
-      for (const key of putKeys.filter((k) => k.startsWith('thumbs/'))) {
-        expect(key).toContain('_edited');
-      }
-    });
+  // A trim must not clobber the asset's normal preview/thumbnail objects: every
+  // image key it writes carries the _edited marker.
+  const putKeys = put.mock.calls.map((call) => call[0] as string);
+  for (const key of putKeys.filter((k) => k.startsWith('thumbs/'))) {
+    expect(key).toContain('_edited');
+  }
+});
 ```
 
 - [ ] **Step 2: Run to verify the reds**
@@ -109,7 +111,8 @@ pnpm test -- --run src/services/media.service.spec.ts
 ```
 
 Expected:
-- **C2** "uploads the trim thumbnails under _edited keys…" → **FAILS**: no `thumbs/` key is ever passed to `put` — only the video key from Slice 5. `thumbnailKeys.length` is 0. This is #671's defect 2.
+
+- **C2** "uploads the trim thumbnails under \_edited keys…" → **FAILS**: no `thumbs/` key is ever passed to `put` — only the video key from Slice 5. `thumbnailKeys.length` is 0. This is #671's defect 2.
 - **C3b** "never overwrites the non-edited preview or thumbnail objects" → **FAILS** for the same reason (no thumbnail `put` at all, so the loop body never runs and `putKeys.filter(...)` is empty — verify it fails on C2's assertion first, then treat C3b as meaningful only once C2 is green).
 
 Note: C3b is only informative once thumbnails are uploaded at all. Its job is to pin that they carry `_edited` **forever after** — including if someone later changes `getRelativeImagePath`'s arguments.
@@ -141,33 +144,33 @@ Replace **all four** call sites:
 1. `handleAssetEditThumbnailGeneration` (~line 240), the loop over `generated.files`:
 
 ```ts
-      // Persist output files to S3 if needed
-      if (generated?.files) {
-        await this.persistImageFiles(asset, generated.files);
-      }
+// Persist output files to S3 if needed
+if (generated?.files) {
+  await this.persistImageFiles(asset, generated.files);
+}
 ```
 
 2. `handleGenerateThumbnails` (~line 394), the loop over `generated.files`:
 
 ```ts
-      // Persist output files to S3 if needed
-      await this.persistImageFiles(asset, generated.files);
+// Persist output files to S3 if needed
+await this.persistImageFiles(asset, generated.files);
 ```
 
 3. `handleGenerateThumbnails` (~line 406), the loop over `editedGenerated.files`:
 
 ```ts
-      const editedGenerated = await this.generateEditedThumbnails(asset, config, localPath);
-      if (editedGenerated) {
-        await this.persistImageFiles(asset, editedGenerated.files);
-        generated.files.push(...editedGenerated.files);
-      }
+const editedGenerated = await this.generateEditedThumbnails(asset, config, localPath);
+if (editedGenerated) {
+  await this.persistImageFiles(asset, editedGenerated.files);
+  generated.files.push(...editedGenerated.files);
+}
 ```
 
 4. `handleVideoTrim`, immediately after the frame temp is unlinked and **before** the video's `persistFile` call added in Slice 5:
 
 ```ts
-    await this.persistImageFiles(asset, thumbnailResult.files);
+await this.persistImageFiles(asset, thumbnailResult.files);
 ```
 
 - [ ] **Step 4: Run to verify they pass**

--- a/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-6.md
+++ b/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-6.md
@@ -1,0 +1,229 @@
+# Video Trim on S3 — Slice 6: Defect 2, persist the trim thumbnails
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Upload the thumbnails a trim generates, instead of storing local paths that S3 deployments cannot serve — and make it structurally hard to forget this again.
+
+**Architecture:** The persist loop (derive the relative key from `fileType`/`format`/`isEdited`, `persistFile`, reassign `file.path`) is copy-pasted **three times** in `media.service.ts` and is missing from `handleVideoTrim`, which is exactly defect 2. Extract it into one `persistImageFiles(asset, files)` and route all four call sites through it, so every image output path persists by construction.
+
+**Tech Stack:** NestJS, vitest.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-12-video-trim-s3-design.md`, Slice 6 (design §5).
+- Slices 1–5 are complete. Slice 5 persists the trimmed video; this slice persists its thumbnails.
+- The three existing loops are at: `handleAssetEditThumbnailGeneration` (over `generated.files`, ~line 240), `handleGenerateThumbnails` (over `generated.files`, ~line 394), and `handleGenerateThumbnails` again (over `editedGenerated.files`, ~line 406). All three must be replaced by the helper — leaving one behind defeats the point.
+- **`server/test/vitest.config.mjs` sets no `restoreMocks`.** Restore `StorageService` spies in `afterEach`.
+- Run tests from `server/`: `pnpm test -- --run src/services/media.service.spec.ts`, then the full suite.
+
+---
+
+### Task 1: Extract `persistImageFiles` and use it in `handleVideoTrim`
+
+**Files:**
+- Modify: `server/src/services/media.service.ts`
+- Test: `server/src/services/media.service.spec.ts`
+
+**Interfaces:**
+- Consumes: `persistFile(localPath, relativeKey, contentType)` (Slice 3); `StorageCore.getRelativeImagePath(asset, { fileType, format, isEdited })` (existing).
+- Produces: `private async persistImageFiles(asset: ThumbnailAsset, files: UpsertFileOptions[]): Promise<void>` — mutates each file's `path` in place to the persisted location (the key on S3, the unchanged local path on disk).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the trim `describe` in `media.service.spec.ts`:
+
+```ts
+    it('uploads the trim thumbnails under _edited keys and stores those keys (S3)', async () => {
+      const put = vi.fn().mockResolvedValue(void 0);
+      const { StorageService } = await import('src/services/storage.service.js');
+      vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+      mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('data')]) as any);
+
+      const asset = AssetFactory.from({ type: AssetType.Video })
+        .exif()
+        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+        .build();
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+      mocks.media.probe.mockResolvedValue({
+        ...videoInfoStub.noAudioStreams,
+        format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+      });
+      mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+      mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+
+      await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+      const putKeys = put.mock.calls.map((call) => call[0] as string);
+      const thumbnailKeys = putKeys.filter((key) => key.startsWith('thumbs/'));
+
+      // preview + thumbnail at minimum (fullsize too, when the config generates one)
+      expect(thumbnailKeys.length).toBeGreaterThanOrEqual(2);
+      for (const key of thumbnailKeys) {
+        expect(key).toContain('_edited');
+      }
+
+      // and the keys — not local paths — are what get written to the DB
+      const upserted = mocks.asset.upsertFiles.mock.calls.flatMap(([files]) => files as any[]);
+      const upsertedThumbs = upserted.filter((file) => file.type !== AssetFileType.EncodedVideo);
+      expect(upsertedThumbs.length).toBeGreaterThanOrEqual(2);
+      for (const file of upsertedThumbs) {
+        expect(file.path.startsWith('/')).toBe(false);
+        expect(file.path).toContain('_edited');
+      }
+    });
+
+    it('never overwrites the non-edited preview or thumbnail objects (S3)', async () => {
+      const put = vi.fn().mockResolvedValue(void 0);
+      const { StorageService } = await import('src/services/storage.service.js');
+      vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+      mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('data')]) as any);
+
+      const asset = AssetFactory.from({ type: AssetType.Video })
+        .exif()
+        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+        .build();
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+      mocks.media.probe.mockResolvedValue({
+        ...videoInfoStub.noAudioStreams,
+        format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+      });
+      mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+      mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+
+      await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+      // A trim must not clobber the asset's normal preview/thumbnail objects: every
+      // image key it writes carries the _edited marker.
+      const putKeys = put.mock.calls.map((call) => call[0] as string);
+      for (const key of putKeys.filter((k) => k.startsWith('thumbs/'))) {
+        expect(key).toContain('_edited');
+      }
+    });
+```
+
+- [ ] **Step 2: Run to verify the reds**
+
+```bash
+cd server
+pnpm test -- --run src/services/media.service.spec.ts
+```
+
+Expected:
+- **C2** "uploads the trim thumbnails under _edited keys…" → **FAILS**: no `thumbs/` key is ever passed to `put` — only the video key from Slice 5. `thumbnailKeys.length` is 0. This is #671's defect 2.
+- **C3b** "never overwrites the non-edited preview or thumbnail objects" → **FAILS** for the same reason (no thumbnail `put` at all, so the loop body never runs and `putKeys.filter(...)` is empty — verify it fails on C2's assertion first, then treat C3b as meaningful only once C2 is green).
+
+Note: C3b is only informative once thumbnails are uploaded at all. Its job is to pin that they carry `_edited` **forever after** — including if someone later changes `getRelativeImagePath`'s arguments.
+
+- [ ] **Step 3: Implement `persistImageFiles` and route all four call sites**
+
+In `server/src/services/media.service.ts`, add the helper next to `persistFile`:
+
+```ts
+  /**
+   * Persists every generated image file and rewrites its path to the stored location.
+   * Every ffmpeg/sharp output path must go through this — forgetting it is how the
+   * trim thumbnails ended up unpersisted on S3 (gh#671).
+   */
+  private async persistImageFiles(asset: ThumbnailAsset, files: UpsertFileOptions[]): Promise<void> {
+    for (const file of files) {
+      const relativeKey = StorageCore.getRelativeImagePath(asset, {
+        fileType: file.type,
+        format: file.path.split('.').pop() as ImageFormat,
+        isEdited: file.isEdited,
+      });
+      file.path = await this.persistFile(file.path, relativeKey, mimeTypes.lookup(file.path));
+    }
+  }
+```
+
+Replace **all four** call sites:
+
+1. `handleAssetEditThumbnailGeneration` (~line 240), the loop over `generated.files`:
+
+```ts
+      // Persist output files to S3 if needed
+      if (generated?.files) {
+        await this.persistImageFiles(asset, generated.files);
+      }
+```
+
+2. `handleGenerateThumbnails` (~line 394), the loop over `generated.files`:
+
+```ts
+      // Persist output files to S3 if needed
+      await this.persistImageFiles(asset, generated.files);
+```
+
+3. `handleGenerateThumbnails` (~line 406), the loop over `editedGenerated.files`:
+
+```ts
+      const editedGenerated = await this.generateEditedThumbnails(asset, config, localPath);
+      if (editedGenerated) {
+        await this.persistImageFiles(asset, editedGenerated.files);
+        generated.files.push(...editedGenerated.files);
+      }
+```
+
+4. `handleVideoTrim`, immediately after the frame temp is unlinked and **before** the video's `persistFile` call added in Slice 5:
+
+```ts
+    await this.persistImageFiles(asset, thumbnailResult.files);
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+pnpm test -- --run src/services/media.service.spec.ts
+```
+
+Expected: PASS, all tests in the file.
+
+- [ ] **Step 5: Mutation-prove the C4 guard (disk mode)**
+
+The disk-mode trim tests (`'should trim video when edits contain Trim action'`, `'should generate thumbnails from extracted frame after trim'`, etc.) are the C4 guard: they pin that disk mode still stores absolute paths and uploads nothing. Prove they have teeth by forcing `persistFile` into its S3 branch:
+
+```ts
+  private async persistFile(localPath: string, relativeKey: string, contentType?: string): Promise<string> {
+    return relativeKey;   // MUTATION: pretend everything is S3
+  }
+```
+
+Run `pnpm test -- --run src/services/media.service.spec.ts`.
+
+Expected: disk-mode assertions **FAIL** (paths become relative keys). Revert and confirm green. If everything still passes under this mutation, the disk-mode tests are not actually pinning paths — say so in your report rather than papering over it.
+
+- [ ] **Step 6: Full server unit suite**
+
+```bash
+pnpm test -- --run
+```
+
+Expected: green. This slice touches `handleGenerateThumbnails` and `handleAssetEditThumbnailGeneration`, whose existing tests are the blast-radius guard — they must pass **unmodified**.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/services/media.service.ts server/src/services/media.service.spec.ts
+git commit -m "fix(media): persist trim thumbnails to the write backend (#671)
+
+The thumbnails a trim generates went straight into syncFiles as local paths,
+so on S3 the preview/thumbnail rows pointed at files that only existed on the
+pod's disk.
+
+The persist loop was copy-pasted three times and missing from the trim path,
+which is precisely how this was missed. Extract persistImageFiles and route
+all four image output paths through it, so persisting is structural rather
+than remembered."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** C2 (RED, thumbnails uploaded under `_edited` keys, keys stored in the DB), C3b (RED→guard, no `put` targets a non-edited thumbnail key), C4 (GUARD, disk mode unchanged, mutation-proved). All from the spec's Slice 6, plus the DRY extraction that is the point of the slice.
+
+**Placeholders:** none.
+
+**Type consistency:** `persistImageFiles(asset: ThumbnailAsset, files: UpsertFileOptions[])` — `ThumbnailAsset` and `UpsertFileOptions` are both declared in `media.service.ts` (lines ~54 and ~63). `mimeTypes` and `ImageFormat` are already imported there. `StorageCore.getRelativeImagePath` takes `{ fileType, format, isEdited }` (`storage.core.ts:356`).
+
+**Not in this slice:** the e2e phase wiring and its green run (Slice 7). After this slice the trim job should be fully correct on S3, so the e2e phase is expected to go green — Slice 7 proves it.

--- a/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-7.md
+++ b/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-7.md
@@ -1,0 +1,187 @@
+# Video Trim on S3 — Slice 7: Turn the e2e phase green and wire it in
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove the fix end to end against real MinIO and real ffmpeg, then wire the `video-trim-s3` phase into CI so #671 cannot come back.
+
+**Architecture:** Slice 1 added the phase and left it unwired (reachable only via `--phase video-trim-s3`), so CI stayed green while the fix landed across Slices 2–6. Now the phase should pass. Once it does — and only once it has passed three times in a row — add it to the explicit phase list in the CI workflow's `backend=s3` group and to the full-workflow sequence in `storage-migration.sh`, and delete the "no video asset upload" line from the harness README's known gaps, because it is no longer true.
+
+**Tech Stack:** Docker Compose (MinIO + Immich server + Postgres), `tsx`, GitHub Actions.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-12-video-trim-s3-design.md`, Slice 7.
+- Slices 1–6 are complete: trim is enabled on S3 at the API, and the job materializes its input, persists the trimmed video under an `_edited` key, and persists its thumbnails.
+- **No flaky test gets wired into CI.** If the phase is not green three consecutive times, do not wire it — fix the root cause. Never add retries or sleeps to paper over a failure.
+- This stack binds :2285 and Postgres :5435. Do not run it alongside `make dev` or `make e2e`.
+- All commands run from `e2e/` with `export COMPOSE_FILE=docker-compose.yml:docker-compose.storage-migration.yml`.
+
+---
+
+### Task 1: Rebuild the server image and turn the phase green
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Rebuild the server image with the fix and bring the stack up in S3 mode**
+
+```bash
+cd e2e
+export COMPOSE_FILE=docker-compose.yml:docker-compose.storage-migration.yml
+docker compose down -v --remove-orphans
+IMMICH_STORAGE_BACKEND=disk docker compose up -d --build --wait --wait-timeout 600
+docker compose exec -T minio sh -c "mc alias set local http://localhost:9000 minioadmin minioadmin && mc mb local/immich-test --ignore-existing"
+pnpm tsx src/storage-migration.ts setup
+IMMICH_STORAGE_BACKEND=s3 docker compose up -d --no-deps --force-recreate --wait --wait-timeout 180 immich-server
+```
+
+The `down -v` matters: the image must be rebuilt from the fixed source, and a stale volume would carry assets from earlier runs.
+
+- [ ] **Step 2: Run the phase — expect GREEN**
+
+```bash
+pnpm tsx src/storage-migration.ts video-trim-s3
+```
+
+Expected: `=== Phase: video-trim-s3 complete ===`, with every assertion passing — the edited video and thumbnails present in MinIO under relative `_edited` keys, the transcoded original byte-identical, playback 200, no local leftover, and the undo removing the edited objects.
+
+If it fails, read the failure carefully before touching anything:
+
+- 400 `cloud-stored` → Slice 2 did not land in the built image; rebuild.
+- ENOENT in the trim job → Slice 4 did not land.
+- `Edited encoded_video missing from MinIO` → Slice 5.
+- `Edited preview/thumbnail missing from MinIO` → Slice 6.
+- `Trimmed video left on local disk` → `persistFile` uploaded but did not unlink.
+- `Non-edited encoded video was overwritten` → the edited key is colliding with the non-edited one; Slice 5's `StorageCore` statics are wrong.
+
+- [ ] **Step 3: Prove it is not flaky — three consecutive green runs**
+
+```bash
+for i in 1 2 3; do
+  echo "=== run $i ==="
+  pnpm tsx src/storage-migration.ts video-trim-s3 || { echo "RUN $i FAILED"; break; }
+done
+```
+
+Expected: three passes. The phase deletes its asset and restores the ffmpeg config in a `finally`, so runs are independent — a second run re-uploads the same bytes and gets a fresh asset.
+
+If any run fails, that is a real defect (most likely a race with `waitForProcessing`, or teardown not restoring state). Fix the cause. **Do not** wire a flaky phase into CI; if it cannot be made deterministic, stop and report, leaving the phase unwired and saying so in the PR.
+
+---
+
+### Task 2: Wire the phase into CI and the full workflow
+
+**Files:**
+- Modify: `.github/workflows/storage-migration-tests.yml`
+- Modify: `e2e/storage-migration.sh`
+- Modify: `e2e/README-storage-migration.md`
+
+- [ ] **Step 1: Add the phase to the CI workflow**
+
+In `.github/workflows/storage-migration-tests.yml`, in the `backend=s3` phase group, immediately after the `'Phase: copy-asset-sidecar-s3'` step:
+
+```yaml
+      - name: 'Phase: video-trim-s3'
+        run: pnpm tsx src/storage-migration.ts video-trim-s3
+```
+
+It must sit inside the s3 group (the server is restarted into `IMMICH_STORAGE_BACKEND=s3` there) and **before** the later `migrate-to-disk` step.
+
+- [ ] **Step 2: Add the phase to the full-workflow sequence**
+
+In `e2e/storage-migration.sh`, in the `Main` block's full-workflow branch, after `run_phase migrate-to-s3` (the server is in s3 mode at that point):
+
+```bash
+  run_phase video-trim-s3
+```
+
+- [ ] **Step 3: Update the README's known gaps**
+
+In `e2e/README-storage-migration.md`, delete the `- No video asset upload (transcoding too slow/unreliable in e2e)` bullet from the **Known gaps** list — it is now false — and document the phase under **Phases**:
+
+```markdown
+4. **video-trim-s3** - Uploads a video, forces a transcode, trims it, and validates that the edited
+   encoded video and its thumbnails are persisted to S3 under `_edited` keys, that the transcoded
+   original is not overwritten, that nothing is left on local disk, and that undo removes the edited
+   objects. Covers gh#671.
+```
+
+- [ ] **Step 4: Run the whole harness end to end**
+
+```bash
+cd e2e
+./storage-migration.sh --cleanup --verbose
+```
+
+Expected: `ALL PHASES PASSED`. This is the regression check that matters — `migrate-to-disk` runs after our phase and has never seen `encoded-video` rows before.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/storage-migration-tests.yml e2e/storage-migration.sh e2e/README-storage-migration.md
+git commit -m "ci(e2e): gate video trim on S3 with the video-trim-s3 phase (#671)
+
+The phase reproduced #671 before the fix and passes after it. Wire it into the
+backend=s3 group so the gap that let this ship — 'no video asset upload' in the
+storage-migration harness — is closed."
+```
+
+---
+
+### Task 3: Push and open the PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin worktree-fix-671-video-trim-s3
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --repo open-noodle/gallery --base main \
+  --title "fix(editing): enable video trim on S3-backed storage (#671)" \
+  --body "$(cat <<'EOF'
+Closes #671.
+
+## What was broken
+
+Two layers, and the issue only described the inner one.
+
+**The feature was fenced off at the API.** `AssetService.editAsset` rejected any trim whose asset was not an `isImmichPath` — which is every S3-backed asset, since those originals are relative keys. `PUT /assets/:id/edits` returned 400 "Video trimming is not available for cloud-stored videos" before a job was ever queued. The web editor has no matching client-side gate, so S3 users saw the trim tool, hit save, and got a refusal.
+
+**Behind that guard, `handleVideoTrim` was broken for S3** in three ways (latent, because the guard made them unreachable): it never persisted the trimmed video, never persisted the trim thumbnails, and handed the existing encoded video's S3 key straight to ffmpeg (ENOENT for any already-transcoded asset — the common case).
+
+## What changed
+
+- The API guard now rejects only absolute paths outside the media location (external-library videos), so S3 assets are allowed through. The pre-flight audio-only probe resolves its input via the new `StorageBackend.getReadableUrl` — an absolute path on disk, a presigned URL on S3 — so ffprobe reads the header without downloading the whole video inside the request.
+- `handleVideoTrim` materializes its encoded-video input with `ensureLocalFile`, persists the trimmed video under a new `_edited` key (`getRelativeEncodedVideoPath` returns the NON-edited key — persisting with it would have overwritten the asset's transcoded original in the bucket), and persists its thumbnails.
+- The persist loop was copy-pasted three times and missing from the trim path, which is how this was missed. It is now one `persistImageFiles` helper used by all four image output paths.
+
+## Tests
+
+- 12 unit tests across `media.service`, `asset.service`, and both storage backends. Five of them are guards that pass on arrival, so each was mutation-proved — the mutation is named in the spec and was run.
+- A new **`video-trim-s3` e2e phase** in the MinIO storage-migration harness: it uploads a video, forces a transcode, trims it, and asserts the edited video and thumbnails land in the bucket under `_edited` keys, the transcoded original is byte-identical afterwards, nothing is left on local disk, playback serves the trimmed video, and undo removes the edited objects. It failed against unfixed code with the exact 400 above, and passes now.
+- That phase closes the harness gap ("no video asset upload") that let #671 ship in the first place.
+
+## Notes
+
+- This **enables a feature on S3 installs** (trim was previously unavailable there), so it wants a release-note line.
+- Fix-forward only: no S3 install ever produced a broken trim, because the guard blocked it, so there is nothing to repair.
+- #741 (realtime HLS ignores the trim) is a separate follow-up and depends on this: it needs the trimmed video to actually exist in the bucket.
+
+Spec: `docs/superpowers/specs/2026-07-12-video-trim-s3-design.md`
+EOF
+)"
+```
+
+- [ ] **Step 3: Babysit CI** — follow the `babysit` skill until green.
+
+---
+
+## Self-Review
+
+**Spec coverage:** all five Slice 7 steps — green run, three-run stability gate, CI + `.sh` wiring, full-harness regression run, README gap removal.
+
+**Placeholders:** none.
+
+**Consistency:** the CI step goes in the `backend=s3` group next to `copy-asset-sidecar-s3` (spec), and before `migrate-to-disk` (which the phase's teardown is designed not to disturb). The PR body's claims match what the slices actually did.

--- a/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-7.md
+++ b/docs/superpowers/plans/2026-07-12-video-trim-s3-slice-7.md
@@ -71,6 +71,7 @@ If any run fails, that is a real defect (most likely a race with `waitForProcess
 ### Task 2: Wire the phase into CI and the full workflow
 
 **Files:**
+
 - Modify: `.github/workflows/storage-migration-tests.yml`
 - Modify: `e2e/storage-migration.sh`
 - Modify: `e2e/README-storage-migration.md`
@@ -80,8 +81,8 @@ If any run fails, that is a real defect (most likely a race with `waitForProcess
 In `.github/workflows/storage-migration-tests.yml`, in the `backend=s3` phase group, immediately after the `'Phase: copy-asset-sidecar-s3'` step:
 
 ```yaml
-      - name: 'Phase: video-trim-s3'
-        run: pnpm tsx src/storage-migration.ts video-trim-s3
+- name: 'Phase: video-trim-s3'
+  run: pnpm tsx src/storage-migration.ts video-trim-s3
 ```
 
 It must sit inside the s3 group (the server is restarted into `IMMICH_STORAGE_BACKEND=s3` there) and **before** the later `migrate-to-disk` step.

--- a/docs/superpowers/specs/2026-07-12-video-trim-s3-design.md
+++ b/docs/superpowers/specs/2026-07-12-video-trim-s3-design.md
@@ -1,0 +1,169 @@
+# Video trim on S3 storage — design
+
+Fixes [#671](https://github.com/open-noodle/gallery/issues/671).
+
+## Problem
+
+`handleVideoTrim` in `server/src/services/media.service.ts` is the only ffmpeg output path in the media
+pipeline that never persists its outputs to the write backend, and it can hand an S3-relative key straight
+to ffmpeg. Server-side video trim is therefore broken on S3-backed deployments. Disk mode is unaffected.
+
+Three defects, all inside `handleVideoTrim`:
+
+1. **Trimmed video never persisted.** `outputPath` is a local nested path; it goes into the `EncodedVideo`
+   `asset_file` row and on to `syncFiles` without a `persistFile` call. On S3 the video is never uploaded and
+   the DB records a local path.
+2. **Trim thumbnails never persisted.** The files returned by `generateImageThumbnails` (local paths) go
+   straight into `syncFiles` with no persist loop, unlike `handleAssetEditThumbnailGeneration`.
+3. **S3 key fed to ffmpeg.** `const inputPath = existingEncoded?.path || localPath` — when a prior non-edited
+   `EncodedVideo` exists in S3, `existingEncoded.path` is a relative key, passed to `mediaRepository.trim`
+   without `ensureLocalFile`, so ffmpeg fails with ENOENT.
+
+### Observed failure modes
+
+- Asset **has** a transcoded (non-edited) `EncodedVideo` — the common case. Defect 3 fires first: ffmpeg gets a
+  relative key, the job fails, trim never works.
+- Asset has **no** transcoded video. ffmpeg reads the original (already materialized by the caller), so the trim
+  "succeeds", but defects 1 and 2 mean the video and its thumbnails exist only on the pod's local disk with
+  absolute paths in the DB. Playback works until the pod is replaced, then 404s permanently — `syncFiles` never
+  revisits those rows.
+
+### Already correct, and therefore out of scope
+
+The serving side is backend-aware: `playbackVideo` selects the edited `EncodedVideo` row
+(`orderBy asset_file.isEdited desc` in `AssetRepository.getForVideo`) and passes the path to `serveFromBackend`
+→ `StorageService.resolveBackendForKey`. Storing a relative key is sufficient; no changes to playback or download.
+
+## Scope
+
+Fix forward only. Assets already carrying a broken trim on an S3 deployment stay broken until the user re-applies
+or undoes the trim in the editor, which rewrites the rows correctly through the fixed path. No repair job and no
+migration.
+
+## Design
+
+### 1. Prerequisite: make `persistFile` testable
+
+`persistFile` reads the generated file with `createReadStream` imported from `node:fs`. Under vitest the generated
+paths do not exist, and because the mocked backend `put` never consumes the stream, the failed open emits an
+`'error'` event with no listener — an unhandled error event that crashes or flakes the test process. This is the
+likely reason no S3 test exists for this file today.
+
+`asset.service`'s S3 sidecar path already avoids this by streaming through the repository layer
+(`storageRepository.createPlainReadStream`, mocked in tests as `mocks.storage.createPlainReadStream`).
+`persistFile` adopts the same pattern:
+
+- `createReadStream(localPath)` → `this.storageRepository.createPlainReadStream(localPath)`
+- `unlink(localPath)` → `this.storageRepository.unlink(localPath)` (still best-effort, error swallowed)
+
+Production behaviour is identical. This change is what makes every test below possible.
+
+### 2. `StorageCore`: one filename convention, two forms
+
+The edited encoded video needs an S3 key. The existing `getRelativeEncodedVideoPath(asset)` returns the
+**non-edited** key (`…/{id}.mp4`), so reusing it would make a trim overwrite the transcoded original in the bucket.
+
+Add fork-only statics next to the existing relative-key block, deriving both the local path and the S3 key from a
+single private filename helper, and leave upstream's `getEncodedVideoPath` untouched (keeps upstream rebases clean):
+
+```ts
+private static getEditedEncodedVideoFilename(asset: ThumbnailPathEntity): string {
+  return `${asset.id}_edited.mp4`;
+}
+
+static getEditedEncodedVideoPath(asset: ThumbnailPathEntity): string {
+  return StorageCore.getNestedPath(
+    StorageFolder.EncodedVideo,
+    asset.ownerId,
+    StorageCore.getEditedEncodedVideoFilename(asset),
+  );
+}
+
+static getRelativeEditedEncodedVideoPath(asset: ThumbnailPathEntity): string {
+  return StorageCore.getRelativeNestedPath(
+    StorageFolder.EncodedVideo,
+    asset.ownerId,
+    StorageCore.getEditedEncodedVideoFilename(asset),
+  );
+}
+```
+
+`handleVideoTrim` uses `getEditedEncodedVideoPath` for its local output instead of the inline
+`getNestedPath(..., \`${asset.id}\_edited.mp4\`)` it has today, so the convention lives in exactly one place.
+
+### 3. `MediaService`: extract `persistImageFiles`
+
+The persist loop (derive the relative key from `fileType` / `format` / `isEdited`, `persistFile`, reassign
+`file.path`) exists twice already and is needed a third time. Forgetting it is precisely defect 2. Extract it:
+
+```ts
+private async persistImageFiles(asset: ThumbnailAsset, files: UpsertFileOptions[]) {
+  for (const file of files) {
+    const relativeKey = StorageCore.getRelativeImagePath(asset, {
+      fileType: file.type,
+      format: file.path.split('.').pop() as ImageFormat,
+      isEdited: file.isEdited,
+    });
+    file.path = await this.persistFile(file.path, relativeKey, mimeTypes.lookup(file.path));
+  }
+}
+```
+
+Route all three call sites through it: `handleAssetEditThumbnailGeneration`, `handleGenerateThumbnails`, and the
+new `handleVideoTrim` persist step. All three loops are fork-only lines, so this adds no upstream-rebase risk.
+
+### 4. `handleVideoTrim`: the three fixes and their ordering
+
+```
+existingEncoded → ensureLocalFile()                     ← fix 3
+  inputPath = encodedLocal?.localPath ?? localPath
+  trim(inputPath, outputPath)                            ← outputPath = getEditedEncodedVideoPath(asset)
+  finally: await encodedLocal?.cleanup()
+probe(outputPath)                        ─┐
+extractFrame(outputPath, framePath)      ─┤ every local read of outputPath
+generateImageThumbnails(frame)           ─┘
+persistImageFiles(asset, thumbnailResult.files)          ← fix 2
+editedVideoFile.path = await persistFile(
+  outputPath, StorageCore.getRelativeEditedEncodedVideoPath(asset), 'video/mp4')   ← fix 1
+syncFiles(oldEdited, [editedVideoFile, ...thumbnailResult.files])
+thumbhash update (unchanged)
+```
+
+The load-bearing invariant: **`persistFile` unlinks the local file after upload**, so probe and frame extraction
+must run before it. Persisting eagerly right after `trim` is the natural-looking mistake and would break frame
+extraction on S3. Carry an inline comment saying so.
+
+In disk mode `persistFile` returns the absolute path unchanged, so disk behaviour is byte-for-byte what it is today.
+
+### 5. Error handling
+
+Unchanged in shape: an ffmpeg failure logs, unlinks the partial output, and returns `JobStatus.Failed`. One
+addition — the encoded-input temp file is released in a `finally` around the trim, so a failed trim does not leak a
+downloaded S3 temp file. The original's temp file is already cleaned by the caller's `finally` in
+`handleAssetEditThumbnailGeneration`.
+
+## Testing
+
+TDD, unit tests in `server/src/services/media.service.spec.ts`. S3 mode is simulated with
+`vi.spyOn(StorageService, 'getWriteBackend')` returning a fake backend — not a `DiskStorageBackend`, so
+`persistFile` takes the S3 branch — plus a `resolveBackendForKey` stub backing `ensureLocalFile`.
+
+1. **Input is materialized** — with a non-edited `EncodedVideo` whose path is a relative key, `mediaRepository.trim`
+   receives the temp local path, not the key, and the temp file's cleanup runs.
+2. **Trimmed video is persisted** — `backend.put` is called with `encoded-video/{ownerId}/{xx}/{yy}/{id}_edited.mp4`
+   and content type `video/mp4`; the upserted `EncodedVideo` row carries that key, not an absolute path.
+3. **Thumbnails are persisted** — `put` is called for preview and thumbnail with `_edited` relative keys, and those
+   keys are what reach `upsertFiles`.
+4. **Collision guard** — the persisted video key differs from `StorageCore.getRelativeEncodedVideoPath(asset)`, so a
+   trim can never overwrite the transcoded original.
+5. **Disk-mode regression** — the existing trim tests still pass with absolute paths, and no `put` occurs.
+
+No e2e coverage: the e2e stack is disk-backed, so an S3 trim test would need infrastructure that suite does not
+have. The unit tests are the gate.
+
+## Files touched
+
+- `server/src/cores/storage.core.ts` — three fork-only statics.
+- `server/src/services/media.service.ts` — `persistFile` streaming source, `persistImageFiles` extraction and its
+  three call sites, `handleVideoTrim` rewrite.
+- `server/src/services/media.service.spec.ts` — the five tests above.

--- a/docs/superpowers/specs/2026-07-12-video-trim-s3-design.md
+++ b/docs/superpowers/specs/2026-07-12-video-trim-s3-design.md
@@ -4,8 +4,8 @@ Fixes [#671](https://github.com/open-noodle/gallery/issues/671).
 
 ## Problem
 
-Video trim does not work on S3-backed deployments. There are **two layers** to that, and #671 only describes the
-inner one.
+Video trim does not work on S3-backed deployments. There are **three layers** to that, and #671 describes only the
+middle one — and describes it partly wrongly. Layers 1 and 3 were found by running the code, not reading it.
 
 ### Layer 1 — the feature is fenced off at the API (the reason nobody has hit the inner bugs)
 
@@ -40,13 +40,36 @@ that never persists its outputs to the write backend, and it can hand an S3-rela
    the DB would record a local path.
 2. **Trim thumbnails never persisted.** The files returned by `generateImageThumbnails` (local paths) go straight
    into `syncFiles` with no persist loop, unlike `handleAssetEditThumbnailGeneration`.
-3. **S3 key fed to ffmpeg.** `const inputPath = existingEncoded?.path || localPath` — when a prior non-edited
-   `EncodedVideo` exists in S3, `existingEncoded.path` is a relative key, passed to `mediaRepository.trim` without
-   `ensureLocalFile`, so ffmpeg fails with ENOENT.
+3. ~~**S3 key fed to ffmpeg.**~~ **This defect does not exist.** `const inputPath = existingEncoded?.path || localPath`
+   looks dangerous, but `existingEncoded` is **always `undefined`**: `getForGenerateThumbnailJob`
+   (`asset-job.repository.ts:135`) loads only `Thumbnail`, `Preview` and `FullSize` files, never `EncodedVideo`. The
+   branch is unreachable, ffmpeg always reads the original, and no ENOENT is possible. Verified by running the trim
+   against a real S3 server with a transcoded video present: the trim **succeeded**. #671's third claim was
+   code-read, not executed.
 
-Lift the guard without fixing these and the common case (asset already transcoded, so a non-edited `EncodedVideo`
-exists in S3) fails immediately with ENOENT; the rarer case writes the video and its thumbnails to the pod's local
-disk with absolute paths in the DB, which survives until the pod is replaced and then 404s forever.
+Lift the guard without fixing defects 1 and 2 and the trim writes the video and its thumbnails to the pod's local
+disk with absolute paths in the DB, which survives until the pod is replaced and then 404s forever. Confirmed live:
+after Slices 2–3 the e2e phase gets past the API and produces
+`/usr/src/app/upload/encoded-video/…/{id}_edited.mp4` in the DB while the bucket holds nothing.
+
+### Layer 3 — undo never deletes the edited encoded video (a live bug on disk too)
+
+Same root cause as the phantom defect 3: because `asset.files` cannot contain `EncodedVideo` rows, the undo path
+(`media.service.ts:227` — `syncFiles(asset.files.filter((file) => file.isEdited), [])`) deletes the edited
+thumbnails but **never the edited encoded video**. `AssetRepository.getForVideo` orders `asset_file.isEdited DESC
+LIMIT 1`, so after a user undoes a trim, playback keeps serving the **trimmed** video forever.
+
+Verified live (disk-backed rows shown mid-fix):
+
+```
+--- AFTER TRIM ---                        --- AFTER UNDO ---
+encoded_video  isEdited=false  <key>      encoded_video  isEdited=false  <key>
+encoded_video  isEdited=true   <path>     encoded_video  isEdited=true   <path>   ← survives
+preview/thumbnail/fullsize isEdited=true  preview/thumbnail isEdited=false only
+```
+
+This is **not S3-specific** — it is broken on disk installs today. It is in scope because it is the same feature and
+because this PR's own e2e phase asserts that undo removes the edited objects from the bucket.
 
 ### Why CI never caught it
 
@@ -70,6 +93,9 @@ inherits the `StorageCore` helpers added here to locate it.
 
 **Enable video trim on S3.** That is a feature enablement for every S3 install, not a pure bugfix — it wants a
 release-note line.
+
+Also fixes the Layer-3 undo bug, which affects disk installs too. It is the same root cause and the same feature, and
+this PR's e2e phase asserts it.
 
 Fix forward only. No repair job and no migration: nothing to repair, because the guard means no S3 install has ever
 produced a broken trim.
@@ -227,10 +253,8 @@ All four loops are fork-only lines, so this adds no upstream-rebase risk.
 ### 6. `handleVideoTrim`: the three fixes and their ordering
 
 ```
-existingEncoded → ensureLocalFile()                     ← fix 3
-  inputPath = encodedLocal?.localPath ?? localPath
-  trim(inputPath, outputPath)                            ← outputPath = getEditedEncodedVideoPath(asset)
-  finally: await encodedLocal?.cleanup()
+trim(localPath, outputPath)                              ← outputPath = getEditedEncodedVideoPath(asset)
+                                                            (input is always the original — see Slice 4a)
 probe(outputPath)                        ─┐
 extractFrame(outputPath, framePath)      ─┤ every local read of outputPath
 generateImageThumbnails(frame)           ─┘
@@ -252,9 +276,8 @@ is today.
 
 ### 7. Error handling
 
-Unchanged in shape: an ffmpeg failure logs, unlinks the partial output, returns `JobStatus.Failed`. One addition —
-the encoded-input temp file is released in a `finally` around the trim, so a failed trim does not leak a downloaded
-S3 temp. The original's temp is already cleaned by the caller's `finally` in `handleAssetEditThumbnailGeneration`.
+Unchanged: an ffmpeg failure logs, unlinks the partial output, returns `JobStatus.Failed`. The original's temp file
+is cleaned by the caller's `finally` in `handleAssetEditThumbnailGeneration`.
 
 ## Test mechanics (get these wrong and the suite lies)
 
@@ -376,20 +399,28 @@ Design §3. Enables every S3 test that follows.
 **Done when:** A1, A2 pass; A2 is mutation-proved; `media.service.spec.ts` is green with **zero changes to existing
 tests**.
 
-### Slice 4 — Defect 3: never hand ffmpeg an S3 key
+### Slice 4 — The `EncodedVideo` blind spot: dead input branch, and undo
 
-`ensureLocalFile` the encoded input; release it in a `finally` around the trim.
+`asset.files` never contains `EncodedVideo` rows. That one fact produces both the phantom defect 3 and the live undo
+bug, so both are fixed here.
 
-- **B1 (RED)** S3, asset has a non-edited `EncodedVideo` with a relative key → `mediaRepository.trim` receives the
-  temp local path, not the key, and that temp's `cleanup` runs. _Expected red:_ `trim` is called with the relative key.
-- **D2 (RED)** S3 trim failure → returns `JobStatus.Failed`, calls no `put`, runs the encoded temp's `cleanup`, and
-  unlinks the partial output. _Expected red:_ `cleanup` is never called (nothing is downloaded today).
-- **B2 (GUARD)** Disk, existing non-edited `EncodedVideo` with an absolute path → `trim` receives it unchanged, no
-  download. _Mutation:_ make `ensureLocalFile` treat absolute paths as keys; B2 must fail.
-- **B3 (GUARD)** No `EncodedVideo` at all → `trim` receives the caller's already-materialized `localPath`, no extra
-  download. _Mutation:_ pass `existingEncoded?.path ?? ''` into `ensureLocalFile`; B3 must fail.
+**(a) Delete the dead input branch.** `existingEncoded` is always `undefined`, so `handleVideoTrim` already trims the
+original — which is also the better source (higher quality than re-trimming a transcoded copy). Remove the lookup and
+read `localPath` directly. No `ensureLocalFile`, no behaviour change, and the phantom S3 hazard goes with it.
 
-**Done when:** B1, D2 pass; B2, B3 pass and are mutation-proved; the suite is green.
+**(b) Delete the edited encoded video on undo.** Add `AssetRepository.getEditedEncodedVideo(assetId)` returning the
+row's `{ id, path }`, and in the video-undo branch delete that row and queue a `FileDelete` for its path.
+`FileDelete` already resolves disk paths and S3 keys through `StorageService.resolveBackendForKey`.
+
+- **B1 (RED)** Even when an asset's `files` contain a non-edited `EncodedVideo` (which production never produces, but
+  a unit test can construct), `mediaRepository.trim` receives the **original**, not the encoded video's path.
+  _Expected red:_ `trim` is called with the encoded video's path.
+- **U1 (RED)** Video undo (`asset.edits` empty) → `assetRepository.deleteFiles` is called with the edited encoded
+  video's row, and a `FileDelete` job is queued for its path. _Expected red:_ neither happens — the row survives.
+- **U2 (GUARD)** Video undo with no edited encoded video → no `deleteFiles` call for one, no crash. _Mutation:_ drop
+  the `if (editedVideo)` guard so it deletes unconditionally; U2 must fail.
+
+**Done when:** B1 and U1 pass; U2 passes and is mutation-proved; the suite is green.
 
 ### Slice 5 — Defect 1: persist the trimmed video
 
@@ -457,9 +488,10 @@ If the phase proves unstable in CI but not locally, it stays a local `make` targ
 - `server/src/services/base.service.ts` — `getProbeInput` (Slice 2).
 - `server/src/interfaces/storage-backend.interface.ts` — `getReadableUrl` (Slice 2).
 - `server/src/backends/s3-storage.backend.ts`, `disk-storage.backend.ts` — `getReadableUrl` (Slice 2).
-- `server/src/services/media.service.ts` — `persistFile` streaming source and the two trim unlinks (Slice 3);
-  `ensureLocalFile` on the trim input (Slice 4); `StorageCore` keys and video persistence (Slice 5);
-  `persistImageFiles` extraction and its four call sites (Slice 6).
+- `server/src/services/media.service.ts` — `persistFile` streaming source and the two trim unlinks (Slice 3); dead
+  input branch removed + undo deletes the edited encoded video (Slice 4); `StorageCore` keys and video persistence
+  (Slice 5); `persistImageFiles` extraction and its four call sites (Slice 6).
+- `server/src/repositories/asset.repository.ts` — `getEditedEncodedVideo` (Slice 4).
 - `server/src/cores/storage.core.ts` — three fork-only statics (Slice 5).
 - Specs: `asset.service.spec.ts` (E1–E4 + rewrite), `s3-storage.backend.spec.ts` (E5),
   `disk-storage.backend.spec.ts` (E6), `media.service.spec.ts` (A1–A2, B1–B3, C1–C4, D1–D3).

--- a/docs/superpowers/specs/2026-07-12-video-trim-s3-design.md
+++ b/docs/superpowers/specs/2026-07-12-video-trim-s3-design.md
@@ -30,16 +30,21 @@ Three defects, all inside `handleVideoTrim`:
 
 ### Why CI never caught it
 
-The unit tests for trim (`media.service.spec.ts`) mock storage and assert only ffmpeg arguments, in disk mode.
-The MinIO-backed S3 e2e suite (`e2e/src/storage-migration.ts`) lists, as its first known gap, _"No video asset
-upload (transcoding too slow/unreliable in e2e)"_. Every S3 output path except the video ones is covered there.
-That gap is the hole #671 came through, and closing it is part of this fix.
+The unit tests for trim mock storage and assert only ffmpeg arguments, in disk mode. The MinIO-backed S3 e2e suite
+(`e2e/src/storage-migration.ts`, 20 phases, gated by `.github/workflows/storage-migration-tests.yml`) lists as its
+first known gap: _"No video asset upload (transcoding too slow/unreliable in e2e)"_. Every S3 output path except
+the video ones is covered there. That gap is the hole #671 came through, and closing it is part of this fix.
 
 ### Already correct, and therefore out of scope
 
 The serving side is backend-aware: `playbackVideo` selects the edited `EncodedVideo` row
 (`orderBy asset_file.isEdited desc` in `AssetRepository.getForVideo`) and passes the path to `serveFromBackend`
 → `StorageService.resolveBackendForKey`. Storing a relative key is sufficient; no changes to playback or download.
+
+Realtime HLS ([#741](https://github.com/open-noodle/gallery/issues/741)) reads `asset.originalPath` only
+(`transcoding.service.ts:227`) and never consults the `EncodedVideo` rows, so this fix neither triggers nor
+half-fixes it. #741 lands afterwards and depends on this: it needs the trimmed video to actually exist in the
+bucket, and inherits the `StorageCore` helpers added here to locate it.
 
 ## Scope
 
@@ -51,29 +56,32 @@ Also unchanged (pre-existing, accepted): if `probe`, `extractFrame`, or thumbnai
 successful trim, the exception propagates and the local partial output is left behind. The next successful trim
 overwrites it.
 
+The local disk path of the trimmed video is **unchanged** by this work — `StorageCore.getEditedEncodedVideoPath`
+produces exactly what the current inline `getNestedPath(EncodedVideo, ownerId, \`${asset.id}\_edited.mp4\`)`
+produces — so disk-mode deployments need no data migration.
+
 ## Design
 
 ### 1. Prerequisite: make `persistFile` testable
 
-`persistFile` reads the generated file with `createReadStream` imported from `node:fs`. Under vitest the generated
-paths do not exist, and because the mocked backend `put` never consumes the stream, the failed open emits an
-`'error'` event with no listener — an unhandled error event that crashes or flakes the test process. Nothing in
-this file can be tested in S3 mode until that changes.
+`persistFile` reads the generated file with `createReadStream` imported from `node:fs`. Under vitest those paths do
+not exist, and because the mocked backend `put` never consumes the stream, the failed open emits an `'error'` event
+with no listener — an unhandled error event that crashes or flakes the run. **Nothing in this file can be tested in
+S3 mode until that changes**, which is why no such test exists today.
 
 `asset.service`'s S3 sidecar path already avoids this by streaming through the repository layer
-(`storageRepository.createPlainReadStream`, mocked in tests as `mocks.storage.createPlainReadStream`).
-`persistFile` adopts the same pattern:
+(`storageRepository.createPlainReadStream`, mocked as `mocks.storage.createPlainReadStream`). `persistFile` adopts
+the same pattern:
 
 - `createReadStream(localPath)` → `this.storageRepository.createPlainReadStream(localPath)`
 - `unlink(localPath)` → `this.storageRepository.unlink(localPath)` (still best-effort; `StorageRepository.unlink`
   warns on ENOENT but rethrows other errors, so keep the surrounding swallow)
 
-For the same reason, `handleVideoTrim`'s two raw `node:fs` unlinks — the partial output on ffmpeg failure and the
-extracted frame temp — move to `this.storageRepository.unlink(...).catch(() => {})`, which makes the failure-path
+For the same reason, `handleVideoTrim`'s two raw `node:fs` unlinks — the partial output on ffmpeg failure, and the
+extracted frame temp — move to `this.storageRepository.unlink(...).catch(() => {})`, which makes failure-path
 cleanup assertable.
 
-Production behaviour is identical. This is a pure refactor, guarded by the existing suite: it must go in first and
-turn the suite green with **zero test changes**.
+Production behaviour is identical.
 
 ### 2. `StorageCore`: one filename convention, two forms
 
@@ -81,8 +89,8 @@ The edited encoded video needs an S3 key. The existing `getRelativeEncodedVideoP
 **non-edited** key (`…/{id}.mp4`), so reusing it would make a trim overwrite the asset's transcoded original in the
 bucket — a worse bug than the one being fixed.
 
-Add fork-only statics next to the existing relative-key block, deriving both the local path and the S3 key from a
-single private filename helper, and leave upstream's `getEncodedVideoPath` untouched (keeps upstream rebases clean):
+Add fork-only statics next to the existing relative-key block, deriving both the local path and the S3 key from one
+private filename helper, and leave upstream's `getEncodedVideoPath` untouched (keeps upstream rebases clean):
 
 ```ts
 private static getEditedEncodedVideoFilename(asset: ThumbnailPathEntity): string {
@@ -106,12 +114,12 @@ static getRelativeEditedEncodedVideoPath(asset: ThumbnailPathEntity): string {
 }
 ```
 
-`handleVideoTrim` uses `getEditedEncodedVideoPath` for its local output instead of the inline
-`getNestedPath(..., \`${asset.id}\_edited.mp4\`)` it has today, so the convention lives in exactly one place.
+Note the two-level nesting is derived from the **filename**, not the id (`filename.slice(0, 2)` / `slice(2, 4)`), so
+`{id}_edited.mp4` lands in the same `{xx}/{yy}` folder as `{id}.mp4` — the keys differ only in the basename.
 
 The key is deterministic per asset, so a re-trim overwrites the same object in place. `syncFiles` then sees an
-unchanged path and correctly queues no `FileDelete` — if the key ever became non-deterministic, `syncFiles` would
-delete the object we had just uploaded. Test D3 locks this down.
+unchanged path and correctly queues no `FileDelete`. If the key ever became non-deterministic, `syncFiles` would
+delete the object we had just uploaded — test D3 locks that down.
 
 ### 3. `MediaService`: extract `persistImageFiles`
 
@@ -122,8 +130,8 @@ The persist loop (derive the relative key from `fileType` / `format` / `isEdited
 - `handleGenerateThumbnails`, over `generated.files`
 - `handleGenerateThumbnails`, again over `editedGenerated.files`
 
-and is needed a fourth time in `handleVideoTrim`. Forgetting it is precisely defect 2. Extract it and route all
-four call sites through it:
+and is needed a fourth time in `handleVideoTrim`. Forgetting it is precisely defect 2. Extract it and route all four
+call sites through it:
 
 ```ts
 private async persistImageFiles(asset: ThumbnailAsset, files: UpsertFileOptions[]) {
@@ -157,138 +165,196 @@ syncFiles(oldEdited, [editedVideoFile, ...thumbnailResult.files])
 thumbhash update (unchanged)
 ```
 
-The load-bearing invariant: **`persistFile` unlinks the local file after upload**, so probe and frame extraction
-must run before it. Persisting eagerly right after `trim` is the natural-looking mistake, and it would break frame
-extraction on S3 while still satisfying every persistence assertion. Test D1 asserts the call order; carry an
-inline comment too.
+The load-bearing invariant: **`persistFile` unlinks the local file after upload**, so probe and frame extraction must
+run before it. Persisting eagerly right after `trim` is the natural-looking mistake, and it would break frame
+extraction on S3 while still satisfying every persistence assertion. Test D1 asserts the call order; carry an inline
+comment too.
+
+`storageCore.ensureFolders(outputPath)` stays: even on S3 the file is written locally first, then uploaded and
+unlinked.
 
 In disk mode `persistFile` returns the absolute path unchanged, so disk behaviour is byte-for-byte what it is today.
 
 ### 5. Error handling
 
-Unchanged in shape: an ffmpeg failure logs, unlinks the partial output, and returns `JobStatus.Failed`. One
-addition — the encoded-input temp file is released in a `finally` around the trim, so a failed trim does not leak a
-downloaded S3 temp. The original's temp file is already cleaned by the caller's `finally` in
-`handleAssetEditThumbnailGeneration`.
+Unchanged in shape: an ffmpeg failure logs, unlinks the partial output, and returns `JobStatus.Failed`. One addition
+— the encoded-input temp file is released in a `finally` around the trim, so a failed trim does not leak a downloaded
+S3 temp. The original's temp file is already cleaned by the caller's `finally` in `handleAssetEditThumbnailGeneration`.
 
-## Testing
-
-### Test mechanics (get these wrong and the suite lies)
+## Test mechanics (get these wrong and the suite lies)
 
 - **`server/test/vitest.config.mjs` sets no `restoreMocks` / `mockReset`, and there are no `setupFiles`.** A
   `vi.spyOn(StorageService, 'getWriteBackend')` therefore leaks into every later test in the file, silently running
-  the disk-mode tests against an S3 backend. The S3 tests must restore their spies in `afterEach`.
+  the disk-mode tests against an S3 backend. Every S3 test must restore its spies in `afterEach`.
 - **Disk mode in unit tests works because `StorageService.diskBackend` is `undefined` in this spec file**, so
   `persistFile` takes its `!writeBackend` branch. That is load-bearing — do not "fix" it by constructing a
   `DiskStorageBackend`.
-- S3 mode is simulated by spying `StorageService.getWriteBackend` to return a fake backend (any object that is not
-  a `DiskStorageBackend` takes the S3 branch), plus a `resolveBackendForKey` stub whose `downloadToTemp` backs
+- S3 mode is simulated by spying `StorageService.getWriteBackend` to return a fake backend (any object that is not a
+  `DiskStorageBackend` takes the S3 branch), plus a `resolveBackendForKey` stub whose `downloadToTemp` backs
   `ensureLocalFile`.
+- `persistFile` is private; call it directly as `(sut as any).persistFile(...)`, following the precedent of
+  `asset.service.spec.ts`'s `copySidecar` tests.
 
-### Unit tests — `server/src/services/media.service.spec.ts`
+## Every test must be seen failing
 
-`persistFile` refactor guards:
+Two kinds of test appear below, and they are **not** interchangeable:
 
-- **A1** S3: uploads via `storageRepository.createPlainReadStream` → `backend.put(key, stream, { contentType })`,
-  then unlinks the local temp.
-- **A2** Disk: returns the local path, calls no `put`, and **does not unlink** — a regression guard against
-  deleting the file we just wrote.
+- **RED** — fails against the code as it stands when the slice begins. The expected failure is named; if it fails for
+  a different reason, stop and find out why.
+- **GUARD** — passes on arrival (it pins behaviour that is already correct and must stay correct). A guard that has
+  never failed proves nothing, so each one names a **mutation**: make that change, watch the guard fail, revert. A
+  guard that survives its mutation is a bug in the test.
 
-Input materialization (defect 3):
+## Slices
 
-- **B1** S3, asset has a non-edited `EncodedVideo` with a relative key → `mediaRepository.trim` receives the temp
-  local path, not the key, and that temp's `cleanup` runs.
-- **B2** Disk, same setup with an absolute path → `trim` receives it unchanged, with no download attempted.
-- **B3** No `EncodedVideo` at all → `trim` receives the caller's already-materialized `localPath`; no extra download.
+### Slice 1 — Reproduce #671 on real S3 (e2e, unwired)
 
-Persistence (defects 1 and 2):
+Author the `video-trim-s3` phase in the MinIO harness and **watch it fail against unfixed code**. Commit it wired
+into the `switch` in `storage-migration.ts` only — **not** into `storage-migration.sh` or the CI workflow, which run
+an explicit phase list. An unwired phase is inert, so every intermediate commit on this branch keeps CI green. Slice
+6 wires it up once it's green.
 
-- **C1** S3: `put` called with `encoded-video/{ownerId}/{xx}/{yy}/{id}_edited.mp4` and `video/mp4`; the upserted
-  `EncodedVideo` row carries that key, not an absolute path.
-- **C2** S3: `put` called for preview and thumbnail with `_edited` relative keys, and those keys are what reach
-  `upsertFiles`.
-- **C3** S3 collision guards: the video key differs from `StorageCore.getRelativeEncodedVideoPath(asset)`, and no
-  `put` targets a non-edited thumbnail key — a trim must never overwrite the asset's transcoded original or its
-  normal preview/thumbnail objects.
-- **C4** Disk: existing trim tests still pass, paths stay absolute, no `put` occurs.
-
-Invariants and failure paths:
-
-- **D1** Ordering: the video `put` happens **after** `extractFrame` (assert via `invocationCallOrder`), proving the
-  local file still existed when the frame was pulled.
-- **D2** S3 trim failure: returns `JobStatus.Failed`, calls no `put`, runs the encoded temp's `cleanup`, and unlinks
-  the partial output.
-- **D3** Re-trim idempotency: asset already has edited files at the same keys → no `FileDelete` job is queued for
-  the edited video key.
-
-### E2E — new `video-trim-s3` phase in the MinIO harness
-
-`e2e/src/storage-migration.ts` runs a real server against real MinIO with `IMMICH_STORAGE_BACKEND=s3` and already
-provides every helper needed: `api`, `uploadAsset`, `waitForProcessing`, `queryDb`, `dockerExec`, `minioFileExists`,
-`diskFileExists`. This phase reproduces #671 exactly, so it must be seen **failing against unfixed code** before the
-fix lands.
+`e2e/src/storage-migration.ts` provides every helper needed: `api`, `uploadAsset`, `waitForProcessing`, `queryDb`,
+`dockerExec`, `minioFileExists`, `diskFileExists`.
 
 Arrange (server in s3 write mode):
 
 1. Force transcoding so the defect-3 precondition exists: set `ffmpeg.transcode = 'all'` through the system-config
-   API (mirroring `setStorageTemplate`), and restore the original config at the end of the phase.
-2. Build a tiny mp4 without committing a binary fixture: `dockerExec('immich-server', …)` runs ffmpeg's `lavfi`
-   test source (a couple of seconds, small frame size), base64s it, and the runner decodes it into a Buffer.
-3. Upload it, `waitForProcessing`, then assert the precondition holds: a non-edited `EncodedVideo` row with a
-   relative path, whose object exists in MinIO. Record its `mc stat` size/etag.
+   API (mirror `setStorageTemplate`), restoring the original config in the phase's teardown.
+2. Build a tiny mp4 without committing a binary fixture: `dockerExec('immich-server', …)` runs ffmpeg's `lavfi` test
+   source (a couple of seconds, small frame size), base64s it (`base64 … | tr -d '\n'`), and the runner decodes it
+   into a Buffer.
+3. Upload, `waitForProcessing`, then assert the precondition: a non-edited `EncodedVideo` row with a relative path
+   whose object exists in MinIO. Record its `mc stat` size/etag.
 
 Act: `PUT /assets/{id}/edits` with a Trim action, then `waitForProcessing`.
 
 Assert:
 
-- Every `isEdited` `asset_file` row (encoded video, preview, thumbnail) has a **relative** path.
+- Every `isEdited` `asset_file` row (encoded video, preview, thumbnail, and fullsize if generated) has a **relative**
+  path.
 - The edited video key is `encoded-video/{ownerId}/{xx}/{yy}/{id}_edited.mp4` and the object **exists in MinIO**.
 - Each edited thumbnail key contains `_edited` and exists in MinIO.
 - The **non-edited** encoded object still exists with an unchanged size/etag — the collision guard, end to end.
-- `GET /assets/{id}/video/playback` returns 200 (the trimmed video is served from S3).
+- `GET /assets/{id}/video/playback` returns 200 — the trimmed video is served from S3.
 - `asset.duration` matches the trimmed length.
 - `diskFileExists(<local encoded-video path>)` is **false** — proof the output was uploaded and the local copy
   released, not merely written to the pod's disk.
-- The server log for the phase contains no `FFmpeg trim failed` and no ENOENT.
+- The phase's server logs contain no `FFmpeg trim failed` and no ENOENT.
 
-Teardown: delete the asset, empty the trash, restore the ffmpeg config, so the phase leaves the suite state as it
-found it. This matters because `migrate-to-disk` runs afterwards and has never seen `encoded-video` rows; leaving
-them behind risks destabilising an existing phase. **During implementation, confirm `phaseMigrateToDisk` still
-passes with this phase in the sequence.**
+Then undo (`DELETE /assets/{id}/edits`), `waitForProcessing`, and assert the edited objects are **gone from MinIO**
+and playback still returns 200 (falling back to the transcoded original). This covers the undo path on S3, which
+nothing tests today. Assert only object deletion and playback — if anything else about undo looks wrong (e.g.
+`duration` not restored), **file it as a separate issue; do not grow this PR**.
 
-Wiring: add the phase to the `switch` in `storage-migration.ts`, to the full-workflow sequence in
-`storage-migration.sh`, and to the `backend=s3` phase group in `.github/workflows/storage-migration-tests.yml` —
-**only after it runs green three consecutive times locally.** If it proves flaky, it stays a local make target and
-the PR says so. No flaky test gets wired into CI.
+Teardown: delete the asset, empty the trash, restore the ffmpeg config, leaving the suite state as it was found.
+`migrate-to-disk` runs later in the same CI job and has never seen `encoded-video` rows.
 
-## Implementation order (TDD)
+**Expected RED:** the trim job fails with ENOENT (ffmpeg is handed the S3 key), so no `isEdited` rows appear and the
+first assertion fails. If it instead fails at the precondition (no non-edited `EncodedVideo`), the transcode never
+ran — fix the arrange step, because without that precondition the phase does not reproduce #671.
 
-1. **Refactor `persistFile` and the trim unlinks onto `storageRepository`.** No new tests, no behaviour change;
-   the existing `media.service.spec.ts` suite must stay green as the guard.
-2. **Write the e2e `video-trim-s3` phase and run it against unfixed code.** It must fail, and fail for the right
-   reason — the trim job erroring on the S3 key. This proves the phase can actually detect #671.
-3. **B1 red → green**: `ensureLocalFile` on the encoded input, cleanup in `finally`. B2 and B3 alongside.
-4. **C1 red → green**: `StorageCore` statics, `persistFile` on the trimmed video.
-5. **C2 red → green**: extract `persistImageFiles`, route all four call sites through it.
-6. **C3, D1, D2, D3** as guards; **A1, A2** to close out `persistFile`; **C4** confirms disk mode is untouched.
-7. **Rerun the e2e phase — now green.** Then run it three times consecutively to earn its place in CI.
+**Done when:** the phase fails for the documented reason, and `phaseMigrateToDisk` still passes when run after it.
+
+### Slice 2 — `persistFile` onto the repository layer
+
+Route `persistFile` and `handleVideoTrim`'s two unlinks through `storageRepository`, per Design §1.
+
+- **A1 (RED)** S3: `(sut as any).persistFile('/local/out.jpg', 'thumbs/aa/bb/x.jpg', 'image/jpeg')` streams via
+  `mocks.storage.createPlainReadStream`, calls `backend.put(key, thatStream, { contentType })`, unlinks the local
+  temp via `mocks.storage.unlink`, and returns the key.
+  _Expected red:_ `createPlainReadStream` is never called (the code uses raw `node:fs`). Run this test on its own for
+  the red observation — the raw stream's ENOENT may also surface as an unhandled error.
+- **A2 (GUARD)** Disk (`getWriteBackend()` → undefined): returns the local path, calls no `put`, and **does not
+  unlink**. _Mutation:_ make `persistFile` unlink unconditionally; A2 must fail. Without this guard, a later
+  "simplification" would delete the very file disk mode just wrote.
+
+**Done when:** A1 and A2 pass, the full `media.service.spec.ts` suite passes **with zero changes to existing tests**,
+and A2 has been mutation-proved.
+
+### Slice 3 — Defect 3: never hand ffmpeg an S3 key
+
+`ensureLocalFile` the encoded input; release it in a `finally` around the trim.
+
+- **B1 (RED)** S3, asset has a non-edited `EncodedVideo` with a relative key → `mediaRepository.trim` receives the
+  temp local path, not the key, and that temp's `cleanup` runs. _Expected red:_ `trim` is called with the relative
+  key.
+- **D2 (RED)** S3 trim failure → returns `JobStatus.Failed`, calls no `put`, runs the encoded temp's `cleanup`, and
+  unlinks the partial output. _Expected red:_ `cleanup` is never called (nothing is downloaded today).
+- **B2 (GUARD)** Disk, existing non-edited `EncodedVideo` with an absolute path → `trim` receives it unchanged, no
+  download attempted. _Mutation:_ make `ensureLocalFile` treat absolute paths as keys; B2 must fail.
+- **B3 (GUARD)** No `EncodedVideo` at all → `trim` receives the caller's already-materialized `localPath`, no extra
+  download. _Mutation:_ pass `existingEncoded?.path ?? ''` into `ensureLocalFile`; B3 must fail.
+
+**Done when:** B1, D2 pass; B2, B3 pass and are mutation-proved; the suite is green.
+
+### Slice 4 — Defect 1: persist the trimmed video
+
+Add the three `StorageCore` statics (Design §2); use `getEditedEncodedVideoPath` for the local output and
+`persistFile` + `getRelativeEditedEncodedVideoPath` for the upload.
+
+- **C1 (RED)** S3: `put` called with `encoded-video/{ownerId}/{xx}/{yy}/{id}_edited.mp4` and `video/mp4`; the upserted
+  `EncodedVideo` row carries that key, not an absolute path. _Expected red:_ `put` is never called.
+- **C3a (RED)** S3: the persisted video key differs from `StorageCore.getRelativeEncodedVideoPath(asset)` — a trim
+  must never overwrite the asset's transcoded original. _Expected red:_ `put` is never called.
+- **D1 (RED)** Ordering: the video `put` happens **after** `extractFrame` (compare `invocationCallOrder`), proving the
+  local file still existed when the frame was pulled. _Expected red:_ `put` is never called. _After green, also
+  mutation-prove it:_ move the `persistFile` call above `extractFrame`; D1 must fail. This is the whole reason D1
+  exists — a D1 that cannot catch the reordering is worthless.
+- **D3 (GUARD)** Re-trim idempotency: an asset that already has edited files at the same keys queues **no**
+  `FileDelete` for the edited video key. _Mutation:_ make the edited filename non-deterministic (append a suffix);
+  D3 must fail, because `syncFiles` would then delete the object just uploaded.
+
+**Done when:** C1, C3a, D1 pass; D3 passes and is mutation-proved; D1 is mutation-proved; the suite is green.
+
+### Slice 5 — Defect 2: persist the trim thumbnails
+
+Extract `persistImageFiles` (Design §3) and route all **four** call sites through it.
+
+- **C2 (RED)** S3: `put` is called for every file `generateImageThumbnails` returns (preview, thumbnail, and fullsize
+  when generated) with `_edited` relative keys, and those keys are what reach `upsertFiles`. _Expected red:_ `put` is
+  called only for the video (Slice 4), never for the thumbnails.
+- **C3b (RED)** S3: no `put` targets a non-edited thumbnail key — a trim must not overwrite the asset's normal
+  preview/thumbnail objects. _Expected red:_ no thumbnail `put` happens at all.
+- **C4 (GUARD)** Disk: the existing trim tests still pass, paths stay absolute, no `put` occurs. _Mutation:_ force
+  `persistFile` into its S3 branch; C4 must fail.
+
+**Done when:** C2, C3b pass; C4 passes and is mutation-proved; the **whole server unit suite** is green (this slice
+touches `handleGenerateThumbnails` and `handleAssetEditThumbnailGeneration`, so their tests are the blast-radius
+guard).
+
+### Slice 6 — Turn the e2e phase green and wire it in
+
+1. Re-run `./storage-migration.sh --phase video-trim-s3` — it must now pass, including the undo assertions.
+2. Run it **three consecutive times**. Flaky means not done: fix the root cause, do not add retries.
+3. Only then wire it into `.github/workflows/storage-migration-tests.yml` (the `backend=s3` phase group, next to
+   `copy-asset-sidecar-s3`) and into the full-workflow sequence in `storage-migration.sh`.
+4. Run the full `./storage-migration.sh --cleanup` suite to prove no existing phase regressed — `migrate-to-disk`
+   especially.
+5. Update `e2e/README-storage-migration.md`: drop "No video asset upload" from the known gaps, document the phase.
+
+If the phase proves genuinely unstable in CI (not in local runs), it stays a local `make` target and the PR says so
+explicitly. **No flaky test gets wired into CI.**
+
+**Done when:** the phase is green three times running, the full harness passes, and CI on the branch is green.
 
 ## Verification
 
 - `cd server && pnpm test -- --run src/services/media.service.spec.ts`, then the full server unit suite.
-- `cd e2e && ./storage-migration.sh --phase video-trim-s3` (red before the fix, green after; ×3 for stability), and
-  a full `./storage-migration.sh --cleanup` run to prove no existing phase regressed. Note this stack binds the same
-  ports as the e2e stack (:2285, pg :5435) — do not run it alongside `make dev` or `make e2e`.
-- Optional but recommended before release: RC build to the personal instance (real S3 on OVH) and trim a video that
-  already has a transcoded version — the exact shape that fails today.
+- Final gate only (not per slice): `make check-server` and `make lint-server`.
+- `cd e2e && ./storage-migration.sh --phase video-trim-s3` (red in Slice 1, green in Slice 6, ×3 for stability), then
+  a full `./storage-migration.sh --cleanup` run. This stack binds the same ports as the e2e stack (:2285, pg :5435) —
+  do not run it alongside `make dev` or `make e2e`.
+- Recommended before release: RC build to the personal instance (real S3 on OVH) and trim a video that already has a
+  transcoded version — the exact shape that fails today.
 
 ## Files touched
 
-- `server/src/cores/storage.core.ts` — three fork-only statics.
-- `server/src/services/media.service.ts` — `persistFile` streaming source, the two trim unlinks, `persistImageFiles`
-  extraction and its four call sites, `handleVideoTrim` rewrite.
-- `server/src/services/media.service.spec.ts` — the twelve tests above.
-- `e2e/src/storage-migration.ts` — `video-trim-s3` phase and its switch entry.
-- `e2e/storage-migration.sh` — phase in the full-workflow sequence.
-- `.github/workflows/storage-migration-tests.yml` — phase in the `backend=s3` group (only if stable).
-- `e2e/README-storage-migration.md` — drop the "no video asset upload" known gap, document the new phase.
+- `server/src/cores/storage.core.ts` — three fork-only statics (Slice 4).
+- `server/src/services/media.service.ts` — `persistFile` streaming source and the two trim unlinks (Slice 2);
+  `ensureLocalFile` on the trim input (Slice 3); `StorageCore` keys and video persistence (Slice 4);
+  `persistImageFiles` extraction and its four call sites (Slice 5).
+- `server/src/services/media.service.spec.ts` — twelve tests: A1–A2, B1–B3, C1–C4, D1–D3.
+- `e2e/src/storage-migration.ts` — `video-trim-s3` phase and its switch entry (Slice 1).
+- `e2e/storage-migration.sh`, `.github/workflows/storage-migration-tests.yml`,
+  `e2e/README-storage-migration.md` — wiring and docs (Slice 6).

--- a/docs/superpowers/specs/2026-07-12-video-trim-s3-design.md
+++ b/docs/superpowers/specs/2026-07-12-video-trim-s3-design.md
@@ -4,20 +4,20 @@ Fixes [#671](https://github.com/open-noodle/gallery/issues/671).
 
 ## Problem
 
-`handleVideoTrim` in `server/src/services/media.service.ts` is the only ffmpeg output path in the media
-pipeline that never persists its outputs to the write backend, and it can hand an S3-relative key straight
-to ffmpeg. Server-side video trim is therefore broken on S3-backed deployments. Disk mode is unaffected.
+`handleVideoTrim` in `server/src/services/media.service.ts` is the only ffmpeg output path in the media pipeline
+that never persists its outputs to the write backend, and it can hand an S3-relative key straight to ffmpeg.
+Server-side video trim is therefore broken on S3-backed deployments. Disk mode is unaffected.
 
 Three defects, all inside `handleVideoTrim`:
 
 1. **Trimmed video never persisted.** `outputPath` is a local nested path; it goes into the `EncodedVideo`
-   `asset_file` row and on to `syncFiles` without a `persistFile` call. On S3 the video is never uploaded and
-   the DB records a local path.
-2. **Trim thumbnails never persisted.** The files returned by `generateImageThumbnails` (local paths) go
-   straight into `syncFiles` with no persist loop, unlike `handleAssetEditThumbnailGeneration`.
+   `asset_file` row and on to `syncFiles` without a `persistFile` call. On S3 the video is never uploaded and the
+   DB records a local path.
+2. **Trim thumbnails never persisted.** The files returned by `generateImageThumbnails` (local paths) go straight
+   into `syncFiles` with no persist loop, unlike `handleAssetEditThumbnailGeneration`.
 3. **S3 key fed to ffmpeg.** `const inputPath = existingEncoded?.path || localPath` — when a prior non-edited
-   `EncodedVideo` exists in S3, `existingEncoded.path` is a relative key, passed to `mediaRepository.trim`
-   without `ensureLocalFile`, so ffmpeg fails with ENOENT.
+   `EncodedVideo` exists in S3, `existingEncoded.path` is a relative key, passed to `mediaRepository.trim` without
+   `ensureLocalFile`, so ffmpeg fails with ENOENT.
 
 ### Observed failure modes
 
@@ -28,6 +28,13 @@ Three defects, all inside `handleVideoTrim`:
   absolute paths in the DB. Playback works until the pod is replaced, then 404s permanently — `syncFiles` never
   revisits those rows.
 
+### Why CI never caught it
+
+The unit tests for trim (`media.service.spec.ts`) mock storage and assert only ffmpeg arguments, in disk mode.
+The MinIO-backed S3 e2e suite (`e2e/src/storage-migration.ts`) lists, as its first known gap, _"No video asset
+upload (transcoding too slow/unreliable in e2e)"_. Every S3 output path except the video ones is covered there.
+That gap is the hole #671 came through, and closing it is part of this fix.
+
 ### Already correct, and therefore out of scope
 
 The serving side is backend-aware: `playbackVideo` selects the edited `EncodedVideo` row
@@ -37,8 +44,12 @@ The serving side is backend-aware: `playbackVideo` selects the edited `EncodedVi
 ## Scope
 
 Fix forward only. Assets already carrying a broken trim on an S3 deployment stay broken until the user re-applies
-or undoes the trim in the editor, which rewrites the rows correctly through the fixed path. No repair job and no
+or undoes the trim in the editor, which rewrites the rows correctly through the fixed path. No repair job, no
 migration.
+
+Also unchanged (pre-existing, accepted): if `probe`, `extractFrame`, or thumbnail generation throws _after_ a
+successful trim, the exception propagates and the local partial output is left behind. The next successful trim
+overwrites it.
 
 ## Design
 
@@ -46,22 +57,29 @@ migration.
 
 `persistFile` reads the generated file with `createReadStream` imported from `node:fs`. Under vitest the generated
 paths do not exist, and because the mocked backend `put` never consumes the stream, the failed open emits an
-`'error'` event with no listener — an unhandled error event that crashes or flakes the test process. This is the
-likely reason no S3 test exists for this file today.
+`'error'` event with no listener — an unhandled error event that crashes or flakes the test process. Nothing in
+this file can be tested in S3 mode until that changes.
 
 `asset.service`'s S3 sidecar path already avoids this by streaming through the repository layer
 (`storageRepository.createPlainReadStream`, mocked in tests as `mocks.storage.createPlainReadStream`).
 `persistFile` adopts the same pattern:
 
 - `createReadStream(localPath)` → `this.storageRepository.createPlainReadStream(localPath)`
-- `unlink(localPath)` → `this.storageRepository.unlink(localPath)` (still best-effort, error swallowed)
+- `unlink(localPath)` → `this.storageRepository.unlink(localPath)` (still best-effort; `StorageRepository.unlink`
+  warns on ENOENT but rethrows other errors, so keep the surrounding swallow)
 
-Production behaviour is identical. This change is what makes every test below possible.
+For the same reason, `handleVideoTrim`'s two raw `node:fs` unlinks — the partial output on ffmpeg failure and the
+extracted frame temp — move to `this.storageRepository.unlink(...).catch(() => {})`, which makes the failure-path
+cleanup assertable.
+
+Production behaviour is identical. This is a pure refactor, guarded by the existing suite: it must go in first and
+turn the suite green with **zero test changes**.
 
 ### 2. `StorageCore`: one filename convention, two forms
 
 The edited encoded video needs an S3 key. The existing `getRelativeEncodedVideoPath(asset)` returns the
-**non-edited** key (`…/{id}.mp4`), so reusing it would make a trim overwrite the transcoded original in the bucket.
+**non-edited** key (`…/{id}.mp4`), so reusing it would make a trim overwrite the asset's transcoded original in the
+bucket — a worse bug than the one being fixed.
 
 Add fork-only statics next to the existing relative-key block, deriving both the local path and the S3 key from a
 single private filename helper, and leave upstream's `getEncodedVideoPath` untouched (keeps upstream rebases clean):
@@ -91,10 +109,21 @@ static getRelativeEditedEncodedVideoPath(asset: ThumbnailPathEntity): string {
 `handleVideoTrim` uses `getEditedEncodedVideoPath` for its local output instead of the inline
 `getNestedPath(..., \`${asset.id}\_edited.mp4\`)` it has today, so the convention lives in exactly one place.
 
+The key is deterministic per asset, so a re-trim overwrites the same object in place. `syncFiles` then sees an
+unchanged path and correctly queues no `FileDelete` — if the key ever became non-deterministic, `syncFiles` would
+delete the object we had just uploaded. Test D3 locks this down.
+
 ### 3. `MediaService`: extract `persistImageFiles`
 
 The persist loop (derive the relative key from `fileType` / `format` / `isEdited`, `persistFile`, reassign
-`file.path`) exists twice already and is needed a third time. Forgetting it is precisely defect 2. Extract it:
+`file.path`) exists **three times** already:
+
+- `handleAssetEditThumbnailGeneration`, over `generated.files`
+- `handleGenerateThumbnails`, over `generated.files`
+- `handleGenerateThumbnails`, again over `editedGenerated.files`
+
+and is needed a fourth time in `handleVideoTrim`. Forgetting it is precisely defect 2. Extract it and route all
+four call sites through it:
 
 ```ts
 private async persistImageFiles(asset: ThumbnailAsset, files: UpsertFileOptions[]) {
@@ -109,8 +138,7 @@ private async persistImageFiles(asset: ThumbnailAsset, files: UpsertFileOptions[
 }
 ```
 
-Route all three call sites through it: `handleAssetEditThumbnailGeneration`, `handleGenerateThumbnails`, and the
-new `handleVideoTrim` persist step. All three loops are fork-only lines, so this adds no upstream-rebase risk.
+All four loops are fork-only lines, so this adds no upstream-rebase risk.
 
 ### 4. `handleVideoTrim`: the three fixes and their ordering
 
@@ -130,8 +158,9 @@ thumbhash update (unchanged)
 ```
 
 The load-bearing invariant: **`persistFile` unlinks the local file after upload**, so probe and frame extraction
-must run before it. Persisting eagerly right after `trim` is the natural-looking mistake and would break frame
-extraction on S3. Carry an inline comment saying so.
+must run before it. Persisting eagerly right after `trim` is the natural-looking mistake, and it would break frame
+extraction on S3 while still satisfying every persistence assertion. Test D1 asserts the call order; carry an
+inline comment too.
 
 In disk mode `persistFile` returns the absolute path unchanged, so disk behaviour is byte-for-byte what it is today.
 
@@ -139,31 +168,127 @@ In disk mode `persistFile` returns the absolute path unchanged, so disk behaviou
 
 Unchanged in shape: an ffmpeg failure logs, unlinks the partial output, and returns `JobStatus.Failed`. One
 addition — the encoded-input temp file is released in a `finally` around the trim, so a failed trim does not leak a
-downloaded S3 temp file. The original's temp file is already cleaned by the caller's `finally` in
+downloaded S3 temp. The original's temp file is already cleaned by the caller's `finally` in
 `handleAssetEditThumbnailGeneration`.
 
 ## Testing
 
-TDD, unit tests in `server/src/services/media.service.spec.ts`. S3 mode is simulated with
-`vi.spyOn(StorageService, 'getWriteBackend')` returning a fake backend — not a `DiskStorageBackend`, so
-`persistFile` takes the S3 branch — plus a `resolveBackendForKey` stub backing `ensureLocalFile`.
+### Test mechanics (get these wrong and the suite lies)
 
-1. **Input is materialized** — with a non-edited `EncodedVideo` whose path is a relative key, `mediaRepository.trim`
-   receives the temp local path, not the key, and the temp file's cleanup runs.
-2. **Trimmed video is persisted** — `backend.put` is called with `encoded-video/{ownerId}/{xx}/{yy}/{id}_edited.mp4`
-   and content type `video/mp4`; the upserted `EncodedVideo` row carries that key, not an absolute path.
-3. **Thumbnails are persisted** — `put` is called for preview and thumbnail with `_edited` relative keys, and those
-   keys are what reach `upsertFiles`.
-4. **Collision guard** — the persisted video key differs from `StorageCore.getRelativeEncodedVideoPath(asset)`, so a
-   trim can never overwrite the transcoded original.
-5. **Disk-mode regression** — the existing trim tests still pass with absolute paths, and no `put` occurs.
+- **`server/test/vitest.config.mjs` sets no `restoreMocks` / `mockReset`, and there are no `setupFiles`.** A
+  `vi.spyOn(StorageService, 'getWriteBackend')` therefore leaks into every later test in the file, silently running
+  the disk-mode tests against an S3 backend. The S3 tests must restore their spies in `afterEach`.
+- **Disk mode in unit tests works because `StorageService.diskBackend` is `undefined` in this spec file**, so
+  `persistFile` takes its `!writeBackend` branch. That is load-bearing — do not "fix" it by constructing a
+  `DiskStorageBackend`.
+- S3 mode is simulated by spying `StorageService.getWriteBackend` to return a fake backend (any object that is not
+  a `DiskStorageBackend` takes the S3 branch), plus a `resolveBackendForKey` stub whose `downloadToTemp` backs
+  `ensureLocalFile`.
 
-No e2e coverage: the e2e stack is disk-backed, so an S3 trim test would need infrastructure that suite does not
-have. The unit tests are the gate.
+### Unit tests — `server/src/services/media.service.spec.ts`
+
+`persistFile` refactor guards:
+
+- **A1** S3: uploads via `storageRepository.createPlainReadStream` → `backend.put(key, stream, { contentType })`,
+  then unlinks the local temp.
+- **A2** Disk: returns the local path, calls no `put`, and **does not unlink** — a regression guard against
+  deleting the file we just wrote.
+
+Input materialization (defect 3):
+
+- **B1** S3, asset has a non-edited `EncodedVideo` with a relative key → `mediaRepository.trim` receives the temp
+  local path, not the key, and that temp's `cleanup` runs.
+- **B2** Disk, same setup with an absolute path → `trim` receives it unchanged, with no download attempted.
+- **B3** No `EncodedVideo` at all → `trim` receives the caller's already-materialized `localPath`; no extra download.
+
+Persistence (defects 1 and 2):
+
+- **C1** S3: `put` called with `encoded-video/{ownerId}/{xx}/{yy}/{id}_edited.mp4` and `video/mp4`; the upserted
+  `EncodedVideo` row carries that key, not an absolute path.
+- **C2** S3: `put` called for preview and thumbnail with `_edited` relative keys, and those keys are what reach
+  `upsertFiles`.
+- **C3** S3 collision guards: the video key differs from `StorageCore.getRelativeEncodedVideoPath(asset)`, and no
+  `put` targets a non-edited thumbnail key — a trim must never overwrite the asset's transcoded original or its
+  normal preview/thumbnail objects.
+- **C4** Disk: existing trim tests still pass, paths stay absolute, no `put` occurs.
+
+Invariants and failure paths:
+
+- **D1** Ordering: the video `put` happens **after** `extractFrame` (assert via `invocationCallOrder`), proving the
+  local file still existed when the frame was pulled.
+- **D2** S3 trim failure: returns `JobStatus.Failed`, calls no `put`, runs the encoded temp's `cleanup`, and unlinks
+  the partial output.
+- **D3** Re-trim idempotency: asset already has edited files at the same keys → no `FileDelete` job is queued for
+  the edited video key.
+
+### E2E — new `video-trim-s3` phase in the MinIO harness
+
+`e2e/src/storage-migration.ts` runs a real server against real MinIO with `IMMICH_STORAGE_BACKEND=s3` and already
+provides every helper needed: `api`, `uploadAsset`, `waitForProcessing`, `queryDb`, `dockerExec`, `minioFileExists`,
+`diskFileExists`. This phase reproduces #671 exactly, so it must be seen **failing against unfixed code** before the
+fix lands.
+
+Arrange (server in s3 write mode):
+
+1. Force transcoding so the defect-3 precondition exists: set `ffmpeg.transcode = 'all'` through the system-config
+   API (mirroring `setStorageTemplate`), and restore the original config at the end of the phase.
+2. Build a tiny mp4 without committing a binary fixture: `dockerExec('immich-server', …)` runs ffmpeg's `lavfi`
+   test source (a couple of seconds, small frame size), base64s it, and the runner decodes it into a Buffer.
+3. Upload it, `waitForProcessing`, then assert the precondition holds: a non-edited `EncodedVideo` row with a
+   relative path, whose object exists in MinIO. Record its `mc stat` size/etag.
+
+Act: `PUT /assets/{id}/edits` with a Trim action, then `waitForProcessing`.
+
+Assert:
+
+- Every `isEdited` `asset_file` row (encoded video, preview, thumbnail) has a **relative** path.
+- The edited video key is `encoded-video/{ownerId}/{xx}/{yy}/{id}_edited.mp4` and the object **exists in MinIO**.
+- Each edited thumbnail key contains `_edited` and exists in MinIO.
+- The **non-edited** encoded object still exists with an unchanged size/etag — the collision guard, end to end.
+- `GET /assets/{id}/video/playback` returns 200 (the trimmed video is served from S3).
+- `asset.duration` matches the trimmed length.
+- `diskFileExists(<local encoded-video path>)` is **false** — proof the output was uploaded and the local copy
+  released, not merely written to the pod's disk.
+- The server log for the phase contains no `FFmpeg trim failed` and no ENOENT.
+
+Teardown: delete the asset, empty the trash, restore the ffmpeg config, so the phase leaves the suite state as it
+found it. This matters because `migrate-to-disk` runs afterwards and has never seen `encoded-video` rows; leaving
+them behind risks destabilising an existing phase. **During implementation, confirm `phaseMigrateToDisk` still
+passes with this phase in the sequence.**
+
+Wiring: add the phase to the `switch` in `storage-migration.ts`, to the full-workflow sequence in
+`storage-migration.sh`, and to the `backend=s3` phase group in `.github/workflows/storage-migration-tests.yml` —
+**only after it runs green three consecutive times locally.** If it proves flaky, it stays a local make target and
+the PR says so. No flaky test gets wired into CI.
+
+## Implementation order (TDD)
+
+1. **Refactor `persistFile` and the trim unlinks onto `storageRepository`.** No new tests, no behaviour change;
+   the existing `media.service.spec.ts` suite must stay green as the guard.
+2. **Write the e2e `video-trim-s3` phase and run it against unfixed code.** It must fail, and fail for the right
+   reason — the trim job erroring on the S3 key. This proves the phase can actually detect #671.
+3. **B1 red → green**: `ensureLocalFile` on the encoded input, cleanup in `finally`. B2 and B3 alongside.
+4. **C1 red → green**: `StorageCore` statics, `persistFile` on the trimmed video.
+5. **C2 red → green**: extract `persistImageFiles`, route all four call sites through it.
+6. **C3, D1, D2, D3** as guards; **A1, A2** to close out `persistFile`; **C4** confirms disk mode is untouched.
+7. **Rerun the e2e phase — now green.** Then run it three times consecutively to earn its place in CI.
+
+## Verification
+
+- `cd server && pnpm test -- --run src/services/media.service.spec.ts`, then the full server unit suite.
+- `cd e2e && ./storage-migration.sh --phase video-trim-s3` (red before the fix, green after; ×3 for stability), and
+  a full `./storage-migration.sh --cleanup` run to prove no existing phase regressed. Note this stack binds the same
+  ports as the e2e stack (:2285, pg :5435) — do not run it alongside `make dev` or `make e2e`.
+- Optional but recommended before release: RC build to the personal instance (real S3 on OVH) and trim a video that
+  already has a transcoded version — the exact shape that fails today.
 
 ## Files touched
 
 - `server/src/cores/storage.core.ts` — three fork-only statics.
-- `server/src/services/media.service.ts` — `persistFile` streaming source, `persistImageFiles` extraction and its
-  three call sites, `handleVideoTrim` rewrite.
-- `server/src/services/media.service.spec.ts` — the five tests above.
+- `server/src/services/media.service.ts` — `persistFile` streaming source, the two trim unlinks, `persistImageFiles`
+  extraction and its four call sites, `handleVideoTrim` rewrite.
+- `server/src/services/media.service.spec.ts` — the twelve tests above.
+- `e2e/src/storage-migration.ts` — `video-trim-s3` phase and its switch entry.
+- `e2e/storage-migration.sh` — phase in the full-workflow sequence.
+- `.github/workflows/storage-migration-tests.yml` — phase in the `backend=s3` group (only if stable).
+- `e2e/README-storage-migration.md` — drop the "no video asset upload" known gap, document the new phase.

--- a/docs/superpowers/specs/2026-07-12-video-trim-s3-design.md
+++ b/docs/superpowers/specs/2026-07-12-video-trim-s3-design.md
@@ -4,70 +4,148 @@ Fixes [#671](https://github.com/open-noodle/gallery/issues/671).
 
 ## Problem
 
-`handleVideoTrim` in `server/src/services/media.service.ts` is the only ffmpeg output path in the media pipeline
-that never persists its outputs to the write backend, and it can hand an S3-relative key straight to ffmpeg.
-Server-side video trim is therefore broken on S3-backed deployments. Disk mode is unaffected.
+Video trim does not work on S3-backed deployments. There are **two layers** to that, and #671 only describes the
+inner one.
 
-Three defects, all inside `handleVideoTrim`:
+### Layer 1 — the feature is fenced off at the API (the reason nobody has hit the inner bugs)
+
+`AssetService.editAsset` (`server/src/services/asset.service.ts:729`) rejects any trim whose asset is not stored on
+local disk:
+
+```ts
+// S3/cloud storage check
+if (!StorageCore.isImmichPath(asset.originalPath)) {
+  throw new BadRequestException('Video trimming is not available for cloud-stored videos');
+}
+```
+
+`StorageCore.isImmichPath` returns `false` for any non-absolute path, and on S3 `originalPath` **is** a relative
+key. So `PUT /assets/:id/edits` with a Trim action returns 400 before a job is ever queued. The guard shipped with
+the original trim feature (`f5218d5749`, #191) and is deliberate. The web editor has **no** matching client-side
+gate — it shows the trim tool, the user hits save, and the server refuses.
+
+Consequence: the three `handleVideoTrim` defects below are **latent, not live**. No S3 user has lost a trimmed
+video, because no S3 user can trim. Fixing #671 therefore means _enabling_ trim on S3, not merely repairing the job.
+
+A second blocker sits right behind the guard, at `asset.service.ts:734`: the pre-flight audio-only check calls
+`mediaRepository.probe(asset.originalPath)` — also a relative key on S3, and it runs inside the HTTP request.
+
+### Layer 2 — `handleVideoTrim` is broken for S3 (the latent bugs, #671 proper)
+
+`handleVideoTrim` (`server/src/services/media.service.ts:282`) is the only ffmpeg output path in the media pipeline
+that never persists its outputs to the write backend, and it can hand an S3-relative key straight to ffmpeg:
 
 1. **Trimmed video never persisted.** `outputPath` is a local nested path; it goes into the `EncodedVideo`
-   `asset_file` row and on to `syncFiles` without a `persistFile` call. On S3 the video is never uploaded and the
-   DB records a local path.
+   `asset_file` row and on to `syncFiles` without a `persistFile` call. On S3 the video would never be uploaded and
+   the DB would record a local path.
 2. **Trim thumbnails never persisted.** The files returned by `generateImageThumbnails` (local paths) go straight
    into `syncFiles` with no persist loop, unlike `handleAssetEditThumbnailGeneration`.
 3. **S3 key fed to ffmpeg.** `const inputPath = existingEncoded?.path || localPath` — when a prior non-edited
    `EncodedVideo` exists in S3, `existingEncoded.path` is a relative key, passed to `mediaRepository.trim` without
    `ensureLocalFile`, so ffmpeg fails with ENOENT.
 
-### Observed failure modes
-
-- Asset **has** a transcoded (non-edited) `EncodedVideo` — the common case. Defect 3 fires first: ffmpeg gets a
-  relative key, the job fails, trim never works.
-- Asset has **no** transcoded video. ffmpeg reads the original (already materialized by the caller), so the trim
-  "succeeds", but defects 1 and 2 mean the video and its thumbnails exist only on the pod's local disk with
-  absolute paths in the DB. Playback works until the pod is replaced, then 404s permanently — `syncFiles` never
-  revisits those rows.
+Lift the guard without fixing these and the common case (asset already transcoded, so a non-edited `EncodedVideo`
+exists in S3) fails immediately with ENOENT; the rarer case writes the video and its thumbnails to the pod's local
+disk with absolute paths in the DB, which survives until the pod is replaced and then 404s forever.
 
 ### Why CI never caught it
 
 The unit tests for trim mock storage and assert only ffmpeg arguments, in disk mode. The MinIO-backed S3 e2e suite
 (`e2e/src/storage-migration.ts`, 20 phases, gated by `.github/workflows/storage-migration-tests.yml`) lists as its
-first known gap: _"No video asset upload (transcoding too slow/unreliable in e2e)"_. Every S3 output path except
-the video ones is covered there. That gap is the hole #671 came through, and closing it is part of this fix.
+first known gap: _"No video asset upload (transcoding too slow/unreliable in e2e)"_. Every S3 output path except the
+video ones is covered there. That gap is the hole #671 came through, and closing it is part of this fix.
 
 ### Already correct, and therefore out of scope
 
 The serving side is backend-aware: `playbackVideo` selects the edited `EncodedVideo` row
-(`orderBy asset_file.isEdited desc` in `AssetRepository.getForVideo`) and passes the path to `serveFromBackend`
-→ `StorageService.resolveBackendForKey`. Storing a relative key is sufficient; no changes to playback or download.
+(`orderBy asset_file.isEdited desc` in `AssetRepository.getForVideo`) and passes the path to `serveFromBackend` →
+`StorageService.resolveBackendForKey`. Storing a relative key is sufficient; no changes to playback or download.
 
 Realtime HLS ([#741](https://github.com/open-noodle/gallery/issues/741)) reads `asset.originalPath` only
-(`transcoding.service.ts:227`) and never consults the `EncodedVideo` rows, so this fix neither triggers nor
-half-fixes it. #741 lands afterwards and depends on this: it needs the trimmed video to actually exist in the
-bucket, and inherits the `StorageCore` helpers added here to locate it.
+(`transcoding.service.ts:227`) and never consults the `EncodedVideo` rows, so this work neither triggers nor
+half-fixes it. #741 lands afterwards and depends on this: it needs the trimmed video to exist in the bucket, and
+inherits the `StorageCore` helpers added here to locate it.
 
 ## Scope
 
-Fix forward only. Assets already carrying a broken trim on an S3 deployment stay broken until the user re-applies
-or undoes the trim in the editor, which rewrites the rows correctly through the fixed path. No repair job, no
-migration.
+**Enable video trim on S3.** That is a feature enablement for every S3 install, not a pure bugfix — it wants a
+release-note line.
 
-Also unchanged (pre-existing, accepted): if `probe`, `extractFrame`, or thumbnail generation throws _after_ a
+Fix forward only. No repair job and no migration: nothing to repair, because the guard means no S3 install has ever
+produced a broken trim.
+
+External-library videos (absolute paths outside the media location) stay blocked — the current guard catches them
+too, and the replacement must keep doing so.
+
+Unchanged and accepted (pre-existing): if `probe`, `extractFrame`, or thumbnail generation throws _after_ a
 successful trim, the exception propagates and the local partial output is left behind. The next successful trim
 overwrites it.
 
-The local disk path of the trimmed video is **unchanged** by this work — `StorageCore.getEditedEncodedVideoPath`
-produces exactly what the current inline `getNestedPath(EncodedVideo, ownerId, \`${asset.id}\_edited.mp4\`)`
-produces — so disk-mode deployments need no data migration.
+The local disk path of the trimmed video is **unchanged** — `StorageCore.getEditedEncodedVideoPath` produces exactly
+what the current inline `getNestedPath(EncodedVideo, ownerId, \`${asset.id}\_edited.mp4\`)` produces — so disk-mode
+deployments need no data migration.
 
 ## Design
 
-### 1. Prerequisite: make `persistFile` testable
+### 1. Lift the guard, keep external libraries out
 
-`persistFile` reads the generated file with `createReadStream` imported from `node:fs`. Under vitest those paths do
-not exist, and because the mocked backend `put` never consumes the stream, the failed open emits an `'error'` event
-with no listener — an unhandled error event that crashes or flakes the run. **Nothing in this file can be tested in
-S3 mode until that changes**, which is why no such test exists today.
+Replace the `isImmichPath` check with one that blocks only absolute paths **outside** the media location. Relative
+paths are storage-backend keys and are now allowed:
+
+```ts
+// Block external-library videos (absolute paths outside the media location).
+// S3-backed originals are relative keys, resolved through the storage backend.
+if (isAbsolute(asset.originalPath) && !StorageCore.isImmichPath(asset.originalPath)) {
+  throw new BadRequestException('Video trimming is not available for external library videos');
+}
+```
+
+The existing unit test `asset.service.spec.ts:2301` ("should reject trim on cloud-stored videos") asserts the old
+behaviour and **must be rewritten**, not preserved. It is the one place in this work where "existing tests stay
+green" does not hold, and that is intentional: it encodes the bug.
+
+### 2. Probe without downloading: `getReadableUrl`
+
+The pre-flight audio-only check runs inside the HTTP request, so `ensureLocalFile` there would download the whole
+video (fine at 20 MB, a gateway timeout at 4 GB). ffprobe can read an HTTPS URL and fetches only the header/moov
+atom it needs, so give the backends a way to hand one over.
+
+Add to `StorageBackend` (`server/src/interfaces/storage-backend.interface.ts`) — non-optional, both backends
+implement it:
+
+```ts
+/**
+ * A path or URL that external tools (ffmpeg/ffprobe) can read directly,
+ * without downloading the object first.
+ */
+getReadableUrl(key: string): Promise<string>;
+```
+
+- `DiskStorageBackend`: `return this.resolvePath(key)` — the existing private `join(this.mediaLocation, key)`.
+- `S3StorageBackend`: a presigned `GetObjectCommand` URL via `getSignedUrl` (already imported for redirect serve
+  mode) with the existing `this.presignedUrlExpiry`.
+
+`BaseService` gains a sibling to `ensureLocalFile`, with the same lazy-import trick to dodge the circular dependency:
+
+```ts
+protected async getProbeInput(filePath: string): Promise<string> {
+  if (isAbsolute(filePath)) {
+    return filePath;
+  }
+  const { StorageService } = await import('./storage.service.js');
+  return StorageService.resolveBackendForKey(filePath).getReadableUrl(filePath);
+}
+```
+
+`editAsset` then probes `await this.getProbeInput(asset.originalPath)`. Disk installs keep passing an absolute path
+and never presign.
+
+### 3. Prerequisite for testing `persistFile`
+
+`persistFile` reads the generated file with `createReadStream` from `node:fs`. Under vitest those paths do not exist,
+and because the mocked backend `put` never consumes the stream, the failed open emits an `'error'` event with no
+listener — an unhandled error that crashes or flakes the run. **Nothing in `media.service.ts` can be tested in S3
+mode until that changes**, which is why no such test exists today.
 
 `asset.service`'s S3 sidecar path already avoids this by streaming through the repository layer
 (`storageRepository.createPlainReadStream`, mocked as `mocks.storage.createPlainReadStream`). `persistFile` adopts
@@ -77,20 +155,18 @@ the same pattern:
 - `unlink(localPath)` → `this.storageRepository.unlink(localPath)` (still best-effort; `StorageRepository.unlink`
   warns on ENOENT but rethrows other errors, so keep the surrounding swallow)
 
-For the same reason, `handleVideoTrim`'s two raw `node:fs` unlinks — the partial output on ffmpeg failure, and the
-extracted frame temp — move to `this.storageRepository.unlink(...).catch(() => {})`, which makes failure-path
-cleanup assertable.
+`handleVideoTrim`'s two raw `node:fs` unlinks — the partial output on ffmpeg failure, and the extracted frame temp —
+move to `this.storageRepository.unlink(...).catch(() => {})` for the same reason: it makes failure-path cleanup
+assertable. Production behaviour is identical.
 
-Production behaviour is identical.
+### 4. `StorageCore`: one filename convention, two forms
 
-### 2. `StorageCore`: one filename convention, two forms
+The edited encoded video needs an S3 key. `getRelativeEncodedVideoPath(asset)` returns the **non-edited** key
+(`…/{id}.mp4`), so reusing it would make a trim overwrite the asset's transcoded original in the bucket — a worse bug
+than the one being fixed.
 
-The edited encoded video needs an S3 key. The existing `getRelativeEncodedVideoPath(asset)` returns the
-**non-edited** key (`…/{id}.mp4`), so reusing it would make a trim overwrite the asset's transcoded original in the
-bucket — a worse bug than the one being fixed.
-
-Add fork-only statics next to the existing relative-key block, deriving both the local path and the S3 key from one
-private filename helper, and leave upstream's `getEncodedVideoPath` untouched (keeps upstream rebases clean):
+Add fork-only statics next to the existing relative-key block, deriving the local path and the S3 key from one
+private filename helper, leaving upstream's `getEncodedVideoPath` untouched (keeps upstream rebases clean):
 
 ```ts
 private static getEditedEncodedVideoFilename(asset: ThumbnailPathEntity): string {
@@ -114,17 +190,17 @@ static getRelativeEditedEncodedVideoPath(asset: ThumbnailPathEntity): string {
 }
 ```
 
-Note the two-level nesting is derived from the **filename**, not the id (`filename.slice(0, 2)` / `slice(2, 4)`), so
-`{id}_edited.mp4` lands in the same `{xx}/{yy}` folder as `{id}.mp4` — the keys differ only in the basename.
+The two-level nesting derives from the **filename** (`filename.slice(0, 2)` / `slice(2, 4)`), so `{id}_edited.mp4`
+lands in the same `{xx}/{yy}` folder as `{id}.mp4`; the keys differ only in the basename.
 
 The key is deterministic per asset, so a re-trim overwrites the same object in place. `syncFiles` then sees an
 unchanged path and correctly queues no `FileDelete`. If the key ever became non-deterministic, `syncFiles` would
-delete the object we had just uploaded — test D3 locks that down.
+delete the object just uploaded — test D3 locks that down.
 
-### 3. `MediaService`: extract `persistImageFiles`
+### 5. `MediaService`: extract `persistImageFiles`
 
-The persist loop (derive the relative key from `fileType` / `format` / `isEdited`, `persistFile`, reassign
-`file.path`) exists **three times** already:
+The persist loop (relative key from `fileType` / `format` / `isEdited`, `persistFile`, reassign `file.path`) exists
+**three times** already:
 
 - `handleAssetEditThumbnailGeneration`, over `generated.files`
 - `handleGenerateThumbnails`, over `generated.files`
@@ -148,7 +224,7 @@ private async persistImageFiles(asset: ThumbnailAsset, files: UpsertFileOptions[
 
 All four loops are fork-only lines, so this adds no upstream-rebase risk.
 
-### 4. `handleVideoTrim`: the three fixes and their ordering
+### 6. `handleVideoTrim`: the three fixes and their ordering
 
 ```
 existingEncoded → ensureLocalFile()                     ← fix 3
@@ -171,69 +247,71 @@ extraction on S3 while still satisfying every persistence assertion. Test D1 ass
 comment too.
 
 `storageCore.ensureFolders(outputPath)` stays: even on S3 the file is written locally first, then uploaded and
-unlinked.
+unlinked. In disk mode `persistFile` returns the absolute path unchanged, so disk behaviour is byte-for-byte what it
+is today.
 
-In disk mode `persistFile` returns the absolute path unchanged, so disk behaviour is byte-for-byte what it is today.
+### 7. Error handling
 
-### 5. Error handling
-
-Unchanged in shape: an ffmpeg failure logs, unlinks the partial output, and returns `JobStatus.Failed`. One addition
-— the encoded-input temp file is released in a `finally` around the trim, so a failed trim does not leak a downloaded
-S3 temp. The original's temp file is already cleaned by the caller's `finally` in `handleAssetEditThumbnailGeneration`.
+Unchanged in shape: an ffmpeg failure logs, unlinks the partial output, returns `JobStatus.Failed`. One addition —
+the encoded-input temp file is released in a `finally` around the trim, so a failed trim does not leak a downloaded
+S3 temp. The original's temp is already cleaned by the caller's `finally` in `handleAssetEditThumbnailGeneration`.
 
 ## Test mechanics (get these wrong and the suite lies)
 
 - **`server/test/vitest.config.mjs` sets no `restoreMocks` / `mockReset`, and there are no `setupFiles`.** A
   `vi.spyOn(StorageService, 'getWriteBackend')` therefore leaks into every later test in the file, silently running
   the disk-mode tests against an S3 backend. Every S3 test must restore its spies in `afterEach`.
-- **Disk mode in unit tests works because `StorageService.diskBackend` is `undefined` in this spec file**, so
-  `persistFile` takes its `!writeBackend` branch. That is load-bearing — do not "fix" it by constructing a
+- **Disk mode in `media.service.spec.ts` works because `StorageService.diskBackend` is `undefined` there**, so
+  `persistFile` takes its `!writeBackend` branch. Load-bearing — do not "fix" it by constructing a
   `DiskStorageBackend`.
-- S3 mode is simulated by spying `StorageService.getWriteBackend` to return a fake backend (any object that is not a
-  `DiskStorageBackend` takes the S3 branch), plus a `resolveBackendForKey` stub whose `downloadToTemp` backs
-  `ensureLocalFile`.
-- `persistFile` is private; call it directly as `(sut as any).persistFile(...)`, following the precedent of
-  `asset.service.spec.ts`'s `copySidecar` tests.
+- S3 mode in `media.service.spec.ts` is simulated by spying `StorageService.getWriteBackend` to return a fake backend
+  (any object that is not a `DiskStorageBackend` takes the S3 branch), plus a `resolveBackendForKey` stub whose
+  `downloadToTemp` backs `ensureLocalFile`.
+- **The media location under unit tests is `/data`**, set at import time by
+  `server/test/repositories/storage.repository.mock.ts:47`. So `/data/library/x.mp4` is an Immich path,
+  `/mnt/external/x.mp4` is an external-library path, and `upload/admin/ab/cd/x.mp4` is an S3 key.
+- `persistFile` is private; call it directly as `(sut as any).persistFile(...)`, following `asset.service.spec.ts`'s
+  `copySidecar` tests.
+- `s3-storage.backend.spec.ts` already mocks `@aws-sdk/s3-request-presigner`'s `getSignedUrl`.
 
 ## Every test must be seen failing
 
-Two kinds of test appear below, and they are **not** interchangeable:
+Two kinds of test below, and they are **not** interchangeable:
 
-- **RED** — fails against the code as it stands when the slice begins. The expected failure is named; if it fails for
-  a different reason, stop and find out why.
+- **RED** — fails against the code as it stands when its slice begins. The expected failure is named; a red for a
+  different reason means stop and find out why.
 - **GUARD** — passes on arrival (it pins behaviour that is already correct and must stay correct). A guard that has
-  never failed proves nothing, so each one names a **mutation**: make that change, watch the guard fail, revert. A
-  guard that survives its mutation is a bug in the test.
+  never failed proves nothing, so each names a **mutation**: make that change, watch the guard fail, revert. A guard
+  that survives its mutation is a bug in the test.
 
 ## Slices
 
-### Slice 1 — Reproduce #671 on real S3 (e2e, unwired)
+### Slice 1 — Reproduce on real S3 (e2e phase, unwired)
 
-Author the `video-trim-s3` phase in the MinIO harness and **watch it fail against unfixed code**. Commit it wired
-into the `switch` in `storage-migration.ts` only — **not** into `storage-migration.sh` or the CI workflow, which run
-an explicit phase list. An unwired phase is inert, so every intermediate commit on this branch keeps CI green. Slice
-6 wires it up once it's green.
+Author the `video-trim-s3` phase in the MinIO harness and watch it fail against unfixed code. Commit it wired into
+the `switch` in `storage-migration.ts` **only** — not into `storage-migration.sh` or the CI workflow, which run an
+explicit phase list. An unwired phase is inert, so every intermediate commit keeps CI green. Slice 7 wires it up.
 
 `e2e/src/storage-migration.ts` provides every helper needed: `api`, `uploadAsset`, `waitForProcessing`, `queryDb`,
-`dockerExec`, `minioFileExists`, `diskFileExists`.
+`dockerExec`, `minioFileExists`, `diskFileExists`, `loginAdmin`.
 
 Arrange (server in s3 write mode):
 
-1. Force transcoding so the defect-3 precondition exists: set `ffmpeg.transcode = 'all'` through the system-config
-   API (mirror `setStorageTemplate`), restoring the original config in the phase's teardown.
+1. Force transcoding so the defect-3 precondition exists: set `ffmpeg.transcode = 'all'` via `GET`/`PUT`
+   `/system-config` (mirror `setStorageTemplate`), restoring the original config in teardown.
 2. Build a tiny mp4 without committing a binary fixture: `dockerExec('immich-server', …)` runs ffmpeg's `lavfi` test
-   source (a couple of seconds, small frame size), base64s it (`base64 … | tr -d '\n'`), and the runner decodes it
-   into a Buffer.
-3. Upload, `waitForProcessing`, then assert the precondition: a non-edited `EncodedVideo` row with a relative path
-   whose object exists in MinIO. Record its `mc stat` size/etag.
+   source — **at least 3 seconds** (`editAsset` rejects videos under 2 s), small frame size — base64s it
+   (`base64 … | tr -d '\n'`), and the runner decodes it into a Buffer.
+3. Upload, `waitForProcessing`, then assert the preconditions: `asset.duration` is set, and a non-edited
+   `EncodedVideo` row exists with a relative path whose object exists in MinIO. Record its `mc stat` size/etag.
 
-Act: `PUT /assets/{id}/edits` with a Trim action, then `waitForProcessing`.
+Act: `PUT /assets/{id}/edits` with `{ edits: [{ action: 'trim', parameters: { startTime, endTime } }] }`, then
+`waitForProcessing`.
 
 Assert:
 
-- Every `isEdited` `asset_file` row (encoded video, preview, thumbnail, and fullsize if generated) has a **relative**
-  path.
-- The edited video key is `encoded-video/{ownerId}/{xx}/{yy}/{id}_edited.mp4` and the object **exists in MinIO**.
+- Every `isEdited` `asset_file` row (encoded video, preview, thumbnail, fullsize if generated) has a **relative** path.
+- The edited video key is `encoded-video/{ownerId}/{xx}/{yy}/{id}_edited.mp4` and the object exists in MinIO.
 - Each edited thumbnail key contains `_edited` and exists in MinIO.
 - The **non-edited** encoded object still exists with an unchanged size/etag — the collision guard, end to end.
 - `GET /assets/{id}/video/playback` returns 200 — the trimmed video is served from S3.
@@ -243,118 +321,148 @@ Assert:
 - The phase's server logs contain no `FFmpeg trim failed` and no ENOENT.
 
 Then undo (`DELETE /assets/{id}/edits`), `waitForProcessing`, and assert the edited objects are **gone from MinIO**
-and playback still returns 200 (falling back to the transcoded original). This covers the undo path on S3, which
-nothing tests today. Assert only object deletion and playback — if anything else about undo looks wrong (e.g.
-`duration` not restored), **file it as a separate issue; do not grow this PR**.
+and playback still returns 200 (falling back to the transcoded original). Nothing tests the undo path on S3 today.
+Assert only object deletion and playback — if something else about undo looks wrong (e.g. `duration` not restored),
+**file it separately; do not grow this PR**.
 
-Teardown: delete the asset, empty the trash, restore the ffmpeg config, leaving the suite state as it was found.
-`migrate-to-disk` runs later in the same CI job and has never seen `encoded-video` rows.
+Teardown: delete the asset, empty the trash, restore the ffmpeg config. `migrate-to-disk` runs later in the same CI
+job and has never seen `encoded-video` rows.
 
-**Expected RED:** the trim job fails with ENOENT (ffmpeg is handed the S3 key), so no `isEdited` rows appear and the
-first assertion fails. If it instead fails at the precondition (no non-edited `EncodedVideo`), the transcode never
-ran — fix the arrange step, because without that precondition the phase does not reproduce #671.
+**Expected RED:** `PUT /assets/{id}/edits` returns **400 "Video trimming is not available for cloud-stored videos"** —
+the Layer-1 guard. That is the outermost blocker and the first thing Slice 2 removes. If instead the phase fails at
+the precondition (no non-edited `EncodedVideo`, or no duration), the transcode never ran — fix the arrange step,
+because without that precondition the phase cannot reproduce #671's Layer-2 defects.
 
-**Done when:** the phase fails for the documented reason, and `phaseMigrateToDisk` still passes when run after it.
+**Done when:** the phase fails with that 400, and `phaseMigrateToDisk` still passes when run after it.
 
-### Slice 2 — `persistFile` onto the repository layer
+### Slice 2 — Enable trim on S3 at the API (Layer 1)
 
-Route `persistFile` and `handleVideoTrim`'s two unlinks through `storageRepository`, per Design §1.
+Guard replacement (Design §1) plus `getReadableUrl` / `getProbeInput` (Design §2).
+
+- **E1 (RED)** `asset.service.spec.ts`: S3 asset (`originalPath: 'upload/admin/ab/cd/video.mp4'`) → trim edit is
+  **accepted**; `mediaRepository.probe` is called with the presigned URL the backend returns; the edit is persisted
+  and the thumbnail job queued. _Expected red:_ throws `Video trimming is not available for cloud-stored videos`.
+- **E2 (RED)** External-library video (`/mnt/external/video.mp4`, absolute, outside `/data`) → still rejected, with
+  the new message `Video trimming is not available for external library videos`. _Expected red:_ the old
+  "cloud-stored" message.
+- **E3 (RED)** Audio-only on S3: the presigned-URL probe returns no video streams → 400 `Cannot trim audio-only
+files`. _Expected red:_ the cloud-stored guard throws first.
+- **E4 (GUARD)** Disk asset (`/data/library/video.mp4`) → `probe` is called with the **absolute path**; no presign
+  happens. _Mutation:_ make `getProbeInput` always presign; E4 must fail.
+- **E5 (RED)** `s3-storage.backend.spec.ts`: `getReadableUrl(key)` returns the presigned URL from `getSignedUrl` for
+  a `GetObjectCommand` on the right bucket/key. _Expected red:_ method does not exist.
+- **E6 (RED)** `disk-storage.backend.spec.ts`: `getReadableUrl(key)` returns `join(mediaLocation, key)`. _Expected
+  red:_ method does not exist.
+- **Rewrite** `asset.service.spec.ts:2301` ("should reject trim on cloud-stored videos") into E1/E2. It encodes the
+  bug; deleting it is the point.
+
+**Done when:** E1–E3, E5, E6 pass; E4 passes and is mutation-proved; the full server unit suite is green; re-running
+the e2e phase now fails **inside the trim job with ENOENT** (defect 3) instead of at the 400 — the red has moved
+inward, which is the proof Layer 1 is done and Layer 2 is real.
+
+### Slice 3 — `persistFile` onto the repository layer
+
+Design §3. Enables every S3 test that follows.
 
 - **A1 (RED)** S3: `(sut as any).persistFile('/local/out.jpg', 'thumbs/aa/bb/x.jpg', 'image/jpeg')` streams via
   `mocks.storage.createPlainReadStream`, calls `backend.put(key, thatStream, { contentType })`, unlinks the local
-  temp via `mocks.storage.unlink`, and returns the key.
-  _Expected red:_ `createPlainReadStream` is never called (the code uses raw `node:fs`). Run this test on its own for
-  the red observation — the raw stream's ENOENT may also surface as an unhandled error.
+  temp via `mocks.storage.unlink`, and returns the key. _Expected red:_ `createPlainReadStream` is never called (the
+  code uses raw `node:fs`). Run this test alone for the red observation — the raw stream's ENOENT may also surface as
+  an unhandled error.
 - **A2 (GUARD)** Disk (`getWriteBackend()` → undefined): returns the local path, calls no `put`, and **does not
   unlink**. _Mutation:_ make `persistFile` unlink unconditionally; A2 must fail. Without this guard, a later
-  "simplification" would delete the very file disk mode just wrote.
+  "simplification" deletes the file disk mode just wrote.
 
-**Done when:** A1 and A2 pass, the full `media.service.spec.ts` suite passes **with zero changes to existing tests**,
-and A2 has been mutation-proved.
+**Done when:** A1, A2 pass; A2 is mutation-proved; `media.service.spec.ts` is green with **zero changes to existing
+tests**.
 
-### Slice 3 — Defect 3: never hand ffmpeg an S3 key
+### Slice 4 — Defect 3: never hand ffmpeg an S3 key
 
 `ensureLocalFile` the encoded input; release it in a `finally` around the trim.
 
 - **B1 (RED)** S3, asset has a non-edited `EncodedVideo` with a relative key → `mediaRepository.trim` receives the
-  temp local path, not the key, and that temp's `cleanup` runs. _Expected red:_ `trim` is called with the relative
-  key.
+  temp local path, not the key, and that temp's `cleanup` runs. _Expected red:_ `trim` is called with the relative key.
 - **D2 (RED)** S3 trim failure → returns `JobStatus.Failed`, calls no `put`, runs the encoded temp's `cleanup`, and
   unlinks the partial output. _Expected red:_ `cleanup` is never called (nothing is downloaded today).
 - **B2 (GUARD)** Disk, existing non-edited `EncodedVideo` with an absolute path → `trim` receives it unchanged, no
-  download attempted. _Mutation:_ make `ensureLocalFile` treat absolute paths as keys; B2 must fail.
+  download. _Mutation:_ make `ensureLocalFile` treat absolute paths as keys; B2 must fail.
 - **B3 (GUARD)** No `EncodedVideo` at all → `trim` receives the caller's already-materialized `localPath`, no extra
   download. _Mutation:_ pass `existingEncoded?.path ?? ''` into `ensureLocalFile`; B3 must fail.
 
 **Done when:** B1, D2 pass; B2, B3 pass and are mutation-proved; the suite is green.
 
-### Slice 4 — Defect 1: persist the trimmed video
+### Slice 5 — Defect 1: persist the trimmed video
 
-Add the three `StorageCore` statics (Design §2); use `getEditedEncodedVideoPath` for the local output and
+Add the three `StorageCore` statics (Design §4); use `getEditedEncodedVideoPath` for the local output and
 `persistFile` + `getRelativeEditedEncodedVideoPath` for the upload.
 
 - **C1 (RED)** S3: `put` called with `encoded-video/{ownerId}/{xx}/{yy}/{id}_edited.mp4` and `video/mp4`; the upserted
   `EncodedVideo` row carries that key, not an absolute path. _Expected red:_ `put` is never called.
 - **C3a (RED)** S3: the persisted video key differs from `StorageCore.getRelativeEncodedVideoPath(asset)` — a trim
-  must never overwrite the asset's transcoded original. _Expected red:_ `put` is never called.
+  must never overwrite the transcoded original. _Expected red:_ `put` is never called.
 - **D1 (RED)** Ordering: the video `put` happens **after** `extractFrame` (compare `invocationCallOrder`), proving the
-  local file still existed when the frame was pulled. _Expected red:_ `put` is never called. _After green, also
-  mutation-prove it:_ move the `persistFile` call above `extractFrame`; D1 must fail. This is the whole reason D1
-  exists — a D1 that cannot catch the reordering is worthless.
+  local file still existed when the frame was pulled. _Expected red:_ `put` is never called. _After green,
+  mutation-prove it:_ move the `persistFile` call above `extractFrame`; D1 must fail. A D1 that cannot catch the
+  reordering is worthless.
 - **D3 (GUARD)** Re-trim idempotency: an asset that already has edited files at the same keys queues **no**
-  `FileDelete` for the edited video key. _Mutation:_ make the edited filename non-deterministic (append a suffix);
-  D3 must fail, because `syncFiles` would then delete the object just uploaded.
+  `FileDelete` for the edited video key. _Mutation:_ make the edited filename non-deterministic (append a suffix); D3
+  must fail, because `syncFiles` would then delete the object just uploaded.
 
 **Done when:** C1, C3a, D1 pass; D3 passes and is mutation-proved; D1 is mutation-proved; the suite is green.
 
-### Slice 5 — Defect 2: persist the trim thumbnails
+### Slice 6 — Defect 2: persist the trim thumbnails
 
-Extract `persistImageFiles` (Design §3) and route all **four** call sites through it.
+Extract `persistImageFiles` (Design §5); route all **four** call sites through it.
 
 - **C2 (RED)** S3: `put` is called for every file `generateImageThumbnails` returns (preview, thumbnail, and fullsize
-  when generated) with `_edited` relative keys, and those keys are what reach `upsertFiles`. _Expected red:_ `put` is
-  called only for the video (Slice 4), never for the thumbnails.
+  when generated) with `_edited` relative keys, and those keys reach `upsertFiles`. _Expected red:_ `put` is called
+  only for the video (Slice 5), never for the thumbnails.
 - **C3b (RED)** S3: no `put` targets a non-edited thumbnail key — a trim must not overwrite the asset's normal
   preview/thumbnail objects. _Expected red:_ no thumbnail `put` happens at all.
-- **C4 (GUARD)** Disk: the existing trim tests still pass, paths stay absolute, no `put` occurs. _Mutation:_ force
+- **C4 (GUARD)** Disk: existing trim tests still pass, paths stay absolute, no `put` occurs. _Mutation:_ force
   `persistFile` into its S3 branch; C4 must fail.
 
-**Done when:** C2, C3b pass; C4 passes and is mutation-proved; the **whole server unit suite** is green (this slice
-touches `handleGenerateThumbnails` and `handleAssetEditThumbnailGeneration`, so their tests are the blast-radius
-guard).
+**Done when:** C2, C3b pass; C4 passes and is mutation-proved; the **whole server unit suite** is green — this slice
+touches `handleGenerateThumbnails` and `handleAssetEditThumbnailGeneration`, so their tests are the blast-radius guard.
 
-### Slice 6 — Turn the e2e phase green and wire it in
+### Slice 7 — Turn the e2e phase green and wire it in
 
 1. Re-run `./storage-migration.sh --phase video-trim-s3` — it must now pass, including the undo assertions.
-2. Run it **three consecutive times**. Flaky means not done: fix the root cause, do not add retries.
-3. Only then wire it into `.github/workflows/storage-migration-tests.yml` (the `backend=s3` phase group, next to
+2. Run it **three consecutive times**. Flaky means not done: fix the root cause, never add retries.
+3. Only then wire it into `.github/workflows/storage-migration-tests.yml` (the `backend=s3` group, next to
    `copy-asset-sidecar-s3`) and into the full-workflow sequence in `storage-migration.sh`.
 4. Run the full `./storage-migration.sh --cleanup` suite to prove no existing phase regressed — `migrate-to-disk`
    especially.
 5. Update `e2e/README-storage-migration.md`: drop "No video asset upload" from the known gaps, document the phase.
 
-If the phase proves genuinely unstable in CI (not in local runs), it stays a local `make` target and the PR says so
-explicitly. **No flaky test gets wired into CI.**
+If the phase proves unstable in CI but not locally, it stays a local `make` target and the PR says so explicitly.
+**No flaky test gets wired into CI.**
 
 **Done when:** the phase is green three times running, the full harness passes, and CI on the branch is green.
 
 ## Verification
 
-- `cd server && pnpm test -- --run src/services/media.service.spec.ts`, then the full server unit suite.
+- `cd server && pnpm test -- --run src/services/media.service.spec.ts src/services/asset.service.spec.ts`, then the
+  full server unit suite.
 - Final gate only (not per slice): `make check-server` and `make lint-server`.
-- `cd e2e && ./storage-migration.sh --phase video-trim-s3` (red in Slice 1, green in Slice 6, ×3 for stability), then
-  a full `./storage-migration.sh --cleanup` run. This stack binds the same ports as the e2e stack (:2285, pg :5435) —
+- `cd e2e && ./storage-migration.sh --phase video-trim-s3` — red in Slice 1 (400), red-but-deeper after Slice 2
+  (ENOENT), green in Slice 7, ×3 for stability. This stack binds the same ports as the e2e stack (:2285, pg :5435) —
   do not run it alongside `make dev` or `make e2e`.
 - Recommended before release: RC build to the personal instance (real S3 on OVH) and trim a video that already has a
-  transcoded version — the exact shape that fails today.
+  transcoded version.
 
 ## Files touched
 
-- `server/src/cores/storage.core.ts` — three fork-only statics (Slice 4).
-- `server/src/services/media.service.ts` — `persistFile` streaming source and the two trim unlinks (Slice 2);
-  `ensureLocalFile` on the trim input (Slice 3); `StorageCore` keys and video persistence (Slice 4);
-  `persistImageFiles` extraction and its four call sites (Slice 5).
-- `server/src/services/media.service.spec.ts` — twelve tests: A1–A2, B1–B3, C1–C4, D1–D3.
-- `e2e/src/storage-migration.ts` — `video-trim-s3` phase and its switch entry (Slice 1).
+- `server/src/services/asset.service.ts` — guard replacement, `getProbeInput` probe (Slice 2).
+- `server/src/services/base.service.ts` — `getProbeInput` (Slice 2).
+- `server/src/interfaces/storage-backend.interface.ts` — `getReadableUrl` (Slice 2).
+- `server/src/backends/s3-storage.backend.ts`, `disk-storage.backend.ts` — `getReadableUrl` (Slice 2).
+- `server/src/services/media.service.ts` — `persistFile` streaming source and the two trim unlinks (Slice 3);
+  `ensureLocalFile` on the trim input (Slice 4); `StorageCore` keys and video persistence (Slice 5);
+  `persistImageFiles` extraction and its four call sites (Slice 6).
+- `server/src/cores/storage.core.ts` — three fork-only statics (Slice 5).
+- Specs: `asset.service.spec.ts` (E1–E4 + rewrite), `s3-storage.backend.spec.ts` (E5),
+  `disk-storage.backend.spec.ts` (E6), `media.service.spec.ts` (A1–A2, B1–B3, C1–C4, D1–D3).
+- `e2e/src/storage-migration.ts` — `video-trim-s3` phase (Slice 1).
 - `e2e/storage-migration.sh`, `.github/workflows/storage-migration-tests.yml`,
-  `e2e/README-storage-migration.md` — wiring and docs (Slice 6).
+  `e2e/README-storage-migration.md` — wiring and docs (Slice 7).

--- a/e2e/README-storage-migration.md
+++ b/e2e/README-storage-migration.md
@@ -27,6 +27,10 @@ cd e2e
 1. **setup** - Uploads test assets (image, live photo, person crop) to Immich running on local disk storage.
 2. **migrate-to-s3** - Triggers migration from disk to S3 (MinIO), then validates the results.
 3. **migrate-to-disk** - Triggers migration from S3 back to disk, then validates the results.
+4. **video-trim-s3** - Uploads a video, forces a transcode, and trims it on an S3-backed server. Validates that
+   the edited encoded video and its thumbnails are persisted to S3 under `_edited` keys, that the transcoded
+   original is not overwritten, that nothing is left behind on local disk, that playback serves the trimmed
+   video, and that undo removes the edited objects from the bucket. Covers gh#671.
 
 ## What it validates (per migration direction)
 
@@ -39,7 +43,6 @@ cd e2e
 
 ## Known gaps
 
-- No video asset upload (transcoding too slow/unreliable in e2e)
 - No fullsize image testing
 - No rollback endpoint testing
 - No concurrent upload during migration testing

--- a/e2e/src/storage-migration.ts
+++ b/e2e/src/storage-migration.ts
@@ -1989,6 +1989,161 @@ async function phaseUserDeleteS3Orphans(): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// Phase: video-trim-s3
+//
+// Covers gh#671. Trims a video on an S3-backed server and asserts every output
+// (edited encoded video + edited thumbnails) is persisted to MinIO as a relative
+// key, that the non-edited encoded object is not overwritten, and that nothing
+// is left behind on the pod's local disk.
+//
+// Runs with the server in s3 write mode. Leaves suite state as it found it, so
+// the later migrate-to-disk phase is unaffected.
+// ---------------------------------------------------------------------------
+async function phaseVideoTrimS3(): Promise<void> {
+  console.log('=== Phase: video-trim-s3 ===');
+  const token = await loginAdmin();
+
+  // Force transcoding so a NON-edited EncodedVideo exists in S3. That object is
+  // the trim job's preferred input, and it is what makes gh#671's defect 3
+  // (an S3 key handed straight to ffmpeg) reachable.
+  const originalConfig = await api('GET', '/system-config', { token });
+  const trimConfig = JSON.parse(JSON.stringify(originalConfig));
+  trimConfig.ffmpeg.transcode = 'all';
+  await api('PUT', '/system-config', { body: trimConfig, token });
+  console.log('  ffmpeg.transcode = all');
+
+  // Cleanup runs even when an assertion fails: a half-finished run must not leave
+  // encoded-video rows behind for the later migrate-to-disk phase to trip over.
+  let assetId: string | undefined;
+
+  try {
+    // 4s test video, tiny frame size. Must be >= 2s or editAsset rejects the trim.
+    const base64 = dockerExec(
+      'immich-server',
+      'ffmpeg -y -loglevel error -f lavfi -i testsrc=duration=4:size=192x144:rate=10 ' +
+        '-c:v libx264 -pix_fmt yuv420p /tmp/trim-src.mp4 && base64 /tmp/trim-src.mp4 | tr -d "\\n"',
+    );
+    const video = Buffer.from(base64, 'base64');
+    assert.ok(video.length > 1000, `Generated video looks too small: ${video.length} bytes`);
+    console.log(`  Generated test video (${video.length} bytes)`);
+
+    assetId = (await uploadAsset(token, 'trim-s3.mp4', video)).id;
+    console.log(`  Uploaded asset ${assetId}`);
+    await waitForProcessing(token, 120_000);
+
+    // Precondition 1: duration was probed — editAsset rejects the trim without it.
+    const assetRows = await queryDb<{ ownerId: string; duration: string | null; originalPath: string }>(
+      'SELECT "ownerId", duration, "originalPath" FROM asset WHERE id = $1',
+      [assetId],
+    );
+    assert.ok(assetRows[0], `Asset ${assetId} not found`);
+    const { ownerId, originalPath } = assetRows[0];
+    assert.ok(assetRows[0].duration, 'Asset duration was not probed — editAsset would reject the trim');
+    assert.ok(!originalPath.startsWith('/'), `Expected S3 (relative) originalPath, got ${originalPath}`);
+
+    // Precondition 2: a NON-edited EncodedVideo exists in S3.
+    // NB: the asset_file.type enum value is 'encoded_video', not 'encodedVideo'.
+    const encodedRows = await queryDb<{ path: string }>(
+      `SELECT path FROM asset_file WHERE "assetId" = $1 AND type = 'encoded_video' AND "isEdited" = false`,
+      [assetId],
+    );
+    assert.equal(encodedRows.length, 1, `Expected 1 non-edited encoded_video row, got ${encodedRows.length}`);
+    const nonEditedKey = encodedRows[0].path;
+    assert.ok(!nonEditedKey.startsWith('/'), `Expected relative encoded_video path, got ${nonEditedKey}`);
+    assert.ok(minioFileExists(nonEditedKey), `Non-edited encoded video missing from MinIO: ${nonEditedKey}`);
+    const nonEditedStatBefore = dockerExec('minio', `mc stat local/immich-test/${nonEditedKey}`);
+    console.log(`  Precondition OK: transcoded video in S3 at ${nonEditedKey}`);
+
+    // Act: trim 1s..3s out of the 4s video.
+    await api('PUT', `/assets/${assetId}/edits`, {
+      token,
+      body: { edits: [{ action: 'trim', parameters: { startTime: 1, endTime: 3 } }] },
+    });
+    console.log('  Trim edit submitted');
+    await waitForProcessing(token, 120_000);
+
+    const editedRows = await queryDb<{ path: string; type: string }>(
+      `SELECT path, type FROM asset_file WHERE "assetId" = $1 AND "isEdited" = true ORDER BY type`,
+      [assetId],
+    );
+    assert.ok(
+      editedRows.length >= 3,
+      `Expected >= 3 edited asset_file rows (video + preview + thumbnail), got ${editedRows.length}`,
+    );
+
+    for (const row of editedRows) {
+      assert.ok(!row.path.startsWith('/'), `Edited ${row.type} path must be an S3 key, got ${row.path}`);
+      assert.ok(minioFileExists(row.path), `Edited ${row.type} missing from MinIO: ${row.path}`);
+    }
+
+    const editedVideo = editedRows.find((r) => r.type === 'encoded_video');
+    assert.ok(editedVideo, 'No edited encoded_video row');
+    const expectedKey = `encoded-video/${ownerId}/${assetId.slice(0, 2)}/${assetId.slice(2, 4)}/${assetId}_edited.mp4`;
+    assert.equal(editedVideo.path, expectedKey, 'Edited encoded video key mismatch');
+    assert.notEqual(editedVideo.path, nonEditedKey, 'Edited video must not reuse the non-edited key');
+
+    for (const row of editedRows.filter((r) => r.type !== 'encoded_video')) {
+      assert.ok(row.path.includes('_edited'), `Edited ${row.type} key must carry _edited: ${row.path}`);
+    }
+
+    // Collision guard: the transcoded original must be untouched.
+    assert.ok(minioFileExists(nonEditedKey), 'Non-edited encoded video disappeared');
+    const nonEditedStatAfter = dockerExec('minio', `mc stat local/immich-test/${nonEditedKey}`);
+    assert.equal(nonEditedStatAfter, nonEditedStatBefore, 'Non-edited encoded video was overwritten by the trim');
+
+    // No local leftovers: persistFile must upload AND unlink.
+    const localEditedPath = `${MEDIA_LOCATION}/encoded-video/${ownerId}/${assetId.slice(0, 2)}/${assetId.slice(2, 4)}/${assetId}_edited.mp4`;
+    assert.ok(!diskFileExists(localEditedPath), `Trimmed video left on local disk: ${localEditedPath}`);
+
+    // Duration reflects the trim (2s), not the original (4s).
+    const trimmedRows = await queryDb<{ duration: string | null }>('SELECT duration FROM asset WHERE id = $1', [
+      assetId,
+    ]);
+    const durationMs = Number(trimmedRows[0].duration);
+    assert.ok(
+      durationMs >= 1500 && durationMs <= 2500,
+      `Expected trimmed duration ~2000ms, got ${trimmedRows[0].duration}`,
+    );
+
+    // Playback serves the trimmed video from S3.
+    const playbackRes = await fetch(`${BASE_URL}/assets/${assetId}/video/playback`, {
+      headers: { Authorization: `Bearer ${token}` },
+      redirect: 'follow',
+    });
+    assert.equal(playbackRes.status, 200, `Expected 200 from playback, got ${playbackRes.status}`);
+    await playbackRes.arrayBuffer();
+    console.log('  Trim persisted to S3 and served');
+
+    // Undo: the edited objects must be removed from the bucket.
+    const editedKeys = editedRows.map((r) => r.path);
+    await api('DELETE', `/assets/${assetId}/edits`, { token });
+    await waitForProcessing(token, 120_000);
+
+    for (const key of editedKeys) {
+      assert.ok(!minioFileExists(key), `Undo left an edited object in MinIO: ${key}`);
+    }
+
+    const undoRes = await fetch(`${BASE_URL}/assets/${assetId}/video/playback`, {
+      headers: { Authorization: `Bearer ${token}` },
+      redirect: 'follow',
+    });
+    assert.equal(undoRes.status, 200, `Expected 200 from playback after undo, got ${undoRes.status}`);
+    await undoRes.arrayBuffer();
+    console.log('  Undo removed edited objects from S3');
+  } finally {
+    // Teardown: leave no trace for the later migrate-to-disk phase.
+    if (assetId) {
+      await api('DELETE', '/assets', { token, body: { ids: [assetId], force: true } });
+      console.log(`  Asset ${assetId} deleted`);
+    }
+    await api('PUT', '/system-config', { body: originalConfig, token });
+    console.log('  ffmpeg config restored');
+  }
+
+  console.log('=== Phase: video-trim-s3 complete ===');
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 async function main() {
@@ -2081,9 +2236,13 @@ async function main() {
         await phaseUserDeleteS3Orphans();
         break;
       }
+      case 'video-trim-s3': {
+        await phaseVideoTrimS3();
+        break;
+      }
       default: {
         throw new Error(
-          `Unknown phase: ${phase}. Valid phases: setup, estimate, migrate-to-s3, migrate-to-disk, rollback, no-files, concurrent-rejection, selective-to-s3, selective-cleanup, delete-source-false, content-verify, sidecar-verify, template-s3-bulk-skipped, template-s3-upload-skipped, template-s3-live-photo-skipped, template-s3-sidecar-skipped, template-s3-queue-migration-skipped, template-disk-baseline, copy-asset-sidecar-s3, user-delete-s3-orphans`,
+          `Unknown phase: ${phase}. Valid phases: setup, estimate, migrate-to-s3, migrate-to-disk, rollback, no-files, concurrent-rejection, selective-to-s3, selective-cleanup, delete-source-false, content-verify, sidecar-verify, template-s3-bulk-skipped, template-s3-upload-skipped, template-s3-live-photo-skipped, template-s3-sidecar-skipped, template-s3-queue-migration-skipped, template-disk-baseline, copy-asset-sidecar-s3, user-delete-s3-orphans, video-trim-s3`,
         );
       }
     }

--- a/e2e/src/storage-migration.ts
+++ b/e2e/src/storage-migration.ts
@@ -2007,7 +2007,7 @@ async function phaseVideoTrimS3(): Promise<void> {
   // the trim job's preferred input, and it is what makes gh#671's defect 3
   // (an S3 key handed straight to ffmpeg) reachable.
   const originalConfig = await api('GET', '/system-config', { token });
-  const trimConfig = JSON.parse(JSON.stringify(originalConfig));
+  const trimConfig = structuredClone(originalConfig);
   trimConfig.ffmpeg.transcode = 'all';
   await api('PUT', '/system-config', { body: trimConfig, token });
   console.log('  ffmpeg.transcode = all');
@@ -2018,16 +2018,24 @@ async function phaseVideoTrimS3(): Promise<void> {
 
   try {
     // 4s test video, tiny frame size. Must be >= 2s or editAsset rejects the trim.
+    //
+    // -g 10 -keyint_min 10 -sc_threshold 0 puts a keyframe on every second (10fps).
+    // MediaRepository.trim runs ffmpeg with `-c copy`, so its seek is keyframe-snapped:
+    // with x264's default GOP a 4s clip has only the frame-0 keyframe, `-ss 1` would snap
+    // back to 0, and the "2s" trim would come out 3.2s long. Real videos carry regular
+    // keyframes; the fixture must too, or it tests a scenario that does not exist.
     const base64 = dockerExec(
       'immich-server',
       'ffmpeg -y -loglevel error -f lavfi -i testsrc=duration=4:size=192x144:rate=10 ' +
-        '-c:v libx264 -pix_fmt yuv420p /tmp/trim-src.mp4 && base64 /tmp/trim-src.mp4 | tr -d "\\n"',
+        '-c:v libx264 -pix_fmt yuv420p -g 10 -keyint_min 10 -sc_threshold 0 /tmp/trim-src.mp4 ' +
+        String.raw`&& base64 /tmp/trim-src.mp4 | tr -d "\n"`,
     );
     const video = Buffer.from(base64, 'base64');
     assert.ok(video.length > 1000, `Generated video looks too small: ${video.length} bytes`);
     console.log(`  Generated test video (${video.length} bytes)`);
 
-    assetId = (await uploadAsset(token, 'trim-s3.mp4', video)).id;
+    const uploaded = await uploadAsset(token, 'trim-s3.mp4', video);
+    assetId = uploaded.id;
     console.log(`  Uploaded asset ${assetId}`);
     await waitForProcessing(token, 120_000);
 
@@ -2095,14 +2103,17 @@ async function phaseVideoTrimS3(): Promise<void> {
     const localEditedPath = `${MEDIA_LOCATION}/encoded-video/${ownerId}/${assetId.slice(0, 2)}/${assetId.slice(2, 4)}/${assetId}_edited.mp4`;
     assert.ok(!diskFileExists(localEditedPath), `Trimmed video left on local disk: ${localEditedPath}`);
 
-    // Duration reflects the trim (2s), not the original (4s).
+    // Duration reflects the trim (~2s), not the original (4s). The trim is a `-c copy`
+    // stream copy, so ffmpeg snaps to keyframes and the result is close to, not exactly,
+    // the requested 2s — which is why handleVideoTrim re-probes the output instead of
+    // trusting the requested duration. The window allows one keyframe interval of slack.
     const trimmedRows = await queryDb<{ duration: string | null }>('SELECT duration FROM asset WHERE id = $1', [
       assetId,
     ]);
     const durationMs = Number(trimmedRows[0].duration);
     assert.ok(
-      durationMs >= 1500 && durationMs <= 2500,
-      `Expected trimmed duration ~2000ms, got ${trimmedRows[0].duration}`,
+      durationMs >= 1500 && durationMs <= 2600,
+      `Expected trimmed duration ~2000ms (keyframe-snapped), got ${trimmedRows[0].duration}`,
     );
 
     // Playback serves the trimmed video from S3.

--- a/e2e/storage-migration.sh
+++ b/e2e/storage-migration.sh
@@ -100,6 +100,7 @@ else
 
   restart_server s3
   run_phase migrate-to-s3
+  run_phase video-trim-s3
 
   restart_server disk
   run_phase migrate-to-disk

--- a/server/src/backends/disk-storage.backend.spec.ts
+++ b/server/src/backends/disk-storage.backend.spec.ts
@@ -149,4 +149,16 @@ describe('DiskStorageBackend', () => {
       await expect(backend.getPrefixUsage('thumbs/ghost/')).resolves.toBe(0);
     });
   });
+
+  describe('getReadableUrl', () => {
+    it('returns the resolved local path for a relative key', async () => {
+      await expect(backend.getReadableUrl('upload/admin/ab/cd/video.mp4')).resolves.toBe(
+        join(testDir, 'upload/admin/ab/cd/video.mp4'),
+      );
+    });
+
+    it('returns absolute paths unchanged', async () => {
+      await expect(backend.getReadableUrl('/data/library/video.mp4')).resolves.toBe('/data/library/video.mp4');
+    });
+  });
 });

--- a/server/src/backends/disk-storage.backend.ts
+++ b/server/src/backends/disk-storage.backend.ts
@@ -69,6 +69,10 @@ export class DiskStorageBackend implements StorageBackend {
     });
   }
 
+  getReadableUrl(key: string): Promise<string> {
+    return Promise.resolve(this.resolvePath(key));
+  }
+
   private async getFolderSize(folder: string): Promise<number> {
     let total = 0;
     let dir;

--- a/server/src/backends/s3-storage.backend.spec.ts
+++ b/server/src/backends/s3-storage.backend.spec.ts
@@ -370,9 +370,7 @@ describe('S3StorageBackend', () => {
       const url = await backend.getReadableUrl('upload/admin/ab/cd/video.mp4');
 
       expect(url).toBe('https://bucket.s3.amazonaws.com/key?X-Amz-Signature=abc123');
-      expect(GetObjectCommand).toHaveBeenCalledWith(
-        expect.objectContaining({ Key: 'upload/admin/ab/cd/video.mp4' }),
-      );
+      expect(GetObjectCommand).toHaveBeenCalledWith(expect.objectContaining({ Key: 'upload/admin/ab/cd/video.mp4' }));
     });
   });
 

--- a/server/src/backends/s3-storage.backend.spec.ts
+++ b/server/src/backends/s3-storage.backend.spec.ts
@@ -372,6 +372,16 @@ describe('S3StorageBackend', () => {
       expect(url).toBe('https://bucket.s3.amazonaws.com/key?X-Amz-Signature=abc123');
       expect(GetObjectCommand).toHaveBeenCalledWith(expect.objectContaining({ Key: 'upload/admin/ab/cd/video.mp4' }));
     });
+
+    it('signs the probe url with a short expiry, not the client serve TTL', async () => {
+      // The backend is configured with presignedUrlExpiry: 3600 (client serving). This URL is
+      // consumed server-side within the request and is a bearer credential, so it must be
+      // short-lived to bound exposure if it ever reaches a log.
+      await backend.getReadableUrl('upload/admin/ab/cd/video.mp4');
+
+      const lastCall = vi.mocked(getSignedUrl).mock.calls.at(-1);
+      expect(lastCall?.[2]).toEqual(expect.objectContaining({ expiresIn: 60 }));
+    });
   });
 
   describe('deletePrefix', () => {

--- a/server/src/backends/s3-storage.backend.spec.ts
+++ b/server/src/backends/s3-storage.backend.spec.ts
@@ -365,6 +365,17 @@ describe('S3StorageBackend', () => {
     });
   });
 
+  describe('getReadableUrl', () => {
+    it('returns a presigned GET url for the key', async () => {
+      const url = await backend.getReadableUrl('upload/admin/ab/cd/video.mp4');
+
+      expect(url).toBe('https://bucket.s3.amazonaws.com/key?X-Amz-Signature=abc123');
+      expect(GetObjectCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ Key: 'upload/admin/ab/cd/video.mp4' }),
+      );
+    });
+  });
+
   describe('deletePrefix', () => {
     it('should not send DeleteObjectsCommand when the prefix matches nothing', async () => {
       mockSend.mockResolvedValueOnce({ Contents: [], IsTruncated: false });

--- a/server/src/backends/s3-storage.backend.ts
+++ b/server/src/backends/s3-storage.backend.ts
@@ -195,6 +195,12 @@ export class S3StorageBackend implements StorageBackend {
     return { type: 'redirect', url };
   }
 
+  async getReadableUrl(key: string): Promise<string> {
+    return getSignedUrl(this.client, new GetObjectCommand({ Bucket: this.bucket, Key: key }), {
+      expiresIn: this.presignedUrlExpiry,
+    });
+  }
+
   async downloadToTemp(key: string): Promise<{ tempPath: string; cleanup: () => Promise<void> }> {
     const tempPath = join(tmpdir(), `immich-${randomUUID()}.tmp`);
     const { stream } = await this.get(key);

--- a/server/src/backends/s3-storage.backend.ts
+++ b/server/src/backends/s3-storage.backend.ts
@@ -19,6 +19,11 @@ import { pipeline } from 'node:stream/promises';
 import { ServeOptions, ServeStrategy, StorageBackend } from 'src/interfaces/storage-backend.interface';
 import { getContentDispositionHeader } from 'src/utils/file';
 
+// getReadableUrl backs server-side, download-free probing (ffprobe) that completes within the
+// request. Its URL is a bearer credential, so it gets a much shorter expiry than the client-facing
+// presignedUrlExpiry — a long TTL only widens exposure if the URL ever reaches a log.
+const READABLE_URL_EXPIRY_SECONDS = 60;
+
 class AsyncLimiter {
   private active = 0;
   private readonly queue: Array<() => void> = [];
@@ -197,7 +202,7 @@ export class S3StorageBackend implements StorageBackend {
 
   async getReadableUrl(key: string): Promise<string> {
     return getSignedUrl(this.client, new GetObjectCommand({ Bucket: this.bucket, Key: key }), {
-      expiresIn: this.presignedUrlExpiry,
+      expiresIn: READABLE_URL_EXPIRY_SECONDS,
     });
   }
 

--- a/server/src/cores/storage.core.spec.ts
+++ b/server/src/cores/storage.core.spec.ts
@@ -187,6 +187,35 @@ describe('StorageCore', () => {
       });
     });
 
+    describe('getEditedEncodedVideoPath', () => {
+      it('nests the _edited video beside the non-edited one', () => {
+        StorageCore.setMediaLocation('/media');
+        const asset = { id: 'abcd1234-0000-0000-0000-000000000000', ownerId: 'owner-id' };
+
+        expect(StorageCore.getEditedEncodedVideoPath(asset as any)).toBe(
+          '/media/encoded-video/owner-id/ab/cd/abcd1234-0000-0000-0000-000000000000_edited.mp4',
+        );
+      });
+    });
+
+    describe('getRelativeEditedEncodedVideoPath', () => {
+      it('returns the _edited key', () => {
+        const asset = { id: 'abcd1234-0000-0000-0000-000000000000', ownerId: 'owner-id' };
+
+        expect(StorageCore.getRelativeEditedEncodedVideoPath(asset as any)).toBe(
+          'encoded-video/owner-id/ab/cd/abcd1234-0000-0000-0000-000000000000_edited.mp4',
+        );
+      });
+
+      it('never collides with the non-edited encoded video key', () => {
+        const asset = { id: 'abcd1234-0000-0000-0000-000000000000', ownerId: 'owner-id' };
+
+        expect(StorageCore.getRelativeEditedEncodedVideoPath(asset as any)).not.toBe(
+          StorageCore.getRelativeEncodedVideoPath(asset as any),
+        );
+      });
+    });
+
     describe('getRelativePersonThumbnailPath', () => {
       it('should return relative path for person thumbnail', () => {
         const result = StorageCore.getRelativePersonThumbnailPath({ id: 'person-1', ownerId: 'user-1' });

--- a/server/src/cores/storage.core.ts
+++ b/server/src/cores/storage.core.ts
@@ -362,6 +362,26 @@ export class StorageCore {
     return StorageCore.getRelativeNestedPath(StorageFolder.EncodedVideo, asset.ownerId, `${asset.id}.mp4`);
   }
 
+  private static getEditedEncodedVideoFilename(asset: ThumbnailPathEntity): string {
+    return `${asset.id}_edited.mp4`;
+  }
+
+  static getEditedEncodedVideoPath(asset: ThumbnailPathEntity): string {
+    return StorageCore.getNestedPath(
+      StorageFolder.EncodedVideo,
+      asset.ownerId,
+      StorageCore.getEditedEncodedVideoFilename(asset),
+    );
+  }
+
+  static getRelativeEditedEncodedVideoPath(asset: ThumbnailPathEntity): string {
+    return StorageCore.getRelativeNestedPath(
+      StorageFolder.EncodedVideo,
+      asset.ownerId,
+      StorageCore.getEditedEncodedVideoFilename(asset),
+    );
+  }
+
   static getRelativePersonThumbnailPath(person: ThumbnailPathEntity): string {
     return StorageCore.getRelativeNestedPath(StorageFolder.Thumbnails, person.ownerId, `${person.id}.jpeg`);
   }

--- a/server/src/interfaces/storage-backend.interface.ts
+++ b/server/src/interfaces/storage-backend.interface.ts
@@ -37,6 +37,13 @@ export interface StorageBackend {
   getServeStrategy(key: string, options: ServeOptions): Promise<ServeStrategy>;
 
   /**
+   * A path or URL that external tools (ffmpeg/ffprobe) can read directly,
+   * without downloading the object first. Disk returns a filesystem path;
+   * S3 returns a presigned URL.
+   */
+  getReadableUrl(key: string): Promise<string>;
+
+  /**
    * Download content to a local temp file for processing by tools
    * that require filesystem paths (ffmpeg, sharp, exiftool).
    * Returns the temp path and a cleanup function.

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -1786,6 +1786,17 @@ export class AssetRepository {
       .executeTakeFirst();
   }
 
+  // No @GenerateSql: undecorated repository methods are not documented; several already are.
+  async getEditedEncodedVideo(assetId: string) {
+    return this.db
+      .selectFrom('asset_file')
+      .select(['asset_file.id', 'asset_file.path'])
+      .where('asset_file.assetId', '=', assetId)
+      .where('asset_file.type', '=', AssetFileType.EncodedVideo)
+      .where('asset_file.isEdited', '=', true)
+      .executeTakeFirst();
+  }
+
   @GenerateSql({ params: [DummyValue.UUID] })
   async getForOcr(id: string) {
     return this.db

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -2691,6 +2691,40 @@ describe(AssetService.name, () => {
       vi.restoreAllMocks();
     });
 
+    it('surfaces a generic error, never the presigned url, when the probe fails', async () => {
+      const assetId = newUuid();
+      const getReadableUrl = vi.fn().mockResolvedValue('https://bucket.s3/key?X-Amz-Signature=SECRET');
+      const { StorageService } = await import('src/services/storage.service.js');
+      vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue({ getReadableUrl } as any);
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
+      mocks.asset.getForEdit.mockResolvedValue({
+        type: AssetType.Video,
+        livePhotoVideoId: null,
+        originalPath: 'upload/admin/ab/cd/video.mp4',
+        originalFileName: 'video.mp4',
+        duration: 30_000,
+        exifImageWidth: 1920,
+        exifImageHeight: 1080,
+        orientation: null,
+        projectionType: null,
+      } as any);
+      mocks.assetEdit.getAll.mockResolvedValue([]);
+      // ffprobe echoes the input (the presigned url, with its signature) in its error message.
+      mocks.media.probe.mockRejectedValue(new Error('https://bucket.s3/key?X-Amz-Signature=SECRET: Invalid data'));
+
+      const error = await sut
+        .editAsset(authStub.admin, assetId, {
+          edits: [{ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } }],
+        })
+        .catch((error_: unknown) => error_);
+
+      expect(error).toBeInstanceOf(BadRequestException);
+      expect((error as Error).message).not.toContain('X-Amz-Signature');
+
+      vi.restoreAllMocks();
+    });
+
     it('should reject trim on external library videos', async () => {
       const assetId = newUuid();
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -2650,26 +2650,128 @@ describe(AssetService.name, () => {
       ).rejects.toBeInstanceOf(BadRequestException);
     });
 
-    it('should reject trim on cloud-stored videos', async () => {
+    it('should accept trim on S3-backed videos and probe via a presigned url', async () => {
       const assetId = newUuid();
+      const getReadableUrl = vi.fn().mockResolvedValue('https://bucket.s3/key?X-Amz-Signature=abc');
+      const { StorageService } = await import('src/services/storage.service.js');
+      vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue({ getReadableUrl } as any);
+
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
       mocks.asset.getForEdit.mockResolvedValue({
         type: AssetType.Video,
         livePhotoVideoId: null,
-        originalPath: 's3://bucket/video.mp4',
+        originalPath: 'upload/admin/ab/cd/video.mp4',
         originalFileName: 'video.mp4',
         duration: 30_000,
         exifImageWidth: 1920,
         exifImageHeight: 1080,
         orientation: null,
         projectionType: null,
+      } as any);
+      mocks.assetEdit.getAll.mockResolvedValue([]);
+      mocks.assetEdit.replaceAll.mockResolvedValue([] as any);
+      mocks.media.probe.mockResolvedValue({
+        videoStreams: [{}],
+        audioStreams: [{}],
+        format: {},
+      } as any);
+
+      await sut.editAsset(authStub.admin, assetId, {
+        edits: [{ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } }],
       });
+
+      expect(getReadableUrl).toHaveBeenCalledWith('upload/admin/ab/cd/video.mp4');
+      expect(mocks.media.probe).toHaveBeenCalledWith('https://bucket.s3/key?X-Amz-Signature=abc');
+      expect(mocks.assetEdit.replaceAll).toHaveBeenCalled();
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.AssetEditThumbnailGeneration,
+        data: { id: assetId },
+      });
+
+      vi.restoreAllMocks();
+    });
+
+    it('should reject trim on external library videos', async () => {
+      const assetId = newUuid();
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
+      mocks.asset.getForEdit.mockResolvedValue({
+        type: AssetType.Video,
+        livePhotoVideoId: null,
+        originalPath: '/mnt/external/video.mp4',
+        originalFileName: 'video.mp4',
+        duration: 30_000,
+        exifImageWidth: 1920,
+        exifImageHeight: 1080,
+        orientation: null,
+        projectionType: null,
+      } as any);
 
       await expect(
         sut.editAsset(authStub.admin, assetId, {
           edits: [{ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } }],
         }),
-      ).rejects.toThrow('Video trimming is not available for cloud-stored videos');
+      ).rejects.toThrow('Video trimming is not available for external library videos');
+    });
+
+    it('should reject trim on audio-only S3 files', async () => {
+      const assetId = newUuid();
+      const getReadableUrl = vi.fn().mockResolvedValue('https://bucket.s3/key?X-Amz-Signature=abc');
+      const { StorageService } = await import('src/services/storage.service.js');
+      vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue({ getReadableUrl } as any);
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
+      mocks.asset.getForEdit.mockResolvedValue({
+        type: AssetType.Video,
+        livePhotoVideoId: null,
+        originalPath: 'upload/admin/ab/cd/audio.m4a',
+        originalFileName: 'audio.m4a',
+        duration: 180_000,
+        exifImageWidth: null,
+        exifImageHeight: null,
+        orientation: null,
+        projectionType: null,
+      } as any);
+      mocks.assetEdit.getAll.mockResolvedValue([]);
+      mocks.media.probe.mockResolvedValue({ videoStreams: [], audioStreams: [{}], format: {} } as any);
+
+      await expect(
+        sut.editAsset(authStub.admin, assetId, {
+          edits: [{ action: AssetEditAction.Trim, parameters: { startTime: 10, endTime: 60 } }],
+        }),
+      ).rejects.toThrow('Cannot trim audio-only files');
+
+      vi.restoreAllMocks();
+    });
+
+    it('should probe disk-backed videos by absolute path, without presigning', async () => {
+      const assetId = newUuid();
+      const { StorageService } = await import('src/services/storage.service.js');
+      const resolveSpy = vi.spyOn(StorageService, 'resolveBackendForKey');
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
+      mocks.asset.getForEdit.mockResolvedValue({
+        type: AssetType.Video,
+        livePhotoVideoId: null,
+        originalPath: '/data/library/video.mp4',
+        originalFileName: 'video.mp4',
+        duration: 30_000,
+        exifImageWidth: 1920,
+        exifImageHeight: 1080,
+        orientation: null,
+        projectionType: null,
+      } as any);
+      mocks.assetEdit.getAll.mockResolvedValue([]);
+      mocks.assetEdit.replaceAll.mockResolvedValue([] as any);
+      mocks.media.probe.mockResolvedValue({ videoStreams: [{}], audioStreams: [{}], format: {} } as any);
+
+      await sut.editAsset(authStub.admin, assetId, {
+        edits: [{ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } }],
+      });
+
+      expect(mocks.media.probe).toHaveBeenCalledWith('/data/library/video.mp4');
+      expect(resolveSpy).not.toHaveBeenCalled();
+
+      vi.restoreAllMocks();
     });
 
     it('should reject trim on audio-only files', async () => {

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -884,7 +884,16 @@ export class AssetService extends BaseService {
       // Audio-only file check. getProbeInput hands ffprobe an absolute path (disk) or a
       // presigned URL (S3) — it does NOT download the video, which matters here because
       // this runs inside the request.
-      const probeResult = await this.mediaRepository.probe(await this.getProbeInput(asset.originalPath));
+      let probeResult: Awaited<ReturnType<typeof this.mediaRepository.probe>>;
+      try {
+        probeResult = await this.mediaRepository.probe(await this.getProbeInput(asset.originalPath));
+      } catch {
+        // Never surface or log the raw ffprobe error: for S3 originals getProbeInput yields a
+        // presigned URL (a bearer credential) that ffprobe echoes in its stderr, which would
+        // otherwise leak into error logs. Log only the asset id.
+        this.logger.error(`Failed to probe video for trim (asset ${id})`);
+        throw new BadRequestException('Unable to read video for trimming');
+      }
       if (!probeResult.videoStreams || probeResult.videoStreams.length === 0) {
         throw new BadRequestException('Cannot trim audio-only files');
       }

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -875,13 +875,16 @@ export class AssetService extends BaseService {
         throw new BadRequestException('Trimming live photos is not supported');
       }
 
-      // S3/cloud storage check
-      if (!StorageCore.isImmichPath(asset.originalPath)) {
-        throw new BadRequestException('Video trimming is not available for cloud-stored videos');
+      // Block external-library videos: absolute paths outside the media location.
+      // S3-backed originals are relative keys, resolved through the storage backend.
+      if (isAbsolute(asset.originalPath) && !StorageCore.isImmichPath(asset.originalPath)) {
+        throw new BadRequestException('Video trimming is not available for external library videos');
       }
 
-      // Audio-only file check
-      const probeResult = await this.mediaRepository.probe(asset.originalPath);
+      // Audio-only file check. getProbeInput hands ffprobe an absolute path (disk) or a
+      // presigned URL (S3) — it does NOT download the video, which matters here because
+      // this runs inside the request.
+      const probeResult = await this.mediaRepository.probe(await this.getProbeInput(asset.originalPath));
       if (!probeResult.videoStreams || probeResult.videoStreams.length === 0) {
         throw new BadRequestException('Cannot trim audio-only files');
       }

--- a/server/src/services/base.service.ts
+++ b/server/src/services/base.service.ts
@@ -406,6 +406,20 @@ export class BaseService {
     return { localPath: tempPath, cleanup };
   }
 
+  /**
+   * Returns something ffmpeg/ffprobe can read directly: an absolute path as-is,
+   * or a presigned URL for a storage-backend key. Unlike ensureLocalFile this
+   * does NOT download the object, so it is safe to call inside a request handler.
+   */
+  protected async getProbeInput(filePath: string): Promise<string> {
+    if (isAbsolute(filePath)) {
+      return filePath;
+    }
+    // lazy import to avoid circular dependency (StorageService extends BaseService)
+    const { StorageService } = await import('./storage.service.js');
+    return StorageService.resolveBackendForKey(filePath).getReadableUrl(filePath);
+  }
+
   protected async getFaceThumbnailSource(assetId: string): Promise<string | null> {
     const preview = await this.assetRepository.getForThumbnail(assetId, AssetFileType.Preview, false);
     if (preview.path) {

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -1,6 +1,7 @@
 import { ShallowDehydrateObject } from 'kysely';
 import { OutputInfo } from 'sharp';
 import { SystemConfig } from 'src/config';
+import { StorageCore } from 'src/cores/storage.core';
 import { Exif } from 'src/database';
 import { AssetEditAction } from 'src/dtos/editing.dto';
 import {
@@ -1853,6 +1854,136 @@ describe(MediaService.name, () => {
 
       expect(result).toBe(JobStatus.Success);
       expect(mocks.asset.deleteFiles).not.toHaveBeenCalled();
+    });
+
+    describe('trim video persistence (S3)', () => {
+      afterEach(() => {
+        // vitest.config.mjs sets no restoreMocks and there are no setupFiles, so a
+        // getWriteBackend spy would leak into every later test in this file and
+        // silently run the disk-mode tests against S3.
+        vi.restoreAllMocks();
+      });
+
+      it('uploads the trimmed video under the _edited key and stores that key (S3)', async () => {
+        const put = vi.fn().mockResolvedValue(void 0);
+        const { StorageService } = await import('src/services/storage.service.js');
+        vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+        mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('mp4')]) as any);
+
+        const asset = AssetFactory.from({ type: AssetType.Video })
+          .exif()
+          .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+          .build();
+        mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+        mocks.media.probe.mockResolvedValue({
+          ...videoInfoStub.noAudioStreams,
+          format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+        });
+        mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+        mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+
+        await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+        const editedKey = StorageCore.getRelativeEditedEncodedVideoPath(asset as any);
+        expect(put).toHaveBeenCalledWith(editedKey, expect.anything(), { contentType: 'video/mp4' });
+        expect(mocks.asset.upsertFiles).toHaveBeenCalledWith(
+          expect.arrayContaining([
+            expect.objectContaining({ type: AssetFileType.EncodedVideo, isEdited: true, path: editedKey }),
+          ]),
+        );
+      });
+
+      it('never uploads the trimmed video over the transcoded original (S3)', async () => {
+        const put = vi.fn().mockResolvedValue(void 0);
+        const { StorageService } = await import('src/services/storage.service.js');
+        vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+        mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('mp4')]) as any);
+
+        const asset = AssetFactory.from({ type: AssetType.Video })
+          .exif()
+          .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+          .build();
+        mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+        mocks.media.probe.mockResolvedValue({
+          ...videoInfoStub.noAudioStreams,
+          format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+        });
+        mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+        mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+
+        await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+        const nonEditedKey = StorageCore.getRelativeEncodedVideoPath(asset as any);
+        const keys = put.mock.calls.map((call) => call[0]);
+        expect(keys).not.toContain(nonEditedKey);
+      });
+
+      it('uploads the trimmed video only after the thumbnail frame is extracted (S3)', async () => {
+        const put = vi.fn().mockResolvedValue(void 0);
+        const { StorageService } = await import('src/services/storage.service.js');
+        vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+        mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('mp4')]) as any);
+
+        const asset = AssetFactory.from({ type: AssetType.Video })
+          .exif()
+          .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+          .build();
+        mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+        mocks.media.probe.mockResolvedValue({
+          ...videoInfoStub.noAudioStreams,
+          format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+        });
+        mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+        mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+
+        await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+        // persistFile unlinks the local file after upload, so extractFrame MUST run first.
+        const extractOrder = mocks.media.extractFrame.mock.invocationCallOrder[0];
+        const putOrder = put.mock.invocationCallOrder[0];
+        expect(extractOrder).toBeLessThan(putOrder);
+      });
+
+      it('does not delete the edited video it just re-uploaded when re-trimming (S3)', async () => {
+        const put = vi.fn().mockResolvedValue(void 0);
+        const { StorageService } = await import('src/services/storage.service.js');
+        vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+        mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('mp4')]) as any);
+
+        const asset = AssetFactory.from({ type: AssetType.Video })
+          .exif()
+          .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+          .build();
+        const editedKey = StorageCore.getRelativeEditedEncodedVideoPath(asset as any);
+        const withExistingEdit = {
+          ...getForGenerateThumbnail(asset),
+          files: [
+            {
+              type: AssetFileType.EncodedVideo,
+              isEdited: true,
+              path: editedKey,
+              isProgressive: false,
+              isTransparent: false,
+            },
+          ],
+        };
+        mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(withExistingEdit as any);
+        mocks.media.probe.mockResolvedValue({
+          ...videoInfoStub.noAudioStreams,
+          format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+        });
+        mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+        mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+
+        await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+        // The key is deterministic, so the re-trim overwrote the same object. syncFiles must
+        // NOT then queue a delete for it — that would erase what we just uploaded.
+        const deletedFiles = mocks.job.queue.mock.calls
+          .filter(([job]) => job.name === JobName.FileDelete)
+          .flatMap(([job]) => (job as any).data.files as string[]);
+        expect(deletedFiles).not.toContain(editedKey);
+      });
     });
   });
 

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -48,6 +48,40 @@ describe(MediaService.name, () => {
     expect(sut).toBeDefined();
   });
 
+  describe('persistFile', () => {
+    afterEach(() => {
+      // vitest.config.mjs sets no restoreMocks and there are no setupFiles, so a
+      // getWriteBackend spy would leak into every later test in this file and
+      // silently run the disk-mode tests against S3.
+      vi.restoreAllMocks();
+    });
+
+    it('uploads to the write backend and removes the local temp (S3 mode)', async () => {
+      const put = vi.fn().mockResolvedValue(void 0);
+      const stream = makeStream([Buffer.from('data')]);
+      const { StorageService } = await import('src/services/storage.service.js');
+      vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+      mocks.storage.createPlainReadStream.mockReturnValue(stream as any);
+
+      const result = await (sut as any).persistFile('/local/out.jpg', 'thumbs/aa/bb/x.jpg', 'image/jpeg');
+
+      expect(mocks.storage.createPlainReadStream).toHaveBeenCalledWith('/local/out.jpg');
+      expect(put).toHaveBeenCalledWith('thumbs/aa/bb/x.jpg', stream, { contentType: 'image/jpeg' });
+      expect(mocks.storage.unlink).toHaveBeenCalledWith('/local/out.jpg');
+      expect(result).toBe('thumbs/aa/bb/x.jpg');
+    });
+
+    it('returns the local path and deletes nothing (disk mode)', async () => {
+      // StorageService.diskBackend is undefined in this spec file, so getWriteBackend()
+      // returns undefined and persistFile takes its disk branch.
+      const result = await (sut as any).persistFile('/local/out.jpg', 'thumbs/aa/bb/x.jpg', 'image/jpeg');
+
+      expect(result).toBe('/local/out.jpg');
+      expect(mocks.storage.createPlainReadStream).not.toHaveBeenCalled();
+      expect(mocks.storage.unlink).not.toHaveBeenCalled();
+    });
+  });
+
   // TODO these should all become medium tests of either the service or the repository.
   // The entire logic of what to queue lives in the SQL query now
   describe('handleQueueGenerateThumbnails', () => {

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -2046,10 +2046,46 @@ describe(MediaService.name, () => {
 
         // A trim must not clobber the asset's normal preview/thumbnail objects: every
         // image key it writes carries the _edited marker.
+        //
+        // Asserted without a bare for-of over a filtered array: with zero thumbnail uploads
+        // such a loop never executes and the test passes with no assertions at all.
         const putKeys = put.mock.calls.map((call) => call[0] as string);
-        for (const key of putKeys.filter((k) => k.startsWith('thumbs/'))) {
-          expect(key).toContain('_edited');
+        const thumbnailKeys = putKeys.filter((key) => key.startsWith('thumbs/'));
+
+        expect(thumbnailKeys.length).toBeGreaterThanOrEqual(2);
+        expect(thumbnailKeys.every((key) => key.includes('_edited'))).toBe(true);
+
+        // and specifically not the non-edited keys, which belong to the untrimmed asset.
+        // Derived from the edited keys themselves, so this cannot pass by comparing against
+        // a key string that was never a real target.
+        for (const editedKey of thumbnailKeys) {
+          expect(putKeys).not.toContain(editedKey.replace('_edited', ''));
         }
+      });
+
+      it('keeps disk-mode trim paths absolute and uploads nothing (regression guard)', async () => {
+        // No getWriteBackend spy: StorageService.diskBackend is undefined in this spec file,
+        // so persistFile takes its disk branch. Nothing here may become a relative key.
+        const asset = AssetFactory.from({ type: AssetType.Video })
+          .exif()
+          .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+          .build();
+        mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+        mocks.media.probe.mockResolvedValue({
+          ...videoInfoStub.noAudioStreams,
+          format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+        });
+        mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+        mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+
+        await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+        const upserted = mocks.asset.upsertFiles.mock.calls.flatMap(([files]) => files);
+        expect(upserted.length).toBeGreaterThanOrEqual(3); // edited video + preview + thumbnail
+        for (const file of upserted) {
+          expect(file.path.startsWith('/')).toBe(true);
+        }
+        expect(mocks.storage.createPlainReadStream).not.toHaveBeenCalled();
       });
     });
   });

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -1848,7 +1848,7 @@ describe(MediaService.name, () => {
         ...getForGenerateThumbnail(asset),
         edits: [],
       } as any);
-      mocks.asset.getEditedEncodedVideo.mockResolvedValue(undefined);
+      mocks.asset.getEditedEncodedVideo.mockResolvedValue(void 0);
 
       const result = await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
 

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -1794,6 +1794,26 @@ describe(MediaService.name, () => {
       expect(mocks.storage.rename).toHaveBeenCalledWith(trimOutputPath, expect.stringMatching(/_edited\.mp4$/));
     });
 
+    it('cleans up the trimmed video when a post-trim step fails', async () => {
+      const asset = AssetFactory.from({ type: AssetType.Video })
+        .exif()
+        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+        .build();
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+      mocks.media.probe.mockResolvedValue({
+        ...videoInfoStub.noAudioStreams,
+        format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+      });
+      // trim() succeeds, but a later step (frame extraction) throws. The locally-written
+      // trimmed video must not be left behind — on S3 outputPath is a pod-local temp.
+      mocks.media.extractFrame.mockRejectedValue(new Error('bad frame'));
+
+      await expect(sut.handleAssetEditThumbnailGeneration({ id: asset.id })).rejects.toThrow('bad frame');
+
+      const outputPath = StorageCore.getEditedEncodedVideoPath(asset as any);
+      expect(mocks.storage.unlink).toHaveBeenCalledWith(outputPath);
+    });
+
     it('should handle video undo by cleaning up edited files', async () => {
       const asset = AssetFactory.from({ type: AssetType.Video })
         .exif()
@@ -1891,6 +1911,31 @@ describe(MediaService.name, () => {
             expect.objectContaining({ type: AssetFileType.EncodedVideo, isEdited: true, path: editedKey }),
           ]),
         );
+      });
+
+      it('does not commit the trimmed duration when persisting the video fails (S3)', async () => {
+        // Upload fails part-way. The new duration must NOT already be committed, or the DB would
+        // report the trimmed length while getForVideo still serves the full-length original.
+        const put = vi.fn().mockRejectedValue(new Error('s3 down'));
+        const { StorageService } = await import('src/services/storage.service.js');
+        vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+        mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('mp4')]) as any);
+
+        const asset = AssetFactory.from({ type: AssetType.Video })
+          .exif()
+          .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+          .build();
+        mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+        mocks.media.probe.mockResolvedValue({
+          ...videoInfoStub.noAudioStreams,
+          format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+        });
+        mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+        mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+
+        await expect(sut.handleAssetEditThumbnailGeneration({ id: asset.id })).rejects.toThrow('s3 down');
+
+        expect(mocks.asset.update).not.toHaveBeenCalledWith(expect.objectContaining({ duration: expect.anything() }));
       });
 
       it('never uploads the trimmed video over the transcoded original (S3)', async () => {

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -1632,6 +1632,27 @@ describe(MediaService.name, () => {
       expect(mocks.media.trim).toHaveBeenCalledWith(expect.any(String), expect.any(String), 5, 20);
     });
 
+    it('always trims the original, even if an encoded video row is present', async () => {
+      const asset = AssetFactory.from({ type: AssetType.Video })
+        .exif()
+        .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+        .files([{ type: AssetFileType.EncodedVideo, isEdited: false, path: 'encoded-video/owner/ab/cd/video.mp4' }])
+        .build();
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+      mocks.media.probe.mockResolvedValue({
+        ...videoInfoStub.noAudioStreams,
+        format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+      });
+      mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+      mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+
+      await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+      // The encoded video is never a valid ffmpeg input: on S3 its path is a relative key.
+      // The original is both readable and higher quality.
+      expect(mocks.media.trim).toHaveBeenCalledWith(asset.originalPath, expect.any(String), 5, 20);
+    });
+
     it('should update asset duration after trimming', async () => {
       const asset = AssetFactory.from({ type: AssetType.Video })
         .exif()
@@ -1789,6 +1810,49 @@ describe(MediaService.name, () => {
         name: JobName.AssetGenerateThumbnails,
         data: { id: asset.id },
       });
+    });
+
+    it('deletes the edited encoded video when the trim is undone', async () => {
+      const asset = AssetFactory.from({ type: AssetType.Video })
+        .exif()
+        .files([{ type: AssetFileType.Preview, isEdited: true, path: '/data/preview_edited.jpeg' }])
+        .build();
+      // no edits => the undo path
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue({
+        ...getForGenerateThumbnail(asset),
+        edits: [],
+      } as any);
+      mocks.asset.getEditedEncodedVideo.mockResolvedValue({
+        id: 'file-id-1',
+        path: 'encoded-video/owner/ab/cd/video_edited.mp4',
+      });
+
+      await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+      // Without this, getForVideo (isEdited DESC) keeps serving the TRIMMED video after an undo.
+      expect(mocks.asset.deleteFiles).toHaveBeenCalledWith([expect.objectContaining({ id: 'file-id-1' })]);
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.FileDelete,
+        data: { files: ['encoded-video/owner/ab/cd/video_edited.mp4'] },
+      });
+    });
+
+    it('undoes cleanly when there is no edited encoded video', async () => {
+      // No edited files at all — unlike U1, this isolates the assertion to the
+      // getEditedEncodedVideo guard: an unrelated edited Preview row would also
+      // produce a deleteFiles call via syncFiles' own cleanup, which would make
+      // the "no deleteFiles call" assertion below pass/fail for the wrong reason.
+      const asset = AssetFactory.from({ type: AssetType.Video }).exif().build();
+      mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue({
+        ...getForGenerateThumbnail(asset),
+        edits: [],
+      } as any);
+      mocks.asset.getEditedEncodedVideo.mockResolvedValue(undefined);
+
+      const result = await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+      expect(result).toBe(JobStatus.Success);
+      expect(mocks.asset.deleteFiles).not.toHaveBeenCalled();
     });
   });
 

--- a/server/src/services/media.service.spec.ts
+++ b/server/src/services/media.service.spec.ts
@@ -1984,6 +1984,73 @@ describe(MediaService.name, () => {
           .flatMap(([job]) => (job as any).data.files as string[]);
         expect(deletedFiles).not.toContain(editedKey);
       });
+
+      it('uploads the trim thumbnails under _edited keys and stores those keys (S3)', async () => {
+        const put = vi.fn().mockResolvedValue(void 0);
+        const { StorageService } = await import('src/services/storage.service.js');
+        vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+        mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('data')]) as any);
+
+        const asset = AssetFactory.from({ type: AssetType.Video })
+          .exif()
+          .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+          .build();
+        mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+        mocks.media.probe.mockResolvedValue({
+          ...videoInfoStub.noAudioStreams,
+          format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+        });
+        mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+        mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+
+        await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+        const putKeys = put.mock.calls.map((call) => call[0] as string);
+        const thumbnailKeys = putKeys.filter((key) => key.startsWith('thumbs/'));
+
+        // preview + thumbnail at minimum (fullsize too, when the config generates one)
+        expect(thumbnailKeys.length).toBeGreaterThanOrEqual(2);
+        for (const key of thumbnailKeys) {
+          expect(key).toContain('_edited');
+        }
+
+        // and the keys — not local paths — are what get written to the DB
+        const upserted = mocks.asset.upsertFiles.mock.calls.flatMap(([files]) => files as any[]);
+        const upsertedThumbs = upserted.filter((file) => file.type !== AssetFileType.EncodedVideo);
+        expect(upsertedThumbs.length).toBeGreaterThanOrEqual(2);
+        for (const file of upsertedThumbs) {
+          expect(file.path.startsWith('/')).toBe(false);
+          expect(file.path).toContain('_edited');
+        }
+      });
+
+      it('never overwrites the non-edited preview or thumbnail objects (S3)', async () => {
+        const put = vi.fn().mockResolvedValue(void 0);
+        const { StorageService } = await import('src/services/storage.service.js');
+        vi.spyOn(StorageService, 'getWriteBackend').mockReturnValue({ put } as any);
+        mocks.storage.createPlainReadStream.mockReturnValue(makeStream([Buffer.from('data')]) as any);
+
+        const asset = AssetFactory.from({ type: AssetType.Video })
+          .exif()
+          .edit({ action: AssetEditAction.Trim, parameters: { startTime: 5, endTime: 25 } as any })
+          .build();
+        mocks.assetJob.getForGenerateThumbnailJob.mockResolvedValue(getForGenerateThumbnail(asset));
+        mocks.media.probe.mockResolvedValue({
+          ...videoInfoStub.noAudioStreams,
+          format: { ...videoInfoStub.noAudioStreams.format, duration: 20 },
+        });
+        mocks.media.decodeImage.mockResolvedValue({ data: rawBuffer, info: rawInfo as OutputInfo });
+        mocks.media.getImageMetadata.mockResolvedValue({ width: 1920, height: 1080, isTransparent: false });
+
+        await sut.handleAssetEditThumbnailGeneration({ id: asset.id });
+
+        // A trim must not clobber the asset's normal preview/thumbnail objects: every
+        // image key it writes carries the _edited marker.
+        const putKeys = put.mock.calls.map((call) => call[0] as string);
+        for (const key of putKeys.filter((k) => k.startsWith('thumbs/'))) {
+          expect(key).toContain('_edited');
+        }
+      });
     });
   });
 

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -309,7 +309,7 @@ export class MediaService extends BaseService {
     const inputPath = localPath;
 
     // Output path for edited encoded video in EncodedVideo directory
-    const outputPath = StorageCore.getNestedPath(StorageFolder.EncodedVideo, asset.ownerId, `${asset.id}_edited.mp4`);
+    const outputPath = StorageCore.getEditedEncodedVideoPath(asset);
     this.storageCore.ensureFolders(outputPath);
 
     // Trim to a unique temp path and atomically rename into place — ffmpeg writing
@@ -358,11 +358,19 @@ export class MediaService extends BaseService {
     // Clean up temp frame
     await this.storageRepository.unlink(framePath).catch(() => {});
 
+    // persistFile unlinks the local file after uploading, so this must come AFTER
+    // probe() and extractFrame() have read outputPath.
+    const editedVideoPath = await this.persistFile(
+      outputPath,
+      StorageCore.getRelativeEditedEncodedVideoPath(asset),
+      'video/mp4',
+    );
+
     // Sync both edited encoded video and edited thumbnail files
     const editedVideoFile: UpsertFileOptions = {
       assetId: asset.id,
       type: AssetFileType.EncodedVideo,
-      path: outputPath,
+      path: editedVideoPath,
       isEdited: true,
       isProgressive: false,
       isTransparent: false,

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -1,8 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import AsyncLock from 'async-lock';
 import { randomUUID } from 'node:crypto';
-import { createReadStream } from 'node:fs';
-import { unlink } from 'node:fs/promises';
 import { isAbsolute } from 'node:path';
 import { DiskStorageBackend } from 'src/backends/disk-storage.backend';
 import { SystemConfig } from 'src/config';
@@ -89,14 +87,12 @@ export class MediaService extends BaseService {
       return localPath;
     }
     // S3 mode: upload the locally-generated file
-    const stream = createReadStream(localPath);
+    const stream = this.storageRepository.createPlainReadStream(localPath);
     await writeBackend.put(relativeKey, stream, { contentType });
     // Clean up local temp file
-    try {
-      await unlink(localPath);
-    } catch {
+    await this.storageRepository.unlink(localPath).catch(() => {
       /* ignore */
-    }
+    });
     return relativeKey;
   }
 
@@ -314,7 +310,7 @@ export class MediaService extends BaseService {
       await this.storageRepository.rename(trimTempPath, outputPath);
     } catch (error) {
       this.logger.error(`FFmpeg trim failed for asset ${asset.id}: ${error}`);
-      await unlink(trimTempPath).catch(() => {});
+      await this.storageRepository.unlink(trimTempPath).catch(() => {});
       return JobStatus.Failed;
     }
 
@@ -349,7 +345,7 @@ export class MediaService extends BaseService {
     );
 
     // Clean up temp frame
-    await unlink(framePath).catch(() => {});
+    await this.storageRepository.unlink(framePath).catch(() => {});
 
     // Sync both edited encoded video and edited thumbnail files
     const editedVideoFile: UpsertFileOptions = {

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -334,74 +334,92 @@ export class MediaService extends BaseService {
       return JobStatus.Failed;
     }
 
-    // Re-probe for actual duration and update asset
-    const probeResult = await this.mediaRepository.probe(outputPath);
-    const probedDuration = probeResult.format.duration;
-    if (probedDuration && probedDuration > 0) {
-      const newDuration = Math.round(probedDuration * 1000);
-      this.logger.debug(`Trim: updating duration from probe: ${newDuration} (${probedDuration}s)`);
-      await this.assetRepository.update({ id: asset.id, duration: newDuration });
-    } else {
-      // Probe didn't return duration — use calculated duration from trim parameters
-      const calculatedDuration = Math.round((params.endTime - params.startTime) * 1000);
-      this.logger.debug(`Trim: probe duration unavailable, using calculated: ${calculatedDuration}`);
-      await this.assetRepository.update({ id: asset.id, duration: calculatedDuration });
-    }
-
-    // Extract a frame at ~10% into the trimmed video for thumbnail generation.
-    // The path is unique per invocation: the in-process trim lock does not cover
-    // other worker processes, and a fixed name would let one job's cleanup unlink
-    // the frame another job is still reading (issue #743 item 2).
-    const frameTime = duration * 0.1;
+    // outputPath is now a locally-written trimmed video. Every step below can throw; on failure
+    // the catch removes it (and the extracted frame) so an S3-mode error doesn't leak temps on
+    // the pod's local disk — persistFile is what hands ownership of outputPath to the write backend.
+    //
+    // The frame path is unique per invocation: the in-process trim lock does not cover other
+    // worker processes, and a fixed name would let one job's cleanup unlink the frame another
+    // job is still reading (issue #743 item 2).
     const framePath = `${outputPath}.frame-${randomUUID()}.jpg`;
-    await this.mediaRepository.extractFrame(outputPath, framePath, frameTime);
+    try {
+      // Re-probe for the actual trimmed duration. It is committed to the DB only after the
+      // trimmed video is durably persisted (below), so a mid-op failure can't leave the asset's
+      // duration pointing at a video that was never stored.
+      const probeResult = await this.mediaRepository.probe(outputPath);
+      const probedDuration = probeResult.format.duration;
+      let newDuration: number;
+      if (probedDuration && probedDuration > 0) {
+        newDuration = Math.round(probedDuration * 1000);
+        this.logger.debug(`Trim: updating duration from probe: ${newDuration} (${probedDuration}s)`);
+      } else {
+        // Probe didn't return duration — use calculated duration from trim parameters
+        newDuration = Math.round((params.endTime - params.startTime) * 1000);
+        this.logger.debug(`Trim: probe duration unavailable, using calculated: ${newDuration}`);
+      }
 
-    // Generate thumbnail/preview/fullsize from extracted frame
-    const thumbnailResult = await this.generateImageThumbnails(
-      { ...asset, originalPath: framePath },
-      config,
-      true,
-      framePath,
-    );
+      // Extract a frame at ~10% into the trimmed video for thumbnail generation
+      const frameTime = duration * 0.1;
+      await this.mediaRepository.extractFrame(outputPath, framePath, frameTime);
 
-    // Clean up temp frame
-    await this.storageRepository.unlink(framePath).catch(() => {});
+      // Generate thumbnail/preview/fullsize from extracted frame
+      const thumbnailResult = await this.generateImageThumbnails(
+        { ...asset, originalPath: framePath },
+        config,
+        true,
+        framePath,
+      );
 
-    // Persist output files to S3 if needed
-    await this.persistImageFiles(asset, thumbnailResult.files);
+      // Clean up temp frame
+      await this.storageRepository.unlink(framePath).catch(() => {});
 
-    // persistFile unlinks the local file after uploading, so this must come AFTER
-    // probe() and extractFrame() have read outputPath.
-    const editedVideoPath = await this.persistFile(
-      outputPath,
-      StorageCore.getRelativeEditedEncodedVideoPath(asset),
-      'video/mp4',
-    );
+      // Persist output files to S3 if needed
+      await this.persistImageFiles(asset, thumbnailResult.files);
 
-    // Sync both edited encoded video and edited thumbnail files
-    const editedVideoFile: UpsertFileOptions = {
-      assetId: asset.id,
-      type: AssetFileType.EncodedVideo,
-      path: editedVideoPath,
-      isEdited: true,
-      isProgressive: false,
-      isTransparent: false,
-    };
-    const newFiles = [editedVideoFile, ...thumbnailResult.files];
+      // persistFile unlinks the local file after uploading, so this must come AFTER
+      // probe() and extractFrame() have read outputPath.
+      const editedVideoPath = await this.persistFile(
+        outputPath,
+        StorageCore.getRelativeEditedEncodedVideoPath(asset),
+        'video/mp4',
+      );
 
-    await this.syncFiles(
-      asset.files.filter((file) => file.isEdited),
-      newFiles,
-    );
+      // Sync both edited encoded video and edited thumbnail files
+      const editedVideoFile: UpsertFileOptions = {
+        assetId: asset.id,
+        type: AssetFileType.EncodedVideo,
+        path: editedVideoPath,
+        isEdited: true,
+        isProgressive: false,
+        isTransparent: false,
+      };
+      const newFiles = [editedVideoFile, ...thumbnailResult.files];
 
-    if (
-      thumbnailResult.thumbhash &&
-      (!asset.thumbhash || Buffer.compare(asset.thumbhash, thumbnailResult.thumbhash) !== 0)
-    ) {
-      await this.assetRepository.update({ id: asset.id, thumbhash: thumbnailResult.thumbhash });
+      await this.syncFiles(
+        asset.files.filter((file) => file.isEdited),
+        newFiles,
+      );
+
+      // Commit the new duration only now that the trimmed video + files are persisted.
+      await this.assetRepository.update({ id: asset.id, duration: newDuration });
+
+      if (
+        thumbnailResult.thumbhash &&
+        (!asset.thumbhash || Buffer.compare(asset.thumbhash, thumbnailResult.thumbhash) !== 0)
+      ) {
+        await this.assetRepository.update({ id: asset.id, thumbhash: thumbnailResult.thumbhash });
+      }
+
+      return JobStatus.Success;
+    } catch (error) {
+      // A post-trim step failed. Remove the local trimmed video + extracted frame so an S3-mode
+      // failure doesn't leak temps on local disk (persistFile may already have removed outputPath
+      // on the S3 happy path — unlink is best-effort). Rethrow so the job fails and BullMQ retries.
+      this.logger.error(`Trim post-processing failed for asset ${asset.id}: ${error}`);
+      await this.storageRepository.unlink(outputPath).catch(() => {});
+      await this.storageRepository.unlink(framePath).catch(() => {});
+      throw error;
     }
-
-    return JobStatus.Success;
   }
 
   @OnJob({ name: JobName.AssetGenerateThumbnails, queue: QueueName.ThumbnailGeneration })

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -96,6 +96,22 @@ export class MediaService extends BaseService {
     return relativeKey;
   }
 
+  /**
+   * Persists every generated image file and rewrites its path to the stored location.
+   * Every ffmpeg/sharp output path must go through this — forgetting it is how the
+   * trim thumbnails ended up unpersisted on S3 (gh#671).
+   */
+  private async persistImageFiles(asset: ThumbnailAsset, files: UpsertFileOptions[]): Promise<void> {
+    for (const file of files) {
+      const relativeKey = StorageCore.getRelativeImagePath(asset, {
+        fileType: file.type,
+        format: file.path.split('.').pop() as ImageFormat,
+        isEdited: file.isEdited,
+      });
+      file.path = await this.persistFile(file.path, relativeKey, mimeTypes.lookup(file.path));
+    }
+  }
+
   @OnJob({ name: JobName.AssetGenerateThumbnailsQueueAll, queue: QueueName.ThumbnailGeneration })
   async handleQueueGenerateThumbnails({ force }: JobOf<JobName.AssetGenerateThumbnailsQueueAll>): Promise<JobStatus> {
     const config = await this.getConfig({ withCache: true });
@@ -253,14 +269,7 @@ export class MediaService extends BaseService {
 
       // Persist output files to S3 if needed
       if (generated?.files) {
-        for (const file of generated.files) {
-          const relativeKey = StorageCore.getRelativeImagePath(asset, {
-            fileType: file.type,
-            format: file.path.split('.').pop() as ImageFormat,
-            isEdited: file.isEdited,
-          });
-          file.path = await this.persistFile(file.path, relativeKey, mimeTypes.lookup(file.path));
-        }
+        await this.persistImageFiles(asset, generated.files);
       }
 
       await this.syncFiles(
@@ -358,6 +367,9 @@ export class MediaService extends BaseService {
     // Clean up temp frame
     await this.storageRepository.unlink(framePath).catch(() => {});
 
+    // Persist output files to S3 if needed
+    await this.persistImageFiles(asset, thumbnailResult.files);
+
     // persistFile unlinks the local file after uploading, so this must come AFTER
     // probe() and extractFrame() have read outputPath.
     const editedVideoPath = await this.persistFile(
@@ -424,25 +436,11 @@ export class MediaService extends BaseService {
       }
 
       // Persist output files to S3 if needed
-      for (const file of generated.files) {
-        const relativeKey = StorageCore.getRelativeImagePath(asset, {
-          fileType: file.type,
-          format: file.path.split('.').pop() as ImageFormat,
-          isEdited: file.isEdited,
-        });
-        file.path = await this.persistFile(file.path, relativeKey, mimeTypes.lookup(file.path));
-      }
+      await this.persistImageFiles(asset, generated.files);
 
       const editedGenerated = await this.generateEditedThumbnails(asset, config, localPath);
       if (editedGenerated) {
-        for (const file of editedGenerated.files) {
-          const relativeKey = StorageCore.getRelativeImagePath(asset, {
-            fileType: file.type,
-            format: file.path.split('.').pop() as ImageFormat,
-            isEdited: file.isEdited,
-          });
-          file.path = await this.persistFile(file.path, relativeKey, mimeTypes.lookup(file.path));
-        }
+        await this.persistImageFiles(asset, editedGenerated.files);
         generated.files.push(...editedGenerated.files);
       }
 

--- a/server/src/services/media.service.ts
+++ b/server/src/services/media.service.ts
@@ -235,6 +235,16 @@ export class MediaService extends BaseService {
           asset.files.filter((file) => file.isEdited),
           [],
         );
+
+        // asset.files never contains EncodedVideo rows (getForGenerateThumbnailJob only loads
+        // thumbnail/preview/fullsize), so syncFiles cannot see the trimmed video. Without this,
+        // getForVideo (isEdited DESC) would keep serving the trimmed video after an undo.
+        const editedVideo = await this.assetRepository.getEditedEncodedVideo(asset.id);
+        if (editedVideo) {
+          await this.assetRepository.deleteFiles([editedVideo]);
+          await this.jobRepository.queue({ name: JobName.FileDelete, data: { files: [editedVideo.path] } });
+        }
+
         await this.jobRepository.queue({ name: JobName.AssetGenerateThumbnails, data: { id } });
         return JobStatus.Success;
       }
@@ -293,9 +303,10 @@ export class MediaService extends BaseService {
     const params = trimEdit.parameters as TrimParameters & { originalDuration: number };
     const duration = params.endTime - params.startTime;
 
-    // Select input: prefer non-edited encoded video, fall back to original
-    const existingEncoded = asset.files.find((f) => f.type === AssetFileType.EncodedVideo && !f.isEdited);
-    const inputPath = existingEncoded?.path || localPath;
+    // ffmpeg always reads the original. The asset's encoded video is not a candidate:
+    // getForGenerateThumbnailJob never loads EncodedVideo rows (asset-job.repository.ts),
+    // and on S3 its path would be a relative key ffmpeg cannot open anyway.
+    const inputPath = localPath;
 
     // Output path for edited encoded video in EncodedVideo directory
     const outputPath = StorageCore.getNestedPath(StorageFolder.EncodedVideo, asset.ownerId, `${asset.id}_edited.mp4`);

--- a/server/test/repositories/asset.repository.mock.ts
+++ b/server/test/repositories/asset.repository.mock.ts
@@ -59,6 +59,7 @@ export const newAssetRepositoryMock = (): Mocked<RepositoryInterface<AssetReposi
     getForOriginals: vitest.fn(),
     getForThumbnail: vitest.fn(),
     getForVideo: vitest.fn(),
+    getEditedEncodedVideo: vitest.fn(),
     getForEdit: vitest.fn(),
     getForOcr: vitest.fn(),
     getForMetadataExtractionTags: vitest.fn(),

--- a/server/test/repositories/storage.repository.mock.ts
+++ b/server/test/repositories/storage.repository.mock.ts
@@ -60,7 +60,7 @@ export const newStorageRepositoryMock = (): Mocked<RepositoryInterface<StorageRe
     createOrOverwriteFile: vitest.fn(),
     existsSync: vitest.fn(),
     overwriteFile: vitest.fn(),
-    unlink: vitest.fn(),
+    unlink: vitest.fn().mockResolvedValue(undefined),
     unlinkDir: vitest.fn().mockResolvedValue(true),
     removeEmptyDirs: vitest.fn(),
     checkFileExists: vitest.fn(),

--- a/server/test/repositories/storage.repository.mock.ts
+++ b/server/test/repositories/storage.repository.mock.ts
@@ -60,7 +60,7 @@ export const newStorageRepositoryMock = (): Mocked<RepositoryInterface<StorageRe
     createOrOverwriteFile: vitest.fn(),
     existsSync: vitest.fn(),
     overwriteFile: vitest.fn(),
-    unlink: vitest.fn().mockResolvedValue(undefined),
+    unlink: vitest.fn().mockResolvedValue(void 0),
     unlinkDir: vitest.fn().mockResolvedValue(true),
     removeEmptyDirs: vitest.fn(),
     checkFileExists: vitest.fn(),


### PR DESCRIPTION
Closes #671.

## What was broken

Three layers. The issue describes only the middle one — and describes it partly wrongly. Layers 1 and 3 were found by *running* the code, not reading it.

**Layer 1 — the feature was fenced off at the API.** `AssetService.editAsset` rejected any trim whose asset was not an `isImmichPath`, which is every S3-backed asset (their originals are relative keys). `PUT /assets/:id/edits` returned `400 "Video trimming is not available for cloud-stored videos"` before a job was ever queued. The web editor has no matching client-side gate, so S3 users saw the trim tool, hit save, and got a refusal. Nobody had lost a trimmed video, because nobody could trim.

**Layer 2 — `handleVideoTrim` was broken for S3.** It never persisted the trimmed video and never persisted the trim thumbnails, so both existed only on the pod's local disk with absolute paths in the DB — surviving until the pod was replaced, then 404ing forever.

The issue's third defect ("S3 key fed to ffmpeg → ENOENT") **does not exist**: `getForGenerateThumbnailJob` never loads `EncodedVideo` rows, so the `existingEncoded` branch is unreachable and ffmpeg always read the original. Verified against a real S3 server with a transcoded video present — the trim succeeded. The dead branch is deleted rather than "fixed".

**Layer 3 — undo never restored the original video, on disk installs too.** Same root cause: `asset.files` cannot contain `EncodedVideo` rows, so the undo path's `syncFiles` could not see the trimmed video and left its row behind. `getForVideo` orders `isEdited DESC`, so after undoing a trim, playback kept serving the trimmed clip **permanently**. Nothing to do with S3; live on `main` today. Confirmed by running trim-then-undo against a real server and diffing `asset_file`.

## What changed

- The API guard now rejects only absolute paths **outside** the media location (external-library videos), letting S3 assets through.
- The pre-flight audio-only probe runs inside the HTTP request, so it must not download the video. New `StorageBackend.getReadableUrl` returns an absolute path (disk) or a **presigned URL** (S3), and ffprobe reads just the header. Verified end to end: ffprobe against a presigned MinIO URL returns `codec_type=video, duration=3.0` without fetching the file.
- `handleVideoTrim` persists the trimmed video under a new `_edited` key. This needed its own `StorageCore` helper: `getRelativeEncodedVideoPath` returns the **non-edited** key, so persisting with it would have silently overwritten the asset's transcoded original in the bucket.
- The persist loop was copy-pasted three times and missing from the trim path — which is exactly how this was missed. It is now one `persistImageFiles` helper used by all four image output paths, so persisting is structural rather than remembered.
- Undo now deletes the edited encoded video row and its object.

## Tests

15 unit tests across `media.service`, `asset.service`, `storage.core` and both storage backends. Every guard test — one that passes on arrival and therefore proves nothing until it has failed once — was **mutation-proved**: the mutation is named in the spec, applied, watched fail, and reverted. Two examples that earned their keep:

- The ordering invariant (`persistFile` unlinks the local file, so the upload must happen *after* `extractFrame` reads it) — moving the call above `extractFrame` makes it fail (`expected 1027 to be less than 1022`), while every other test still passes. That reordering is the natural-looking mistake.
- Two tests that *looked* like coverage but could never fail (an `expect` inside a `for...of` over an empty array; disk-mode tests asserting `expect.any(String)` for paths) were found and rewritten, then mutation-proved.

**New `video-trim-s3` e2e phase** in the MinIO storage-migration harness: uploads a video, forces a transcode, trims it, and asserts the edited video and thumbnails land in the bucket under `_edited` keys, the transcoded original is byte-identical afterwards, nothing is left on local disk, playback serves the trimmed video, and undo removes the edited objects. It failed against unfixed code with the exact 400 above, passes now, and was run three consecutive times before being wired into CI. Full harness green, including `migrate-to-disk` after it.

That phase closes the gap the harness README itself listed — *"No video asset upload (transcoding too slow/unreliable in e2e)"* — which is the hole #671 came through.

## Notes

- This **enables a feature on S3 installs** (trim was previously unavailable there) and **fixes undo on all installs**, so it wants a release-note line.
- Fix-forward only: no S3 install ever produced a broken trim, because the guard blocked it. Nothing to repair.
- #741 (realtime HLS ignores the trim) is a follow-up that depends on this — it needs the trimmed video to actually exist in the bucket.
- Unrelated: `activity.controller.spec.ts` has a pre-existing flake (HTTP parse error under the worker pool) that reproduces on an unmodified tree. Not touched here; worth its own issue.

Spec: `docs/superpowers/specs/2026-07-12-video-trim-s3-design.md`