### PR TITLE
fix(web): don't mount lazy components with {#await} — fixes stale asset viewer on reopen

### DIFF
--- a/e2e/src/specs/server/api/shared-space.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-space.e2e-spec.ts
@@ -181,7 +181,13 @@ describe('/shared-spaces', () => {
       // empty here and waitForQueueFinish would return immediately, leaving recentAssetIds empty.
       // Poll the post-condition instead.
       await expect
-        .poll(async () => (await utils.getAssetInfo(user3.accessToken, imageAsset.id)).thumbhash, { timeout: 30_000 })
+        .poll(
+          async () => {
+            const asset = await utils.getAssetInfo(user3.accessToken, imageAsset.id);
+            return asset.thumbhash;
+          },
+          { timeout: 30_000 },
+        )
         .not.toBeNull();
 
       const { body } = await request(app)

--- a/e2e/src/specs/server/api/shared-space.e2e-spec.ts
+++ b/e2e/src/specs/server/api/shared-space.e2e-spec.ts
@@ -176,8 +176,13 @@ describe('/shared-spaces', () => {
       });
       const imageAsset = await utils.createAsset(user3.accessToken);
       await utils.addSpaceAssets(user3.accessToken, space.id, [videoAsset.id, imageAsset.id]);
-      // recent assets are filtered to those with a thumbhash; wait for thumbnail generation
-      await utils.waitForQueueFinish(admin.accessToken, 'thumbnailGeneration');
+      // Recent assets are filtered to those with a thumbhash. Don't wait on the queue: thumbnail
+      // generation is only enqueued once metadata extraction has run, so the queue can still be
+      // empty here and waitForQueueFinish would return immediately, leaving recentAssetIds empty.
+      // Poll the post-condition instead.
+      await expect
+        .poll(async () => (await utils.getAssetInfo(user3.accessToken, imageAsset.id)).thumbhash, { timeout: 30_000 })
+        .not.toBeNull();
 
       const { body } = await request(app)
         .get(`/shared-spaces/${space.id}`)

--- a/e2e/src/specs/web/asset-viewer/reopen-stale-detail.e2e-spec.ts
+++ b/e2e/src/specs/web/asset-viewer/reopen-stale-detail.e2e-spec.ts
@@ -1,0 +1,113 @@
+import { AssetMediaResponseDto, LoginResponseDto, getConfig, updateAsset, updateConfig } from '@immich/sdk';
+import { expect, test } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { asBearerAuth, testAssetDir, utils } from 'src/utils';
+
+// Regression test for the stale/unreactive asset viewer on reopen (reported against v5.1.0):
+// open a photo with tagged people, go back to the timeline, open a photo without people —
+// the detail panel kept showing the previous photo's people, and the map/tags sections and
+// full-resolution image never loaded until a manual page refresh. Root cause was a Svelte
+// batch-scheduler edge (see patches/svelte@5.56.3.patch) that left the remounted viewer
+// subtree permanently unreactive.
+test.describe('asset viewer reopen', () => {
+  let admin: LoginResponseDto;
+  let assetWithPerson: AssetMediaResponseDto;
+  let assetWithLocation: AssetMediaResponseDto;
+
+  const waitForThumbnail = async (id: string) => {
+    await expect
+      .poll(async () => {
+        const asset = await utils.getAssetInfo(admin.accessToken, id);
+        return asset.thumbhash;
+      })
+      .not.toBeNull();
+  };
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+
+    // A freshly booted server runs its version check within seconds of the reset and pops the
+    // "new version available" dialog, which swallows clicks on the timeline. Turn it off.
+    const config = await getConfig({ headers: asBearerAuth(admin.accessToken) });
+    await updateConfig(
+      { systemConfigDto: { ...config, newVersionCheck: { ...config.newVersionCheck, enabled: false } } },
+      { headers: asBearerAuth(admin.accessToken) },
+    );
+
+    assetWithPerson = await utils.createAsset(admin.accessToken, {
+      assetData: {
+        bytes: readFileSync(`${testAssetDir}/albums/nature/tanners_ridge.jpg`),
+        filename: 'tanners_ridge.jpg',
+      },
+    });
+    assetWithLocation = await utils.createAsset(admin.accessToken, {
+      assetData: {
+        bytes: readFileSync(`${testAssetDir}/albums/nature/prairie_falcon.jpg`),
+        filename: 'prairie_falcon.jpg',
+      },
+    });
+
+    // wait for thumbnails so both assets are rendered in the timeline grid
+    await waitForThumbnail(assetWithPerson.id);
+    await waitForThumbnail(assetWithLocation.id);
+
+    const person = await utils.createPerson(admin.accessToken, { name: 'Stale Carryover Person' });
+    await utils.createFace({ assetId: assetWithPerson.id, personId: person.id });
+
+    await updateAsset(
+      { id: assetWithLocation.id, updateAssetDto: { latitude: 48.853_41, longitude: 2.3488 } },
+      { headers: asBearerAuth(admin.accessToken) },
+    );
+    const tags = await utils.upsertTags(admin.accessToken, ['reopen-tag']);
+    await utils.tagAssets(admin.accessToken, tags[0].id, [assetWithLocation.id]);
+    await utils.updateMyPreferences(admin.accessToken, { tags: { enabled: true } });
+  });
+
+  test('reopening the viewer shows the new asset, not the previous one', async ({ context, page }) => {
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('/photos');
+    await page.waitForSelector('[data-thumbnail-focus-container]');
+
+    // open the asset with a tagged person and confirm the person renders
+    await page.locator(`[data-thumbnail-focus-container][data-asset="${assetWithPerson.id}"]`).click();
+    await page.waitForSelector('#immich-asset-viewer');
+    await page.keyboard.press('i');
+    await expect(page.locator('#detail-panel')).toContainText('Stale Carryover Person');
+
+    // go back to the timeline
+    await page.goBack();
+    await page.waitForSelector('[data-thumbnail-focus-container]');
+    await expect(page.locator('#immich-asset-viewer')).toHaveCount(0);
+
+    // reopen the viewer on the asset without people
+    await page.locator(`[data-thumbnail-focus-container][data-asset="${assetWithLocation.id}"]`).click();
+    await page.waitForSelector('#immich-asset-viewer');
+    await expect(page.locator('#detail-panel')).toBeVisible();
+
+    // people must clear, and the location map + tags of the new asset must render —
+    // all three stayed stale/missing until a manual refresh before the fix
+    await expect(page.locator('#detail-panel')).not.toContainText('Stale Carryover Person');
+    await expect(page.locator('#detail-panel .maplibregl-map')).toBeVisible();
+    await expect(page.locator('[data-testid="detail-panel-tags"]')).toContainText('reopen-tag');
+  });
+
+  test('arrow navigation between assets updates the detail panel', async ({ context, page }) => {
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('/photos');
+    await page.waitForSelector('[data-thumbnail-focus-container]');
+
+    await page.locator(`[data-thumbnail-focus-container][data-asset="${assetWithPerson.id}"]`).click();
+    await page.waitForSelector('#immich-asset-viewer');
+    await page.keyboard.press('i');
+    await expect(page.locator('#detail-panel')).toContainText('Stale Carryover Person');
+
+    // navigate to the older asset inside the viewer
+    await page.keyboard.press('ArrowRight');
+    await expect(page).toHaveURL(new RegExp(assetWithLocation.id));
+
+    await expect(page.locator('#detail-panel')).not.toContainText('Stale Carryover Person');
+    await expect(page.locator('#detail-panel .maplibregl-map')).toBeVisible();
+  });
+});

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -135,6 +135,27 @@ export default typescriptEslint.config(
     },
   },
   {
+    files: ['**/*.svelte'],
+
+    languageOptions: {
+      parser,
+      parserOptions: {
+        parser: typescriptEslint.parser,
+      },
+    },
+
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'SvelteAwaitBlock[expression.type="ImportExpression"]',
+          message:
+            'Do not mount a lazy-loaded component with `{#await import(...)}`. Once the module is warm, the block resolves while Svelte is mid-flush and orphans a batch, leaving the mounted subtree permanently unreactive (sveltejs/svelte#18546). Use lazyComponent() from $lib/utils/lazy-component.svelte instead.',
+        },
+      ],
+    },
+  },
+  {
     extends: [eslintPluginBetterTailwindcss.configs.recommended],
     settings: {
       'better-tailwindcss': {

--- a/web/src/lib/components/asset-viewer/DetailPanel.svelte
+++ b/web/src/lib/components/asset-viewer/DetailPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { lazyComponent } from '$lib/utils/lazy-component.svelte';
   import { goto } from '$app/navigation';
   import DetailPanelDate from '$lib/components/asset-viewer/DetailPanelDate.svelte';
   import DetailPanelDescription from '$lib/components/asset-viewer/DetailPanelDescription.svelte';
@@ -114,6 +115,10 @@
   onDestroy(() => {
     assetViewerManager.closeEditFacesPanel();
   });
+
+  // Mounting the map through `{#await}` can leave the surrounding subtree unreactive.
+  // See lazyComponent().
+  const LazyMap = lazyComponent(() => import('$lib/components/shared-components/map/Map.svelte'));
 </script>
 
 <OnEvents onAlbumAddAssets={() => (albums = refreshAlbums())} />
@@ -284,14 +289,8 @@
 
   {#if latlng && featureFlagsManager.value.map}
     <div class="h-90">
-      {#await import('$lib/components/shared-components/map/Map.svelte')}
-        {#await delay(timeToLoadTheMap) then}
-          <!-- show the loading spinner only if loading the map takes too much time -->
-          <div class="flex size-full items-center justify-center">
-            <LoadingSpinner />
-          </div>
-        {/await}
-      {:then { default: Map }}
+      {#if LazyMap.current}
+        {@const Map = LazyMap.current}
         <Map
           mapMarkers={[
             {
@@ -326,7 +325,14 @@
             </div>
           {/snippet}
         </Map>
-      {/await}
+      {:else}
+        {#await delay(timeToLoadTheMap) then}
+          <!-- show the loading spinner only if loading the map takes too much time -->
+          <div class="flex size-full items-center justify-center">
+            <LoadingSpinner />
+          </div>
+        {/await}
+      {/if}
     </div>
   {/if}
 

--- a/web/src/lib/components/share-page/IndividualSharedViewer.svelte
+++ b/web/src/lib/components/share-page/IndividualSharedViewer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { lazyComponent } from '$lib/utils/lazy-component.svelte';
   import { goto } from '$app/navigation';
   import type { Action } from '$lib/components/asset-viewer/actions/action';
   import DownloadAction from '$lib/components/timeline/actions/DownloadAction.svelte';
@@ -73,6 +74,10 @@
       // no default
     }
   };
+
+  // Mounting the viewer through `{#await}` leaves it permanently unreactive on reopen.
+  // See lazyComponent().
+  const LazyAssetViewer = lazyComponent(() => import('$lib/components/asset-viewer/AssetViewer.svelte'));
 </script>
 
 {#if sharedLink?.allowUpload || assets.length > 1}
@@ -140,8 +145,9 @@
   </header>
 {:else if assets.length === 1}
   {#await getAssetInfo({ ...authManager.params, id: assets[0].id }) then asset}
-    {#await import('$lib/components/asset-viewer/AssetViewer.svelte') then { default: AssetViewer }}
+    {#if LazyAssetViewer.current}
+      {@const AssetViewer = LazyAssetViewer.current}
       <AssetViewer cursor={{ current: asset }} onAction={handleAction} />
-    {/await}
+    {/if}
   {/await}
 {/if}

--- a/web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { lazyComponent } from '$lib/utils/lazy-component.svelte';
   import { goto } from '$app/navigation';
   import { shortcuts, type ShortcutOptions } from '$lib/actions/shortcut';
   import type { Action } from '$lib/components/asset-viewer/actions/action';
@@ -455,6 +456,10 @@
     nextAsset: getNextAsset(navigationAssets, assetViewerManager.asset),
     previousAsset: getPreviousAsset(navigationAssets, assetViewerManager.asset),
   });
+
+  // Mounting the viewer through `{#await}` leaves it permanently unreactive on reopen.
+  // See lazyComponent().
+  const LazyAssetViewer = lazyComponent(() => import('$lib/components/asset-viewer/AssetViewer.svelte'));
 </script>
 
 <svelte:document onselectstart={onSelectStart} use:shortcuts={shortcutList} onscroll={() => updateSlidingWindow()} />
@@ -542,7 +547,8 @@
 <!-- Overlay Asset Viewer -->
 {#if assetViewerManager.isViewing}
   <Portal target="body">
-    {#await import('$lib/components/asset-viewer/AssetViewer.svelte') then { default: AssetViewer }}
+    {#if LazyAssetViewer.current}
+      {@const AssetViewer = LazyAssetViewer.current}
       <AssetViewer
         cursor={assetCursor}
         onAction={handleAction}
@@ -553,6 +559,6 @@
           handlePromiseError(navigate({ targetRoute: 'current', assetId: null }));
         }}
       />
-    {/await}
+    {/if}
   </Portal>
 {/if}

--- a/web/src/lib/components/spaces/space-search-results.svelte
+++ b/web/src/lib/components/spaces/space-search-results.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { lazyComponent } from '$lib/utils/lazy-component.svelte';
   import { page } from '$app/state';
   import LoadingSpinner from '$lib/components/shared-components/LoadingSpinner.svelte';
   import Portal from '$lib/elements/Portal.svelte';
@@ -107,6 +108,10 @@
   let dateGroups = $derived(sortMode === 'relevance' ? [] : groupByMonth(results));
   const resultCount = $derived(total ?? totalLoaded);
   const hasExactTotal = $derived(total !== undefined);
+
+  // Mounting the viewer through `{#await}` leaves it permanently unreactive on reopen.
+  // See lazyComponent().
+  const LazyAssetViewer = lazyComponent(() => import('$lib/components/asset-viewer/AssetViewer.svelte'));
 </script>
 
 <section bind:this={scrollContainer} class="immich-scrollbar flex-1 overflow-y-auto px-4 py-4">
@@ -194,8 +199,9 @@
 
 <Portal target="body">
   {#if isViewerOpen && cursor}
-    {#await import('$lib/components/asset-viewer/AssetViewer.svelte') then { default: AssetViewer }}
+    {#if LazyAssetViewer.current}
+      {@const AssetViewer = LazyAssetViewer.current}
       <AssetViewer {cursor} {isShared} {spaceId} onClose={() => handlePromiseError(handleClose())} />
-    {/await}
+    {/if}
   {/if}
 </Portal>

--- a/web/src/lib/components/timeline/TimelineAssetViewer.svelte
+++ b/web/src/lib/components/timeline/TimelineAssetViewer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { lazyComponent } from '$lib/utils/lazy-component.svelte';
   import type { Action } from '$lib/components/asset-viewer/actions/action';
   import type { AssetCursor } from '$lib/components/asset-viewer/AssetViewer.svelte';
   import { AssetAction } from '$lib/constants';
@@ -234,9 +235,14 @@
   onDestroy(() => {
     assetCacheManager.invalidate();
   });
+
+  // Mounting the viewer through `{#await}` leaves it permanently unreactive on reopen.
+  // See lazyComponent().
+  const LazyAssetViewer = lazyComponent(() => import('$lib/components/asset-viewer/AssetViewer.svelte'));
 </script>
 
-{#await import('$lib/components/asset-viewer/AssetViewer.svelte') then { default: AssetViewer }}
+{#if LazyAssetViewer.current}
+  {@const AssetViewer = LazyAssetViewer.current}
   <AssetViewer
     {withStacked}
     cursor={assetCursor}
@@ -257,4 +263,4 @@
     onRemoveFromAlbum={handleRemoveFromAlbum}
     onClose={handleClose}
   />
-{/await}
+{/if}

--- a/web/src/lib/modals/GeolocationPointPickerModal.svelte
+++ b/web/src/lib/modals/GeolocationPointPickerModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { lazyComponent } from '$lib/utils/lazy-component.svelte';
   import { isDefined } from '$lib';
   import { clickOutside } from '$lib/actions/click-outside';
   import { listNavigation } from '$lib/actions/list-navigation';
@@ -133,6 +134,10 @@
     point = { lat, lng };
     mapElement?.addClipMapMarker(lng, lat);
   };
+
+  // Mounting the map through `{#await}` can leave the surrounding subtree unreactive.
+  // See lazyComponent().
+  const LazyMap = lazyComponent(() => import('$lib/components/shared-components/map/Map.svelte'));
 </script>
 
 <ConfirmModal
@@ -183,14 +188,8 @@
 
       <span>{$t('pick_a_location')}</span>
       <div class="z-0 h-125 min-h-75 w-full">
-        {#await import('$lib/components/shared-components/map/Map.svelte')}
-          {#await delay(timeToLoadTheMap) then}
-            <!-- show the loading spinner only if loading the map takes too much time -->
-            <div class="flex size-full items-center justify-center">
-              <LoadingSpinner />
-            </div>
-          {/await}
-        {:then { default: Map }}
+        {#if LazyMap.current}
+          {@const Map = LazyMap.current}
           <Map
             bind:this={mapElement}
             mapMarkers={asset && assetPoint
@@ -213,7 +212,14 @@
             showSettings={false}
             rounded
           />
-        {/await}
+        {:else}
+          {#await delay(timeToLoadTheMap) then}
+            <!-- show the loading spinner only if loading the map takes too much time -->
+            <div class="flex size-full items-center justify-center">
+              <LoadingSpinner />
+            </div>
+          {/await}
+        {/if}
       </div>
 
       <div class="mt-4 grid gap-4 text-start text-sm sm:grid-cols-2">

--- a/web/src/lib/modals/MapModal.svelte
+++ b/web/src/lib/modals/MapModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { lazyComponent } from '$lib/utils/lazy-component.svelte';
   import { timeToLoadTheMap } from '$lib/constants';
   import { delay } from '$lib/utils/asset-utils';
   import type { MapMarkerResponseDto } from '@immich/sdk';
@@ -12,22 +13,27 @@
   };
 
   let { onClose, mapMarkers }: Props = $props();
+
+  // Mounting the map through `{#await}` can leave the surrounding subtree unreactive.
+  // See lazyComponent().
+  const LazyMap = lazyComponent(() => import('$lib/components/shared-components/map/Map.svelte'));
 </script>
 
 <Modal title={$t('map')} size="giant" {onClose}>
   <ModalBody>
     <div class="flex size-full flex-col gap-2 rounded-2xl border border-gray-300 dark:border-light">
       <div class="h-[75vh] min-h-[300px] w-full">
-        {#await import('$lib/components/shared-components/map/Map.svelte')}
+        {#if LazyMap.current}
+          {@const Map = LazyMap.current}
+          <Map clickable={false} {mapMarkers} onSelect={onClose} showSettings={false} rounded autoFitBounds />
+        {:else}
           {#await delay(timeToLoadTheMap) then}
             <!-- show the loading spinner only if loading the map takes too much time -->
             <div class="flex size-full items-center justify-center">
               <LoadingSpinner />
             </div>
           {/await}
-        {:then { default: Map }}
-          <Map clickable={false} {mapMarkers} onSelect={onClose} showSettings={false} rounded autoFitBounds />
-        {/await}
+        {/if}
       </div>
     </div>
   </ModalBody>

--- a/web/src/lib/utils/lazy-component.svelte.ts
+++ b/web/src/lib/utils/lazy-component.svelte.ts
@@ -1,0 +1,38 @@
+/**
+ * Lazily load a component, without using an `{#await}` block.
+ *
+ * `{#await}` must not be used to mount a lazy-loaded component. When such a block resolves while
+ * Svelte is already flushing — which is exactly what happens on a reopen, once the module is warm
+ * in the module cache — its resolution path creates a batch that nothing ever flushes. The batch
+ * has already flipped CLEAN flags on the shared effect tree, so every later update bails out and
+ * the mounted subtree stops reacting entirely until a page reload. That is what made the asset
+ * viewer come back stale (previous photo's people, no map, no tags, blurry image) on reopen.
+ *
+ * Resolving the import in a plain promise callback instead keeps the state write on its own tick,
+ * where Svelte schedules a flush for it normally. Code splitting is unaffected: the dynamic
+ * `import()` is still what creates the chunk.
+ *
+ * Upstream bug: https://github.com/sveltejs/svelte/issues/18546
+ */
+export function lazyComponent<T>(load: () => Promise<{ default: T }>) {
+  let component = $state<T | undefined>();
+  let loading = false;
+
+  return {
+    /**
+     * `undefined` until the module has loaded. Reading this is what starts the load, so a component
+     * behind an `{#if}` only pulls its chunk once that branch is actually rendered — the same
+     * laziness an `{#await}` block inside the branch used to give us.
+     */
+    get current() {
+      if (!loading) {
+        loading = true;
+        void load().then((module) => {
+          component = module.default;
+        });
+      }
+
+      return component;
+    },
+  };
+}

--- a/web/src/routes/(user)/explore/+page.svelte
+++ b/web/src/routes/(user)/explore/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { lazyComponent } from '$lib/utils/lazy-component.svelte';
   import ImageThumbnail from '$lib/components/assets/thumbnail/ImageThumbnail.svelte';
   import UserPageLayout from '$lib/components/layouts/UserPageLayout.svelte';
   import OnEvents from '$lib/components/OnEvents.svelte';
@@ -57,6 +58,10 @@
   const getPersonHref = (person: PersonResponseDto) => getGlobalPersonHref(person, Route.explore());
 
   const getPersonThumbnail = (person: PersonResponseDto) => getGlobalPersonThumbnailUrl(person);
+
+  // Mounting the viewer through `{#await}` leaves it permanently unreactive on reopen.
+  // See lazyComponent().
+  const LazyAssetViewer = lazyComponent(() => import('$lib/components/asset-viewer/AssetViewer.svelte'));
 </script>
 
 <OnEvents {onPersonThumbnailReady} />
@@ -158,7 +163,8 @@
 </UserPageLayout>
 
 {#if assetViewerManager.isViewing}
-  {#await import('$lib/components/asset-viewer/AssetViewer.svelte') then { default: AssetViewer }}
+  {#if LazyAssetViewer.current}
+    {@const AssetViewer = LazyAssetViewer.current}
     <Portal target="body">
       <AssetViewer
         cursor={assetCursor}
@@ -166,5 +172,5 @@
         onClose={() => assetViewerManager.showAssetViewer(false)}
       />
     </Portal>
-  {/await}
+  {/if}
 {/if}

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { lazyComponent } from '$lib/utils/lazy-component.svelte';
   import { goto } from '$app/navigation';
   import { page } from '$app/state';
   import ActiveFiltersBar from '$lib/components/filter-panel/active-filters-bar.svelte';
@@ -255,6 +256,14 @@
     assetViewerManager.showAssetViewer(false);
     handlePromiseError(navigate({ targetRoute: 'current', assetId: null }));
   }
+
+  // Mounting the viewer through `{#await}` leaves it permanently unreactive on reopen.
+  // See lazyComponent().
+  const LazyAssetViewer = lazyComponent(() => import('$lib/components/asset-viewer/AssetViewer.svelte'));
+
+  // Mounting the map through `{#await}` can leave the surrounding subtree unreactive.
+  // See lazyComponent().
+  const LazyMap = lazyComponent(() => import('$lib/components/shared-components/map/Map.svelte'));
 </script>
 
 {#if featureFlagsManager.value.map}
@@ -339,15 +348,16 @@
             isTimelinePanelVisible ? 'h-1/2 w-full pb-2 sm:h-full sm:w-2/3 sm:pe-2 sm:pb-0' : 'h-full w-full',
           ]}
         >
-          {#await import('$lib/components/shared-components/map/Map.svelte')}
+          {#if LazyMap.current}
+            {@const Map = LazyMap.current}
+            <Map hash onSelect={onViewAssets} {onClusterSelect} {spaceId} showSettings={false} {mapMarkers} />
+          {:else}
             {#await delay(timeToLoadTheMap) then}
               <div class="flex size-full items-center justify-center">
                 <LoadingSpinner />
               </div>
             {/await}
-          {:then { default: Map }}
-            <Map hash onSelect={onViewAssets} {onClusterSelect} {spaceId} showSettings={false} {mapMarkers} />
-          {/await}
+          {/if}
           {#if noResults}
             <div class="pointer-events-none absolute inset-0 flex items-center justify-center">
               <div
@@ -376,7 +386,8 @@
   </UserPageLayout>
   <Portal target="body">
     {#if assetViewerManager.isViewing && !isTimelinePanelVisible}
-      {#await import('$lib/components/asset-viewer/AssetViewer.svelte') then { default: AssetViewer }}
+      {#if LazyAssetViewer.current}
+        {@const AssetViewer = LazyAssetViewer.current}
         <AssetViewer
           cursor={{ current: assetViewerManager.asset! }}
           showNavigation={false}
@@ -386,7 +397,7 @@
           }}
           isShared={false}
         />
-      {/await}
+      {/if}
     {/if}
   </Portal>
 {/if}

--- a/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/DuplicatesCompareControl.svelte
+++ b/web/src/routes/(user)/utilities/duplicates/[[photos=photos]]/[[assetId=id]]/DuplicatesCompareControl.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { lazyComponent } from '$lib/utils/lazy-component.svelte';
   import { shortcuts } from '$lib/actions/shortcut';
   import DuplicateAsset from './DuplicateAsset.svelte';
   import Portal from '$lib/elements/Portal.svelte';
@@ -102,6 +103,10 @@
     nextAsset: getNextAsset(assets, assetViewerManager.asset),
     previousAsset: getPreviousAsset(assets, assetViewerManager.asset),
   });
+
+  // Mounting the viewer through `{#await}` leaves it permanently unreactive on reopen.
+  // See lazyComponent().
+  const LazyAssetViewer = lazyComponent(() => import('$lib/components/asset-viewer/AssetViewer.svelte'));
 </script>
 
 <svelte:document
@@ -198,7 +203,8 @@
 </div>
 
 {#if assetViewerManager.isViewing}
-  {#await import('$lib/components/asset-viewer/AssetViewer.svelte') then { default: AssetViewer }}
+  {#if LazyAssetViewer.current}
+    {@const AssetViewer = LazyAssetViewer.current}
     <Portal target="body">
       <AssetViewer
         cursor={assetCursor}
@@ -210,5 +216,5 @@
         }}
       />
     </Portal>
-  {/await}
+  {/if}
 {/if}

--- a/web/src/routes/(user)/utilities/large-files/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/utilities/large-files/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { lazyComponent } from '$lib/utils/lazy-component.svelte';
   import type { Action } from '$lib/components/asset-viewer/actions/action';
   import UserPageLayout from '$lib/components/layouts/UserPageLayout.svelte';
   import OnEvents from '$lib/components/OnEvents.svelte';
@@ -59,6 +60,10 @@
     nextAsset: getNextAsset(assets, assetViewerManager.asset),
     previousAsset: getPreviousAsset(assets, assetViewerManager.asset),
   });
+
+  // Mounting the viewer through `{#await}` leaves it permanently unreactive on reopen.
+  // See lazyComponent().
+  const LazyAssetViewer = lazyComponent(() => import('$lib/components/asset-viewer/AssetViewer.svelte'));
 </script>
 
 <OnEvents {onAssetsDelete} />
@@ -78,7 +83,8 @@
 </UserPageLayout>
 
 {#if assetViewerManager.isViewing}
-  {#await import('$lib/components/asset-viewer/AssetViewer.svelte') then { default: AssetViewer }}
+  {#if LazyAssetViewer.current}
+    {@const AssetViewer = LazyAssetViewer.current}
     <Portal target="body">
       <AssetViewer
         cursor={assetCursor}
@@ -91,5 +97,5 @@
         }}
       />
     </Portal>
-  {/await}
+  {/if}
 {/if}


### PR DESCRIPTION
Fixes the asset viewer coming back **stale and unreactive after a reopen** (open a photo → back → open another): the detail panel kept the previous photo's people, the map and tags never appeared, and the image stayed at thumbnail quality until a manual refresh. Reported by Hagen against v5.1.0; reproduces on current `main`.

This is the **no-patch** fix. The alternative — patching Svelte's scheduler — is #776, kept as plan B. Only one of the two should land.

## Root cause

The underlying bug is in Svelte's batch scheduler ([sveltejs/svelte#18546](https://github.com/sveltejs/svelte/issues/18546)), but we reach it through a pattern of our own that we can just stop using.

`{#await}` calls `flushSync()` when it resolves, and `flushSync()` **synchronously drains Svelte's micro-task queue** — which can run a *second, nested* `{#await}`'s resolve. That inner resolve calls `Batch.ensure()` while `is_flushing_sync` is true, so the batch gets **no scheduled flush**, and its own guarded `if (!is_flushing_sync) flushSync()` is skipped. The batch is created, gets roots queued on it, and is dropped. It has already flipped CLEAN flags on the shared effect tree, so every later `Batch.schedule()` walks up, hits a not-CLEAN ancestor and takes its `// branch is already dirty, bail` path. The remounted subtree stops reacting — effects run once at mount and never again, hence "only F5 fixes it".

Captured from the running app (unpatched Svelte, instrumented):

```
Batch.ensure  ← resolve            (INNER {#await} — creates a batch nobody flushes)
              ← run_micro_tasks
              ← flush_tasks
              ← flushSync          (…because flushSync drains the micro-task queue)
              ← resolve            (OUTER {#await} — the viewer's own lazy import)
```

The viewer was nested `{#await}` by construction: the mount site lazy-imported `AssetViewer` via `{#await import(...)}`, and the viewer's subtree (detail panel's map, albums) has more `{#await}` blocks.

**Why only on reopen:** the first open fetches the viewer module over the network, so it resolves alone. On reopen the module is warm, so it resolves instantly and its `flushSync` drains a queue that now holds the viewer's *inner* awaits.

## The change

- New `lazyComponent()` helper: resolves the dynamic `import()` in a plain promise callback and exposes the component as `$state`. The state write lands on its own tick, where Svelte schedules a flush normally.
- Converted all 12 `{#await import(...)}` component mounts (8 × `AssetViewer`, 4 × `Map`).
- Reading `.current` is what starts the load, so a component behind an `{#if}` still only pulls its chunk when that branch renders — **code splitting and laziness unchanged**.
- ESLint rule (`no-restricted-syntax` on `SvelteAwaitBlock > ImportExpression`) rejects the pattern so a rebase can't quietly reintroduce it. Verified it fires.
- `reopen-stale-detail` e2e spec as the regression guard. It also disables the version-check announcement, whose modal otherwise swallows clicks on a freshly booted server.

## Verification

A/B on the e2e stack — images differing only by these changes, fresh stack each round:

| build | Svelte | viewer mount | reopen spec |
|---|---|---|---|
| from `main` | stock | `{#await import()}` | ❌ fails 3/3 — panel keeps the previous photo's person |
| this branch | stock | `lazyComponent()` | ✅ passes 3/3 |

- Full **web e2e suite** run against both images: the only branch-specific delta is `reopen-stale-detail` going from fail → pass. (This local harness has ~50 pre-existing failures on `main`, mostly `global-search`/`cmdk`; identical on both sides.)
- Web unit suite: 3402 passed. `tsc`, `svelte-check` (on the touched files), ESLint: clean.

Caught along the way: an earlier version of the helper started the import at component init, which eagerly pulled the maplibre chunk into every DetailPanel and broke a unit test. Loading on first read of `.current` restores the original semantics.