### PR TITLE
fix(mobile): force plugin subprojects to JVM 17 to unblock Android release

### DIFF
--- a/mobile/android/build.gradle
+++ b/mobile/android/build.gradle
@@ -24,6 +24,38 @@ rootProject.buildDir = '../build'
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
     project.evaluationDependsOn(':app')
+
+    // The home_widget 0.8.1 plugin hardcodes `jvmTarget "1.8"` but depends on
+    // androidx.glance:glance-appwidget:1.1.1, which is compiled at JVM target 11.
+    // On a clean release build Kotlin refuses to inline the JVM-11 glance bytecode
+    // into home_widget's 1.8 compilation ("Cannot inline bytecode built with JVM
+    // target 11 into bytecode that is being built with JVM target 1.8" →
+    // `:home_widget:compileReleaseKotlin` fails). Cached (smoke) builds skip the
+    // recompile and hide it. Force every Android plugin subproject to compile
+    // Java + Kotlin at JVM 17, matching the :app module, so the whole graph is one
+    // JVM target. Java compatibility must go through android.compileOptions (AGP
+    // overrides the raw JavaCompile task), and Kotlin through kotlinOptions — set
+    // both or AGP reports "Inconsistent JVM-target compatibility" per module.
+    // Guard: evaluationDependsOn(':app') above force-evaluates :app, and
+    // afterEvaluate throws on an already-evaluated project. :app is already JVM 17,
+    // so only the not-yet-evaluated plugin subprojects need this.
+    if (!project.state.executed) {
+        project.afterEvaluate { subproject ->
+            if (subproject.hasProperty('android')) {
+                subproject.android {
+                    compileOptions {
+                        sourceCompatibility JavaVersion.VERSION_17
+                        targetCompatibility JavaVersion.VERSION_17
+                    }
+                    if (subproject.plugins.hasPlugin('kotlin-android')) {
+                        kotlinOptions {
+                            jvmTarget = '17'
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 tasks.register("clean", Delete) {


### PR DESCRIPTION
## Problem

The **Release Mobile** Android job fails on a clean build with:
```
:home_widget:compileReleaseKotlin — Cannot inline bytecode built with JVM target 11
into bytecode that is being built with JVM target 1.8
```

**Root cause:** `home_widget` 0.8.1's `android/build.gradle` hardcodes `jvmTarget "1.8"`, but it depends on `androidx.glance:glance-appwidget:1.+` — pinned to **1.1.1** (compiled at JVM 11) by our root `build.gradle` (the earlier alpha-pin fix). Kotlin 1.9+ refuses to inline JVM-11 `inline` functions into a 1.8 target. The `:app` module is already JVM 17, but plugin subprojects don't inherit that.

**Why it slipped through smoke builds:** smoke/dispatch builds restore a shared Gradle cache where `:home_widget:compileReleaseKotlin` is up-to-date, so it's skipped. Release runs do a clean build (no cache restore) and recompile it → fail. Not caused by the v3.0.3 rebase (which touched zero Android build config).

## Fix

Force every Android plugin subproject to compile Java + Kotlin at **JVM 17**, matching `:app`, in the root `mobile/android/build.gradle` `subprojects {}` block. One JVM target across the whole graph → no inline mismatch.

## Validation

Dispatched `gallery-build-mobile.yml` (Android, `version=''` = no store upload) on this branch. The changed `jvmTarget` invalidates the `compileReleaseKotlin` task cache, forcing a real recompile of `home_widget` — so a green Android AAB build here is a genuine pass, not a cache skip.