### PR TITLE
ci(docs): upload-then-prune docs deploy so the site never goes blank mid-deploy

### DIFF
--- a/.github/workflows/gallery-docs-deploy.yml
+++ b/.github/workflows/gallery-docs-deploy.yml
@@ -77,6 +77,14 @@ jobs:
           # references a not-yet-uploaded asset.
           cd build
 
+          # Safety net: never prune against an empty build. If the artifact ever
+          # unzipped to nothing, the orphan diff (remote - local) would treat the
+          # whole zone as orphans and delete everything → blank site. Refuse
+          # before uploading or deleting anything.
+          if [ -z "$(find . -type f | head -1)" ]; then
+            echo "::error::build/ is empty — refusing to deploy (would wipe the zone)"; exit 1
+          fi
+
           echo "Uploading build/ (assets first, HTML last) ..."
           { find . -type f ! -name '*.html'; find . -type f -name '*.html'; } \
             | sed 's|^\./||' \

--- a/.github/workflows/gallery-docs-deploy.yml
+++ b/.github/workflows/gallery-docs-deploy.yml
@@ -58,37 +58,65 @@ jobs:
           set -euo pipefail
           base="https://$STORAGE_HOST/$STORAGE_ZONE"
 
-          # True-sync semantics (parity with the old `aws s3 sync --delete`):
-          # wipe the zone's current contents, re-upload the fresh build, then
-          # purge LAST (next step). Because the purge only fires after a fully
-          # successful upload, the Bunny edge keeps serving the previous build
-          # throughout — the wipe window is invisible to visitors, and removed
-          # or renamed pages never linger. Deleting a directory entry (trailing
-          # slash) removes its contents recursively, so wiping the top level
-          # clears the whole zone.
-          echo "Listing existing storage zone contents..."
-          status=$(curl -sS -o /tmp/listing.json -w '%{http_code}' \
-            -H "AccessKey: $STORAGE_PW" -H 'Accept: application/json' "$base/")
-          if [ "$status" = "200" ]; then
-            jq -r '.[] | .ObjectName + (if .IsDirectory then "/" else "" end)' /tmp/listing.json \
-            | while IFS= read -r entry; do
-                [ -z "$entry" ] && continue
-                echo "  delete $entry"
-                curl -fsS -X DELETE -H "AccessKey: $STORAGE_PW" "$base/$entry" -o /dev/null
-              done
-          elif [ "$status" = "404" ]; then
-            echo "Zone is empty (404) — nothing to wipe."
-          else
-            echo "::error::Unexpected list status $status"; cat /tmp/listing.json; exit 1
-          fi
-
-          echo "Uploading build/ ..."
+          # Upload-then-prune — the real `aws s3 sync --delete` semantics: upload
+          # the fresh build FIRST, then delete only the orphans (files the new
+          # build no longer contains), and purge LAST (next step). The zone is
+          # never emptied, so it stays a complete set the whole time. Reference
+          # implementation: scripts/lib/bunny_deploy.py in the platform repo.
+          #
+          # The previous approach wiped the entire zone *before* re-uploading, on
+          # the assumption that the Bunny edge would keep serving the old build so
+          # the gap was invisible. That's false for a pull CDN: index.html has a
+          # 300s TTL and assets are pulled on demand, so any request during the
+          # wipe/upload window hit missing files, 404'd, and Bunny cached those
+          # 404s — taking docs.opennoodle.de down (blank page: no runtime/CSS) on
+          # every deploy until the final purge. Uploading first avoids the gap;
+          # because Docusaurus asset filenames are content-hashed, new and old
+          # assets coexist without collision. Uploading the immutable assets
+          # before the mutable *.html means a freshly pulled index.html never
+          # references a not-yet-uploaded asset.
           cd build
-          while IFS= read -r f; do
-            curl -fsS -X PUT -H "AccessKey: $STORAGE_PW" \
-              --data-binary @"$f" "$base/$f" -o /dev/null
-          done < <(find . -type f | sed 's|^\./||')
+
+          echo "Uploading build/ (assets first, HTML last) ..."
+          { find . -type f ! -name '*.html'; find . -type f -name '*.html'; } \
+            | sed 's|^\./||' \
+            | while IFS= read -r f; do
+                curl -fsS -X PUT -H "AccessKey: $STORAGE_PW" \
+                  --data-binary @"$f" "$base/$f" -o /dev/null
+              done
           echo "Upload complete."
+
+          # Recursively list the storage zone and delete anything the new build no
+          # longer contains. Each directory listing is captured in a variable (no
+          # shared temp file) so the function can recurse safely.
+          list_remote() {
+            local prefix="$1" resp status body dir
+            resp=$(curl -sS -w $'\n%{http_code}' \
+              -H "AccessKey: $STORAGE_PW" -H 'Accept: application/json' "$base/$prefix")
+            status="${resp##*$'\n'}"
+            body="${resp%$'\n'*}"
+            [ "$status" = "404" ] && return 0
+            if [ "$status" != "200" ]; then
+              echo "::error::list '$prefix' -> $status: $body" >&2; exit 1
+            fi
+            printf '%s' "$body" | jq -r --arg p "$prefix" \
+              '.[] | select(.IsDirectory | not) | $p + .ObjectName'
+            while IFS= read -r dir; do
+              [ -z "$dir" ] && continue
+              list_remote "$prefix$dir/"
+            done < <(printf '%s' "$body" | jq -r '.[] | select(.IsDirectory) | .ObjectName')
+          }
+
+          echo "Pruning orphans ..."
+          list_remote "" | sort -u > /tmp/remote.txt
+          find . -type f | sed 's|^\./||' | sort -u > /tmp/local.txt
+          comm -23 /tmp/remote.txt /tmp/local.txt \
+            | while IFS= read -r f; do
+                [ -z "$f" ] && continue
+                echo "  delete $f"
+                curl -fsS -X DELETE -H "AccessKey: $STORAGE_PW" "$base/$f" -o /dev/null
+              done
+          echo "Prune complete."
 
       - name: Purge Bunny cache
         env:


### PR DESCRIPTION
## Problem

`docs.opennoodle.de` serves a **blank page during (and briefly after) every docs deploy**.

Root cause: the **Deploy to Bunny Storage** step wipes the entire storage zone *before* re-uploading the new build. On a pull CDN this guarantees an outage window:

- `index.html` is cached with only `max-age=300` and assets are pulled on demand.
- During the wipe/upload window, asset requests hit missing files → **404** (the webpack runtime `runtime~main.*.js` and `styles.*.css` disappear), so React never hydrates and `<div id="__docusaurus">` stays empty → blank page.
- Bunny **caches those 404s**; the site only recovers when the final cache purge fires.

The old step's comment claimed the wipe window was "invisible to visitors because the edge keeps serving the previous build" — that's false for a pull CDN with per-file on-demand pulls and a short HTML TTL.

Observed live (mid-deploy): `runtime~main.aa155c8a.js` → 404, `styles.98380c54.css` → 404, `main.a1b13fbd.js` → 200; page blank. After the deploy's purge: all → 200, page renders.

## Fix

Switch to real `aws s3 sync --delete` semantics — the order the comment *claimed* but had inverted:

1. **Upload the fresh build first** (immutable `assets/` first, `*.html` last — content-hashed filenames let old + new coexist, so a freshly-pulled `index.html` never references a not-yet-uploaded asset)
2. **Delete only orphans** (`remote − local`, via a recursive zone listing)
3. **Purge last** (unchanged)

The zone stays a complete set the whole time — no gap, no cached 404s, and removed/renamed pages still get pruned.

This mirrors the already-correct `scripts/lib/bunny_deploy.py` in the platform repo (the manual `make deploy-docs` path), which does upload → prune → purge. Only this CI workflow had reimplemented the logic backwards.

## Verification

- Mock-harness test of the new bash logic: assets upload before HTML ✓; orphan diff deletes exactly the stale files ✓; no current build file is ever deleted ✓
- `shellcheck` clean (exit 0); YAML parses ✓
- Confirmed the live site self-heals once a deploy's purge fires (assets 404 → 200)

Only touches the CI workflow (runs on push to `main`), so real-world validation is the next docs deploy after merge.
