### PR TITLE
fix(mobile): show shared-space people in the photos-filter people picker for space viewers

### DIFF
--- a/mobile/lib/domain/models/person.model.dart
+++ b/mobile/lib/domain/models/person.model.dart
@@ -10,6 +10,7 @@ class PersonDto {
     required this.thumbnailPath,
     this.updatedAt,
     this.numberOfAssets,
+    this.spaceId,
   });
 
   final String id;
@@ -24,9 +25,15 @@ class PersonDto {
   /// (e.g. the offline local-Drift fallback path never populates it).
   final int? numberOfAssets;
 
+  /// Space scope for a photos-filter person. Non-null when this is a shared-space person, in
+  /// which case [id] is the tokenized `space-person:<uuid>` filter id and the avatar routes to
+  /// the membership-gated space thumbnail endpoint (the owner endpoint 404s that id). Null for
+  /// personal/owned people. Mirrors [DriftPerson.spaceId] / web `primaryProfile.spaceId`.
+  final String? spaceId;
+
   @override
   String toString() {
-    return 'Person(id: $id, birthDate: $birthDate, isHidden: $isHidden, name: $name, thumbnailPath: $thumbnailPath, updatedAt: $updatedAt, numberOfAssets: $numberOfAssets)';
+    return 'Person(id: $id, birthDate: $birthDate, isHidden: $isHidden, name: $name, thumbnailPath: $thumbnailPath, updatedAt: $updatedAt, numberOfAssets: $numberOfAssets, spaceId: $spaceId)';
   }
 
   PersonDto copyWith({
@@ -37,6 +44,7 @@ class PersonDto {
     String? thumbnailPath,
     DateTime? updatedAt,
     int? numberOfAssets,
+    String? spaceId,
   }) {
     return PersonDto(
       id: id ?? this.id,
@@ -46,6 +54,7 @@ class PersonDto {
       thumbnailPath: thumbnailPath ?? this.thumbnailPath,
       updatedAt: updatedAt ?? this.updatedAt,
       numberOfAssets: numberOfAssets ?? this.numberOfAssets,
+      spaceId: spaceId ?? this.spaceId,
     );
   }
 
@@ -58,6 +67,7 @@ class PersonDto {
       'thumbnailPath': thumbnailPath,
       'updatedAt': updatedAt?.millisecondsSinceEpoch,
       'numberOfAssets': numberOfAssets,
+      'spaceId': spaceId,
     };
   }
 
@@ -70,6 +80,7 @@ class PersonDto {
       thumbnailPath: map['thumbnailPath'] as String,
       updatedAt: map['updatedAt'] != null ? DateTime.fromMillisecondsSinceEpoch(map['updatedAt'] as int) : null,
       numberOfAssets: map['numberOfAssets'] as int?,
+      spaceId: map['spaceId'] as String?,
     );
   }
 
@@ -89,7 +100,8 @@ class PersonDto {
         other.name == name &&
         other.thumbnailPath == thumbnailPath &&
         other.updatedAt == updatedAt &&
-        other.numberOfAssets == numberOfAssets;
+        other.numberOfAssets == numberOfAssets &&
+        other.spaceId == spaceId;
   }
 
   @override
@@ -100,7 +112,8 @@ class PersonDto {
         name.hashCode ^
         thumbnailPath.hashCode ^
         updatedAt.hashCode ^
-        numberOfAssets.hashCode;
+        numberOfAssets.hashCode ^
+        spaceId.hashCode;
   }
 }
 

--- a/mobile/lib/presentation/pages/photos_filter/widgets/person_picker_list.widget.dart
+++ b/mobile/lib/presentation/pages/photos_filter/widgets/person_picker_list.widget.dart
@@ -138,7 +138,12 @@ class _PersonRow extends ConsumerWidget {
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 6),
         child: Row(
           children: [
-            CircleAvatar(radius: 20, backgroundImage: RemoteImageProvider(url: getFaceThumbnailUrl(person.id))),
+            CircleAvatar(
+              radius: 20,
+              backgroundImage: RemoteImageProvider(
+                url: getFilterPersonThumbnailUrl(person.id, spaceId: person.spaceId),
+              ),
+            ),
             const SizedBox(width: 14),
             Expanded(
               child: Column(

--- a/mobile/lib/presentation/pages/photos_filter/widgets/recent_people_strip.widget.dart
+++ b/mobile/lib/presentation/pages/photos_filter/widgets/recent_people_strip.widget.dart
@@ -84,7 +84,9 @@ class _RecentTile extends ConsumerWidget {
               ),
               child: CircleAvatar(
                 radius: 22,
-                backgroundImage: RemoteImageProvider(url: getFaceThumbnailUrl(person.id)),
+                backgroundImage: RemoteImageProvider(
+                  url: getFilterPersonThumbnailUrl(person.id, spaceId: person.spaceId),
+                ),
               ),
             ),
             const SizedBox(height: 4),

--- a/mobile/lib/presentation/widgets/filter_sheet/active_filter_chip.widget.dart
+++ b/mobile/lib/presentation/widgets/filter_sheet/active_filter_chip.widget.dart
@@ -88,6 +88,9 @@ class ActiveFilterChip extends ConsumerWidget {
     switch (spec.visual) {
       case ChipVisual.person:
         final ids = spec.avatarPersonIds ?? const <String>[];
+        // Index-aligned with ids (see ActiveChipSpec.avatarPersonSpaceIds). A shorter/absent list
+        // degrades to null → owner endpoint, matching a personal person.
+        final spaceIds = spec.avatarPersonSpaceIds ?? const <String?>[];
         final width = ids.isEmpty ? 0.0 : 18.0 + (ids.length - 1) * 14.0;
         return SizedBox(
           width: width,
@@ -104,7 +107,9 @@ class ActiveFilterChip extends ConsumerWidget {
                     ),
                     child: CircleAvatar(
                       radius: 9,
-                      backgroundImage: RemoteImageProvider(url: getFaceThumbnailUrl(ids[i])),
+                      backgroundImage: RemoteImageProvider(
+                        url: getFilterPersonThumbnailUrl(ids[i], spaceId: i < spaceIds.length ? spaceIds[i] : null),
+                      ),
                     ),
                   ),
                 ),

--- a/mobile/lib/providers/photos_filter/active_chips.dart
+++ b/mobile/lib/providers/photos_filter/active_chips.dart
@@ -19,6 +19,12 @@ class ActiveChipSpec {
   final String label;
   final ChipVisual visual;
   final List<String>? avatarPersonIds;
+
+  /// Space scope for each avatar in [avatarPersonIds], index-aligned (same length, non-null when
+  /// that avatar is a shared-space person). The chip avatar routes a Space person to the
+  /// membership-gated space thumbnail endpoint via getFilterPersonThumbnailUrl — the tokenized
+  /// avatar id alone doesn't carry the spaceId, so it 404s the owner endpoint without this.
+  final List<String?>? avatarPersonSpaceIds;
   final int? tagDotSeed;
   final IconData? icon;
   final String? semanticsLabel;
@@ -28,6 +34,7 @@ class ActiveChipSpec {
     required this.label,
     required this.visual,
     this.avatarPersonIds,
+    this.avatarPersonSpaceIds,
     this.tagDotSeed,
     this.icon,
     this.semanticsLabel,
@@ -47,6 +54,7 @@ List<ActiveChipSpec> activeChipsFromFilter(SearchFilter filter, {FilterSuggestio
           label: p.name.isEmpty ? 'filter_sheet_unnamed_person' : p.name,
           visual: ChipVisual.person,
           avatarPersonIds: [p.id],
+          avatarPersonSpaceIds: [p.spaceId],
         ),
       );
     }
@@ -59,18 +67,21 @@ List<ActiveChipSpec> activeChipsFromFilter(SearchFilter filter, {FilterSuggestio
           label: p.name.isEmpty ? 'filter_sheet_unnamed_person' : p.name,
           visual: ChipVisual.person,
           avatarPersonIds: [p.id],
+          avatarPersonSpaceIds: [p.spaceId],
         ),
       );
     }
     final tail = people.skip(2).toList();
     final firstTail = tail.first;
     final avatars = <String>[people[0].id, people[1].id, firstTail.id];
+    final avatarSpaceIds = <String?>[people[0].spaceId, people[1].spaceId, firstTail.spaceId];
     out.add(
       ActiveChipSpec(
         id: PersonChipId(firstTail.id),
         label: '${people[0].name}, ${people[1].name} +${tail.length}',
         visual: ChipVisual.person,
         avatarPersonIds: avatars,
+        avatarPersonSpaceIds: avatarSpaceIds,
       ),
     );
   }

--- a/mobile/lib/providers/photos_filter/people_picker.provider.dart
+++ b/mobile/lib/providers/photos_filter/people_picker.provider.dart
@@ -3,18 +3,28 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/person.model.dart';
 import 'package:immich_mobile/providers/infrastructure/people.provider.dart';
 
-/// DriftPerson -> PersonDto. thumbnailPath is intentionally empty — thumbnails
-/// are fetched lazily via getFaceThumbnailUrl(id) at the widget layer, matching
-/// PeopleStrip._PersonTile. numberOfAssets carries straight through (no extra
-/// network call) so the picker row can render a photo count.
+/// DriftPerson -> PersonDto for the photos filter.
+///
+/// [PersonDto.id] carries the **tokenized filter id** (`space-person:<id>` for a shared-space
+/// person, else `person:<id>`) — the exact value the server emits as `PersonResponseDto.filterId`.
+/// This is what the withSharedSpaces search expects in `personIds`: a shared-space person's raw
+/// profile id is not in the owner-scoped `person` table, so a bare id resolves to nothing and the
+/// person silently filters out. Tokenizing also matches the collapsed suggestions strip (which
+/// always tokenizes), so the same person is never selected twice across surfaces.
+///
+/// [PersonDto.spaceId] carries the Space scope so the avatar routes to the membership-gated space
+/// thumbnail endpoint via getFilterPersonThumbnailUrl (the owner endpoint 404s a space-person id).
+/// thumbnailPath stays empty — thumbnails are built lazily at the widget layer. numberOfAssets
+/// carries straight through (no extra network call) so the picker row can render a photo count.
 PersonDto _toPersonDto(DriftPerson p) => PersonDto(
-  id: p.id,
+  id: p.spaceId == null ? 'person:${p.id}' : 'space-person:${p.id}',
   name: p.name,
   isHidden: p.isHidden,
   thumbnailPath: '',
   birthDate: p.birthDate,
   updatedAt: p.updatedAt,
   numberOfAssets: p.numberOfAssets,
+  spaceId: p.spaceId,
 );
 
 /// All non-hidden, non-blank people, including shared-space people (matches the web

--- a/mobile/lib/utils/image_url_builder.dart
+++ b/mobile/lib/utils/image_url_builder.dart
@@ -39,6 +39,23 @@ String getPersonThumbnailUrl(final String personId, {final String? spaceId}) {
   return spaceId == null ? getFaceThumbnailUrl(personId) : getSpacePersonThumbnailUrl(spaceId, personId);
 }
 
+/// Thumbnail URL for a photos-filter [PersonDto] whose id is the tokenized filter id
+/// (`person:<uuid>` / `space-person:<uuid>`) the picker/recent/chip surfaces store, with the
+/// Space scope carried separately in [spaceId]. De-tokenizes to the raw profile id, then routes a
+/// Space person (non-null [spaceId]) to the membership-gated space endpoint and everyone else to
+/// the owner endpoint — the tokenized id 404s the owner endpoint for Space people. Mirrors web
+/// getPhotosPersonFilterThumbnailUrl.
+String getFilterPersonThumbnailUrl(final String filterPersonId, {final String? spaceId}) {
+  const spacePrefix = 'space-person:';
+  const personPrefix = 'person:';
+  final rawId = filterPersonId.startsWith(spacePrefix)
+      ? filterPersonId.substring(spacePrefix.length)
+      : filterPersonId.startsWith(personPrefix)
+      ? filterPersonId.substring(personPrefix.length)
+      : filterPersonId;
+  return getPersonThumbnailUrl(rawId, spaceId: spaceId);
+}
+
 /// Thumbnail URL for a photos-filter suggestion person. When the filter requests shared spaces
 /// (`withSharedSpaces: true`) the server returns a tokenized [FilterSuggestionsPersonDto.id]
 /// (`person:<uuid>` / `space-person:<uuid>`) whose raw form 404s through [getFaceThumbnailUrl];

--- a/mobile/test/presentation/pages/photos_filter/widgets/person_picker_list_test.dart
+++ b/mobile/test/presentation/pages/photos_filter/widgets/person_picker_list_test.dart
@@ -10,6 +10,7 @@ import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
 import 'package:immich_mobile/presentation/pages/photos_filter/widgets/person_picker_list.widget.dart';
+import 'package:immich_mobile/presentation/widgets/images/remote_image_provider.dart';
 import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
 
 import '../../../../widget_tester_extensions.dart';
@@ -38,15 +39,47 @@ void main() {
     await db.close();
   });
 
-  PersonDto person(String id, String name, {int? numberOfAssets}) =>
-      PersonDto(id: id, name: name, isHidden: false, thumbnailPath: '', numberOfAssets: numberOfAssets);
+  PersonDto person(String id, String name, {int? numberOfAssets, String? spaceId}) => PersonDto(
+    id: id,
+    name: name,
+    isHidden: false,
+    thumbnailPath: '',
+    numberOfAssets: numberOfAssets,
+    spaceId: spaceId,
+  );
+
+  RemoteImageProvider avatarProviderFor(WidgetTester tester, String rowKey) {
+    final avatar = tester.widget<CircleAvatar>(
+      find.descendant(of: find.byKey(Key(rowKey)), matching: find.byType(CircleAvatar)),
+    );
+    return avatar.backgroundImage! as RemoteImageProvider;
+  }
 
   group('PersonPickerList', () {
-    testWidgets('shows a photo-count subtitle when numberOfAssets is present', (tester) async {
+    // A shared-space person's avatar must hit the membership-gated space thumbnail endpoint —
+    // its tokenized id 404s the owner-only /people endpoint (the reported gray-circle bug).
+    testWidgets('shared-space person avatar routes to the space thumbnail endpoint', (tester) async {
       _setLogicalSize(tester, const Size(400, 800));
       await tester.pumpConsumerWidget(
-        PersonPickerList(people: [person('a', 'Alice', numberOfAssets: 1204)]),
+        PersonPickerList(people: [person('space-person:sp-1', 'Zoe', spaceId: 'space-1')]),
       );
+      await tester.pumpAndSettle();
+      expect(
+        avatarProviderFor(tester, 'person-row-space-person:sp-1').url,
+        'http://localhost:0/shared-spaces/space-1/people/sp-1/thumbnail',
+      );
+    });
+
+    testWidgets('personal person avatar routes to the owner thumbnail endpoint', (tester) async {
+      _setLogicalSize(tester, const Size(400, 800));
+      await tester.pumpConsumerWidget(PersonPickerList(people: [person('person:p-1', 'Alice')]));
+      await tester.pumpAndSettle();
+      expect(avatarProviderFor(tester, 'person-row-person:p-1').url, 'http://localhost:0/people/p-1/thumbnail');
+    });
+
+    testWidgets('shows a photo-count subtitle when numberOfAssets is present', (tester) async {
+      _setLogicalSize(tester, const Size(400, 800));
+      await tester.pumpConsumerWidget(PersonPickerList(people: [person('a', 'Alice', numberOfAssets: 1204)]));
       await tester.pumpAndSettle();
       final finder = find.byKey(const Key('person-row-count-a'));
       expect(finder, findsOneWidget);

--- a/mobile/test/presentation/pages/photos_filter/widgets/recent_people_strip_test.dart
+++ b/mobile/test/presentation/pages/photos_filter/widgets/recent_people_strip_test.dart
@@ -10,6 +10,7 @@ import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
 import 'package:immich_mobile/presentation/pages/photos_filter/widgets/recent_people_strip.widget.dart';
+import 'package:immich_mobile/presentation/widgets/images/remote_image_provider.dart';
 import 'package:immich_mobile/providers/photos_filter/people_picker.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
 
@@ -28,9 +29,31 @@ void main() {
     await db.close();
   });
 
-  PersonDto person(String id, String name) => PersonDto(id: id, name: name, isHidden: false, thumbnailPath: '');
+  PersonDto person(String id, String name, {String? spaceId}) =>
+      PersonDto(id: id, name: name, isHidden: false, thumbnailPath: '', spaceId: spaceId);
 
   group('RecentPeopleStrip', () {
+    // Same routing as the picker rows: a recent shared-space person must hit the space endpoint.
+    testWidgets('shared-space recent avatar routes to the space thumbnail endpoint', (tester) async {
+      await tester.pumpConsumerWidget(
+        const RecentPeopleStrip(),
+        overrides: [
+          recentPeopleProvider.overrideWith((ref) async => [person('space-person:sp-1', 'Zoe', spaceId: 'space-1')]),
+        ],
+      );
+      await tester.pumpAndSettle();
+      final avatar = tester.widget<CircleAvatar>(
+        find.descendant(
+          of: find.byKey(const Key('recent-person-space-person:sp-1')),
+          matching: find.byType(CircleAvatar),
+        ),
+      );
+      expect(
+        (avatar.backgroundImage! as RemoteImageProvider).url,
+        'http://localhost:0/shared-spaces/space-1/people/sp-1/thumbnail',
+      );
+    });
+
     testWidgets('renders one tile per recent person with stable key', (tester) async {
       await tester.pumpConsumerWidget(
         const RecentPeopleStrip(),

--- a/mobile/test/presentation/widgets/filter_sheet/active_filter_chip_test.dart
+++ b/mobile/test/presentation/widgets/filter_sheet/active_filter_chip_test.dart
@@ -1,8 +1,16 @@
+import 'package:drift/drift.dart' as drift;
+import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/person.model.dart';
+import 'package:immich_mobile/domain/models/store.model.dart';
+import 'package:immich_mobile/domain/services/store.service.dart';
+import 'package:immich_mobile/entities/store.entity.dart';
+import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
+import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/active_filter_chip.widget.dart';
+import 'package:immich_mobile/presentation/widgets/images/remote_image_provider.dart';
 import 'package:immich_mobile/providers/photos_filter/active_chips.dart';
 import 'package:immich_mobile/providers/photos_filter/chip_id.dart';
 import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
@@ -12,7 +20,53 @@ import '../../../widget_tester_extensions.dart';
 const _alice = PersonDto(id: 'a', name: 'Alice', isHidden: false, thumbnailPath: '');
 
 void main() {
+  late Drift db;
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    db = Drift(drift.DatabaseConnection(NativeDatabase.memory(), closeStreamsSynchronously: true));
+    await StoreService.init(storeRepository: DriftStoreRepository(db));
+    await Store.put(StoreKey.serverEndpoint, 'http://localhost:0');
+  });
+  tearDownAll(() async {
+    await Store.clear();
+    await db.close();
+  });
+
   group('ActiveFilterChip', () {
+    // The chip avatar had the same gray-circle bug as the picker: a shared-space person's tokenized
+    // id 404s the owner endpoint. With the spaceId threaded through the spec it routes to the space
+    // endpoint.
+    testWidgets('shared-space person avatar routes to the space thumbnail endpoint', (tester) async {
+      const spec = ActiveChipSpec(
+        id: PersonChipId('space-person:sp-1'),
+        label: 'Zoe',
+        visual: ChipVisual.person,
+        avatarPersonIds: ['space-person:sp-1'],
+        avatarPersonSpaceIds: ['space-1'],
+      );
+      await tester.pumpConsumerWidget(const ActiveFilterChip(spec: spec));
+      await tester.pumpAndSettle();
+      final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
+      expect(
+        (avatar.backgroundImage! as RemoteImageProvider).url,
+        'http://localhost:0/shared-spaces/space-1/people/sp-1/thumbnail',
+      );
+    });
+
+    testWidgets('personal person avatar routes to the owner thumbnail endpoint', (tester) async {
+      const spec = ActiveChipSpec(
+        id: PersonChipId('person:p-1'),
+        label: 'Alice',
+        visual: ChipVisual.person,
+        avatarPersonIds: ['person:p-1'],
+        avatarPersonSpaceIds: [null],
+      );
+      await tester.pumpConsumerWidget(const ActiveFilterChip(spec: spec));
+      await tester.pumpAndSettle();
+      final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
+      expect((avatar.backgroundImage! as RemoteImageProvider).url, 'http://localhost:0/people/p-1/thumbnail');
+    });
+
     testWidgets('renders label + close icon', (tester) async {
       const spec = ActiveChipSpec(
         id: LocationChipId(),

--- a/mobile/test/providers/photos_filter/active_chips_test.dart
+++ b/mobile/test/providers/photos_filter/active_chips_test.dart
@@ -9,6 +9,9 @@ import 'package:openapi/api.dart';
 
 PersonDto _person(String id, String name) => PersonDto(id: id, name: name, isHidden: false, thumbnailPath: '');
 
+PersonDto _spacePerson(String id, String name, String spaceId) =>
+    PersonDto(id: id, name: name, isHidden: false, thumbnailPath: '', spaceId: spaceId);
+
 SearchFilter _base() => SearchFilter(
   people: <PersonDto>{},
   location: SearchLocationFilter(),
@@ -33,6 +36,35 @@ void main() {
       expect(chips.single.label, 'Alice');
       expect(chips.single.visual, ChipVisual.person);
       expect(chips.single.avatarPersonIds, ['p1']);
+    });
+
+    // The chip avatar must route a shared-space person to the space thumbnail endpoint, which
+    // needs the spaceId — the tokenized avatar id alone doesn't carry it. So each avatar id gets
+    // an index-aligned spaceId slot (null for personal people).
+    test('a shared-space person chip threads its spaceId aligned with the tokenized avatar id', () {
+      final f = _base()..people.add(_spacePerson('space-person:sp-1', 'Zoe', 'space-1'));
+      final chip = activeChipsFromFilter(f).single;
+      expect(chip.avatarPersonIds, ['space-person:sp-1']);
+      expect(chip.avatarPersonSpaceIds, ['space-1']);
+    });
+
+    test('a personal person chip has a null spaceId slot aligned with its avatar id', () {
+      final f = _base()..people.add(_person('person:p-2', 'Bob'));
+      final chip = activeChipsFromFilter(f).single;
+      expect(chip.avatarPersonIds, ['person:p-2']);
+      expect(chip.avatarPersonSpaceIds, [null]);
+    });
+
+    test('spillover chip threads spaceIds for all three preview avatars', () {
+      final f = _base()
+        ..people.addAll({
+          _spacePerson('space-person:s1', 'Amy', 'space-1'),
+          _person('person:p2', 'Bob'),
+          _spacePerson('space-person:s3', 'Cara', 'space-3'),
+        });
+      final spill = activeChipsFromFilter(f).last;
+      expect(spill.avatarPersonIds, ['space-person:s1', 'person:p2', 'space-person:s3']);
+      expect(spill.avatarPersonSpaceIds, ['space-1', null, 'space-3']);
     });
 
     test('2 people → 2 individual chips (no spillover)', () {

--- a/mobile/test/providers/photos_filter/people_picker_provider_test.dart
+++ b/mobile/test/providers/photos_filter/people_picker_provider_test.dart
@@ -4,7 +4,7 @@ import 'package:immich_mobile/domain/models/person.model.dart';
 import 'package:immich_mobile/providers/infrastructure/people.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/people_picker.provider.dart';
 
-DriftPerson _d(String id, String name, {bool isHidden = false, int? numberOfAssets}) => DriftPerson(
+DriftPerson _d(String id, String name, {bool isHidden = false, int? numberOfAssets, String? spaceId}) => DriftPerson(
   id: id,
   createdAt: DateTime(2024, 1, 1),
   updatedAt: DateTime(2024, 1, 1),
@@ -14,6 +14,7 @@ DriftPerson _d(String id, String name, {bool isHidden = false, int? numberOfAsse
   isHidden: isHidden,
   color: null,
   numberOfAssets: numberOfAssets,
+  spaceId: spaceId,
 );
 
 PersonDto _p(String id, String name) => PersonDto(id: id, name: name, isHidden: false, thumbnailPath: '');
@@ -28,26 +29,51 @@ ProviderContainer _containerWith(List<DriftPerson> people) {
 }
 
 void main() {
+  group('photos-filter id + scope mapping', () {
+    // A shared-space person must carry the tokenized `space-person:<id>` filter id (so the
+    // withSharedSpaces search resolves it) and its Space scope (so the avatar routes to the
+    // membership-gated space thumbnail endpoint instead of 404ing the owner endpoint). The raw
+    // profile id alone breaks both. Mirrors web getPhotosPersonFilterId / primaryProfile.
+    test('a shared-space person maps to a space-person: filter id and carries spaceId', () async {
+      final c = _containerWith([_d('sp-1', 'Zoe', spaceId: 'space-1')]);
+      addTearDown(c.dispose);
+      final result = await c.read(peoplePickerAllProvider.future);
+      expect(result.single.id, 'space-person:sp-1');
+      expect(result.single.spaceId, 'space-1');
+    });
+
+    // A personal/owned person is tokenized `person:<id>` so its filter id matches the collapsed
+    // suggestions strip (which always tokenizes), keeping the same person from being selected
+    // twice across surfaces; spaceId stays null (owner thumbnail endpoint).
+    test('a personal person maps to a person: filter id with null spaceId', () async {
+      final c = _containerWith([_d('a', 'Alice')]);
+      addTearDown(c.dispose);
+      final result = await c.read(peoplePickerAllProvider.future);
+      expect(result.single.id, 'person:a');
+      expect(result.single.spaceId, isNull);
+    });
+  });
+
   group('peoplePickerAllProvider', () {
     test('excludes hidden people', () async {
       final c = _containerWith([_d('a', 'Alice'), _d('b', 'Bob', isHidden: true)]);
       addTearDown(c.dispose);
       final result = await c.read(peoplePickerAllProvider.future);
-      expect(result.map((p) => p.id), ['a']);
+      expect(result.map((p) => p.id), ['person:a']);
     });
 
     test('excludes blank names', () async {
       final c = _containerWith([_d('a', 'Alice'), _d('b', '')]);
       addTearDown(c.dispose);
       final result = await c.read(peoplePickerAllProvider.future);
-      expect(result.map((p) => p.id), ['a']);
+      expect(result.map((p) => p.id), ['person:a']);
     });
 
     test('maps DriftPerson to PersonDto with empty thumbnailPath', () async {
       final c = _containerWith([_d('a', 'Alice')]);
       addTearDown(c.dispose);
       final result = await c.read(peoplePickerAllProvider.future);
-      expect(result.single.id, 'a');
+      expect(result.single.id, 'person:a');
       expect(result.single.name, 'Alice');
       expect(result.single.thumbnailPath, '');
       expect(result.single.isHidden, false);
@@ -63,7 +89,7 @@ void main() {
       );
       addTearDown(c.dispose);
       final result = await c.read(peoplePickerAllProvider.future);
-      expect(result.map((p) => p.id), ['pinned']);
+      expect(result.map((p) => p.id), ['person:pinned']);
     });
 
     // Slice 3: the picker row's photo count reads straight off the already-fetched
@@ -76,9 +102,9 @@ void main() {
       ]);
       addTearDown(c.dispose);
       final result = await c.read(peoplePickerAllProvider.future);
-      expect(result.firstWhere((p) => p.id == 'a').numberOfAssets, 1204);
-      expect(result.firstWhere((p) => p.id == 'b').numberOfAssets, 0);
-      expect(result.firstWhere((p) => p.id == 'c').numberOfAssets, isNull);
+      expect(result.firstWhere((p) => p.id == 'person:a').numberOfAssets, 1204);
+      expect(result.firstWhere((p) => p.id == 'person:b').numberOfAssets, 0);
+      expect(result.firstWhere((p) => p.id == 'person:c').numberOfAssets, isNull);
     });
   });
 
@@ -95,7 +121,7 @@ void main() {
       addTearDown(c.dispose);
       c.read(peoplePickerQueryProvider.notifier).state = 'aL';
       final result = await c.read(peoplePickerFilteredProvider.future);
-      expect(result.map((p) => p.id), ['a']);
+      expect(result.map((p) => p.id), ['person:a']);
     });
 
     test('whitespace-only query returns full list', () async {
@@ -161,7 +187,7 @@ void main() {
       ]);
       addTearDown(c.dispose);
       final recent = await c.read(recentPeopleProvider.future);
-      expect(recent.map((p) => p.id), ['a', 'b']);
+      expect(recent.map((p) => p.id), ['person:a', 'person:b']);
     });
 
     test('caps result at 7 items, newest first', () async {
@@ -173,7 +199,15 @@ void main() {
       final recent = await c.read(recentPeopleProvider.future);
       expect(recent, hasLength(7));
       // p0 is newest, then p1, ..., p6.
-      expect(recent.map((p) => p.id), ['p0', 'p1', 'p2', 'p3', 'p4', 'p5', 'p6']);
+      expect(recent.map((p) => p.id), [
+        'person:p0',
+        'person:p1',
+        'person:p2',
+        'person:p3',
+        'person:p4',
+        'person:p5',
+        'person:p6',
+      ]);
     });
 
     test('empty when no people updated in last 7 days', () async {

--- a/mobile/test/unit/utils/image_url_builder_test.dart
+++ b/mobile/test/unit/utils/image_url_builder_test.dart
@@ -99,4 +99,30 @@ void main() {
       expect(photosFilterPersonThumbnailUrl(person), 'http://localhost:0/people/raw-uuid/thumbnail');
     });
   });
+
+  // The photos-filter picker/recent/chip surfaces store the tokenized filter id
+  // (`person:<uuid>` / `space-person:<uuid>`) on PersonDto.id and the Space scope on
+  // PersonDto.spaceId. This helper de-tokenizes to the raw profile id and routes a Space
+  // person to the membership-gated space endpoint, everyone else to the owner endpoint.
+  // Mirrors web getPhotosPersonFilterThumbnailUrl.
+  group('getFilterPersonThumbnailUrl', () {
+    test('routes a space-person token (with spaceId) to the membership-gated space endpoint', () {
+      expect(
+        getFilterPersonThumbnailUrl('space-person:sp-1', spaceId: 'space-1'),
+        'http://localhost:0/shared-spaces/space-1/people/sp-1/thumbnail',
+      );
+    });
+
+    test('routes a person: token (no spaceId) to the owner endpoint using the de-tokenized id', () {
+      expect(getFilterPersonThumbnailUrl('person:p-1'), 'http://localhost:0/people/p-1/thumbnail');
+    });
+
+    test('routes a bare id (no prefix, no spaceId) to the owner endpoint', () {
+      expect(getFilterPersonThumbnailUrl('p-1'), 'http://localhost:0/people/p-1/thumbnail');
+    });
+
+    test('de-tokenizes a space-person token even when spaceId is unexpectedly null (owner endpoint)', () {
+      expect(getFilterPersonThumbnailUrl('space-person:sp-1'), 'http://localhost:0/people/sp-1/thumbnail');
+    });
+  });
 }


### PR DESCRIPTION
## Problem

A **space viewer** opening **Filter → People → "N Personen suchen"** (the full-screen `PersonPickerPage`) saw **all-gray avatars**, and **tapping people had no effect** on the results.

## Root cause (one cause, both symptoms)

The picker sources `GET /api/people?withSharedSpaces=true` → `DriftPerson` → `PersonDto`, but `_toPersonDto` used the person's **raw profile id** and **dropped the Space scope**. For a shared-space person that raw id is a `shared_space_person` row id, which:

1. **404s the owner-only** `GET /people/{id}/thumbnail` (the row lives in `shared_space_person`, not `person`) → gray circle.
2. **Isn't the tokenized `filterId`** (`space-person:<uuid>`) the `withSharedSpaces` search needs — the server's `resolveScopedPersonTokens` treats a bare id as an *owned* `person` lookup, finds nothing, and drops it → selecting filters to nothing.

The viewer's *own* people were unaffected (a raw id is valid on both endpoints), which is why only shared-space people broke. The collapsed "PERSONEN" strip already worked because it sources `FilterSuggestionsPersonDto`, whose id is *already* tokenized and which carries `primaryProfile` for thumbnail routing.

## Fix (mirrors the working suggestion path)

- `PersonDto` gains a nullable `spaceId`.
- `_toPersonDto` emits the **tokenized filter id** (`space-person:<id>` / `person:<id>` — exactly the server's `filterId`) and carries `spaceId`. Tokenizing personal people too fixes a latent cross-surface double-select vs the always-tokenized collapsed strip.
- New `getFilterPersonThumbnailUrl(id, {spaceId})` de-tokenizes then routes to the space or owner endpoint. Used in the picker rows, the recent strip, and the active-filter **chip avatars** (which had the same pre-existing gray-avatar bug for space people).

## Tests

TDD (each new test watched failing first). **612 mobile tests pass**; `dart analyze --fatal-infos lib test` clean; `dart format` clean.