### PR TITLE
fix(web): make maintenance integrity counts readable in light mode (#779)

### DIFF
--- a/web/src/lib/components/server-statistics/ServerStatisticsCard.svelte
+++ b/web/src/lib/components/server-statistics/ServerStatisticsCard.svelte
@@ -38,18 +38,18 @@
 
   {#await valuePromise}
     <div class="relative mx-auto font-mono text-2xl font-medium" aria-label="0">
-      <span class="shimmer-text text-gray-300 dark:text-gray-600">{zeros()}</span>
+      <span class="shimmer-text text-gray-400 dark:text-gray-600">{zeros()}</span>
     </div>
   {:then data}
     <div class="relative mx-auto font-mono text-2xl font-medium" aria-label="{data.value} {data.unit ?? ''}">
-      <span class="text-gray-300 dark:text-gray-600">{zeros(data)}</span><span>{data.value}</span>
+      <span class="text-gray-400 dark:text-gray-600">{zeros(data)}</span><span>{data.value}</span>
       {#if data.unit}
         <code class="font-mono text-base font-normal">{data.unit}</code>
       {/if}
     </div>
   {:catch _}
     <div class="relative mx-auto font-mono text-2xl font-medium" aria-label="0">
-      <span class="text-gray-300 dark:text-gray-600">{zeros()}</span>
+      <span class="text-gray-400 dark:text-gray-600">{zeros()}</span>
     </div>
   {/await}
 


### PR DESCRIPTION
Closes #779

## Problem

On the maintenance **Integrity Report** screen, the count numbers (e.g. the leading `0`s) are invisible in light mode — they only appear once you select the text.

## Root cause

`ServerStatisticsCard` renders the odometer-style placeholder zeros with `text-gray-300`. In the fork's light theme (`web/src/styles/gallery-theme.css`):

- `--color-gray-300: #dde3ea`
- `--immich-ui-gray: #dde3ea` — the "subtle surface" that `bg-subtle` (the card background) paints

So the placeholder digits are drawn in **the exact same hex as the card background** → invisible. The fork's earlier light-mode readability pass darkened `gray-400`/`gray-500` *"for counts / placeholders,"* but this upstream card used `gray-300`, so it slipped through. Dark mode uses distinct values, so this was a **light-mode-only** bug.

## Fix

Switch the three placeholder spans from `text-gray-300` → `text-gray-400`. `gray-400` is already the fork's darkened, readable light-mode gray (`#6e7378`); the dark-mode variant (`dark:text-gray-600`) is unchanged. This aligns the card with the fork's own "placeholders use text-gray-400" convention.

`ServerStatisticsCard` is shared, so this also fixes the same latent invisibility on the other admin pages that use it (users, server-status, library-management).

## Verification

Rendered with the fork's real token values — before: only the blue value digit shows; after: all digits legible while the value still pops in the accent color (odometer hierarchy preserved). Verified live at `/admin/maintenance` on the local dev stack.
