### PR TITLE
fix(web): asset viewer stuck stale/blurry after reopen — patch Svelte batch scheduler

### DIFF
--- a/e2e/src/specs/web/asset-viewer/reopen-stale-detail.e2e-spec.ts
+++ b/e2e/src/specs/web/asset-viewer/reopen-stale-detail.e2e-spec.ts
@@ -1,0 +1,105 @@
+import { AssetMediaResponseDto, LoginResponseDto, updateAsset } from '@immich/sdk';
+import { expect, test } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { asBearerAuth, testAssetDir, utils } from 'src/utils';
+
+// Regression test for the stale/unreactive asset viewer on reopen (reported against v5.1.0):
+// open a photo with tagged people, go back to the timeline, open a photo without people —
+// the detail panel kept showing the previous photo's people, and the map/tags sections and
+// full-resolution image never loaded until a manual page refresh. Root cause was a Svelte
+// batch-scheduler edge (see patches/svelte@5.56.3.patch) that left the remounted viewer
+// subtree permanently unreactive.
+test.describe('asset viewer reopen', () => {
+  let admin: LoginResponseDto;
+  let assetWithPerson: AssetMediaResponseDto;
+  let assetWithLocation: AssetMediaResponseDto;
+
+  const waitForThumbnail = async (id: string) => {
+    await expect
+      .poll(async () => {
+        const asset = await utils.getAssetInfo(admin.accessToken, id);
+        return asset.thumbhash;
+      })
+      .not.toBeNull();
+  };
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+
+    assetWithPerson = await utils.createAsset(admin.accessToken, {
+      assetData: {
+        bytes: readFileSync(`${testAssetDir}/albums/nature/tanners_ridge.jpg`),
+        filename: 'tanners_ridge.jpg',
+      },
+    });
+    assetWithLocation = await utils.createAsset(admin.accessToken, {
+      assetData: {
+        bytes: readFileSync(`${testAssetDir}/albums/nature/prairie_falcon.jpg`),
+        filename: 'prairie_falcon.jpg',
+      },
+    });
+
+    // wait for thumbnails so both assets are rendered in the timeline grid
+    await waitForThumbnail(assetWithPerson.id);
+    await waitForThumbnail(assetWithLocation.id);
+
+    const person = await utils.createPerson(admin.accessToken, { name: 'Stale Carryover Person' });
+    await utils.createFace({ assetId: assetWithPerson.id, personId: person.id });
+
+    await updateAsset(
+      { id: assetWithLocation.id, updateAssetDto: { latitude: 48.853_41, longitude: 2.3488 } },
+      { headers: asBearerAuth(admin.accessToken) },
+    );
+    const tags = await utils.upsertTags(admin.accessToken, ['reopen-tag']);
+    await utils.tagAssets(admin.accessToken, tags[0].id, [assetWithLocation.id]);
+    await utils.updateMyPreferences(admin.accessToken, { tags: { enabled: true } });
+  });
+
+  test('reopening the viewer shows the new asset, not the previous one', async ({ context, page }) => {
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('/photos');
+    await page.waitForSelector('[data-thumbnail-focus-container]');
+
+    // open the asset with a tagged person and confirm the person renders
+    await page.locator(`[data-thumbnail-focus-container][data-asset="${assetWithPerson.id}"]`).click();
+    await page.waitForSelector('#immich-asset-viewer');
+    await page.keyboard.press('i');
+    await expect(page.locator('#detail-panel')).toContainText('Stale Carryover Person');
+
+    // go back to the timeline
+    await page.goBack();
+    await page.waitForSelector('[data-thumbnail-focus-container]');
+    await expect(page.locator('#immich-asset-viewer')).toHaveCount(0);
+
+    // reopen the viewer on the asset without people
+    await page.locator(`[data-thumbnail-focus-container][data-asset="${assetWithLocation.id}"]`).click();
+    await page.waitForSelector('#immich-asset-viewer');
+    await expect(page.locator('#detail-panel')).toBeVisible();
+
+    // people must clear, and the location map + tags of the new asset must render —
+    // all three stayed stale/missing until a manual refresh before the fix
+    await expect(page.locator('#detail-panel')).not.toContainText('Stale Carryover Person');
+    await expect(page.locator('#detail-panel .maplibregl-map')).toBeVisible();
+    await expect(page.locator('[data-testid="detail-panel-tags"]')).toContainText('reopen-tag');
+  });
+
+  test('arrow navigation between assets updates the detail panel', async ({ context, page }) => {
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('/photos');
+    await page.waitForSelector('[data-thumbnail-focus-container]');
+
+    await page.locator(`[data-thumbnail-focus-container][data-asset="${assetWithPerson.id}"]`).click();
+    await page.waitForSelector('#immich-asset-viewer');
+    await page.keyboard.press('i');
+    await expect(page.locator('#detail-panel')).toContainText('Stale Carryover Person');
+
+    // navigate to the older asset inside the viewer
+    await page.keyboard.press('ArrowRight');
+    await expect(page).toHaveURL(new RegExp(assetWithLocation.id));
+
+    await expect(page.locator('#detail-panel')).not.toContainText('Stale Carryover Person');
+    await expect(page.locator('#detail-panel .maplibregl-map')).toBeVisible();
+  });
+});

--- a/patches/svelte@5.56.3.patch
+++ b/patches/svelte@5.56.3.patch
@@ -1,0 +1,36 @@
+diff --git a/src/internal/client/reactivity/batch.js b/src/internal/client/reactivity/batch.js
+index 7d14b80519a4a2ca5e8913ed05dc4bf3a6a64447..35263db2087e06a32d3bb2dc0df63efcd9ae63f7 100644
+--- a/src/internal/client/reactivity/batch.js
++++ b/src/internal/client/reactivity/batch.js
+@@ -959,16 +959,25 @@ export class Batch {
+ 			}
+ 
+ 			if ((flags & (ROOT_EFFECT | BRANCH_EFFECT)) !== 0) {
+-				if ((flags & CLEAN) === 0) {
+-					// branch is already dirty, bail
+-					return;
++				// Gallery patch (fix: stale/unreactive asset viewer on reopen): do NOT bail when an
++				// ancestor branch is already not-CLEAN. The early bail assumes that branch is
++				// registered on a root path of some live batch, but interleaved traversals (e.g.
++				// closing and reopening the asset viewer during navigation) can reset intermediate
++				// branches to CLEAN without executing the dirty descendants, leaving effects
++				// permanently DIRTY-but-unscheduled: mark_reactions never re-schedules an
++				// already-DIRTY effect and batch traversal skips CLEAN branches, so the whole
++				// subtree stops reacting until a full page reload. Walking the entire ancestor
++				// chain and pushing the deduplicated root restores the invariant that a scheduled
++				// effect always sits under a not-CLEAN path from a queued root.
++				if ((flags & CLEAN) !== 0) {
++					e.f ^= CLEAN;
+ 				}
+-
+-				e.f ^= CLEAN;
+ 			}
+ 		}
+ 
+-		this.#roots.push(e);
++		if (!this.#roots.includes(e)) {
++			this.#roots.push(e);
++		}
+ 	}
+ 
+ 	#unlink() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ pnpmfileChecksum: sha256-un98do36L0wZyqsjcLozQ3YUadCAn2yz5bXcBbOuyDA=
 
 patchedDependencies:
   '@immich/ui@0.81.1': 7c8fa3353faeaff394133721d78504acddee05537acfdba49728a2853b5fc33d
+  svelte@5.56.3: c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7
 
 importers:
 
@@ -820,7 +821,7 @@ importers:
         version: link:../packages/sdk
       '@immich/ui':
         specifier: ^0.81.1
-        version: 0.81.1(patch_hash=7c8fa3353faeaff394133721d78504acddee05537acfdba49728a2853b5fc33d)(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))
+        version: 0.81.1(patch_hash=7c8fa3353faeaff394133721d78504acddee05537acfdba49728a2853b5fc33d)(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))
       '@mapbox/mapbox-gl-rtl-text':
         specifier: 0.4.0
         version: 0.4.0
@@ -859,10 +860,10 @@ importers:
         version: 0.42.0
       '@zoom-image/svelte':
         specifier: ^0.3.0
-        version: 0.3.9(svelte@5.56.3(@typescript-eslint/types@8.59.4))
+        version: 0.3.9(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))
       bits-ui:
         specifier: ^2.15.7
-        version: 2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))
+        version: 2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))
       dom-to-image:
         specifier: ^2.6.0
         version: 2.6.0
@@ -922,16 +923,16 @@ importers:
         version: 5.2.2
       svelte-i18n:
         specifier: ^4.0.1
-        version: 4.0.1(svelte@5.56.3(@typescript-eslint/types@8.59.4))
+        version: 4.0.1(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))
       svelte-jsoneditor:
         specifier: ^3.10.0
-        version: 3.12.0(svelte@5.56.3(@typescript-eslint/types@8.59.4))
+        version: 3.12.0(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))
       svelte-maplibre:
         specifier: ^1.2.5
-        version: 1.3.0(svelte@5.56.3(@typescript-eslint/types@8.59.4))
+        version: 1.3.0(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))
       svelte-persisted-store:
         specifier: ^0.12.0
-        version: 0.12.0(svelte@5.56.3(@typescript-eslint/types@8.59.4))
+        version: 0.12.0(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))
       tabbable:
         specifier: ^6.2.0
         version: 6.4.0
@@ -965,16 +966,16 @@ importers:
         version: 3.1.2
       '@sveltejs/adapter-static':
         specifier: ^3.0.8
-        version: 3.0.10(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))
+        version: 3.0.10(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))
       '@sveltejs/enhanced-img':
         specifier: ^0.10.4
-        version: 0.10.4(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(rollup@4.60.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 0.10.4(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(rollup@4.60.4)(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
       '@sveltejs/kit':
         specifier: ^2.56.1
-        version: 2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: 7.1.2
-        version: 7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.3.0(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
@@ -983,13 +984,13 @@ importers:
         version: 6.9.1
       '@testing-library/svelte':
         specifier: ^5.2.8
-        version: 5.3.1(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)
+        version: 5.3.1(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^6.0.2
-        version: 6.0.2(prettier-plugin-svelte@4.1.0(prettier@3.8.3)(svelte@5.56.3(@typescript-eslint/types@8.59.4)))(prettier@3.8.3)(svelte@5.56.3(@typescript-eslint/types@8.59.4))
+        version: 6.0.2(prettier-plugin-svelte@4.1.0(prettier@3.8.3)(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)))(prettier@3.8.3)(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))
       '@types/chromecast-caf-sender':
         specifier: ^1.0.11
         version: 1.0.11
@@ -1028,7 +1029,7 @@ importers:
         version: 7.0.2(eslint@10.4.0(jiti@2.7.0))
       eslint-plugin-svelte:
         specifier: ^3.12.4
-        version: 3.17.1(eslint@10.4.0(jiti@2.7.0))(svelte@5.56.3(@typescript-eslint/types@8.59.4))
+        version: 3.17.1(eslint@10.4.0(jiti@2.7.0))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))
       eslint-plugin-unicorn:
         specifier: ^64.0.0
         version: 64.0.0(eslint@10.4.0(jiti@2.7.0))
@@ -1046,19 +1047,19 @@ importers:
         version: 4.2.0(prettier@3.8.3)
       prettier-plugin-svelte:
         specifier: ^4.0.0
-        version: 4.1.0(prettier@3.8.3)(svelte@5.56.3(@typescript-eslint/types@8.59.4))
+        version: 4.1.0(prettier@3.8.3)(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))
       rollup-plugin-visualizer:
         specifier: ^7.0.0
         version: 7.0.1(rolldown@1.0.1)(rollup@4.60.4)
       svelte:
         specifier: 5.56.3
-        version: 5.56.3(@typescript-eslint/types@8.59.4)
+        version: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
       svelte-check:
         specifier: ^4.4.6
-        version: 4.4.8(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.3)
+        version: 4.4.8(picomatch@4.0.4)(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(typescript@6.0.3)
       svelte-eslint-parser:
         specifier: ^1.3.3
-        version: 1.6.1(svelte@5.56.3(@typescript-eslint/types@8.59.4))
+        version: 1.6.1(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))
       tailwindcss:
         specifier: ^4.2.4
         version: 4.3.0
@@ -16892,15 +16893,15 @@ snapshots:
       pg-connection-string: 2.13.0
       postgres: 3.4.9
 
-  '@immich/ui@0.81.1(patch_hash=7c8fa3353faeaff394133721d78504acddee05537acfdba49728a2853b5fc33d)(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))':
+  '@immich/ui@0.81.1(patch_hash=7c8fa3353faeaff394133721d78504acddee05537acfdba49728a2853b5fc33d)(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))':
     dependencies:
       '@internationalized/date': 3.12.2
       '@mdi/js': 7.4.47
-      '@sveltejs/kit': 2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
-      bits-ui: 2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))
+      '@sveltejs/kit': 2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
+      bits-ui: 2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))
       luxon: 3.7.2
       simple-icons: 16.20.0
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
       svelte-highlight: 7.9.0
       tailwind-merge: 3.6.0
       tailwind-variants: 3.2.2(tailwind-merge@3.6.0)(tailwindcss@4.3.0)
@@ -18838,28 +18839,28 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))':
     dependencies:
-      '@sveltejs/kit': 2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
+      '@sveltejs/kit': 2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
 
-  '@sveltejs/enhanced-img@0.10.4(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(rollup@4.60.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))':
+  '@sveltejs/enhanced-img@0.10.4(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(rollup@4.60.4)(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
       magic-string: 0.30.21
       sharp: 0.34.5
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
-      svelte-parse-markup: 0.1.5(svelte@5.56.3(@typescript-eslint/types@8.59.4))
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
+      svelte-parse-markup: 0.1.5(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))
       vite: 8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
       vite-imagetools: 9.0.3(rollup@4.60.4)
       zimmerframe: 1.1.4
     transitivePeerDependencies:
       - rollup
 
-  '@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))':
+  '@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
+      '@sveltejs/vite-plugin-svelte': 7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.6.0
@@ -18870,18 +18871,18 @@ snapshots:
       mrmime: 2.0.1
       set-cookie-parser: 3.1.0
       sirv: 3.0.2
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
       vite: 8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       typescript: 6.0.3
 
-  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))':
+  '@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
       vite: 8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
 
@@ -19135,15 +19136,15 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/svelte-core@1.0.0(svelte@5.56.3(@typescript-eslint/types@8.59.4))':
+  '@testing-library/svelte-core@1.0.0(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))':
     dependencies:
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
 
-  '@testing-library/svelte@5.3.1(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)':
+  '@testing-library/svelte@5.3.1(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)':
     dependencies:
       '@testing-library/dom': 10.4.1
-      '@testing-library/svelte-core': 1.0.0(svelte@5.56.3(@typescript-eslint/types@8.59.4))
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
+      '@testing-library/svelte-core': 1.0.0(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
     optionalDependencies:
       vite: 8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
       vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@26.1.0(canvas@3.2.3))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
@@ -19161,7 +19162,7 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@trivago/prettier-plugin-sort-imports@6.0.2(prettier-plugin-svelte@4.1.0(prettier@3.8.3)(svelte@5.56.3(@typescript-eslint/types@8.59.4)))(prettier@3.8.3)(svelte@5.56.3(@typescript-eslint/types@8.59.4))':
+  '@trivago/prettier-plugin-sort-imports@6.0.2(prettier-plugin-svelte@4.1.0(prettier@3.8.3)(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)))(prettier@3.8.3)(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))':
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/parser': 7.29.3
@@ -19173,8 +19174,8 @@ snapshots:
       parse-imports-exports: 0.2.4
       prettier: 3.8.3
     optionalDependencies:
-      prettier-plugin-svelte: 4.1.0(prettier@3.8.3)(svelte@5.56.3(@typescript-eslint/types@8.59.4))
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
+      prettier-plugin-svelte: 4.1.0(prettier@3.8.3)(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -20069,10 +20070,10 @@ snapshots:
     dependencies:
       '@namnode/store': 0.1.0
 
-  '@zoom-image/svelte@0.3.9(svelte@5.56.3(@typescript-eslint/types@8.59.4))':
+  '@zoom-image/svelte@0.3.9(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))':
     dependencies:
       '@zoom-image/core': 0.42.0
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
 
   abbrev@1.1.1: {}
 
@@ -20449,15 +20450,15 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  bits-ui@2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4)):
+  bits-ui@2.18.1(@internationalized/date@3.12.2)(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)):
     dependencies:
       '@floating-ui/core': 1.7.5
       '@floating-ui/dom': 1.7.6
       '@internationalized/date': 3.12.2
       esm-env: 1.2.2
-      runed: 0.35.1(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
-      svelte-toolbelt: 0.10.6(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))
+      runed: 0.35.1(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
+      svelte-toolbelt: 0.10.6(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))
       tabbable: 6.4.0
     transitivePeerDependencies:
       - '@sveltejs/kit'
@@ -21997,7 +21998,7 @@ snapshots:
       '@types/eslint': 9.6.1
       eslint-config-prettier: 10.1.8(eslint@10.4.0(jiti@2.7.0))
 
-  eslint-plugin-svelte@3.17.1(eslint@10.4.0(jiti@2.7.0))(svelte@5.56.3(@typescript-eslint/types@8.59.4)):
+  eslint-plugin-svelte@3.17.1(eslint@10.4.0(jiti@2.7.0))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.7.0))
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -22009,9 +22010,9 @@ snapshots:
       postcss-load-config: 3.1.4(postcss@8.5.15)
       postcss-safe-parser: 7.0.1(postcss@8.5.15)
       semver: 7.8.1
-      svelte-eslint-parser: 1.6.1(svelte@5.56.3(@typescript-eslint/types@8.59.4))
+      svelte-eslint-parser: 1.6.1(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))
     optionalDependencies:
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
     transitivePeerDependencies:
       - ts-node
 
@@ -25664,10 +25665,10 @@ snapshots:
     dependencies:
       prettier: 3.8.3
 
-  prettier-plugin-svelte@4.1.0(prettier@3.8.3)(svelte@5.56.3(@typescript-eslint/types@8.59.4)):
+  prettier-plugin-svelte@4.1.0(prettier@3.8.3)(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)):
     dependencies:
       prettier: 3.8.3
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
 
   prettier@3.8.3: {}
 
@@ -26280,14 +26281,14 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  runed@0.35.1(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4)):
+  runed@0.35.1(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)):
     dependencies:
       dequal: 2.0.3
       esm-env: 1.2.2
       lz-string: 1.5.0
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
     optionalDependencies:
-      '@sveltejs/kit': 2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
+      '@sveltejs/kit': 2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
 
   rw@1.3.3: {}
 
@@ -26890,23 +26891,23 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-awesome@3.3.5(svelte@5.56.3(@typescript-eslint/types@8.59.4)):
+  svelte-awesome@3.3.5(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)):
     dependencies:
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
 
-  svelte-check@4.4.8(picomatch@4.0.4)(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.3):
+  svelte-check@4.4.8(picomatch@4.0.4)(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(typescript@6.0.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
       fdir: 6.5.0(picomatch@4.0.4)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
       typescript: 6.0.3
     transitivePeerDependencies:
       - picomatch
 
-  svelte-eslint-parser@1.6.1(svelte@5.56.3(@typescript-eslint/types@8.59.4)):
+  svelte-eslint-parser@1.6.1(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)):
     dependencies:
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -26916,7 +26917,7 @@ snapshots:
       postcss-selector-parser: 7.1.1
       semver: 7.8.1
     optionalDependencies:
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
 
   svelte-floating-ui@1.5.8:
     dependencies:
@@ -26929,7 +26930,7 @@ snapshots:
     dependencies:
       highlight.js: 11.11.1
 
-  svelte-i18n@4.0.1(svelte@5.56.3(@typescript-eslint/types@8.59.4)):
+  svelte-i18n@4.0.1(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)):
     dependencies:
       cli-color: 2.0.4
       deepmerge: 4.3.1
@@ -26937,10 +26938,10 @@ snapshots:
       estree-walker: 2.0.2
       intl-messageformat: 10.7.18
       sade: 1.8.1
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
       tiny-glob: 0.2.9
 
-  svelte-jsoneditor@3.12.0(svelte@5.56.3(@typescript-eslint/types@8.59.4)):
+  svelte-jsoneditor@3.12.0(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)):
     dependencies:
       '@codemirror/autocomplete': 6.20.2
       '@codemirror/commands': 6.10.3
@@ -26967,42 +26968,42 @@ snapshots:
       memoize-one: 6.0.0
       natural-compare-lite: 1.4.0
       sass: 1.99.0
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
-      svelte-awesome: 3.3.5(svelte@5.56.3(@typescript-eslint/types@8.59.4))
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
+      svelte-awesome: 3.3.5(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))
       svelte-select: 5.8.3
       vanilla-picker: 2.12.3
 
-  svelte-maplibre@1.3.0(svelte@5.56.3(@typescript-eslint/types@8.59.4)):
+  svelte-maplibre@1.3.0(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)):
     dependencies:
       d3-geo: 3.1.1
       dequal: 2.0.3
       just-compare: 2.3.0
       maplibre-gl: 5.24.0
       pmtiles: 3.2.1
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
 
-  svelte-parse-markup@0.1.5(svelte@5.56.3(@typescript-eslint/types@8.59.4)):
+  svelte-parse-markup@0.1.5(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)):
     dependencies:
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
 
-  svelte-persisted-store@0.12.0(svelte@5.56.3(@typescript-eslint/types@8.59.4)):
+  svelte-persisted-store@0.12.0(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)):
     dependencies:
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
 
   svelte-select@5.8.3:
     dependencies:
       svelte-floating-ui: 1.5.8
 
-  svelte-toolbelt@0.10.6(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4)):
+  svelte-toolbelt@0.10.6(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)):
     dependencies:
       clsx: 2.1.1
-      runed: 0.35.1(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(@typescript-eslint/types@8.59.4))
+      runed: 0.35.1(@sveltejs/kit@2.60.1(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))(typescript@6.0.3)(vite@8.0.13(@types/node@24.13.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)))(svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4))
       style-to-object: 1.0.14
-      svelte: 5.56.3(@typescript-eslint/types@8.59.4)
+      svelte: 5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4)
     transitivePeerDependencies:
       - '@sveltejs/kit'
 
-  svelte@5.56.3(@typescript-eslint/types@8.59.4):
+  svelte@5.56.3(patch_hash=c3b58c40c475b0204ef8977fdd448bf4baa06180b78ac69ca996fc32320ac8b7)(@typescript-eslint/types@8.59.4):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,6 +65,7 @@ packageExtensions:
       typescript: '*'
 patchedDependencies:
   '@immich/ui@0.81.1': patches/@immich__ui@0.81.1.patch
+  svelte@5.56.3: patches/svelte@5.56.3.patch
 preferWorkspacePackages: true
 shamefullyHoist: false
 verifyDepsBeforeRun: install


### PR DESCRIPTION
fix(web): asset viewer stuck stale/blurry after reopen — patch Svelte batch scheduler

Reopening the asset viewer (open a photo, go back to the timeline, open
another photo) left the new photo's detail panel permanently broken until a
manual page refresh: the People section kept the previous photo's people,
the location map and tags never appeared, and the image stayed at thumbnail
quality. Reported by Hagen against v5.1.0; reproduces on current main.

Root cause is a bug in Svelte's batch scheduler, reported upstream as
sveltejs/svelte#18546 with a minimal standalone reproduction. A Batch's
`#roots` list is per-batch, but the CLEAN/DIRTY flags it manipulates live on
the shared effect tree. A batch that is created mid-traversal and then
dropped therefore leaves branches marked not-CLEAN with no batch owning
them. From that point on, `Batch.schedule()` walks up the ancestor chain,
finds a not-CLEAN ancestor and takes its "branch is already dirty, bail"
path, so the new batch queues zero roots and traverses nothing. Nothing can
recover it: `mark_reactions` won't re-schedule an already-DIRTY effect and
traversal skips CLEAN branches. The whole remounted viewer subtree simply
stops reacting — its effects run once at mount and never again, which is why
only a page reload fixed it.

The pnpm patch removes the early bail: walk the full ancestor chain, flip any
CLEAN branches, and push the deduplicated root. That restores the invariant
the bail assumed — a scheduled effect always sits under a not-CLEAN path from
a root queued on this batch. Verified against svelte 5.56.3 and 5.56.4.

Note: upstream Immich's demo does not reproduce this, even though it pins the
same Svelte version and its viewer mount site is byte-identical to ours. What
tips our build into the buggy path is not yet identified, so this patch is not
justified by "upstream has it too" — it is justified by the A/B below.

Verification: the new Playwright spec (reopen + arrow-nav) was run against two
server images that differ only by this patch. On an image built from main it
fails — the reopened detail panel still shows the previous photo's person. On
this branch both tests pass.

The spec is also a tripwire. The patch is version-keyed
(patches/svelte@5.56.3.patch) and a Svelte bump or an upstream rebase will
silently drop it; the spec hard-fails if that happens.
