### PR TITLE
ci(release): fix ROCm build (drop expiring GHA cache) + reclaim runner disk

### DIFF
--- a/.github/workflows/gallery-prerelease-server.yml
+++ b/.github/workflows/gallery-prerelease-server.yml
@@ -374,8 +374,13 @@ jobs:
           build-args: |
             DEVICE=rocm
           outputs: type=image,"name=ghcr.io/open-noodle/gallery-ml",push-by-digest=true,name-resolution=short,push=true
-          cache-from: type=gha,scope=ml-rocm-linux-amd64
-          cache-to: type=gha,scope=ml-rocm-linux-amd64,mode=max
+          # No GHA cache here (unlike the GitHub-hosted ML jobs): the Actions
+          # cache backend hands out an Azure SAS token valid for only ~1h, but
+          # the ROCm image (~40GB base) builds for >1h on the self-hosted runner
+          # — the final `cache-to` blob PUT then 403s ("Signature not valid in
+          # the specified time frame") and fails the whole build. The self-hosted
+          # builder is ephemeral (torn down each run), so a persistent GHA cache
+          # bought nothing here anyway.
 
       - name: Export digest
         run: | # zizmor: ignore[template-injection]
@@ -390,6 +395,19 @@ jobs:
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
+
+      # The `gallery-rocm` runner is a shared self-hosted machine — reclaim the
+      # large ROCm build cache after every run (incl. failures/cancels) so it
+      # can't fill the disk. Prunes build cache + dangling layers only; never
+      # removes tagged images. The image is already pushed to GHCR by digest, so
+      # this is safe and does not affect the merge-ml-rocm step.
+      - name: Reclaim disk space
+        if: always()
+        run: |
+          echo "Disk before prune:"; df -h / | tail -1
+          docker buildx prune --all --force || true
+          docker image prune --force || true
+          echo "Disk after prune:"; df -h / | tail -1
 
   merge-ml-rocm:
     name: Merge ML Manifest (rocm)

--- a/.github/workflows/gallery-release-server-only.yml
+++ b/.github/workflows/gallery-release-server-only.yml
@@ -385,8 +385,13 @@ jobs:
           build-args: |
             DEVICE=rocm
           outputs: type=image,"name=ghcr.io/open-noodle/gallery-ml",push-by-digest=true,name-resolution=short,push=true
-          cache-from: type=gha,scope=ml-rocm-linux-amd64
-          cache-to: type=gha,scope=ml-rocm-linux-amd64,mode=max
+          # No GHA cache here (unlike the GitHub-hosted ML jobs): the Actions
+          # cache backend hands out an Azure SAS token valid for only ~1h, but
+          # the ROCm image (~40GB base) builds for >1h on the self-hosted runner
+          # — the final `cache-to` blob PUT then 403s ("Signature not valid in
+          # the specified time frame") and fails the whole build. The self-hosted
+          # builder is ephemeral (torn down each run), so a persistent GHA cache
+          # bought nothing here anyway.
 
       - name: Export digest
         run: | # zizmor: ignore[template-injection]
@@ -401,6 +406,19 @@ jobs:
           path: ${{ runner.temp }}/digests/*
           if-no-files-found: error
           retention-days: 1
+
+      # The `gallery-rocm` runner is a shared self-hosted machine — reclaim the
+      # large ROCm build cache after every run (incl. failures/cancels) so it
+      # can't fill the disk. Prunes build cache + dangling layers only; never
+      # removes tagged images. The image is already pushed to GHCR by digest, so
+      # this is safe and does not affect the merge-ml-rocm step.
+      - name: Reclaim disk space
+        if: always()
+        run: |
+          echo "Disk before prune:"; df -h / | tail -1
+          docker buildx prune --all --force || true
+          docker image prune --force || true
+          echo "Disk after prune:"; df -h / | tail -1
 
   merge-ml-rocm:
     name: Merge ML Manifest (rocm)


### PR DESCRIPTION
## Problem

The first-ever ROCm build in the `v5.2.0-rc.0` pre-release ([run 29695717823](https://github.com/open-noodle/gallery/actions/runs/29695717823)) **failed** — but not because of code. The ROCm image compiled successfully for ~70 min on the self-hosted `gallery-rocm` runner, then died at the final **cache-export** step:

```
#22 ERROR: error writing layer blob: PUT .../actions-cache/ccc-5871254372
RESPONSE 403: AuthenticationFailed
AuthenticationErrorDetail: Signature not valid in the specified time frame:
  Start [17:03:51] - Expiry [18:03:56] - Current [18:03:56]
```

`cache-to: type=gha,mode=max` uses the GitHub Actions cache backend, which hands out an **Azure SAS token valid for exactly 1 hour**. The ROCm image (~40 GB `rocm/dev-ubuntu-24.04:*-complete` base) builds for **>1 h**, so by the time buildx writes the final cache blob the token has expired → **403** → the whole `docker buildx build` returns non-zero → `Merge ML Manifest (rocm)` is skipped → no `-rocm` tag published.

The GitHub-hosted CPU/CUDA/OpenVINO ML jobs are unaffected: they build in minutes, well inside the 1-hour window.

## Fix

1. **Drop `cache-from`/`cache-to: type=gha`** from the ROCm build step in both `gallery-prerelease-server.yml` and `gallery-release-server-only.yml`. The self-hosted builder is an ephemeral `docker-container` builder that `setup-buildx-action` tears down after every run, so a persistent GHA cache never actually helped this job — it only introduced the SAS-expiry failure.
2. **Add an `if: always()` "Reclaim disk space" step** so the large ROCm build cache is pruned after every run (including failures/cancellations), keeping the shared self-hosted machine from filling up.

## Safety of the cleanup step

- `docker buildx prune --all --force` targets **only the current (ephemeral) builder** created for this run — it does not touch other builders' caches on the machine.
- `docker image prune --force` removes **dangling (untagged) layers only** — never tagged images.
- The built image is already pushed to GHCR **by digest** before cleanup runs, so pruning does not affect the downstream `merge-ml-rocm` manifest step.

## Runner disk (verified before this change)

`gallery-rocm` (omarchy) currently: **952 G total, 223 G free (77% used)** — ample headroom for a ~40 GB build. No orphaned ephemeral builders or dangling buildkit volumes were present, and the runner `_work` dir was 274 MB — i.e. the ephemeral-builder teardown already reclaims space today; this step makes it explicit and failure-proof.

## Tradeoff / future option

Without a persistent cache, each ROCm build is a full ~70 min rebuild. That's fine within the job's 180 min timeout and ROCm releases are infrequent. If build time ever becomes a pain, a **registry cache** (`type=registry,ref=ghcr.io/open-noodle/gallery-ml:rocm-buildcache`) would give cross-run caching without the SAS-expiry class of failure and without local disk growth — deferred to keep this change minimal.