### PR TITLE
fix(server): resolve shared-space birthdays on the asset faces endpoint (#808)

### DIFF
--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -32,7 +32,6 @@ import {
   TrimParameters,
 } from 'src/dtos/editing.dto';
 import { AssetOcrResponseDto } from 'src/dtos/ocr.dto';
-import { PersonResponseDto } from 'src/dtos/person.dto';
 import {
   AssetFileType,
   AssetStatus,
@@ -59,6 +58,7 @@ import {
 } from 'src/utils/asset.util';
 import { updateLockedColumns } from 'src/utils/database';
 import { asDateTimeString, extractTimeZone } from 'src/utils/date';
+import { applyResolvedIdentityMetadata } from 'src/utils/person-identity';
 import { transformOcrBoundingBox } from 'src/utils/transform';
 
 @Injectable()
@@ -167,29 +167,14 @@ export class AssetService extends BaseService {
         identityByPersonId.set(face.person.id, face.person.identityId);
       }
     }
-    if (identityByPersonId.size === 0) {
-      return;
-    }
 
-    const uniqueIdentityIds = [...new Set(identityByPersonId.values())];
-    const resolvedByIdentity = new Map<string, PersonResponseDto>();
-    await Promise.all(
-      uniqueIdentityIds.map(async (identityId) => {
-        const resolved = await this.faceIdentityRepository.getResolvedPersonByIdentityId(auth.user.id, identityId);
-        if (resolved) {
-          resolvedByIdentity.set(identityId, resolved);
-        }
-      }),
-    );
-
-    for (const person of people) {
-      const identityId = identityByPersonId.get(person.id);
-      const resolved = identityId ? resolvedByIdentity.get(identityId) : undefined;
-      if (resolved) {
-        person.name = resolved.name;
-        person.birthDate = resolved.birthDate;
-      }
-    }
+    // Shared with PersonService.getFacesById, the sibling read path the Info panel uses for the
+    // owner — the two have to resolve identically or the age appears on one surface only (#808).
+    await applyResolvedIdentityMetadata({
+      people,
+      identityByPersonId,
+      resolve: (identityId) => this.faceIdentityRepository.getResolvedPersonByIdentityId(auth.user.id, identityId),
+    });
   }
 
   private applySpacePeople(data: AssetResponseDto, spacePersonMap: Map<string, LinkedSpacePerson>) {

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -1513,7 +1513,10 @@ describe(PersonService.name, () => {
 
       const [result] = await sut.getFacesById(auth, { id: face.assetId });
 
-      expect(result.person).toBeNull();
+      // #796 surfaces the person to any viewer with asset read access; #808 must still not
+      // identity-resolve a face the caller does not own, so the person is returned raw (birthDate
+      // untouched) and the resolver is never called.
+      expect(result.person).toEqual(expect.objectContaining({ id: face.person!.id, birthDate: null }));
       expect((mocks.faceIdentity as any).getResolvedPersonByIdentityId).not.toHaveBeenCalled();
     });
 

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -1435,6 +1435,136 @@ describe(PersonService.name, () => {
         BadRequestException,
       );
     });
+
+    // #808: a birthday set inside a shared space lives on `shared_space_person`, never on `person`.
+    // The asset viewer Info panel reads this endpoint for the owner, so it must apply the same
+    // identity-wide resolution as PersonService.getById — otherwise the age silently disappears.
+    it("should resolve the identity-wide birthday and name for the owner's own person", async () => {
+      const auth = AuthFactory.create();
+      const face = AssetFaceFactory.from()
+        .person({ ownerId: auth.user.id, identityId: newUuid(), name: 'Owner Local Name', birthDate: null })
+        .build();
+      const asset = AssetFactory.from({ id: face.assetId }).exif().build();
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.person.getFaces.mockResolvedValue([getForAssetFace(face)]);
+      mocks.asset.getForFaces.mockResolvedValue({ edits: [], ...asset.exifInfo });
+      (mocks.faceIdentity as any).getResolvedPersonByIdentityId.mockResolvedValue({
+        id: face.person!.id,
+        name: 'Karolin',
+        birthDate: '2014-02-14',
+      });
+
+      const [result] = await sut.getFacesById(auth, { id: face.assetId });
+
+      expect(result.person).toEqual(
+        expect.objectContaining({ id: face.person!.id, name: 'Karolin', birthDate: '2014-02-14' }),
+      );
+      expect((mocks.faceIdentity as any).getResolvedPersonByIdentityId).toHaveBeenCalledWith(
+        auth.user.id,
+        face.person!.identityId,
+      );
+    });
+
+    it('should not resolve via identity when the owned person has no identity', async () => {
+      const auth = AuthFactory.create();
+      const face = AssetFaceFactory.from()
+        .person({ ownerId: auth.user.id, identityId: null, name: 'Owner Local Name', birthDate: null })
+        .build();
+      const asset = AssetFactory.from({ id: face.assetId }).exif().build();
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.person.getFaces.mockResolvedValue([getForAssetFace(face)]);
+      mocks.asset.getForFaces.mockResolvedValue({ edits: [], ...asset.exifInfo });
+
+      const [result] = await sut.getFacesById(auth, { id: face.assetId });
+
+      expect(result.person).toEqual(expect.objectContaining({ name: 'Owner Local Name', birthDate: null }));
+      expect((mocks.faceIdentity as any).getResolvedPersonByIdentityId).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to the raw person when identity resolution finds nothing', async () => {
+      const auth = AuthFactory.create();
+      const face = AssetFaceFactory.from()
+        .person({ ownerId: auth.user.id, identityId: newUuid(), name: 'Owner Local Name', birthDate: null })
+        .build();
+      const asset = AssetFactory.from({ id: face.assetId }).exif().build();
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.person.getFaces.mockResolvedValue([getForAssetFace(face)]);
+      mocks.asset.getForFaces.mockResolvedValue({ edits: [], ...asset.exifInfo });
+      (mocks.faceIdentity as any).getResolvedPersonByIdentityId.mockResolvedValue(void 0);
+
+      const [result] = await sut.getFacesById(auth, { id: face.assetId });
+
+      expect(result.person).toEqual(expect.objectContaining({ name: 'Owner Local Name', birthDate: null }));
+    });
+
+    it('should not resolve identities for faces belonging to another owner', async () => {
+      const auth = AuthFactory.create();
+      const face = AssetFaceFactory.from()
+        .person({ ownerId: newUuid(), identityId: newUuid(), birthDate: null })
+        .build();
+      const asset = AssetFactory.from({ id: face.assetId }).exif().build();
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.person.getFaces.mockResolvedValue([getForAssetFace(face)]);
+      mocks.asset.getForFaces.mockResolvedValue({ edits: [], ...asset.exifInfo });
+
+      const [result] = await sut.getFacesById(auth, { id: face.assetId });
+
+      expect(result.person).toBeNull();
+      expect((mocks.faceIdentity as any).getResolvedPersonByIdentityId).not.toHaveBeenCalled();
+    });
+
+    it('should resolve each identity once when several faces share it', async () => {
+      const auth = AuthFactory.create();
+      const identityId = newUuid();
+      const assetId = newUuid();
+      const first = AssetFaceFactory.from({ assetId })
+        .person({ ownerId: auth.user.id, identityId, birthDate: null })
+        .build();
+      const second = AssetFaceFactory.from({ assetId })
+        .person({ ownerId: auth.user.id, identityId, birthDate: null })
+        .build();
+      const asset = AssetFactory.from({ id: assetId }).exif().build();
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
+      mocks.person.getFaces.mockResolvedValue([getForAssetFace(first), getForAssetFace(second)]);
+      mocks.asset.getForFaces.mockResolvedValue({ edits: [], ...asset.exifInfo });
+      (mocks.faceIdentity as any).getResolvedPersonByIdentityId.mockResolvedValue({
+        id: first.person!.id,
+        name: 'Karolin',
+        birthDate: '2014-02-14',
+      });
+
+      const results = await sut.getFacesById(auth, { id: assetId });
+
+      expect(results.map((r) => r.person?.birthDate)).toEqual(['2014-02-14', '2014-02-14']);
+      expect((mocks.faceIdentity as any).getResolvedPersonByIdentityId).toHaveBeenCalledTimes(1);
+    });
+
+    it("should keep the birthday when identity resolution echoes the base person's own value", async () => {
+      const auth = AuthFactory.create();
+      const face = AssetFaceFactory.from()
+        .person({ ownerId: auth.user.id, identityId: newUuid(), name: 'Karolin', birthDate: new Date('2014-02-14') })
+        .build();
+      const asset = AssetFactory.from({ id: face.assetId }).exif().build();
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.person.getFaces.mockResolvedValue([getForAssetFace(face)]);
+      mocks.asset.getForFaces.mockResolvedValue({ edits: [], ...asset.exifInfo });
+      // The resolver ranks a non-null birthDate first, so it echoes the base person's own value back.
+      (mocks.faceIdentity as any).getResolvedPersonByIdentityId.mockResolvedValue({
+        id: face.person!.id,
+        name: 'Karolin',
+        birthDate: '2014-02-14',
+      });
+
+      const [result] = await sut.getFacesById(auth, { id: face.assetId });
+
+      expect(result.person).toEqual(expect.objectContaining({ name: 'Karolin', birthDate: '2014-02-14' }));
+    });
   });
 
   describe('createFace', () => {

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -63,6 +63,7 @@ import { ImmichMediaResponse } from 'src/utils/file';
 import { createCrossOwnerMergeAuthorizer } from 'src/utils/merge-policy';
 import { mimeTypes } from 'src/utils/mime-types';
 import { isFacialRecognitionEnabled } from 'src/utils/misc';
+import { applyResolvedIdentityMetadata } from 'src/utils/person-identity';
 import { getPreferences } from 'src/utils/preferences';
 import { Point, transformPoints } from 'src/utils/transform';
 
@@ -279,9 +280,29 @@ export class PersonService extends BaseService {
     // A person the owner marked hidden must never reach another viewer (#796). Filtering on the
     // client would be cosmetic — the identity would still be on the wire — so drop the face here.
     // The owner keeps seeing their hidden people; the web decides whether to display them.
-    return faces
+    const response = faces
       .filter((face) => !face.person?.isHidden || face.person?.ownerId === auth.user.id)
       .map((face) => mapFaces(face, auth, asset.edits, assetDimensions));
+
+    // #808: a name or birthday set inside a shared space lives on `shared_space_person` and is
+    // resolved at read time — it is never written back to `person`. The asset viewer Info panel
+    // reads this endpoint for the owner, so it has to apply the same identity-wide resolution
+    // PersonService.getById does; otherwise the age silently disappears for every person whose
+    // birthday only ever existed on a space profile. `mapFaces` already nulls people the caller
+    // does not own, so only owned faces are resolved here.
+    const identityByPersonId = new Map<string, string>();
+    for (const face of faces) {
+      if (face.person?.ownerId === auth.user.id && face.person.identityId) {
+        identityByPersonId.set(face.person.id, face.person.identityId);
+      }
+    }
+    await applyResolvedIdentityMetadata({
+      people: response.map((face) => face.person).filter((person) => person !== null),
+      identityByPersonId,
+      resolve: (identityId) => this.faceIdentityRepository.getResolvedPersonByIdentityId(auth.user.id, identityId),
+    });
+
+    return response;
   }
 
   async createNewFeaturePhoto(changeFeaturePhoto: string[]) {

--- a/server/src/utils/person-identity.ts
+++ b/server/src/utils/person-identity.ts
@@ -1,0 +1,46 @@
+import { PersonResponseDto } from 'src/dtos/person.dto';
+
+type ResolvablePerson = Pick<PersonResponseDto, 'id' | 'name' | 'birthDate'>;
+
+/**
+ * Overlay the identity-wide name/birthday resolution onto already-mapped people.
+ *
+ * A name or birthday set inside a shared space is stored on `shared_space_person` and resolved at
+ * read time against the face identity — it is never written back to `person`. Any read path that
+ * maps a raw `person` row therefore has to re-apply that resolution, or it hands back the raw
+ * (often empty) `person.birthDate` and the age disappears (#808).
+ *
+ * Each distinct identity is resolved once, regardless of how many people map onto it.
+ */
+export const applyResolvedIdentityMetadata = async <T extends ResolvablePerson>({
+  people,
+  identityByPersonId,
+  resolve,
+}: {
+  people: T[];
+  identityByPersonId: Map<string, string>;
+  resolve: (identityId: string) => Promise<PersonResponseDto | undefined>;
+}): Promise<void> => {
+  if (people.length === 0 || identityByPersonId.size === 0) {
+    return;
+  }
+
+  const resolvedByIdentity = new Map<string, PersonResponseDto>();
+  await Promise.all(
+    [...new Set(identityByPersonId.values())].map(async (identityId) => {
+      const resolved = await resolve(identityId);
+      if (resolved) {
+        resolvedByIdentity.set(identityId, resolved);
+      }
+    }),
+  );
+
+  for (const person of people) {
+    const identityId = identityByPersonId.get(person.id);
+    const resolved = identityId ? resolvedByIdentity.get(identityId) : undefined;
+    if (resolved) {
+      person.name = resolved.name;
+      person.birthDate = resolved.birthDate;
+    }
+  }
+};

--- a/server/test/medium/specs/services/person.service.spec.ts
+++ b/server/test/medium/specs/services/person.service.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException } from '@nestjs/common';
 import { Kysely } from 'kysely';
 import { AssetEditAction, MirrorAxis } from 'src/dtos/editing.dto';
 import { AssetFaceCreateDto } from 'src/dtos/person.dto';
@@ -92,6 +93,48 @@ const setupFaceDetection = (db?: Kysely<DB>) => {
     });
 
   return { sut, ctx };
+};
+
+/**
+ * #808: reproduces the reported shape against a real database — `person.birthDate` is NULL and the
+ * birthday only ever existed on a `shared_space_person` profile reached through the shared
+ * `identityId`. This is the payload the asset viewer Info panel renders for the owner, so the age
+ * has to survive the trip. The small tests stub the resolver; these prove the real
+ * `hydrateAccessiblePeople` query actually returns the space birthday for this shape.
+ */
+const seedSpaceOnlyBirthday = async (birthDateSource: 'manual' | 'inherited') => {
+  const { sut, ctx } = setup();
+  const faceIdentityRepository = ctx.get(FaceIdentityRepository);
+  const { user } = await ctx.newUser();
+  const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Karolin', birthDate: null });
+  const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+  await ctx.newExif({ assetId: asset.id, exifImageWidth: 400, exifImageHeight: 500 });
+  const { result: faceId } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+  const identity = await faceIdentityRepository.ensurePersonIdentity(person.id);
+  await faceIdentityRepository.linkFace({ assetFaceId: faceId, identityId: identity.id, source: 'owner-person' });
+
+  const { space } = await ctx.newSharedSpace({ createdById: user.id });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: user.id });
+
+  const spacePerson = await ctx.database
+    .insertInto('shared_space_person')
+    .values({
+      spaceId: space.id,
+      name: 'Karolin',
+      identityId: identity.id,
+      birthDate: '2014-02-14',
+      birthDateSource,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+  await ctx.database
+    .insertInto('shared_space_person_face')
+    .values({ personId: spacePerson.id, assetFaceId: faceId })
+    .execute();
+
+  return { sut, ctx, user, person, asset, identity, space };
 };
 
 const setupFaceRecognition = (db?: Kysely<DB>) => {
@@ -1657,6 +1700,54 @@ describe(PersonService.name, () => {
       const faces = await sut.getFacesById(factory.auth({ user: owner }), { id: asset.id });
 
       expect(faces[0].person).toEqual(expect.objectContaining({ id: person.id, name: 'Alice' }));
+    });
+  });
+
+  describe('getFacesById shared-space birthday resolution', () => {
+    it('returns a birthday that only exists on a manual shared-space profile', async () => {
+      const { sut, user, person, asset } = await seedSpaceOnlyBirthday('manual');
+
+      const faces = await sut.getFacesById(factory.auth({ user }), { id: asset.id });
+
+      expect(faces).toHaveLength(1);
+      expect(faces[0].person).toEqual(
+        expect.objectContaining({ id: person.id, name: 'Karolin', birthDate: '2014-02-14' }),
+      );
+    });
+
+    it('returns a birthday inherited across spaces from a sibling profile', async () => {
+      const { sut, user, asset } = await seedSpaceOnlyBirthday('inherited');
+
+      const faces = await sut.getFacesById(factory.auth({ user }), { id: asset.id });
+
+      expect(faces[0].person?.birthDate).toBe('2014-02-14');
+    });
+
+    it('leaves the birthday null when no profile of the identity carries one', async () => {
+      const { sut, ctx } = setup();
+      const faceIdentityRepository = ctx.get(FaceIdentityRepository);
+      const { user } = await ctx.newUser();
+      const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Karolin', birthDate: null });
+      const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+      await ctx.newExif({ assetId: asset.id, exifImageWidth: 400, exifImageHeight: 500 });
+      const { result: faceId } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+      const identity = await faceIdentityRepository.ensurePersonIdentity(person.id);
+      await faceIdentityRepository.linkFace({ assetFaceId: faceId, identityId: identity.id, source: 'owner-person' });
+
+      const faces = await sut.getFacesById(factory.auth({ user }), { id: asset.id });
+
+      expect(faces[0].person).toEqual(expect.objectContaining({ id: person.id, birthDate: null }));
+    });
+
+    it("does not leak a space birthday to a viewer who cannot see the person's face", async () => {
+      const { sut, ctx, asset } = await seedSpaceOnlyBirthday('manual');
+      const { user: outsider } = await ctx.newUser();
+
+      // The outsider is not a member of the space and does not own the asset — `mapFaces` must keep
+      // returning no person at all rather than an identity-resolved one.
+      await expect(sut.getFacesById(factory.auth({ user: outsider }), { id: asset.id })).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
     });
   });
 });

--- a/web/src/lib/components/asset-viewer/detail-panel.spec.ts
+++ b/web/src/lib/components/asset-viewer/detail-panel.spec.ts
@@ -308,6 +308,106 @@ describe('DetailPanel', () => {
     ).toHaveLength(0);
   });
 
+  // #808: for the owner the People section renders `faceManager.people` (GET /faces), not
+  // `asset.people`. The server now resolves a birthday that only lives on a shared-space profile
+  // onto that payload, so the age must appear here. The birth date is asserted via the title
+  // attribute because it is locale-formatted by luxon rather than translated.
+  it('renders the age for a person whose birthday arrives on the faces payload', async () => {
+    const person: PersonResponseDto = {
+      id: 'global-person-1',
+      name: 'Karolin',
+      thumbnailPath: '/person.jpg',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+      isHidden: false,
+      birthDate: '2014-02-14',
+      type: 'person',
+    };
+    const face = makeFace('face-1', person, {
+      boundingBoxX1: 100,
+      boundingBoxY1: 200,
+      boundingBoxX2: 300,
+      boundingBoxY2: 400,
+    });
+    faceManagerMock.data = [face];
+    faceManagerMock.people = [person];
+    faceManagerMock.facesByPersonId = new Map([[person.id, [face]]]);
+
+    const asset = assetFactory.build({
+      ownerId: 'owner-1',
+      localDateTime: '2026-01-01T00:00:00.000Z',
+      people: [],
+    });
+
+    const { container } = renderWithTooltips(DetailPanel, { asset, currentAlbum: null });
+
+    await waitFor(() => expect(screen.getByText('Karolin')).toBeInTheDocument());
+    expect(container.querySelector('p[title="February 14, 2014"]')).toBeTruthy();
+  });
+
+  it('renders no age for a person without a birthday', async () => {
+    const person: PersonResponseDto = {
+      id: 'global-person-1',
+      name: 'Karolin',
+      thumbnailPath: '/person.jpg',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+      isHidden: false,
+      birthDate: null,
+      type: 'person',
+    };
+    const face = makeFace('face-1', person, {
+      boundingBoxX1: 100,
+      boundingBoxY1: 200,
+      boundingBoxX2: 300,
+      boundingBoxY2: 400,
+    });
+    faceManagerMock.data = [face];
+    faceManagerMock.people = [person];
+    faceManagerMock.facesByPersonId = new Map([[person.id, [face]]]);
+
+    const asset = assetFactory.build({
+      ownerId: 'owner-1',
+      localDateTime: '2026-01-01T00:00:00.000Z',
+      people: [],
+    });
+
+    const { container } = renderWithTooltips(DetailPanel, { asset, currentAlbum: null });
+
+    await waitFor(() => expect(screen.getByText('Karolin')).toBeInTheDocument());
+    expect(container.querySelector('p[title*="2014"]')).toBeNull();
+  });
+
+  it('renders no age when the birthday is after the photo was taken', async () => {
+    const person: PersonResponseDto = {
+      id: 'global-person-1',
+      name: 'Karolin',
+      thumbnailPath: '/person.jpg',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+      isHidden: false,
+      birthDate: '2027-02-14',
+      type: 'person',
+    };
+    const face = makeFace('face-1', person, {
+      boundingBoxX1: 100,
+      boundingBoxY1: 200,
+      boundingBoxX2: 300,
+      boundingBoxY2: 400,
+    });
+    faceManagerMock.data = [face];
+    faceManagerMock.people = [person];
+    faceManagerMock.facesByPersonId = new Map([[person.id, [face]]]);
+
+    const asset = assetFactory.build({
+      ownerId: 'owner-1',
+      localDateTime: '2026-01-01T00:00:00.000Z',
+      people: [],
+    });
+
+    const { container } = renderWithTooltips(DetailPanel, { asset, currentAlbum: null });
+
+    await waitFor(() => expect(screen.getByText('Karolin')).toBeInTheDocument());
+    expect(container.querySelector('p[title*="2027"]')).toBeNull();
+  });
+
   it('renders Google, Apple, and OpenStreetMap links in the image info panel map popup', async () => {
     const lat = 48.853_41;
     const lon = 2.3488;


### PR DESCRIPTION
Fixes #808.

## The bug

A name or birthday set inside a shared space is stored on `shared_space_person` and resolved at read time against the face identity — it is **never** written back to `person`. `PersonService.getById` already overlays that resolution, which is why the person's own overview page (`/people/{id}`) shows the age correctly.

The asset viewer Info panel does not read that endpoint. For the owner it renders `faceManager.people`, fed by `GET /faces?id=` (`DetailPanelPeople.svelte:28`), and `PersonService.getFacesById` mapped the raw `person` row straight through `mapFaces`. When the birthday only ever existed on a space profile — the common case when a non-owner sets it inside a Space — `person.birthDate` is `NULL`, so the age silently disappeared on **every** photo, exactly as reported.

## The fix

Apply the same identity-wide resolution in `getFacesById`.

- `mapFaces` already nulls people the caller does not own, so only owned faces are resolved — no cross-owner metadata is exposed.
- Each distinct identity is resolved once regardless of how many faces map onto it.
- The overlay is extracted to `src/utils/person-identity.ts`, and `AssetService.applyResolvedPersonMetadata` — the sibling read path the Info panel uses for a space member — now shares it, so the two surfaces cannot drift apart again. That refactor is behaviour-preserving; the existing `asset.service.spec.ts` identity tests cover both branches and still pass untouched.

## Coverage

Written test-first; each test was watched failing before the fix landed.

**Unit** (`person.service.spec.ts`, 6 new) — resolution applied; person without an identity; resolver returns nothing; face owned by someone else (stays `null`, resolver never called); one identity shared by several faces resolved exactly once; birthday already on the base person preserved.

**Medium / real database** (`test/medium/specs/services/person.service.spec.ts`, 4 new) — reproduces the reported shape: `person.birthDate` NULL, birthday only on a `shared_space_person` profile reached via the shared `identityId`. Covers `manual` and `inherited` `birthDateSource`, the no-birthday-anywhere case, and a non-member outsider. These matter because the unit tests stub the resolver; these prove the real `hydrateAccessiblePeople` query actually returns the space birthday for this shape. Verified RED against a real DB (`expected null to be '2014-02-14'`) before the fix.

**Web** (`detail-panel.spec.ts`, 3 new) — pins the user-visible symptom: age renders when the birthday arrives on the faces payload, and does not render with no birthday or a birthday after the photo was taken.

## Deliberately not changed

`AssetService.applySpacePeople` still lets a space profile's `NULL` birthDate win in explicit space context, discarding the base person's value. That looks adjacent but is a member-visibility boundary (`sharePersonMetadata`), not the reported bug — the reporter's three space profiles all carry the birthday. Changing it would be an RBAC decision, so it is left alone and flagged here.

## Verification

- `server`: 5099 unit tests pass; `tsc --noEmit` clean; eslint `--max-warnings 0` clean; prettier clean
- `server` medium `person.service.spec.ts`: 25/25 pass. The repo has 28 pre-existing medium failures on this base (unbuilt plugin-core, exiftool) — baseline captured before and after; this branch adds none
- `web`: 3657 tests pass; `tsc --noEmit` clean; lint 0 errors