### PR TITLE
fix(web): scope memory viewer navigation to the current memory (#790)

### DIFF
--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -48,6 +48,7 @@ export enum QueryParameter {
   ACTION = 'action',
   ID = 'id',
   IS_OPEN = 'isOpen',
+  MEMORY_ID = 'memoryId',
   OPEN_SETTING = 'openSetting',
   PREVIOUS_ROUTE = 'previousRoute',
   QUERY = 'query',

--- a/web/src/lib/managers/memory-manager.svelte.ts
+++ b/web/src/lib/managers/memory-manager.svelte.ts
@@ -29,8 +29,8 @@ class MemoryManager {
 
   memories = $state<MemoryResponseDto[]>([]);
 
-  getMemoryAsset(assetId: string | undefined) {
-    return findMemoryAsset(this.memories, assetId);
+  getMemoryAsset(assetId: string | undefined, memoryId?: string) {
+    return findMemoryAsset(this.memories, assetId, memoryId);
   }
 
   hideAssetsFromMemory(ids: string[]) {

--- a/web/src/lib/route.ts
+++ b/web/src/lib/route.ts
@@ -91,7 +91,7 @@ export const Route = {
 
   // memories
   memories: () => '/memories',
-  memoryViewer: (params?: { id?: string; source?: 'history' }) => '/memory' + asQueryString(params),
+  memoryViewer: (params?: { id?: string; memoryId?: string; source?: 'history' }) => '/memory' + asQueryString(params),
 
   // partners
   viewPartner: ({ id }: { id: string }) => `/partners/${id}`,

--- a/web/src/lib/utils/memory-viewer-source.spec.ts
+++ b/web/src/lib/utils/memory-viewer-source.spec.ts
@@ -106,4 +106,37 @@ describe('memory viewer source', () => {
     expect(getMemoryViewerExitRoute('history')).toBe('/memories');
     expect(getMemoryViewerExitRoute()).toBe('/photos');
   });
+
+  describe('duplicate assets across memories (#790)', () => {
+    // rule memories (e.g. birthday) sort first and can contain assets that also
+    // appear in a later on-this-day memory
+    const withDuplicates = [
+      memory('birthday', ['b1', 'dup']),
+      memory('one-year-ago', ['a1']),
+      memory('three-years-ago', ['dup', 'a2']),
+    ];
+
+    it('resolves the occurrence inside the requested memory', () => {
+      const selected = findMemoryAsset(withDuplicates, 'dup', 'three-years-ago');
+
+      expect(selected?.memory.id).toBe('three-years-ago');
+      expect(selected?.memoryIndex).toBe(2);
+      expect(selected?.assetIndex).toBe(0);
+      // navigation keeps advancing forward instead of looping back to the birthday memory
+      expect(selected?.next?.asset.id).toBe('a2');
+    });
+
+    it('falls back to the first occurrence without a memory id', () => {
+      const selected = findMemoryAsset(withDuplicates, 'dup');
+
+      expect(selected?.memory.id).toBe('birthday');
+      expect(selected?.memoryIndex).toBe(0);
+    });
+
+    it('falls back to the first occurrence when the requested memory does not contain the asset', () => {
+      const selected = findMemoryAsset(withDuplicates, 'dup', 'one-year-ago');
+
+      expect(selected?.memory.id).toBe('birthday');
+    });
+  });
 });

--- a/web/src/lib/utils/memory-viewer-source.ts
+++ b/web/src/lib/utils/memory-viewer-source.ts
@@ -43,9 +43,18 @@ export const buildMemoryAssets = (memories: MemoryResponseDto[]) => {
   return memoryAssets;
 };
 
-export const findMemoryAsset = (memories: MemoryResponseDto[], assetId: string | undefined) => {
+export const findMemoryAsset = (memories: MemoryResponseDto[], assetId: string | undefined, memoryId?: string) => {
   const memoryAssets = buildMemoryAssets(memories);
-  return memoryAssets.find((memoryAsset) => memoryAsset.asset.id === assetId) ?? memoryAssets[0];
+  // the same asset can appear in multiple memories (e.g. a birthday memory and an on-this-day
+  // memory), so prefer the occurrence inside the requested memory to keep navigation from
+  // jumping back to an earlier memory (#790)
+  return (
+    (memoryId
+      ? memoryAssets.find((memoryAsset) => memoryAsset.memory.id === memoryId && memoryAsset.asset.id === assetId)
+      : undefined) ??
+    memoryAssets.find((memoryAsset) => memoryAsset.asset.id === assetId) ??
+    memoryAssets[0]
+  );
 };
 
 export const removeAssetsFromMemoryList = (memories: MemoryResponseDto[], ids: string[]) => {

--- a/web/src/routes/(user)/memories/memory-card.spec.ts
+++ b/web/src/routes/(user)/memories/memory-card.spec.ts
@@ -57,7 +57,7 @@ describe('MemoryCard component', () => {
     expect(screen.getByTestId('memory-saved-indicator')).toBeInTheDocument();
 
     const link = screen.getByTestId('memory-card');
-    expect(link).toHaveAttribute('href', '/memory?id=asset-1&source=history');
+    expect(link).toHaveAttribute('href', '/memory?id=asset-1&memoryId=memory-id&source=history');
     expect(link).toHaveAttribute('aria-label', 'Seven years ago');
 
     const images = container.querySelectorAll('img');

--- a/web/src/routes/(user)/memories/memory-card.svelte
+++ b/web/src/routes/(user)/memories/memory-card.svelte
@@ -24,7 +24,7 @@
 
 {#if firstAsset}
   <a
-    href={Route.memoryViewer({ id: firstAsset.id, source: 'history' })}
+    href={Route.memoryViewer({ id: firstAsset.id, memoryId: item.memory.id, source: 'history' })}
     aria-label={item.title}
     data-testid="memory-card"
     class="group relative block rounded-2xl border border-transparent p-5 hover:border-gray-200 hover:bg-gray-100 dark:hover:border-gray-800 dark:hover:bg-gray-900"

--- a/web/src/routes/(user)/memory/[[photos=photos]]/[[assetId=id]]/MemoryViewer.spec.ts
+++ b/web/src/routes/(user)/memory/[[photos=photos]]/[[assetId=id]]/MemoryViewer.spec.ts
@@ -1,6 +1,6 @@
 import { AssetTypeEnum, MemoryType, type MemoryResponseDto } from '@immich/sdk';
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/svelte';
+import { render, screen, waitFor } from '@testing-library/svelte';
 import type { Component } from 'svelte';
 import TestWrapper from '$lib/components/TestWrapper.svelte';
 import { findMemoryAsset } from '$lib/utils/memory-viewer-source';
@@ -46,7 +46,7 @@ const {
   },
   mockPage: {
     url: new URL('https://gallery.test/memory/photos/memory-asset-1'),
-    params: { assetId: 'memory-asset-1' },
+    params: { assetId: 'memory-asset-1' } as { assetId?: string },
   },
 }));
 
@@ -204,6 +204,8 @@ function renderViewer() {
 describe('MemoryViewer GalleryViewer grouping', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPage.url = new URL('https://gallery.test/memory/photos/memory-asset-1');
+    mockPage.params = { assetId: 'memory-asset-1' };
     mockMemoryManager.memories = [memory('memory-1', ['memory-asset-1', 'memory-asset-2'])];
     mockMemoryManager.ready.mockResolvedValue(undefined);
     mockMemoryManager.getMemoryAsset.mockImplementation((assetId: string | undefined) =>
@@ -226,5 +228,49 @@ describe('MemoryViewer GalleryViewer grouping', () => {
     renderViewer();
 
     expect(await screen.findByTestId('gallery-viewer')).toHaveAttribute('data-enable-grouping', 'true');
+  });
+});
+
+describe('MemoryViewer memory-scoped navigation (#790)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // the same asset appears in two memories (e.g. a birthday memory and an on-this-day memory)
+    mockMemoryManager.memories = [memory('memory-1', ['dup-asset', 'm1-b']), memory('memory-2', ['dup-asset', 'm2-b'])];
+    mockMemoryManager.ready.mockResolvedValue(undefined);
+    mockMemoryManager.getMemoryAsset.mockImplementation((assetId: string | undefined, memoryId?: string) =>
+      findMemoryAsset(mockMemoryManager.memories, assetId, memoryId),
+    );
+    mockGetAssetInfo.mockResolvedValue(mockMemoryManager.memories[0].assets[0]);
+    mockPage.url = new URL('https://gallery.test/memory?id=dup-asset&memoryId=memory-2');
+    mockPage.params = {};
+    mockAfterNavigate.mockImplementation((callback) => {
+      callback({ from: null, to: { params: mockPage.params, url: mockPage.url } });
+    });
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        observe = vi.fn();
+        disconnect = vi.fn();
+      },
+    );
+  });
+
+  it('resolves the viewer position within the memory from the url', async () => {
+    renderViewer();
+
+    await waitFor(() => expect(mockMemoryManager.getMemoryAsset).toHaveBeenCalledWith('dup-asset', 'memory-2'));
+  });
+
+  it('links progress bar segments to assets scoped to the current memory', async () => {
+    const { container } = renderViewer();
+
+    await screen.findByTestId('gallery-viewer');
+    await waitFor(() => {
+      const hrefs = [...container.querySelectorAll('a[href^="/memory"]')].map((anchor) => anchor.getAttribute('href'));
+      expect(hrefs.length).toBeGreaterThan(0);
+      for (const href of hrefs) {
+        expect(href).toContain('memoryId=memory-2');
+      }
+    });
   });
 });

--- a/web/src/routes/(user)/memory/[[photos=photos]]/[[assetId=id]]/MemoryViewer.svelte
+++ b/web/src/routes/(user)/memory/[[photos=photos]]/[[assetId=id]]/MemoryViewer.svelte
@@ -102,9 +102,10 @@
   let videoPlayer: HTMLVideoElement | undefined = $state();
   const memoryViewerSource = $derived(isHistorySource ? 'history' : undefined);
   const exitRoute = $derived(getMemoryViewerExitRoute(memoryViewerSource));
-  const asHref = (asset: { id: string }) => Route.memoryViewer({ id: asset.id, source: memoryViewerSource });
+  const asHref = (asset: { id: string }, memory?: { id: string }) =>
+    Route.memoryViewer({ id: asset.id, memoryId: memory?.id, source: memoryViewerSource });
 
-  const handleNavigate = async (asset?: { id: string }) => {
+  const handleNavigate = async (asset?: { id: string }, memory?: { id: string }) => {
     if (assetViewerManager.isViewing) {
       return asset;
     }
@@ -113,7 +114,7 @@
       return;
     }
 
-    await goto(asHref(asset));
+    await goto(asHref(asset, memory));
   };
 
   const setProgressDuration = (asset: TimelineAsset) => {
@@ -123,10 +124,10 @@
     });
   };
 
-  const handleNextAsset = () => handleNavigate(current?.next?.asset);
-  const handlePreviousAsset = () => handleNavigate(current?.previous?.asset);
-  const handleNextMemory = () => handleNavigate(current?.nextMemory?.assets[0]);
-  const handlePreviousMemory = () => handleNavigate(current?.previousMemory?.assets[0]);
+  const handleNextAsset = () => handleNavigate(current?.next?.asset, current?.next?.memory);
+  const handlePreviousAsset = () => handleNavigate(current?.previous?.asset, current?.previous?.memory);
+  const handleNextMemory = () => handleNavigate(current?.nextMemory?.assets[0], current?.nextMemory);
+  const handlePreviousMemory = () => handleNavigate(current?.previousMemory?.assets[0], current?.previousMemory);
   const handleEscape = async () => goto(exitRoute);
   const handleSelectAll = () =>
     assetMultiSelectManager.selectAssets(current?.memory.assets.map((a) => toTimelineAsset(a)) || []);
@@ -300,7 +301,10 @@
 
   const loadFromParams = (page: Page | NavigationTarget | null) => {
     const assetId = page?.params?.assetId ?? page?.url.searchParams.get(QueryParameter.ID) ?? undefined;
-    return isHistorySource ? findMemoryAsset(historyMemories, assetId) : memoryManager.getMemoryAsset(assetId);
+    const memoryId = page?.url.searchParams.get(QueryParameter.MEMORY_ID) ?? undefined;
+    return isHistorySource
+      ? findMemoryAsset(historyMemories, assetId, memoryId)
+      : memoryManager.getMemoryAsset(assetId, memoryId);
   };
 
   const init = (target: Page | NavigationTarget | null) => {
@@ -466,7 +470,7 @@
         />
 
         {#each current.memory.assets as asset, index (asset.id)}
-          <a class="relative grow py-2" href={asHref(asset)} aria-label={$t('view')}>
+          <a class="relative grow py-2" href={asHref(asset, current.memory)} aria-label={$t('view')}>
             <span class="absolute inset-s-0 h-0.5 w-full bg-gray-500"></span>
             <span class="absolute inset-s-0 h-0.5 bg-white" style:width={`${toProgressPercentage(index)}%`}></span>
           </a>

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -542,7 +542,7 @@
     memoryManager.memories.map((memory) => ({
       id: memory.id,
       title: $memoryLaneTitle(memory),
-      href: Route.memoryViewer({ id: memory.assets[0].id }),
+      href: Route.memoryViewer({ id: memory.assets[0].id, memoryId: memory.id }),
       alt: $t('memory_lane_title', { values: { title: $getAltText(toTimelineAsset(memory.assets[0])) } }),
       src: getAssetMediaUrl({ id: memory.assets[0].id }),
     })),


### PR DESCRIPTION
Fixes #790

## Root cause

The memory viewer identifies its position by **asset id alone**: every next/previous action round-trips through the URL (`/memory?id=<assetId>`), and `findMemoryAsset` resolves that id to its **first occurrence** across all memories.

Rule memories (e.g. birthday) can contain assets that also appear in on-this-day memories — a photo of the birthday person taken on this day in a past year is in both. Since rule memories have `memoryAt = today`, they sort **first** in the lane. Advancing past a duplicated asset therefore snapped the viewer back into the earlier (birthday) memory, looping forever — exactly the reported "always loops after the 2-years-ago mark".

This will matter even more once #789 (Tier 1 memory types) lands, since every new rule type multiplies cross-memory asset overlap.

## Fix

Carry the memory id through viewer URLs (`memoryId` query param) and prefer the occurrence **inside that memory** when resolving the viewer position, falling back to the old first-match behavior for deep links without `memoryId`.

## Verification

- TDD: new unit tests for `findMemoryAsset` duplicate-asset scoping + component tests for the URL wiring (watched fail pre-fix, pass post-fix)
- Full web unit suite green (260 files / 3,408 tests), tsc, svelte-check, eslint, prettier clean
- **End-to-end repro** on an isolated stack through the real memory-generation pipeline (birthday person + photos on today's day-of-year across 4 years):
  - pre-fix: viewer ping-pongs between two birthday assets, never reaches "1 year ago"
  - post-fix: birthday → 1 year ago → … → 4 years ago → clean stop, no loop