### PR TITLE
fix(release): list Gallery commits in the release notes, not just upstream

### DIFF
--- a/.github/workflows/gallery-release-server-only.yml
+++ b/.github/workflows/gallery-release-server-only.yml
@@ -393,28 +393,59 @@ jobs:
           notes="Based on [Immich v${upstream_version}](https://github.com/immich-app/immich/releases/tag/v${upstream_version})"
 
           if [[ -n "$prev_tag" ]]; then
-            all_commits=$(git log --pretty=format:'%s' "${prev_tag}..${SHA}" 2>/dev/null)
+            # Upstream stamps each of its own releases with a `chore: version vX.Y.Z`
+            # commit; the most recent one reachable from a ref is that release's
+            # upstream base, and everything above it is fork work. Diffing the two
+            # bases rather than the raw prev_tag..SHA range is what keeps an upstream
+            # rebase — which rewrites every fork commit's SHA — from re-listing fork
+            # commits that already shipped in the previous release.
+            base_new=$(git log --format=%H --grep='^chore: version v' -1 "$SHA" || true)
+            base_old=$(git log --format=%H --grep='^chore: version v' -1 "$prev_tag" || true)
 
-            gallery_commits=$(echo "$all_commits" | while IFS= read -r line; do
-              [[ -z "$line" ]] && continue
-              pr_num=$(echo "$line" | grep -oP '\(#\K[0-9]+(?=\))' | head -1)
-              if [[ -z "$pr_num" || "$pr_num" -lt 1000 ]]; then
-                echo "- $line"
+            if [[ -n "$base_new" && -n "$base_old" ]]; then
+              shipped=$(mktemp)
+              git log --pretty=format:'%s' "${base_old}..${prev_tag}" > "$shipped"
+              if [[ -s "$shipped" ]]; then
+                gallery_all=$(git log --pretty=format:'%s' "${base_new}..${SHA}" | grep -Fxv -f "$shipped" || true)
+              else
+                gallery_all=$(git log --pretty=format:'%s' "${base_new}..${SHA}" || true)
               fi
-            done)
+              rm -f "$shipped"
 
-            upstream_commits=$(echo "$all_commits" | while IFS= read -r line; do
-              [[ -z "$line" ]] && continue
-              pr_num=$(echo "$line" | grep -oP '\(#\K[0-9]+(?=\))' | head -1)
-              if [[ -n "$pr_num" && "$pr_num" -ge 1000 ]]; then
-                echo "- $line"
-              fi
-            done)
+              upstream_commits=$(git log --pretty=format:'- %s' "${base_old}..${base_new}" || true)
+            else
+              # Fallback if upstream ever changes its release-commit convention:
+              # split the raw range by PR number (fork PRs < 1000, upstream >= 1000).
+              all_commits=$(git log --pretty=format:'%s' "${prev_tag}..${SHA}")
+              gallery_all=$(echo "$all_commits" | awk '{ if (match($0, /\(#[0-9]+\)/)) { n = substr($0, RSTART+2, RLENGTH-3) + 0; if (n >= 1000) next } print }')
+              upstream_commits=$(echo "$all_commits" | awk '{ if (match($0, /\(#[0-9]+\)/)) { n = substr($0, RSTART+2, RLENGTH-3) + 0; if (n >= 1000) print "- " $0 } }')
+            fi
 
+            # A commit reverted within the same range never shipped — drop both it
+            # and its revert, so we never advertise a feature that isn't in the build.
+            gallery_all=$(echo "$gallery_all" | awk '
+              { lines[NR] = $0
+                if (match($0, /^Revert "/)) {
+                  inner = substr($0, 9, length($0) - 9)
+                  reverted[inner] = 1
+                  skip[NR] = 1
+                }
+              }
+              END { for (i = 1; i <= NR; i++) if (!skip[i] && !(lines[i] in reverted)) print lines[i] }
+            ')
+
+            highlights=$(echo "$gallery_all" | grep -E '^(feat|fix|perf)' | sed 's/^/- /' || true)
+            other=$(echo "$gallery_all" | grep -vE '^(feat|fix|perf)' | sed 's/^/- /' || true)
+
+            # Gallery's own changes lead; upstream's go in a collapsed section.
+            if [[ -n "$highlights" ]]; then
+              printf -v notes '%s\n\n## Gallery changes\n\n%s' "$notes" "$highlights"
+            fi
+            if [[ -n "$other" ]]; then
+              printf -v notes '%s\n\n<details>\n<summary>Other Gallery changes</summary>\n\n%s\n\n</details>' "$notes" "$other"
+            fi
             if [[ -n "$upstream_commits" ]]; then
               printf -v notes '%s\n\n<details>\n<summary>Upstream commits</summary>\n\n%s\n\n</details>' "$notes" "$upstream_commits"
-            elif [[ -n "$gallery_commits" ]]; then
-              printf -v notes '%s\n\n## Changes\n\n%s' "$notes" "$gallery_commits"
             fi
           fi
 


### PR DESCRIPTION
## Problem

The v5.1.0 release notes credited **only Immich** — not one Gallery commit appeared. `#707`, `#722`/`#723`, `#736`, `#748`, `#758`, `#761`, `#762` were all missing.

Two bugs in the notes builder:

1. **The `if/elif` discarded fork commits.** `gallery_commits` and `upstream_commits` were both computed, but rendered with `if [[ -n "$upstream_commits" ]] … elif [[ -n "$gallery_commits" ]]`. The Gallery list was therefore only ever emitted when there were *zero* upstream commits. Any release after an upstream rebase takes the first branch and throws the fork list away.

2. **The classification broke across a rebase.** It split the raw `prev_tag..SHA` range by PR number (fork < 1000, upstream >= 1000). But a rebase rewrites every fork commit's SHA, so the ~890 fork commits already shipped in v5.0.0 reappeared in the range — and upstream commits whose subject carries no `(#NNNN)` ref got misfiled as fork work. Fixing only the `if/elif` would have published a 904-entry "Gallery" list.

## Fix

Split on the upstream release-commit boundary: upstream stamps each release with `chore: version vX.Y.Z`, so the most recent one reachable from a ref is that release's upstream base, and everything above it is fork work. Fork commits already shipped above the *previous* release's base are subtracted by subject, which is what neutralises the rebase SHA rewrite.

Both sections now render, Gallery first, with upstream collapsed. Revert pairs are dropped, so a feature added and reverted in the same range (e.g. `feat(spaces): in-space album management (#749)`) isn't advertised as shipped when it isn't.

A fallback to the old PR-number split remains if upstream ever changes its release-commit convention.

## Verification

Ran the workflow's own step script against the real v5.0.0 → v5.1.0 range:

| Section | Old code | New code |
|---|---|---|
| Gallery changes | 0 | 12 |
| Other Gallery changes | 0 | 7 |
| Upstream commits | 61 | 55 |

The 12 are exactly the real user-facing fork commits. Upstream drops from 61 to 55 because fork rebase-fixups whose subjects cite upstream PR numbers (e.g. `fix(rolling): … (#29267)`) were previously misfiled as upstream.

The [v5.1.0 release notes](https://github.com/open-noodle/gallery/releases/tag/v5.1.0) have already been corrected in place with this generator's output.