### PR TITLE
fix(config): keep empty-object defaults as known config keys

### DIFF
--- a/server/src/services/system-config.service.spec.ts
+++ b/server/src/services/system-config.service.spec.ts
@@ -315,6 +315,18 @@ describe(SystemConfigService.name, () => {
       await expect(sut.getSystemConfig()).resolves.toEqual(updatedConfig);
     });
 
+    it('should keep defaults when a partial supplies an empty object for a populated section', async () => {
+      // Guards the deliberate asymmetry: emptyObjectsAsLeaves is used only for the DEFAULTS enumeration,
+      // never for the user-supplied partial. An empty object in the partial must not wipe a populated
+      // default section, and must not be reported as an unknown key.
+      mocks.systemMetadata.get.mockResolvedValue({ machineLearning: {} });
+
+      const result = await sut.getSystemConfig();
+
+      expect(result.machineLearning).toEqual(defaults.machineLearning);
+      expect(mocks.logger.warn).not.toHaveBeenCalled();
+    });
+
     it('should default missing classification faceExclusion to off', () => {
       const result = SystemConfigSchema.parse({
         ...defaults,
@@ -445,6 +457,14 @@ describe(SystemConfigService.name, () => {
       const result = await sut.getSystemConfig();
 
       expect(result.memories.types).toEqual({ recent_trip: false });
+    });
+
+    it('should not warn about unknown keys for the default per-type memory availability map', async () => {
+      mocks.systemMetadata.get.mockResolvedValue({});
+
+      await sut.getSystemConfig();
+
+      expect(mocks.logger.warn).not.toHaveBeenCalled();
     });
 
     it('should accept zero generated memory retention from a config file', async () => {
@@ -693,6 +713,21 @@ describe(SystemConfigService.name, () => {
       });
       expect(mocks.systemMetadata.set).toHaveBeenCalledWith(SystemMetadataKey.SystemConfig, {
         memories: { birthday: false, recentTrips: false },
+      });
+    });
+
+    it('should persist per-type memory availability overrides', async () => {
+      const config = structuredClone(defaults);
+      config.memories.types = { recent_trip: false };
+      mocks.systemMetadata.get
+        .mockResolvedValueOnce({})
+        .mockResolvedValueOnce({ memories: { types: { recent_trip: false } } });
+
+      await expect(sut.updateSystemConfig(config)).resolves.toMatchObject({
+        memories: { types: { recent_trip: false } },
+      });
+      expect(mocks.systemMetadata.set).toHaveBeenCalledWith(SystemMetadataKey.SystemConfig, {
+        memories: { types: { recent_trip: false } },
       });
     });
 

--- a/server/src/utils/config.ts
+++ b/server/src/utils/config.ts
@@ -43,7 +43,7 @@ export const updateConfig = async (repos: RepoDeps, newConfig: SystemConfig): Pr
   const { metadataRepo } = repos;
   // get the difference between the new config and the default config
   const partialConfig: DeepPartial<SystemConfig> = {};
-  for (const property of getKeysDeep(defaults)) {
+  for (const property of getKeysDeep(defaults, [], { emptyObjectsAsLeaves: true })) {
     const newValue = _.get(newConfig, property);
     const isEmpty = newValue === undefined || newValue === null || newValue === '';
     const defaultValue = _.get(defaults, property);
@@ -81,15 +81,18 @@ const buildConfig = async (repos: RepoDeps) => {
     ? await loadFromFile(repos, configFile)
     : await metadataRepo.get(SystemMetadataKey.SystemConfig);
 
-  // merge with defaults
+  // merge with defaults. Enumerate the user-supplied partial WITHOUT emptyObjectsAsLeaves: an empty
+  // object in the partial must yield no path so it can't `_.set` over (and wipe) a populated default
+  // section. Only the defaults enumeration below opts into empty-object leaves.
   const rawConfig = _.cloneDeep(defaults);
   for (const property of getKeysDeep(partial)) {
     _.set(rawConfig, property, _.get(partial, property));
   }
 
-  // check for extra properties
+  // check for extra properties. Enumerate defaults with empty objects kept as leaves so sparse-map
+  // defaults (e.g. `memories.types: {}`) count as known keys instead of being reported as unknown.
   const unknownKeys = _.cloneDeep(rawConfig);
-  for (const property of getKeysDeep(defaults)) {
+  for (const property of getKeysDeep(defaults, [], { emptyObjectsAsLeaves: true })) {
     unsetDeep(unknownKeys, property);
   }
 

--- a/server/src/utils/misc.spec.ts
+++ b/server/src/utils/misc.spec.ts
@@ -50,6 +50,26 @@ describe('getKeysDeep', () => {
   it('should list nested properties', () => {
     expect(getKeysDeep({ foo: 'bar', hello: { world: true } })).toEqual(['foo', 'hello.world']);
   });
+
+  it('should skip empty objects by default', () => {
+    expect(getKeysDeep({ foo: 'bar', empty: {} })).toEqual(['foo']);
+    expect(getKeysDeep({ foo: 'bar', nested: { empty: {} } })).toEqual(['foo']);
+  });
+
+  it('should emit empty objects as leaf paths when emptyObjectsAsLeaves is set', () => {
+    expect(getKeysDeep({ foo: 'bar', empty: {} }, [], { emptyObjectsAsLeaves: true })).toEqual(['foo', 'empty']);
+    expect(getKeysDeep({ foo: 'bar', nested: { empty: {} } }, [], { emptyObjectsAsLeaves: true })).toEqual([
+      'foo',
+      'nested.empty',
+    ]);
+  });
+
+  it('should still recurse into non-empty objects when emptyObjectsAsLeaves is set', () => {
+    expect(getKeysDeep({ foo: 'bar', hello: { world: true } }, [], { emptyObjectsAsLeaves: true })).toEqual([
+      'foo',
+      'hello.world',
+    ]);
+  });
 });
 
 describe('unsetDeep', () => {

--- a/server/src/utils/misc.ts
+++ b/server/src/utils/misc.ts
@@ -56,7 +56,7 @@ export const getExternalDomain = (server: SystemConfig['server'], defaultDomain 
 /**
  * @returns a list of strings representing the keys of the object in dot notation
  */
-export const getKeysDeep = (target: unknown, path: string[] = []) => {
+export const getKeysDeep = (target: unknown, path: string[] = [], options: { emptyObjectsAsLeaves?: boolean } = {}) => {
   if (!target || typeof target !== 'object') {
     return [];
   }
@@ -71,7 +71,15 @@ export const getKeysDeep = (target: unknown, path: string[] = []) => {
     }
 
     if (_.isObject(value) && !_.isArray(value) && !_.isDate(value)) {
-      properties.push(...getKeysDeep(value, [...path, key]));
+      // An empty object has no leaf paths, so recursing yields nothing and the key vanishes from the
+      // flattened list. When enumerating known defaults (e.g. the sparse `memories.types` override map,
+      // default `{}`), that makes the key look "unknown" on load and drops overrides on save. Treat an
+      // empty object as a leaf so its path is preserved.
+      if (options.emptyObjectsAsLeaves && Object.keys(value).length === 0) {
+        properties.push([...path, key].join('.'));
+      } else {
+        properties.push(...getKeysDeep(value, [...path, key], options));
+      }
       continue;
     }
 


### PR DESCRIPTION
## Problem

After #707 (config-driven memory types), the server logged this on **every config load**:

```
WARN [Api:AuthService] Unknown keys found: {
  "memories": {
    "types": {}
  }
}
```

## Root cause

`#707` added a sparse override map with an **empty-object default**:

```ts
// server/src/config.ts
memories: { …, types: {} }
```

`getKeysDeep()` flattens the config into dot-notation leaf paths, but an **empty object has no leaves** — so `memories.types` vanished from the flattened list. That broke the config machinery in two places, both from the same cause:

1. **The warning:** `buildConfig`'s unknown-key check subtracts every *known* default path from the config; because `memories.types` was never emitted as known, it couldn't be subtracted and was falsely reported as unknown on every boot.
2. **A latent second bug:** `updateConfig` diffs a new config against defaults by iterating the same default paths — so any admin override to `memories.types` was **silently dropped and never persisted**.

## Fix

Added an opt-in `{ emptyObjectsAsLeaves: true }` to `getKeysDeep` that treats a truly-empty object as a leaf, applied **only** at the two sites that enumerate the known defaults (`buildConfig`'s unknown-key check and `updateConfig`'s diff). The user-supplied `partial`/`dto` enumerations keep their exact old behavior, so an empty object in a hand-written config file can't wipe a populated default section.

The empty-map default stays empty on purpose — it must remain `{}` for the legacy `birthday`/`recentTrips` back-compat precedence (`explicit types[key]` > legacy bool > metadata default) to work.

## Tests (TDD)

- `getKeysDeep` option behaviour + regression guards (empty objects still skipped by default; non-empty objects still recurse).
- Asserts **no** `Unknown keys found` warning on default config load.
- Asserts `memories.types` overrides are persisted by `updateConfig`.

Full server unit suite (4797 passed), `tsc --noEmit`, and `eslint` on changed files all green locally.