### PR TITLE
perf(web): speed up People page first load

### DIFF
--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -75,6 +75,13 @@ export enum OpenQueryParam {
 
 export const maximumLengthSearchPeople = 100;
 
+// Number of people fetched per page on the global People page. Every `getAllPeople` call that
+// participates in that page's pagination (initial load, infinite-scroll next page, and the
+// restore-on-return catch-up) MUST share this value — the server paginates by `page * size`, so a
+// mismatch between call sites would skip or duplicate people across page boundaries. Kept modest so
+// first paint hydrates/serializes/transfers a small batch; the rest streams in on scroll.
+export const PEOPLE_PAGE_SIZE = 150;
+
 export const MAX_SPACE_ASSETS_PER_REQUEST = 50_000;
 
 // time to load the map before displaying the loading spinner

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -11,7 +11,7 @@
   import SearchPeople from '$lib/components/faces-page/PeopleSearch.svelte';
   import UserPageLayout from '$lib/components/layouts/UserPageLayout.svelte';
   import OnEvents from '$lib/components/OnEvents.svelte';
-  import { QueryParameter, SessionStorageKey } from '$lib/constants';
+  import { PEOPLE_PAGE_SIZE, QueryParameter, SessionStorageKey } from '$lib/constants';
   import { authManager } from '$lib/managers/auth-manager.svelte';
   import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
   import PersonMergeSuggestionModal from '$lib/modals/PersonMergeSuggestionModal.svelte';
@@ -99,7 +99,12 @@
           handlePromiseError(
             Promise.all(
               Array.from({ length: pagesToLoad }).map((_, i) => {
-                return getAllPeople({ withHidden: true, withSharedSpaces: true, page: startingPage + i });
+                return getAllPeople({
+                  withHidden: true,
+                  withSharedSpaces: true,
+                  page: startingPage + i,
+                  size: PEOPLE_PAGE_SIZE,
+                });
               }),
             ).then((pages) => {
               for (const page of pages) {
@@ -127,6 +132,7 @@
         withHidden: true,
         withSharedSpaces: true,
         page: nextPage,
+        size: PEOPLE_PAGE_SIZE,
       });
       people = people.concat(newPeople);
       if (nextPage !== null) {

--- a/web/src/routes/(user)/people/+page.ts
+++ b/web/src/routes/(user)/people/+page.ts
@@ -1,14 +1,24 @@
 import { getAllPeople, getPeopleStatistics } from '@immich/sdk';
+import { PEOPLE_PAGE_SIZE } from '$lib/constants';
+import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
 import { authenticate } from '$lib/utils/auth';
 import { getFormatter } from '$lib/utils/i18n';
 import type { PageLoad } from './$types';
 
-export const load = (async ({ url }) => {
+export const load = (async ({ parent, url }) => {
   await authenticate(url);
+  // Wait for the root layout's init() so the feature-flags manager is populated before we read it.
+  await parent();
+
+  // The peopleStatistics flag only gates *display* in +page.svelte, but the overview stats query is
+  // expensive. Skip it entirely when the flag is off (the default) instead of running it and
+  // discarding the result. valueOrUndefined fails safe to "off" when flags are unavailable (e.g.
+  // maintenance mode, where the layout skips featureFlagsManager.init()).
+  const statisticsEnabled = featureFlagsManager.valueOrUndefined?.peopleStatistics ?? false;
 
   const [people, peopleStatistics] = await Promise.all([
-    getAllPeople({ withHidden: true, withSharedSpaces: true }),
-    getPeopleStatistics({ withSharedSpaces: true }).catch(() => null),
+    getAllPeople({ withHidden: true, withSharedSpaces: true, size: PEOPLE_PAGE_SIZE }),
+    statisticsEnabled ? getPeopleStatistics({ withSharedSpaces: true }).catch(() => null) : Promise.resolve(null),
   ]);
   const $t = await getFormatter();
 

--- a/web/src/routes/(user)/people/+page.ts
+++ b/web/src/routes/(user)/people/+page.ts
@@ -7,7 +7,13 @@ import type { PageLoad } from './$types';
 
 export const load = (async ({ parent, url }) => {
   await authenticate(url);
-  // Wait for the root layout's init() so the feature-flags manager is populated before we read it.
+
+  // Fire the (heavy) people query up front so it overlaps the root layout's init() instead of
+  // serializing behind await parent(). ssr=false, so the SDK's global fetch works even before
+  // init() assigns defaults.fetch. It is awaited below via Promise.all.
+  const peoplePromise = getAllPeople({ withHidden: true, withSharedSpaces: true, size: PEOPLE_PAGE_SIZE });
+
+  // parent() resolves once the root layout's init() has populated the feature-flags manager.
   await parent();
 
   // The peopleStatistics flag only gates *display* in +page.svelte, but the overview stats query is
@@ -17,7 +23,7 @@ export const load = (async ({ parent, url }) => {
   const statisticsEnabled = featureFlagsManager.valueOrUndefined?.peopleStatistics ?? false;
 
   const [people, peopleStatistics] = await Promise.all([
-    getAllPeople({ withHidden: true, withSharedSpaces: true, size: PEOPLE_PAGE_SIZE }),
+    peoplePromise,
     statisticsEnabled ? getPeopleStatistics({ withSharedSpaces: true }).catch(() => null) : Promise.resolve(null),
   ]);
   const $t = await getFormatter();

--- a/web/src/routes/(user)/people/page-load.spec.ts
+++ b/web/src/routes/(user)/people/page-load.spec.ts
@@ -1,13 +1,18 @@
 import { sdkMock } from '$lib/__mocks__/sdk.mock';
+import { PEOPLE_PAGE_SIZE } from '$lib/constants';
 import { load } from './+page';
 
-const { authenticate, getFormatter } = vi.hoisted(() => ({
+const { authenticate, getFormatter, featureFlagsMock } = vi.hoisted(() => ({
   authenticate: vi.fn(),
   getFormatter: vi.fn(),
+  featureFlagsMock: {
+    valueOrUndefined: undefined as { peopleStatistics: boolean } | undefined,
+  },
 }));
 
 vi.mock('$lib/utils/auth', () => ({ authenticate }));
 vi.mock('$lib/utils/i18n', () => ({ getFormatter }));
+vi.mock('$lib/managers/feature-flags-manager.svelte', () => ({ featureFlagsManager: featureFlagsMock }));
 
 describe('people page load', () => {
   const peopleResponse = {
@@ -23,32 +28,77 @@ describe('people page load', () => {
     detectedFaceCount: 2901,
   };
 
+  let parent: ReturnType<typeof vi.fn>;
+
+  const runLoad = (url: URL) => load({ url, parent } as never);
+
   beforeEach(() => {
     vi.resetAllMocks();
     getFormatter.mockResolvedValue((key: string) => key);
     sdkMock.getAllPeople.mockResolvedValue(peopleResponse);
     sdkMock.getPeopleStatistics.mockResolvedValue(statisticsResponse);
+    parent = vi.fn().mockResolvedValue({});
+    featureFlagsMock.valueOrUndefined = { peopleStatistics: true };
   });
 
-  it('authenticates and loads people with overview statistics', async () => {
+  it('authenticates, awaits parent, and loads a bounded first page with overview statistics when enabled', async () => {
     const url = new URL('https://gallery.test/people');
 
-    await expect(load({ url } as never)).resolves.toEqual({
+    await expect(runLoad(url)).resolves.toEqual({
       people: peopleResponse,
       peopleStatistics: statisticsResponse,
       meta: { title: 'people' },
     });
 
     expect(authenticate).toHaveBeenCalledWith(url);
-    expect(sdkMock.getAllPeople).toHaveBeenCalledWith({ withHidden: true, withSharedSpaces: true });
+    // parent() resolves only after the root layout's init() runs, which is what guarantees the
+    // feature-flags manager is populated before we read it.
+    expect(parent).toHaveBeenCalled();
+    expect(sdkMock.getAllPeople).toHaveBeenCalledWith({
+      withHidden: true,
+      withSharedSpaces: true,
+      size: PEOPLE_PAGE_SIZE,
+    });
     expect(sdkMock.getPeopleStatistics).toHaveBeenCalledWith({ withSharedSpaces: true });
     expect(sdkMock.getPeopleFaceStatistics).not.toHaveBeenCalled();
+  });
+
+  it('skips the overview statistics query when the peopleStatistics flag is disabled', async () => {
+    featureFlagsMock.valueOrUndefined = { peopleStatistics: false };
+    const url = new URL('https://gallery.test/people');
+
+    await expect(runLoad(url)).resolves.toEqual({
+      people: peopleResponse,
+      peopleStatistics: null,
+      meta: { title: 'people' },
+    });
+
+    // People still load (with the bounded size); only the discarded stats query is skipped.
+    expect(sdkMock.getAllPeople).toHaveBeenCalledWith({
+      withHidden: true,
+      withSharedSpaces: true,
+      size: PEOPLE_PAGE_SIZE,
+    });
+    expect(sdkMock.getPeopleStatistics).not.toHaveBeenCalled();
+  });
+
+  it('treats an uninitialized feature-flags manager as statistics-disabled', async () => {
+    // In maintenance mode the root layout skips featureFlagsManager.init(), so valueOrUndefined is
+    // undefined. Fail safe: skip the stats query rather than throw.
+    featureFlagsMock.valueOrUndefined = undefined;
+    const url = new URL('https://gallery.test/people');
+
+    const result = await runLoad(url);
+
+    expect(result.peopleStatistics).toBeNull();
+    expect(sdkMock.getPeopleStatistics).not.toHaveBeenCalled();
+    expect(sdkMock.getAllPeople).toHaveBeenCalled();
   });
 
   it('does not forward unsupported search parameters to overview statistics', async () => {
     const url = new URL('https://gallery.test/people?searchedPeople=Ali&closestPersonId=p1&closestAssetId=a1');
 
-    await load({ url } as never);
+    await runLoad(url);
 
     expect(sdkMock.getPeopleStatistics).toHaveBeenCalledWith({ withSharedSpaces: true });
   });
@@ -57,7 +107,7 @@ describe('people page load', () => {
     const url = new URL('https://gallery.test/people');
     sdkMock.getPeopleStatistics.mockRejectedValue(new Error('stats unavailable'));
 
-    await expect(load({ url } as never)).resolves.toEqual({
+    await expect(runLoad(url)).resolves.toEqual({
       people: peopleResponse,
       peopleStatistics: null,
       meta: { title: 'people' },
@@ -69,6 +119,6 @@ describe('people page load', () => {
     const error = new Error('people unavailable');
     sdkMock.getAllPeople.mockRejectedValue(error);
 
-    await expect(load({ url } as never)).rejects.toThrow(error);
+    await expect(runLoad(url)).rejects.toThrow(error);
   });
 });

--- a/web/src/routes/(user)/people/people-page.spec.ts
+++ b/web/src/routes/(user)/people/people-page.spec.ts
@@ -600,10 +600,18 @@ describe('Global people page', () => {
     expect(screen.queryByText('hide_person')).not.toBeInTheDocument();
   });
 
-  it('loads the next page with the shared page size and the correct page offset', async () => {
+  it('requests the next page at the shared size and merges the rows across the boundary', async () => {
     // The initial load fetched page 1 at PEOPLE_PAGE_SIZE; infinite scroll must continue with the
     // SAME size or the page*size offset would skip or duplicate people across the boundary.
-    sdkMock.getAllPeople.mockResolvedValue({ people: [], total: 3, hidden: 0, hasNextPage: false });
+    sdkMock.getAllPeople.mockResolvedValue({
+      people: [
+        makePerson({ id: 'p3', name: 'Carol', numberOfAssets: 3 }),
+        makePerson({ id: 'p4', name: 'Dave', numberOfAssets: 2 }),
+      ],
+      total: 4,
+      hidden: 0,
+      hasNextPage: false,
+    });
 
     // Drive the infinite-scroll sentinel deterministically: capture the grid's IntersectionObserver
     // callback and the element it observes, then report an intersection.
@@ -623,8 +631,11 @@ describe('Global people page', () => {
     );
 
     renderPage(
-      [makePerson({ id: 'p1' }), makePerson({ id: 'p2' })],
-      { total: 3, hidden: 0, detectedFaceCount: 0 },
+      [
+        makePerson({ id: 'p1', name: 'Alice', numberOfAssets: 5 }),
+        makePerson({ id: 'p2', name: 'Bob', numberOfAssets: 4 }),
+      ],
+      { total: 4, hidden: 0, detectedFaceCount: 0 },
       true,
     );
 
@@ -642,5 +653,14 @@ describe('Global people page', () => {
         size: PEOPLE_PAGE_SIZE,
       });
     });
+
+    // Page 2's rows are appended to page 1's — all four render, none dropped or duplicated.
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Carol')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('Dave')).toBeInTheDocument();
+    });
+    expect(screen.getByDisplayValue('Alice')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Bob')).toBeInTheDocument();
+    expect(screen.getAllByPlaceholderText('add_a_name')).toHaveLength(4);
   });
 });

--- a/web/src/routes/(user)/people/people-page.spec.ts
+++ b/web/src/routes/(user)/people/people-page.spec.ts
@@ -15,6 +15,7 @@ import { getAnimateMock } from '$lib/__mocks__/animate.mock';
 import { getIntersectionObserverMock } from '$lib/__mocks__/intersection-observer.mock';
 import { sdkMock } from '$lib/__mocks__/sdk.mock';
 import { clearPeopleFaceStatisticsInfoCache } from '$lib/components/people/people-face-statistics-info-cache';
+import { PEOPLE_PAGE_SIZE } from '$lib/constants';
 import { authManager } from '$lib/managers/auth-manager.svelte';
 import { PeopleSortBy, peopleViewSettings } from '$lib/stores/preferences.store';
 import { personFactory } from '@test-data/factories/person-factory';
@@ -116,6 +117,7 @@ function getDefaultPeopleStatistics(people: PersonResponseDto[]): PeopleStatisti
 function renderPage(
   people: PersonResponseDto[] = [makePerson()],
   peopleStatistics: PeopleStatisticsResponseDto | null = getDefaultPeopleStatistics(people),
+  hasNextPage = false,
 ) {
   return render(PeoplePage, {
     props: {
@@ -124,7 +126,7 @@ function renderPage(
           people,
           total: people.length,
           hidden: people.filter((person) => person.isHidden).length,
-          hasNextPage: false,
+          hasNextPage,
         },
         peopleStatistics,
         meta: { title: 'People' },
@@ -596,5 +598,49 @@ describe('Global people page', () => {
     expect(screen.queryByLabelText('show_person_options')).not.toBeInTheDocument();
     expect(screen.queryByText('to_favorite')).not.toBeInTheDocument();
     expect(screen.queryByText('hide_person')).not.toBeInTheDocument();
+  });
+
+  it('loads the next page with the shared page size and the correct page offset', async () => {
+    // The initial load fetched page 1 at PEOPLE_PAGE_SIZE; infinite scroll must continue with the
+    // SAME size or the page*size offset would skip or duplicate people across the boundary.
+    sdkMock.getAllPeople.mockResolvedValue({ people: [], total: 3, hidden: 0, hasNextPage: false });
+
+    // Drive the infinite-scroll sentinel deterministically: capture the grid's IntersectionObserver
+    // callback and the element it observes, then report an intersection.
+    let intersectionCallback: IntersectionObserverCallback | undefined;
+    let observedSentinel: Element | undefined;
+    vi.stubGlobal(
+      'IntersectionObserver',
+      vi.fn(function (callback: IntersectionObserverCallback) {
+        intersectionCallback = callback;
+        return {
+          observe: (element: Element) => (observedSentinel = element),
+          disconnect: vi.fn(),
+          unobserve: vi.fn(),
+          takeRecords: vi.fn(),
+        };
+      }),
+    );
+
+    renderPage(
+      [makePerson({ id: 'p1' }), makePerson({ id: 'p2' })],
+      { total: 3, hidden: 0, detectedFaceCount: 0 },
+      true,
+    );
+
+    await waitFor(() => expect(observedSentinel).toBeDefined());
+    intersectionCallback?.(
+      [{ target: observedSentinel, isIntersecting: true } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+
+    await waitFor(() => {
+      expect(sdkMock.getAllPeople).toHaveBeenCalledWith({
+        withHidden: true,
+        withSharedSpaces: true,
+        page: 2,
+        size: PEOPLE_PAGE_SIZE,
+      });
+    });
   });
 });


### PR DESCRIPTION
Follow-up performance work for the global People page (`/people`), on top of the PostgreSQL JIT fix (#798).

## What

1. **Gate the overview-statistics query.** `+page.ts` called `getPeopleStatistics` unconditionally, but the `peopleStatistics` feature flag (server default **off**) only gates *display* in `+page.svelte`. When off, the ~1s query ran and the result was discarded. It is now skipped when the flag is off — read after `await parent()`, and fails safe to "off" when flags are unavailable (e.g. maintenance mode).

2. **Cut the initial page size 500 → 150.** A shared `PEOPLE_PAGE_SIZE` constant is threaded into every People-page `getAllPeople` call (initial load, infinite-scroll next page, and the restore-on-return catch-up) so the `page * size` offset stays consistent across sites. First paint hydrates/serializes/transfers a smaller batch; the rest streams in on scroll.

Also fires the people query **before** `await parent()` so it overlaps the root layout's `init()` instead of serializing behind it.

## Impact

- **Stats gating** helps the **default** config (flag off): removes a wasted ~1s query per load. It does not change first paint (it ran in parallel with the long-pole people query) and is a no-op where the flag is on.
- **Page-size cut** is the first-paint lever on large libraries (~5× smaller first payload + less hydrate/serialize). The two heavy accessible-faces queries are unbounded, so first-paint SQL is unchanged; `total`/`hidden` are global counts, so the header person-count is unaffected at any page size.

## Testing

- Load unit tests: flag on / off / undefined (maintenance), stats-query failure, people-query failure, and `size` on the initial call.
- Component test: infinite scroll requests page 2 at the shared size and merges the rows into the grid (no gap/duplicate across the page boundary).
- Full `web` unit suite green; `tsc` + ESLint + Prettier clean.

## Notes (intentionally out of scope)

- The restore-on-return path (`loadInitialScroll`) is currently **dead code** — the `scrollMemory` action reads `beforeScroll` but the page passes the hook under `beforeLoad` (a pre-existing key mismatch, likely from upstream refactor #25313), and the function also never resolves on the fresh-load path. Left as-is by decision; the `size` param added there is dormant-but-correct if it's ever revived. Tracked for a separate fix.
- The sibling Space People page has a similar unconditional stats call, but its person count derives **solely** from the stats response (no `getSpacePeople` total fallback, unlike this page), so gating it would regress the header count. Left as-is (a safe fix needs a server-side total).
