### PR TITLE
fix(spaces): make stacks atomic in shared spaces (#751)

### DIFF
--- a/docs/docs/features/shared-spaces.md
+++ b/docs/docs/features/shared-spaces.md
@@ -149,6 +149,16 @@ If you're a server admin, you can [link an external library](#connected-librarie
 2. Long-press to select photos.
 3. Tap **Remove from Space** in the bottom sheet.
 
+## Stacked Photos
+
+Stacks (for example a RAW + JPEG pair or a burst) are treated as a single unit in a space:
+
+- **Adding** any frame of a stack contributes the **whole stack**. The space collapses it to the stack cover with a badge showing the frame count, exactly like your main timeline — tap or click through to see every frame.
+- **Removing** any frame removes the **whole stack**, so no hidden frames are left behind.
+- **Changing the cover** (promoting a different frame to primary) keeps the stack visible in the space.
+
+Only frames with space-eligible visibility are pulled in — Hidden and Locked frames are never added automatically.
+
 ## Timeline Integration
 
 Each member can choose whether a space's photos appear in their personal timeline. Tap or click the **eye icon** in the space header to toggle between **Show on timeline** and **Hide from timeline**.

--- a/mobile/lib/infrastructure/repositories/timeline.repository.dart
+++ b/mobile/lib/infrastructure/repositories/timeline.repository.dart
@@ -487,12 +487,20 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
                 _db.sharedSpaceLibraryEntity.spaceId.equals(spaceId),
             useColumns: false,
           ),
+          leftOuterJoin(
+            _db.stackEntity,
+            _db.stackEntity.id.equalsExp(_db.remoteAssetEntity.stackId),
+            useColumns: false,
+          ),
         ])
         ..where(
           _db.remoteAssetEntity.deletedAt.isNull() &
               _db.remoteAssetEntity.visibility.equalsValue(AssetVisibility.timeline) &
               _remoteWithinTemporalScope(_db.remoteAssetEntity, temporalScope) &
-              (_db.sharedSpaceAssetEntity.assetId.isNotNull() | _db.sharedSpaceLibraryEntity.libraryId.isNotNull()),
+              (_db.sharedSpaceAssetEntity.assetId.isNotNull() | _db.sharedSpaceLibraryEntity.libraryId.isNotNull()) &
+              // Collapse stacks to their primary (#751), mirroring the main timeline.
+              (_db.remoteAssetEntity.stackId.isNull() |
+                  _db.remoteAssetEntity.id.equalsExp(_db.stackEntity.primaryAssetId)),
         );
       return countQuery
           .map((row) => row.read(countExp) ?? 0)
@@ -519,12 +527,16 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
               _db.sharedSpaceLibraryEntity.spaceId.equals(spaceId),
           useColumns: false,
         ),
+        leftOuterJoin(_db.stackEntity, _db.stackEntity.id.equalsExp(_db.remoteAssetEntity.stackId), useColumns: false),
       ])
       ..where(
         _db.remoteAssetEntity.deletedAt.isNull() &
             _db.remoteAssetEntity.visibility.equalsValue(AssetVisibility.timeline) &
             _remoteWithinTemporalScope(_db.remoteAssetEntity, temporalScope) &
-            (_db.sharedSpaceAssetEntity.assetId.isNotNull() | _db.sharedSpaceLibraryEntity.libraryId.isNotNull()),
+            (_db.sharedSpaceAssetEntity.assetId.isNotNull() | _db.sharedSpaceLibraryEntity.libraryId.isNotNull()) &
+            // Collapse stacks to their primary (#751), mirroring the main timeline.
+            (_db.remoteAssetEntity.stackId.isNull() |
+                _db.remoteAssetEntity.id.equalsExp(_db.stackEntity.primaryAssetId)),
       )
       ..groupBy([dateExp])
       ..orderBy([OrderingTerm.desc(dateExp)]);
@@ -564,12 +576,20 @@ class DriftTimelineRepository extends DriftDatabaseRepository {
               _db.remoteAssetEntity.checksum.equalsExp(_db.localAssetEntity.checksum),
               useColumns: false,
             ),
+            leftOuterJoin(
+              _db.stackEntity,
+              _db.stackEntity.id.equalsExp(_db.remoteAssetEntity.stackId),
+              useColumns: false,
+            ),
           ])
           ..where(
             _db.remoteAssetEntity.deletedAt.isNull() &
                 _db.remoteAssetEntity.visibility.equalsValue(AssetVisibility.timeline) &
                 _remoteWithinTemporalScope(_db.remoteAssetEntity, temporalScope) &
-                membership,
+                membership &
+                // Collapse stacks to their primary (#751), mirroring the main timeline.
+                (_db.remoteAssetEntity.stackId.isNull() |
+                    _db.remoteAssetEntity.id.equalsExp(_db.stackEntity.primaryAssetId)),
           )
           ..orderBy([OrderingTerm.desc(_db.remoteAssetEntity.createdAt)])
           ..limit(count, offset: offset);

--- a/mobile/test/medium/repositories/timeline_repository_test.dart
+++ b/mobile/test/medium/repositories/timeline_repository_test.dart
@@ -72,6 +72,64 @@ void main() {
     });
   });
 
+  group('aggregated-space stack collapse (#751)', () {
+    test('collapses a stack to its primary in the grouped space timeline', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      const stackId = 'space-stack-1';
+      final primary = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId);
+      final child = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId);
+      await ctx.insertStack(id: stackId, ownerId: user.id, primaryAssetId: primary.id);
+      await ctx.insertSharedSpaceAsset(spaceId: space.id, assetId: primary.id);
+      await ctx.insertSharedSpaceAsset(spaceId: space.id, assetId: child.id);
+
+      final query = sut.sharedSpace(space.id, GroupAssetsBy.day);
+
+      final buckets = await query.bucketSource().first;
+      expect(buckets.fold<int>(0, (sum, b) => sum + b.assetCount), 1);
+
+      final assets = await query.assetSource(0, 10);
+      expect(assets, hasLength(1));
+      expect((assets.single as RemoteAsset).id, primary.id);
+    });
+
+    test('collapses the ungrouped (none) space count query', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      const stackId = 'space-stack-2';
+      final primary = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId);
+      final child = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId);
+      await ctx.insertStack(id: stackId, ownerId: user.id, primaryAssetId: primary.id);
+      await ctx.insertSharedSpaceAsset(spaceId: space.id, assetId: primary.id);
+      await ctx.insertSharedSpaceAsset(spaceId: space.id, assetId: child.id);
+
+      final buckets = await sut.sharedSpace(space.id, GroupAssetsBy.none).bucketSource().first;
+      expect(buckets.fold<int>(0, (sum, b) => sum + b.assetCount), 1);
+    });
+
+    test('keeps an un-stacked asset alongside a collapsed stack', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      const stackId = 'space-stack-3';
+      final primary = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId);
+      final child = await ctx.newRemoteAsset(ownerId: user.id, stackId: stackId);
+      final loner = await ctx.newRemoteAsset(ownerId: user.id);
+      await ctx.insertStack(id: stackId, ownerId: user.id, primaryAssetId: primary.id);
+      await ctx.insertSharedSpaceAsset(spaceId: space.id, assetId: primary.id);
+      await ctx.insertSharedSpaceAsset(spaceId: space.id, assetId: child.id);
+      await ctx.insertSharedSpaceAsset(spaceId: space.id, assetId: loner.id);
+
+      final query = sut.sharedSpace(space.id, GroupAssetsBy.day);
+
+      final buckets = await query.bucketSource().first;
+      expect(buckets.fold<int>(0, (sum, b) => sum + b.assetCount), 2);
+
+      final assets = await query.assetSource(0, 10);
+      expect(assets.map((a) => (a as RemoteAsset).id), containsAll([primary.id, loner.id]));
+      expect(assets.map((a) => (a as RemoteAsset).id), isNot(contains(child.id)));
+    });
+  });
+
   group('live photos', () {
     test('remote-only live photo contains livePhotoVideoId and is marked as a motion photo', () async {
       final user = await ctx.newUser();

--- a/mobile/test/medium/repository_context.dart
+++ b/mobile/test/medium/repository_context.dart
@@ -23,6 +23,7 @@ import 'package:immich_mobile/infrastructure/entities/shared_space.entity.drift.
 import 'package:immich_mobile/infrastructure/entities/shared_space_asset.entity.drift.dart';
 import 'package:immich_mobile/infrastructure/entities/shared_space_library.entity.drift.dart';
 import 'package:immich_mobile/infrastructure/entities/shared_space_member.entity.drift.dart';
+import 'package:immich_mobile/infrastructure/entities/stack.entity.drift.dart';
 import 'package:immich_mobile/infrastructure/entities/user.entity.drift.dart';
 import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
 import 'package:immich_mobile/utils/option.dart';
@@ -400,6 +401,12 @@ class MediumRepositoryContext {
     return db
         .into(db.sharedSpaceAssetEntity)
         .insert(SharedSpaceAssetEntityCompanion.insert(spaceId: spaceId, assetId: assetId));
+  }
+
+  Future<void> insertStack({required String id, required String ownerId, required String primaryAssetId}) {
+    return db
+        .into(db.stackEntity)
+        .insert(StackEntityCompanion.insert(id: id, ownerId: ownerId, primaryAssetId: primaryAssetId));
   }
 
   Future<LibraryEntityData> newLibrary({

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -16,7 +16,7 @@ import { SharedSpacePersonTable } from 'src/schema/tables/shared-space-person.ta
 import { SharedSpaceTable } from 'src/schema/tables/shared-space.table';
 import { anyUuid, searchAssetBuilder } from 'src/utils/database';
 
-const visibleSpaceAssetVisibilities = [AssetVisibility.Archive, AssetVisibility.Timeline];
+export const visibleSpaceAssetVisibilities = [AssetVisibility.Archive, AssetVisibility.Timeline];
 
 type SpacePersonStatistics = {
   assets: number;

--- a/server/src/repositories/stack.repository.ts
+++ b/server/src/repositories/stack.repository.ts
@@ -4,6 +4,7 @@ import { jsonArrayFrom } from 'kysely/helpers/postgres';
 import { InjectKysely } from 'nestjs-kysely';
 import { columns } from 'src/database';
 import { DummyValue, GenerateSql } from 'src/decorators';
+import { AssetVisibility } from 'src/enum';
 import { DB } from 'src/schema';
 import { StackTable } from 'src/schema/tables/stack.table';
 import { asUuid, withDefaultVisibility } from 'src/utils/database';
@@ -162,7 +163,7 @@ export class StackRepository {
    * asset then counts toward the space but never renders in the (stack-collapsed)
    * timeline. See discussion #751.
    */
-  async getStackedAssetIds(assetIds: string[]): Promise<string[]> {
+  async getStackedAssetIds(assetIds: string[], visibilities?: AssetVisibility[]): Promise<string[]> {
     if (assetIds.length === 0) {
       return [];
     }
@@ -171,6 +172,7 @@ export class StackRepository {
       .selectFrom('asset')
       .select('asset.id')
       .where('asset.deletedAt', 'is', null)
+      .$if(!!visibilities && visibilities.length > 0, (qb) => qb.where('asset.visibility', 'in', visibilities!))
       .where((eb) =>
         eb.or([
           eb('asset.id', 'in', assetIds),

--- a/server/src/repositories/stack.repository.ts
+++ b/server/src/repositories/stack.repository.ts
@@ -153,6 +153,43 @@ export class StackRepository {
       .executeTakeFirst();
   }
 
+  /**
+   * Expand a set of asset ids to include every other (non-deleted) asset that
+   * shares a stack with any of them. Assets with no stack map to themselves.
+   * Used to keep shared-space membership stack-atomic: adding/removing any
+   * member of a stack must add/remove the whole stack, otherwise a stack child
+   * can end up contributed to a space while its collapse-primary is not — the
+   * asset then counts toward the space but never renders in the (stack-collapsed)
+   * timeline. See discussion #751.
+   */
+  async getStackedAssetIds(assetIds: string[]): Promise<string[]> {
+    if (assetIds.length === 0) {
+      return [];
+    }
+
+    const rows = await this.db
+      .selectFrom('asset')
+      .select('asset.id')
+      .where('asset.deletedAt', 'is', null)
+      .where((eb) =>
+        eb.or([
+          eb('asset.id', 'in', assetIds),
+          eb(
+            'asset.stackId',
+            'in',
+            eb
+              .selectFrom('asset as seed')
+              .select('seed.stackId')
+              .where('seed.id', 'in', assetIds)
+              .where('seed.stackId', 'is not', null),
+          ),
+        ]),
+      )
+      .execute();
+
+    return rows.map((row) => row.id);
+  }
+
   @GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID] })
   getForAssetRemoval(assetId: string) {
     return this.db

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -8,6 +8,7 @@ import { MapMarkerResponseDto } from 'src/dtos/map.dto';
 import {
   AssetFileType,
   AssetType,
+  AssetVisibility,
   CacheControl,
   ImageFormat,
   JobName,
@@ -2327,7 +2328,11 @@ describe(SharedSpaceService.name, () => {
 
       await sut.addAssets(auth, spaceId, { assetIds: [primaryId] });
 
-      expect(mocks.stack.getStackedAssetIds).toHaveBeenCalledWith([primaryId]);
+      // Add restricts auto-expanded siblings to space-eligible visibility.
+      expect(mocks.stack.getStackedAssetIds).toHaveBeenCalledWith(
+        [primaryId],
+        [AssetVisibility.Archive, AssetVisibility.Timeline],
+      );
       expect(mocks.sharedSpace.addAssets).toHaveBeenCalledWith([
         { spaceId, assetId: primaryId, addedById: auth.user.id },
         { spaceId, assetId: childId, addedById: auth.user.id },
@@ -2671,7 +2676,8 @@ describe(SharedSpaceService.name, () => {
 
       await sut.removeAssets(auth, spaceId, { assetIds: [primaryId] });
 
-      expect(mocks.stack.getStackedAssetIds).toHaveBeenCalledWith([primaryId]);
+      // Remove reaches every live member regardless of visibility (no whitelist).
+      expect(mocks.stack.getStackedAssetIds).toHaveBeenCalledWith([primaryId], undefined);
       expect(mocks.sharedSpace.removeAssets).toHaveBeenCalledWith(spaceId, [primaryId, childId]);
       expect(mocks.sharedSpace.removePersonFacesByAssetIds).toHaveBeenCalledWith(spaceId, [primaryId, childId]);
     });

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -227,6 +227,9 @@ describe(SharedSpaceService.name, () => {
       personalProfileConflictCount: 0,
       spaceProfileConflictCount: 0,
     });
+    // Default: no stacks — expansion is the identity. Individual tests override
+    // this to exercise stack-atomic add/remove (#751).
+    mocks.stack.getStackedAssetIds.mockImplementation((ids: string[]) => Promise.resolve(ids));
   });
 
   it('should work', () => {
@@ -2298,6 +2301,85 @@ describe(SharedSpaceService.name, () => {
       );
       expectNoSharedSpaceFaceIdentityRootJobs(mocks);
     });
+
+    // #751 — stacks in spaces must be atomic. Adding any stack member must
+    // contribute the WHOLE stack, otherwise a child can be contributed while
+    // its collapse-primary is not, and it counts but never renders.
+    it('should expand a stacked asset to its whole stack before inserting', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const primaryId = newUuid();
+      const childId = newUuid();
+      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: false });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      // The client only selected the primary, but the stack has a child.
+      mocks.stack.getStackedAssetIds.mockResolvedValue([primaryId, childId]);
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([primaryId, childId]));
+      mocks.sharedSpace.addAssets.mockResolvedValue([
+        { spaceId, assetId: primaryId, addedById: auth.user.id },
+        { spaceId, assetId: childId, addedById: auth.user.id },
+      ] as any);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.update.mockResolvedValue(space);
+      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+
+      await sut.addAssets(auth, spaceId, { assetIds: [primaryId] });
+
+      expect(mocks.stack.getStackedAssetIds).toHaveBeenCalledWith([primaryId]);
+      expect(mocks.sharedSpace.addAssets).toHaveBeenCalledWith([
+        { spaceId, assetId: primaryId, addedById: auth.user.id },
+        { spaceId, assetId: childId, addedById: auth.user.id },
+      ]);
+    });
+
+    it('should reject the add when an expanded stack sibling is not accessible', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const childId = newUuid();
+      const inaccessiblePrimaryId = newUuid();
+      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      // Selecting the child expands to a primary the user cannot read.
+      mocks.stack.getStackedAssetIds.mockResolvedValue([childId, inaccessiblePrimaryId]);
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([childId]));
+      mocks.access.asset.checkAlbumAccess.mockResolvedValue(new Set());
+      mocks.access.asset.checkPartnerAccess.mockResolvedValue(new Set());
+      mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set());
+
+      await expect(sut.addAssets(auth, spaceId, { assetIds: [childId] })).rejects.toThrow();
+
+      expect(mocks.sharedSpace.addAssets).not.toHaveBeenCalled();
+    });
+
+    it('should queue SharedSpaceFaceMatch jobs for every expanded stack member', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const primaryId = newUuid();
+      const childId = newUuid();
+      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+      const space = factory.sharedSpace({ id: spaceId, faceRecognitionEnabled: true });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.stack.getStackedAssetIds.mockResolvedValue([primaryId, childId]);
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([primaryId, childId]));
+      mocks.sharedSpace.addAssets.mockResolvedValue([
+        { spaceId, assetId: primaryId, addedById: auth.user.id },
+        { spaceId, assetId: childId, addedById: auth.user.id },
+      ] as any);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.sharedSpace.update.mockResolvedValue(space);
+      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+
+      await sut.addAssets(auth, spaceId, { assetIds: [primaryId] });
+
+      expect(mocks.job.queueAll).toHaveBeenCalledWith([
+        { name: JobName.SharedSpaceFaceMatch, data: { spaceId, assetId: primaryId } },
+        { name: JobName.SharedSpaceFaceMatch, data: { spaceId, assetId: childId } },
+      ]);
+    });
   });
 
   describe('queueBulkAdd', () => {
@@ -2567,6 +2649,77 @@ describe(SharedSpaceService.name, () => {
       expect(mocks.job.queue).not.toHaveBeenCalledWith(
         expect.objectContaining({ name: JobName.FacialRecognitionQueueAll }),
       );
+    });
+
+    // #751 — removal must be stack-atomic too, otherwise removing the visible
+    // (primary) tile leaves an orphaned child contributed to the space: it
+    // counts but never renders.
+    it('should expand removal to the whole stack', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const primaryId = newUuid();
+      const childId = newUuid();
+      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId }));
+      mocks.stack.getStackedAssetIds.mockResolvedValue([primaryId, childId]);
+      mocks.sharedSpace.removeAssets.mockResolvedValue(void 0);
+      mocks.sharedSpace.getLastAssetAddedAt.mockResolvedValue(void 0);
+      mocks.sharedSpace.update.mockResolvedValue(factory.sharedSpace({ id: spaceId }));
+      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+
+      await sut.removeAssets(auth, spaceId, { assetIds: [primaryId] });
+
+      expect(mocks.stack.getStackedAssetIds).toHaveBeenCalledWith([primaryId]);
+      expect(mocks.sharedSpace.removeAssets).toHaveBeenCalledWith(spaceId, [primaryId, childId]);
+      expect(mocks.sharedSpace.removePersonFacesByAssetIds).toHaveBeenCalledWith(spaceId, [primaryId, childId]);
+    });
+
+    it('should clear the cover when a removed stack sibling is the cover photo', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const primaryId = newUuid();
+      const childId = newUuid();
+      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+      // The cover is the child; the user removes only the primary tile.
+      const space = factory.sharedSpace({ id: spaceId, thumbnailAssetId: childId });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.sharedSpace.getById.mockResolvedValue(space);
+      mocks.stack.getStackedAssetIds.mockResolvedValue([primaryId, childId]);
+      mocks.sharedSpace.removeAssets.mockResolvedValue(void 0);
+      mocks.sharedSpace.getLastAssetAddedAt.mockResolvedValue(void 0);
+      mocks.sharedSpace.update.mockResolvedValue(factory.sharedSpace({ id: spaceId, thumbnailAssetId: null }));
+      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+
+      await sut.removeAssets(auth, spaceId, { assetIds: [primaryId] });
+
+      expect(mocks.sharedSpace.update).toHaveBeenCalledWith(spaceId, {
+        lastActivityAt: null,
+        thumbnailAssetId: null,
+      });
+    });
+
+    it('should still remove an explicitly requested trashed asset even if the stack query omits it', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      const trashedId = newUuid();
+      const editorMember = makeMemberResult({ spaceId, userId: auth.user.id, role: SharedSpaceRole.Editor });
+
+      mocks.sharedSpace.getMember.mockResolvedValue(editorMember);
+      mocks.sharedSpace.getById.mockResolvedValue(factory.sharedSpace({ id: spaceId }));
+      // getStackedAssetIds excludes soft-deleted assets, so a trashed input is
+      // absent from its result — the service must still honor the explicit id.
+      mocks.stack.getStackedAssetIds.mockResolvedValue([]);
+      mocks.sharedSpace.removeAssets.mockResolvedValue(void 0);
+      mocks.sharedSpace.getLastAssetAddedAt.mockResolvedValue(void 0);
+      mocks.sharedSpace.update.mockResolvedValue(factory.sharedSpace({ id: spaceId }));
+      mocks.sharedSpace.logActivity.mockResolvedValue(void 0);
+
+      await sut.removeAssets(auth, spaceId, { assetIds: [trashedId] });
+
+      expect(mocks.sharedSpace.removeAssets).toHaveBeenCalledWith(spaceId, [trashedId]);
     });
   });
 

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -51,6 +51,7 @@ import {
   UserAvatarColor,
 } from 'src/enum';
 import type { SpaceFaceAssignment } from 'src/repositories/shared-space.repository';
+import { visibleSpaceAssetVisibilities } from 'src/repositories/shared-space.repository';
 import {
   buildAutomaticReconciliationClaim,
   chooseAutomaticTargetIdentity,
@@ -570,8 +571,8 @@ export class SharedSpaceService extends BaseService {
    * explicit add/remove is never silently dropped; the added siblings are the
    * live stack members only.
    */
-  private async expandStackAssetIds(assetIds: string[]): Promise<string[]> {
-    const stacked = await this.stackRepository.getStackedAssetIds(assetIds);
+  private async expandStackAssetIds(assetIds: string[], visibilities?: AssetVisibility[]): Promise<string[]> {
+    const stacked = await this.stackRepository.getStackedAssetIds(assetIds, visibilities);
     return [...new Set([...assetIds, ...stacked])];
   }
 
@@ -580,9 +581,11 @@ export class SharedSpaceService extends BaseService {
     // Stacks are atomic in a space: contributing any member contributes the
     // whole stack. Otherwise a stack child can be added without its
     // collapse-primary and would count toward the space but never render in the
-    // stack-collapsed timeline (#751). Access is checked on the full expanded
-    // set so we never contribute a sibling the actor cannot read.
-    const assetIds = await this.expandStackAssetIds(dto.assetIds);
+    // stack-collapsed timeline (#751). Auto-expanded siblings are restricted to
+    // space-eligible visibility so we never pull a Hidden/Locked frame in, and
+    // access is checked on the full expanded set so we never contribute a
+    // sibling the actor cannot read.
+    const assetIds = await this.expandStackAssetIds(dto.assetIds, visibleSpaceAssetVisibilities);
     await this.requireAccess({ auth, permission: Permission.AssetRead, ids: assetIds });
     const inserted = await this.sharedSpaceRepository.addAssets(
       assetIds.map((assetId) => ({ spaceId, assetId, addedById: auth.user.id })),

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -563,11 +563,29 @@ export class SharedSpaceService extends BaseService {
     await this.queueSpacePersonMetadataBackfill();
   }
 
+  /**
+   * Expand a set of asset ids to include every live sibling that shares a stack
+   * with them, so shared-space membership stays stack-atomic (discussion #751).
+   * The explicitly-passed ids are always preserved (even if soft-deleted) so an
+   * explicit add/remove is never silently dropped; the added siblings are the
+   * live stack members only.
+   */
+  private async expandStackAssetIds(assetIds: string[]): Promise<string[]> {
+    const stacked = await this.stackRepository.getStackedAssetIds(assetIds);
+    return [...new Set([...assetIds, ...stacked])];
+  }
+
   async addAssets(auth: AuthDto, spaceId: string, dto: SharedSpaceAssetAddDto): Promise<void> {
     await this.requireRole(auth, spaceId, SharedSpaceRole.Editor);
-    await this.requireAccess({ auth, permission: Permission.AssetRead, ids: dto.assetIds });
+    // Stacks are atomic in a space: contributing any member contributes the
+    // whole stack. Otherwise a stack child can be added without its
+    // collapse-primary and would count toward the space but never render in the
+    // stack-collapsed timeline (#751). Access is checked on the full expanded
+    // set so we never contribute a sibling the actor cannot read.
+    const assetIds = await this.expandStackAssetIds(dto.assetIds);
+    await this.requireAccess({ auth, permission: Permission.AssetRead, ids: assetIds });
     const inserted = await this.sharedSpaceRepository.addAssets(
-      dto.assetIds.map((assetId) => ({ spaceId, assetId, addedById: auth.user.id })),
+      assetIds.map((assetId) => ({ spaceId, assetId, addedById: auth.user.id })),
     );
 
     await this.sharedSpaceRepository.update(spaceId, { lastActivityAt: new Date() });
@@ -582,7 +600,7 @@ export class SharedSpaceService extends BaseService {
     const space = await this.sharedSpaceRepository.getById(spaceId);
     if (space?.faceRecognitionEnabled) {
       await this.jobRepository.queueAll(
-        dto.assetIds.map((assetId) => ({
+        assetIds.map((assetId) => ({
           name: JobName.SharedSpaceFaceMatch as const,
           data: { spaceId, assetId },
         })),
@@ -676,14 +694,17 @@ export class SharedSpaceService extends BaseService {
     if (!space) {
       throw new NotFoundException('Space not found');
     }
-    await this.sharedSpaceRepository.removeAssets(spaceId, dto.assetIds);
+    // Removal is stack-atomic too — removing any member removes the whole stack
+    // so no orphaned child is left contributed to the space (#751).
+    const assetIds = await this.expandStackAssetIds(dto.assetIds);
+    await this.sharedSpaceRepository.removeAssets(spaceId, assetIds);
 
     const lastAddedAt = await this.sharedSpaceRepository.getLastAssetAddedAt(spaceId);
     const updateData: { lastActivityAt: Date | null; thumbnailAssetId?: null } = {
       lastActivityAt: lastAddedAt ?? null,
     };
 
-    if (space?.thumbnailAssetId && dto.assetIds.includes(space.thumbnailAssetId)) {
+    if (space?.thumbnailAssetId && assetIds.includes(space.thumbnailAssetId)) {
       updateData.thumbnailAssetId = null;
     }
 
@@ -693,10 +714,10 @@ export class SharedSpaceService extends BaseService {
       spaceId,
       userId: auth.user.id,
       type: SharedSpaceActivityType.AssetRemove,
-      data: { count: dto.assetIds.length },
+      data: { count: assetIds.length },
     });
 
-    await this.sharedSpaceRepository.removePersonFacesByAssetIds(spaceId, dto.assetIds);
+    await this.sharedSpaceRepository.removePersonFacesByAssetIds(spaceId, assetIds);
     await this.sharedSpaceRepository.deleteOrphanedPersons(spaceId);
     await this.queueSpacePersonMetadataBackfill();
   }

--- a/server/test/medium/specs/repositories/stack.repository.spec.ts
+++ b/server/test/medium/specs/repositories/stack.repository.spec.ts
@@ -1,4 +1,5 @@
 import { Kysely } from 'kysely';
+import { AssetVisibility } from 'src/enum';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { StackRepository } from 'src/repositories/stack.repository';
 import { DB } from 'src/schema';
@@ -129,6 +130,33 @@ describe(StackRepository.name, () => {
 
       const result = await sut.getStackedAssetIds([asset.id, '00000000-0000-0000-0000-000000000000']);
       expect(result).toEqual([asset.id]);
+    });
+
+    it('excludes Hidden and Locked siblings when a visibility whitelist is given', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset: primary } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+      const { asset: archived } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Archive });
+      const { asset: hidden } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Hidden });
+      const { asset: locked } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Locked });
+      await ctx.newStack({ ownerId: user.id }, [primary.id, archived.id, hidden.id, locked.id]);
+
+      const result = await sut.getStackedAssetIds([primary.id], [AssetVisibility.Archive, AssetVisibility.Timeline]);
+      // Hidden/Locked (RBAC-sensitive tiers) must never be auto-contributed to a space.
+      expect(sorted(result)).toEqual(sorted([primary.id, archived.id]));
+    });
+
+    it('returns siblings of any visibility when no whitelist is given', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset: primary } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+      const { asset: hidden } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Hidden });
+      await ctx.newStack({ ownerId: user.id }, [primary.id, hidden.id]);
+
+      // The remove path passes no whitelist — it must reach every live member so
+      // nothing is left orphaned in the space.
+      const result = await sut.getStackedAssetIds([primary.id]);
+      expect(sorted(result)).toEqual(sorted([primary.id, hidden.id]));
     });
   });
 });

--- a/server/test/medium/specs/repositories/stack.repository.spec.ts
+++ b/server/test/medium/specs/repositories/stack.repository.spec.ts
@@ -1,0 +1,134 @@
+import { Kysely } from 'kysely';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { StackRepository } from 'src/repositories/stack.repository';
+import { DB } from 'src/schema';
+import { BaseService } from 'src/services/base.service';
+import { newMediumService } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = (db?: Kysely<DB>) => {
+  const { ctx } = newMediumService(BaseService, {
+    database: db || defaultDatabase,
+    real: [],
+    mock: [LoggingRepository],
+  });
+  return { ctx, sut: ctx.get(StackRepository) };
+};
+
+const sorted = (ids: string[]) => [...ids].sort();
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+describe(StackRepository.name, () => {
+  describe('getStackedAssetIds', () => {
+    it('returns an empty array for empty input', async () => {
+      const { sut } = setup();
+      await expect(sut.getStackedAssetIds([])).resolves.toEqual([]);
+    });
+
+    it('returns a non-stacked asset unchanged', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+
+      await expect(sut.getStackedAssetIds([asset.id])).resolves.toEqual([asset.id]);
+    });
+
+    it('expands the stack primary to include all its children', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+      const { asset: child } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newStack({ ownerId: user.id }, [primary.id, child.id]);
+
+      const result = await sut.getStackedAssetIds([primary.id]);
+      expect(sorted(result)).toEqual(sorted([primary.id, child.id]));
+    });
+
+    it('expands a stack child to include the primary and every sibling', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+      const { asset: childA } = await ctx.newAsset({ ownerId: user.id });
+      const { asset: childB } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newStack({ ownerId: user.id }, [primary.id, childA.id, childB.id]);
+
+      // Seeding from a NON-primary member must still return the whole stack —
+      // this is the exact case that broke #751 (child in a space, primary not).
+      const result = await sut.getStackedAssetIds([childA.id]);
+      expect(sorted(result)).toEqual(sorted([primary.id, childA.id, childB.id]));
+    });
+
+    it('deduplicates when multiple members of the same stack are passed', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+      const { asset: child } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newStack({ ownerId: user.id }, [primary.id, child.id]);
+
+      const result = await sut.getStackedAssetIds([primary.id, child.id]);
+      expect(sorted(result)).toEqual(sorted([primary.id, child.id]));
+      expect(result).toHaveLength(2);
+    });
+
+    it('expands every distinct stack referenced by the input', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset: primaryA } = await ctx.newAsset({ ownerId: user.id });
+      const { asset: childA } = await ctx.newAsset({ ownerId: user.id });
+      const { asset: primaryB } = await ctx.newAsset({ ownerId: user.id });
+      const { asset: childB } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newStack({ ownerId: user.id }, [primaryA.id, childA.id]);
+      await ctx.newStack({ ownerId: user.id }, [primaryB.id, childB.id]);
+
+      const result = await sut.getStackedAssetIds([childA.id, primaryB.id]);
+      expect(sorted(result)).toEqual(sorted([primaryA.id, childA.id, primaryB.id, childB.id]));
+    });
+
+    it('unions stacked and non-stacked inputs', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+      const { asset: child } = await ctx.newAsset({ ownerId: user.id });
+      const { asset: loner } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newStack({ ownerId: user.id }, [primary.id, child.id]);
+
+      const result = await sut.getStackedAssetIds([primary.id, loner.id]);
+      expect(sorted(result)).toEqual(sorted([primary.id, child.id, loner.id]));
+    });
+
+    it('excludes soft-deleted siblings from the expansion', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset: primary } = await ctx.newAsset({ ownerId: user.id });
+      const { asset: liveChild } = await ctx.newAsset({ ownerId: user.id });
+      const { asset: deletedChild } = await ctx.newAsset({ ownerId: user.id, deletedAt: new Date() });
+      await ctx.newStack({ ownerId: user.id }, [primary.id, liveChild.id, deletedChild.id]);
+
+      const result = await sut.getStackedAssetIds([primary.id]);
+      expect(sorted(result)).toEqual(sorted([primary.id, liveChild.id]));
+    });
+
+    it('excludes a soft-deleted input asset', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset: deleted } = await ctx.newAsset({ ownerId: user.id, deletedAt: new Date() });
+
+      await expect(sut.getStackedAssetIds([deleted.id])).resolves.toEqual([]);
+    });
+
+    it('ignores ids that do not exist', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+
+      const result = await sut.getStackedAssetIds([asset.id, '00000000-0000-0000-0000-000000000000']);
+      expect(result).toEqual([asset.id]);
+    });
+  });
+});

--- a/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
+++ b/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
@@ -8,6 +8,7 @@ import { LoggingRepository } from 'src/repositories/logging.repository';
 import { PersonRepository } from 'src/repositories/person.repository';
 import { SearchRepository } from 'src/repositories/search.repository';
 import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
+import { StackRepository } from 'src/repositories/stack.repository';
 import { SystemMetadataRepository } from 'src/repositories/system-metadata.repository';
 import { DB } from 'src/schema';
 import { SharedSpaceService } from 'src/services/shared-space.service';
@@ -29,6 +30,7 @@ const setup = (db?: Kysely<DB>) => {
       ConfigRepository,
       SystemMetadataRepository,
       SearchRepository,
+      StackRepository,
     ],
     mock: [LoggingRepository, JobRepository],
   });

--- a/server/test/medium/specs/services/shared-space-stacks.spec.ts
+++ b/server/test/medium/specs/services/shared-space-stacks.spec.ts
@@ -1,0 +1,173 @@
+import { Insertable, Kysely } from 'kysely';
+import { AssetVisibility, SharedSpaceRole, TimeBucketSize } from 'src/enum';
+import { AccessRepository } from 'src/repositories/access.repository';
+import { AssetRepository } from 'src/repositories/asset.repository';
+import { JobRepository } from 'src/repositories/job.repository';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
+import { StackRepository } from 'src/repositories/stack.repository';
+import { DB } from 'src/schema';
+import { AssetTable } from 'src/schema/tables/asset.table';
+import { SharedSpaceService } from 'src/services/shared-space.service';
+import { newMediumService } from 'test/medium.factory';
+import { factory } from 'test/small.factory';
+import { getKyselyDB } from 'test/utils';
+import { beforeAll, describe, expect, it, Mocked } from 'vitest';
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = (db?: Kysely<DB>) => {
+  const { ctx, sut } = newMediumService(SharedSpaceService, {
+    database: db || defaultDatabase,
+    real: [SharedSpaceRepository, AssetRepository, StackRepository, AccessRepository],
+    mock: [LoggingRepository, JobRepository],
+  });
+  const jobs = ctx.getMock<JobRepository, Mocked<JobRepository>>(JobRepository);
+  jobs.queue.mockResolvedValue();
+  jobs.queueAll.mockResolvedValue();
+  return {
+    ctx,
+    sut,
+    assetRepo: ctx.get(AssetRepository),
+    spaceRepo: ctx.get(SharedSpaceRepository),
+  };
+};
+
+const createTimelineAsset = async (
+  ctx: ReturnType<typeof setup>['ctx'],
+  ownerId: string,
+  localDateTime: Date,
+  options: Partial<Insertable<AssetTable>> = {},
+) => {
+  const { asset } = await ctx.newAsset({
+    ownerId,
+    visibility: AssetVisibility.Timeline,
+    fileCreatedAt: localDateTime,
+    localDateTime,
+    width: 400,
+    height: 200,
+    thumbhash: Buffer.from('thumbhash'),
+    ...options,
+  });
+  await ctx.newExif({ assetId: asset.id, timeZone: 'UTC' });
+  return asset;
+};
+
+const spaceTimelineCount = async (
+  assetRepo: ReturnType<typeof setup>['assetRepo'],
+  spaceId: string,
+): Promise<number> => {
+  const buckets = await assetRepo.getTimeBuckets({
+    spaceId,
+    visibility: AssetVisibility.Timeline,
+    bucketSize: TimeBucketSize.Year,
+    withStacked: true,
+  });
+  return buckets.reduce((total, bucket) => total + bucket.count, 0);
+};
+
+const seedOwnedSpaceWithStack = async (ctx: ReturnType<typeof setup>['ctx']) => {
+  const { user } = await ctx.newUser();
+  const auth = factory.auth({
+    user: { id: user.id, name: user.name, email: user.email, isAdmin: user.isAdmin },
+  });
+  const { space } = await ctx.newSharedSpace({ createdById: user.id });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+
+  const primary = await createTimelineAsset(ctx, user.id, new Date('2024-01-01T12:00:00.000Z'));
+  const child = await createTimelineAsset(ctx, user.id, new Date('2024-01-02T12:00:00.000Z'));
+  await ctx.newStack({ ownerId: user.id }, [primary.id, child.id]);
+
+  return { user, auth, space, primary, child };
+};
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+describe(`${SharedSpaceService.name} stacks in spaces (#751)`, () => {
+  it('contributes the whole stack when only the primary is selected, keeping count and timeline consistent', async () => {
+    const { ctx, sut, assetRepo, spaceRepo } = setup();
+    const { auth, space, primary } = await seedOwnedSpaceWithStack(ctx);
+
+    await sut.addAssets(auth, space.id, { assetIds: [primary.id] });
+
+    // Both stack members are contributed (raw membership count = 2)...
+    await expect(spaceRepo.getAssetCount(space.id)).resolves.toBe(2);
+    // ...and the stack-collapsed timeline shows exactly one tile (the primary).
+    await expect(spaceTimelineCount(assetRepo, space.id)).resolves.toBe(1);
+  });
+
+  it('contributes the whole stack when only a child is selected', async () => {
+    const { ctx, sut, assetRepo, spaceRepo } = setup();
+    const { auth, space, child } = await seedOwnedSpaceWithStack(ctx);
+
+    await sut.addAssets(auth, space.id, { assetIds: [child.id] });
+
+    await expect(spaceRepo.getAssetCount(space.id)).resolves.toBe(2);
+    await expect(spaceTimelineCount(assetRepo, space.id)).resolves.toBe(1);
+  });
+
+  it('removes the whole stack when the primary tile is removed — no orphaned child left counting', async () => {
+    const { ctx, sut, assetRepo, spaceRepo } = setup();
+    const { auth, space, primary } = await seedOwnedSpaceWithStack(ctx);
+
+    await sut.addAssets(auth, space.id, { assetIds: [primary.id] });
+    // This is Pierre's exact repro: remove the single visible (primary) tile.
+    await sut.removeAssets(auth, space.id, { assetIds: [primary.id] });
+
+    // Count and timeline must BOTH be empty — the child must not linger.
+    await expect(spaceRepo.getAssetCount(space.id)).resolves.toBe(0);
+    await expect(spaceTimelineCount(assetRepo, space.id)).resolves.toBe(0);
+  });
+
+  it('removes the whole stack when a child is removed', async () => {
+    const { ctx, sut, assetRepo, spaceRepo } = setup();
+    const { auth, space, child } = await seedOwnedSpaceWithStack(ctx);
+
+    await sut.addAssets(auth, space.id, { assetIds: [child.id] });
+    await sut.removeAssets(auth, space.id, { assetIds: [child.id] });
+
+    await expect(spaceRepo.getAssetCount(space.id)).resolves.toBe(0);
+    await expect(spaceTimelineCount(assetRepo, space.id)).resolves.toBe(0);
+  });
+
+  // The exact #751 repro: the client contributes BOTH members (count shows 2),
+  // then the user removes the single visible (primary) tile. Before the fix,
+  // removal touched only the primary, leaving the child orphaned — the space
+  // reported "1 remaining photo" while the timeline was empty.
+  it('reproduces #751: removing the primary tile clears the space even when both members were contributed', async () => {
+    const { ctx, sut, assetRepo, spaceRepo } = setup();
+    const { auth, space, primary, child } = await seedOwnedSpaceWithStack(ctx);
+
+    await sut.addAssets(auth, space.id, { assetIds: [primary.id, child.id] });
+    await expect(spaceRepo.getAssetCount(space.id)).resolves.toBe(2);
+
+    await sut.removeAssets(auth, space.id, { assetIds: [primary.id] });
+
+    await expect(spaceRepo.getAssetCount(space.id)).resolves.toBe(0);
+    await expect(spaceTimelineCount(assetRepo, space.id)).resolves.toBe(0);
+  });
+
+  // Characterization test: this is the exact divergence the stack-atomic
+  // membership fix prevents. A stack CHILD contributed without its global
+  // collapse-primary counts toward the space but is filtered out of the
+  // stack-collapsed timeline. The service can no longer produce this state,
+  // but the raw query still behaves this way — which is *why* atomicity is
+  // required at the contribution layer.
+  it('a lone stack child diverges: counted but invisible in the collapsed timeline', async () => {
+    const { ctx, assetRepo, spaceRepo } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+
+    const primary = await createTimelineAsset(ctx, user.id, new Date('2024-02-01T12:00:00.000Z'));
+    const child = await createTimelineAsset(ctx, user.id, new Date('2024-02-02T12:00:00.000Z'));
+    await ctx.newStack({ ownerId: user.id }, [primary.id, child.id]);
+
+    // Contribute ONLY the child directly (bypassing the atomic service path).
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: child.id, addedById: user.id });
+
+    await expect(spaceRepo.getAssetCount(space.id)).resolves.toBe(1);
+    await expect(spaceTimelineCount(assetRepo, space.id)).resolves.toBe(0);
+  });
+});

--- a/server/test/medium/specs/services/shared-space-stacks.spec.ts
+++ b/server/test/medium/specs/services/shared-space-stacks.spec.ts
@@ -170,4 +170,30 @@ describe(`${SharedSpaceService.name} stacks in spaces (#751)`, () => {
     await expect(spaceRepo.getAssetCount(space.id)).resolves.toBe(1);
     await expect(spaceTimelineCount(assetRepo, space.id)).resolves.toBe(0);
   });
+
+  // RBAC: auto-expansion must not pull a Hidden/Locked stack frame into a space.
+  it('does not contribute a Hidden stack sibling when expanding on add', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const auth = factory.auth({
+      user: { id: user.id, name: user.name, email: user.email, isAdmin: user.isAdmin },
+    });
+    const { space } = await ctx.newSharedSpace({ createdById: user.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+
+    const primary = await createTimelineAsset(ctx, user.id, new Date('2024-03-01T12:00:00.000Z'));
+    const { asset: hidden } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Hidden });
+    await ctx.newStack({ ownerId: user.id }, [primary.id, hidden.id]);
+
+    await sut.addAssets(auth, space.id, { assetIds: [primary.id] });
+
+    const members = await defaultDatabase
+      .selectFrom('shared_space_asset')
+      .select('assetId')
+      .where('spaceId', '=', space.id)
+      .execute();
+    const memberIds = members.map((m) => m.assetId);
+    expect(memberIds).toContain(primary.id);
+    expect(memberIds).not.toContain(hidden.id);
+  });
 });

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -1131,6 +1131,7 @@
             enableRouting={false}
             bind:timelineManager
             {options}
+            withStacked
             assetInteraction={assetMultiSelectManager}
             {isSelectionMode}
             onEscape={handleEscape}

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/mock-timeline.test-wrapper.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/mock-timeline.test-wrapper.svelte
@@ -12,6 +12,7 @@
     onGroupingChange?: (grouping: TimelineGrouping) => void;
     temporalAnchor?: { year: number; month?: number };
     onTemporalAnchorResolved?: () => void;
+    withStacked?: boolean;
     children?: Snippet;
     [key: string]: unknown;
   }
@@ -25,6 +26,7 @@
     onGroupingChange,
     temporalAnchor,
     onTemporalAnchorResolved,
+    withStacked = false,
     ...rest
   }: Props = $props();
 
@@ -56,6 +58,7 @@
 
 <div {...rest} data-testid="timeline-stub" data-has-timeline={String(timelineManager !== undefined)}>
   <div data-testid="timeline-options">{JSON.stringify(options)}</div>
+  <div data-testid="timeline-withstacked">{String(withStacked)}</div>
   <button
     type="button"
     data-testid="activate-year-bucket"

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -979,4 +979,18 @@ describe('Spaces page search URL state', () => {
     const bar = await screen.findByTestId('active-filters-bar-stub');
     expect(bar).toHaveAttribute('data-has-add-all', 'true');
   });
+
+  // #751 — the space Timeline must receive the `withStacked` prop, not just the
+  // `withStacked` query option, or the collapsed stack renders as a lone photo
+  // with no stack badge (showStackedIcon is gated on the prop).
+  it('passes the withStacked prop into the space Timeline so stacks show a badge', async () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos');
+
+    renderPage();
+
+    expect(await screen.findByTestId('timeline-withstacked')).toHaveTextContent('true');
+    // The query option must remain set too (the server only returns stack data
+    // when withStacked is requested).
+    expect(screen.getByTestId('timeline-options')).toHaveTextContent('"withStacked":true');
+  });
 });


### PR DESCRIPTION
## What this does

Makes photo stacks behave correctly inside shared spaces across web, server, and mobile: a stack is contributed to and removed from a space as a single unit, the space timeline collapses it to its cover with a badge, and only space-eligible frames are pulled in. This is the complete implementation of discussion #751 — it supersedes #755, whose work was reverted alongside the space-albums branch during the v3.0.2 cutover and never re-applied. Closes #751.

## Cause

Space membership is stored per asset (`shared_space_asset`), while the space timeline collapses stacks by the stack's primary asset (`withTimeBucketAssetFilters` in `asset.repository.ts`). The two operate independently:

- `getAssetCount` counts membership rows directly, so each stack member counts.
- the timeline keeps a row only when it is unstacked or is the stack primary, dropping non-primary children.

Because membership was per-asset, a space could hold some members of a stack and not others. A child contributed without its primary counted toward the space total but never rendered in the collapsed timeline, and removing the primary left the child behind.

## Fix

**Stack-atomic membership (server).** Contributing or removing any member of a stack now acts on the whole stack, so a space always holds complete stacks:

- `StackRepository.getStackedAssetIds(ids, visibilities?)` expands a set of ids to their full live stacks, optionally restricted to a visibility whitelist.
- `SharedSpaceService.addAssets` / `removeAssets` expand through this before writing membership. On add, auto-expanded siblings are restricted to space-eligible visibility (`[Archive, Timeline]`) so a Hidden or Locked frame is never pulled in; access is verified on the full expanded set; explicitly-passed ids are always preserved. Removal reaches every live member. Scoped to the two `/shared-spaces/:id/assets` endpoints — the deduplication keeper path uses the repository directly and is intentionally unaffected.

**Badge rendering (web).** The space `<Timeline>` now receives the `withStacked` prop so the collapsed stack shows its badge, matching every other timeline surface.

**Mobile collapse.** The aggregated-space Drift timeline now collapses stacks to their primary (grouped bucket, ungrouped count, and asset fetch), mirroring the main timeline. Un-stacked assets are unaffected; the album-detail path stays uncollapsed.

**Docs.** Documented stacked photos in shared spaces.

## Tests

- `StackRepository.getStackedAssetIds` — medium cases: primary/child seeds, multi-stack, dedup, soft-deleted siblings and inputs, non-existent ids, and visibility-whitelist filtering (Hidden/Locked excluded; no-whitelist reaches every member).
- `SharedSpaceService.add/removeAssets` — unit cases: expansion on add and remove, the visibility whitelist passed on add (and not on remove), access check on the expanded set, face-match jobs per member, cover-clear when a removed sibling is the cover, trashed-input preservation.
- `shared-space-stacks.spec.ts` — end-to-end medium spec driving the real service: `getAssetCount` and the collapsed timeline stay consistent through add and remove, and a Hidden sibling is never contributed.
- Mobile `timeline_repository_test.dart` — Drift collapse for the grouped bucket, ungrouped count, and un-stacked-alongside-stack cases.
- Web `spaces-page.spec.ts` — asserts the `withStacked` prop reaches the space Timeline.

Server unit + medium, mobile Drift, and web suites all green; type-check, ESLint, and `dart analyze --fatal-infos` clean.