### PR TITLE
fix(web): align filter panel sections across every view (#802)

### DIFF
--- a/docs/docs/features/map-filtering.md
+++ b/docs/docs/features/map-filtering.md
@@ -1,17 +1,20 @@
 # Map Filtering
 
-The map view supports the same filter panel available on the Photos and Spaces pages. Filter map markers by people, camera, tags, rating, favorites, media type, and date range.
+The map view supports the same filter panel available on the Photos and Spaces pages, with the same set of filter sections. Filter map markers by people, location, camera, tags, rating, favorites, media type, album membership, text, and date range.
 
 ## How it works
 
 Open the map from the sidebar or from a Space's map button. The filter panel appears on the left side, expanded by default.
 
 - **People** — show only photos containing specific people
+- **Location** — narrow to a country or city by name, alongside panning the map itself
 - **Camera** — filter by camera make and model
 - **Tags** — narrow to photos with specific tags
 - **Rating** — minimum star rating
 - **Favorites** — toggle between all photos and favorites only
 - **Media type** — photos, videos, or both
+- **Albums** — restrict to photos that are, or are not, in any album
+- **Text** — match on description, original file name, or text recognised in the image (OCR)
 - **Timeline** — pick a year or month to see photos from that period
 
 Markers on the map update as you change filters. When you click a cluster, the timeline panel also respects your active filters and its counts stay scoped to the filtered result set.
@@ -27,6 +30,6 @@ Map search uses smart search to find matching assets, then intersects those resu
 - **Global map** (`/map`) — shows your own geotagged photos with global filter suggestions
 - **Space map** (`/map?spaceId=...`) — scoped to a specific space, with space-aware filter suggestions (only people and cameras that exist in that space)
 
-## No location filter
+## Location filtering on a map
 
-The map itself serves as the location filter — pan and zoom to explore geographically. The filter panel omits the location section to avoid redundancy.
+The map itself is the primary location filter — pan and zoom to explore geographically. The **Location** section complements it when you want to jump straight to a named country or city rather than navigating there by hand; the two intersect, so a city filter combined with a zoomed-in viewport shows only markers satisfying both.

--- a/mobile/openapi/lib/api/gallery_map_api.dart
+++ b/mobile/openapi/lib/api/gallery_map_api.dart
@@ -30,6 +30,9 @@ class GalleryMapApi {
   /// * [String] country:
   ///   Filter by country
   ///
+  /// * [String] description:
+  ///   Filter by description text
+  ///
   /// * [bool] isFavorite:
   ///   Filter by favorite status
   ///
@@ -44,6 +47,12 @@ class GalleryMapApi {
   ///
   /// * [String] model:
   ///   Camera model
+  ///
+  /// * [String] ocr:
+  ///   Filter by text recognised in the image
+  ///
+  /// * [String] originalFileName:
+  ///   Filter by original file name
   ///
   /// * [List<String>] personIds:
   ///   Filter by person IDs
@@ -68,7 +77,7 @@ class GalleryMapApi {
   ///
   /// * [bool] withSharedSpaces:
   ///   Include shared space assets
-  Future<Response> getFilteredMapMarkersWithHttpInfo({ String? city, String? country, bool? isFavorite, bool? isInAlbum, bool? isNotInAlbum, String? make, String? model, List<String>? personIds, num? rating, String? spaceId, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, MapMediaType? type, bool? withSharedSpaces, Future<void>? abortTrigger, }) async {
+  Future<Response> getFilteredMapMarkersWithHttpInfo({ String? city, String? country, String? description, bool? isFavorite, bool? isInAlbum, bool? isNotInAlbum, String? make, String? model, String? ocr, String? originalFileName, List<String>? personIds, num? rating, String? spaceId, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, MapMediaType? type, bool? withSharedSpaces, Future<void>? abortTrigger, }) async {
     // ignore: prefer_const_declarations
     final apiPath = r'/gallery/map/markers';
 
@@ -85,6 +94,9 @@ class GalleryMapApi {
     if (country != null) {
       queryParams.addAll(_queryParams('', 'country', country));
     }
+    if (description != null) {
+      queryParams.addAll(_queryParams('', 'description', description));
+    }
     if (isFavorite != null) {
       queryParams.addAll(_queryParams('', 'isFavorite', isFavorite));
     }
@@ -99,6 +111,12 @@ class GalleryMapApi {
     }
     if (model != null) {
       queryParams.addAll(_queryParams('', 'model', model));
+    }
+    if (ocr != null) {
+      queryParams.addAll(_queryParams('', 'ocr', ocr));
+    }
+    if (originalFileName != null) {
+      queryParams.addAll(_queryParams('', 'originalFileName', originalFileName));
     }
     if (personIds != null) {
       queryParams.addAll(_queryParams('multi', 'personIds', personIds));
@@ -152,6 +170,9 @@ class GalleryMapApi {
   /// * [String] country:
   ///   Filter by country
   ///
+  /// * [String] description:
+  ///   Filter by description text
+  ///
   /// * [bool] isFavorite:
   ///   Filter by favorite status
   ///
@@ -166,6 +187,12 @@ class GalleryMapApi {
   ///
   /// * [String] model:
   ///   Camera model
+  ///
+  /// * [String] ocr:
+  ///   Filter by text recognised in the image
+  ///
+  /// * [String] originalFileName:
+  ///   Filter by original file name
   ///
   /// * [List<String>] personIds:
   ///   Filter by person IDs
@@ -190,8 +217,8 @@ class GalleryMapApi {
   ///
   /// * [bool] withSharedSpaces:
   ///   Include shared space assets
-  Future<List<MapMarkerResponseDto>?> getFilteredMapMarkers({ String? city, String? country, bool? isFavorite, bool? isInAlbum, bool? isNotInAlbum, String? make, String? model, List<String>? personIds, num? rating, String? spaceId, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, MapMediaType? type, bool? withSharedSpaces, Future<void>? abortTrigger, }) async {
-    final response = await getFilteredMapMarkersWithHttpInfo(city: city, country: country, isFavorite: isFavorite, isInAlbum: isInAlbum, isNotInAlbum: isNotInAlbum, make: make, model: model, personIds: personIds, rating: rating, spaceId: spaceId, tagIds: tagIds, takenAfter: takenAfter, takenBefore: takenBefore, type: type, withSharedSpaces: withSharedSpaces, abortTrigger: abortTrigger,);
+  Future<List<MapMarkerResponseDto>?> getFilteredMapMarkers({ String? city, String? country, String? description, bool? isFavorite, bool? isInAlbum, bool? isNotInAlbum, String? make, String? model, String? ocr, String? originalFileName, List<String>? personIds, num? rating, String? spaceId, List<String>? tagIds, DateTime? takenAfter, DateTime? takenBefore, MapMediaType? type, bool? withSharedSpaces, Future<void>? abortTrigger, }) async {
+    final response = await getFilteredMapMarkersWithHttpInfo(city: city, country: country, description: description, isFavorite: isFavorite, isInAlbum: isInAlbum, isNotInAlbum: isNotInAlbum, make: make, model: model, ocr: ocr, originalFileName: originalFileName, personIds: personIds, rating: rating, spaceId: spaceId, tagIds: tagIds, takenAfter: takenAfter, takenBefore: takenBefore, type: type, withSharedSpaces: withSharedSpaces, abortTrigger: abortTrigger,);
     if (response.statusCode >= HttpStatus.badRequest) {
       throw ApiException(response.statusCode, await _decodeBodyBytes(response));
     }

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -6499,6 +6499,15 @@
             }
           },
           {
+            "name": "description",
+            "required": false,
+            "in": "query",
+            "description": "Filter by description text",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "isFavorite",
             "required": false,
             "in": "query",
@@ -6539,6 +6548,24 @@
             "required": false,
             "in": "query",
             "description": "Camera model",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ocr",
+            "required": false,
+            "in": "query",
+            "description": "Filter by text recognised in the image",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "originalFileName",
+            "required": false,
+            "in": "query",
+            "description": "Filter by original file name",
             "schema": {
               "type": "string"
             }

--- a/packages/sdk/src/fetch-client.ts
+++ b/packages/sdk/src/fetch-client.ts
@@ -5760,14 +5760,17 @@ export function reassignFacesById({ id, faceDto }: {
 /**
  * Get filtered map markers
  */
-export function getFilteredMapMarkers({ city, country, isFavorite, isInAlbum, isNotInAlbum, make, model, personIds, rating, spaceId, tagIds, takenAfter, takenBefore, $type, withSharedSpaces }: {
+export function getFilteredMapMarkers({ city, country, description, isFavorite, isInAlbum, isNotInAlbum, make, model, ocr, originalFileName, personIds, rating, spaceId, tagIds, takenAfter, takenBefore, $type, withSharedSpaces }: {
     city?: string;
     country?: string;
+    description?: string;
     isFavorite?: boolean;
     isInAlbum?: boolean;
     isNotInAlbum?: boolean;
     make?: string;
     model?: string;
+    ocr?: string;
+    originalFileName?: string;
     personIds?: string[];
     rating?: number;
     spaceId?: string;
@@ -5783,11 +5786,14 @@ export function getFilteredMapMarkers({ city, country, isFavorite, isInAlbum, is
     }>(`/gallery/map/markers${QS.query(QS.explode({
         city,
         country,
+        description,
         isFavorite,
         isInAlbum,
         isNotInAlbum,
         make,
         model,
+        ocr,
+        originalFileName,
         personIds,
         rating,
         spaceId,

--- a/server/src/dtos/gallery-map.dto.spec.ts
+++ b/server/src/dtos/gallery-map.dto.spec.ts
@@ -128,4 +128,63 @@ describe('FilteredMapMarkerDto', () => {
       expect(result.data?.isInAlbum).toBeUndefined();
     });
   });
+
+  // #802 — the Map filter panel now renders the "Text" section, so the marker endpoint has to
+  // accept the same three predicates the map timeline (TimeBucketDto) already accepts.
+  describe.each(['description', 'originalFileName', 'ocr'] as const)('%s', (field) => {
+    it('should accept a plain string', () => {
+      const result = parse({ [field]: 'birthday cake' });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.[field]).toBe('birthday cake');
+    });
+
+    it('should accept a string containing regex and wildcard characters verbatim', () => {
+      const result = parse({ [field]: '100% off (2024) [draft].jpg' });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.[field]).toBe('100% off (2024) [draft].jpg');
+    });
+
+    it('should accept an empty string', () => {
+      const result = parse({ [field]: '' });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.[field]).toBe('');
+    });
+
+    it('should leave undefined when not provided', () => {
+      const result = parse({});
+
+      expect(result.success).toBe(true);
+      expect(result.data?.[field]).toBeUndefined();
+    });
+
+    it('should reject a non-string value', () => {
+      const result = parse({ [field]: 42 });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  it('should accept all three text filters together alongside the existing filters', () => {
+    const result = parse({
+      description: 'birthday cake',
+      originalFileName: 'IMG_1234.jpg',
+      ocr: 'happy birthday',
+      rating: '4',
+      isFavorite: 'true',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(
+      expect.objectContaining({
+        description: 'birthday cake',
+        originalFileName: 'IMG_1234.jpg',
+        ocr: 'happy birthday',
+        rating: 4,
+        isFavorite: true,
+      }),
+    );
+  });
 });

--- a/server/src/dtos/gallery-map.dto.ts
+++ b/server/src/dtos/gallery-map.dto.ts
@@ -39,6 +39,12 @@ const FilteredMapMarkerSchema = z
     isInAlbum: stringToBool.optional().describe('Filter assets in at least one album'),
     city: z.string().optional().describe('Filter by city'),
     country: z.string().optional().describe('Filter by country'),
+    // The Map filter panel renders the same "Text" section as every other surface (#802), so
+    // markers accept the same three predicates the map timeline (TimeBucketDto) already does.
+    // searchAssetBuilder already implements all three.
+    description: z.string().optional().describe('Filter by description text'),
+    originalFileName: z.string().optional().describe('Filter by original file name'),
+    ocr: z.string().optional().describe('Filter by text recognised in the image'),
     withSharedSpaces: stringToBool.optional().describe('Include shared space assets'),
   })
   .meta({ id: 'FilteredMapMarkerDto' });

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -11160,6 +11160,85 @@ describe(SharedSpaceService.name, () => {
       );
     });
 
+    // #802 — the Map filter panel gained the "Text" section, so markers must honour the same
+    // three text predicates the map timeline already does. searchAssetBuilder already implements
+    // all three; only this mapping was missing.
+    it('should pass description, originalFileName and ocr to repository', async () => {
+      const auth = factory.auth();
+      mocks.sharedSpace.getFilteredMapMarkers.mockResolvedValue([]);
+
+      await sut.getFilteredMapMarkers(auth, {
+        description: 'birthday cake',
+        originalFileName: 'IMG_1234.jpg',
+        ocr: 'happy birthday',
+      });
+
+      expect(mocks.sharedSpace.getFilteredMapMarkers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: 'birthday cake',
+          originalFileName: 'IMG_1234.jpg',
+          ocr: 'happy birthday',
+        }),
+      );
+    });
+
+    it('should pass text filters when scoped to a space', async () => {
+      const auth = factory.auth();
+      const spaceId = newUuid();
+      mocks.access.sharedSpace.checkMemberAccess.mockResolvedValue(new Set([spaceId]));
+      mocks.sharedSpace.getFilteredMapMarkers.mockResolvedValue([]);
+
+      await sut.getFilteredMapMarkers(auth, { spaceId, description: 'birthday cake', ocr: 'happy birthday' });
+
+      expect(mocks.sharedSpace.getFilteredMapMarkers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          spaceId,
+          description: 'birthday cake',
+          ocr: 'happy birthday',
+        }),
+      );
+    });
+
+    it('should leave text filters undefined when not provided', async () => {
+      const auth = factory.auth();
+      mocks.sharedSpace.getFilteredMapMarkers.mockResolvedValue([]);
+
+      await sut.getFilteredMapMarkers(auth, {});
+
+      expect(mocks.sharedSpace.getFilteredMapMarkers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: undefined,
+          originalFileName: undefined,
+          ocr: undefined,
+        }),
+      );
+    });
+
+    // The DTO documents `rating` as "Minimum star rating" and every other surface sets
+    // ratingIsMinimum. Without it searchAssetBuilder falls to the `=` branch, so map markers
+    // silently did exact-rating matching while the map timeline did >=.
+    it('should request minimum-rating matching so markers agree with every other surface', async () => {
+      const auth = factory.auth();
+      mocks.sharedSpace.getFilteredMapMarkers.mockResolvedValue([]);
+
+      await sut.getFilteredMapMarkers(auth, { rating: 4 });
+
+      expect(mocks.sharedSpace.getFilteredMapMarkers).toHaveBeenCalledWith(
+        expect.objectContaining({ rating: 4, ratingIsMinimum: true }),
+      );
+    });
+
+    it('should not request minimum-rating matching when no rating filter is set', async () => {
+      const auth = factory.auth();
+      mocks.sharedSpace.getFilteredMapMarkers.mockResolvedValue([]);
+
+      await sut.getFilteredMapMarkers(auth, {});
+
+      expect(mocks.sharedSpace.getFilteredMapMarkers).toHaveBeenCalledWith(
+        expect.objectContaining({ rating: undefined, ratingIsMinimum: undefined }),
+      );
+    });
+
     it('should pass city and country to repository', async () => {
       const auth = factory.auth();
       mocks.sharedSpace.getFilteredMapMarkers.mockResolvedValue([]);

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -1067,6 +1067,12 @@ export class SharedSpaceService extends BaseService {
       make: dto.make,
       model: dto.model,
       rating: dto.rating,
+      // `rating` is documented as a MINIMUM. Without this flag searchAssetBuilder falls to its
+      // `=` branch, so markers matched exact ratings while every other surface matched `>=`.
+      ratingIsMinimum: dto.rating === undefined ? undefined : true,
+      description: dto.description,
+      originalFileName: dto.originalFileName,
+      ocr: dto.ocr,
       type: dto.type === 'IMAGE' ? AssetType.Image : dto.type === 'VIDEO' ? AssetType.Video : undefined,
       takenAfter: dto.takenAfter,
       takenBefore: dto.takenBefore,

--- a/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { init, register, waitLocale } from 'svelte-i18n';
 import type { FilterSection } from '../filter-panel';
-import { createFilterState } from '../filter-panel';
+import { ALL_FILTER_SECTIONS, createFilterState } from '../filter-panel';
 import FilterPanel from '../filter-panel.svelte';
 
 beforeAll(async () => {
@@ -750,6 +750,70 @@ describe('Section Selector', () => {
     expect(screen.getByTestId('filter-section-media')).toBeTruthy();
     expect(screen.queryByTestId('filter-section-rating')).toBeNull();
     expect(screen.queryByTestId('filter-section-favorites')).toBeNull();
+  });
+
+  // #802 upgrade path: a returning Map user already has a stored section set whose `known` list
+  // is the pre-fix nine. The fix only reaches them if 'text' is treated as newly introduced — and
+  // it must not silently un-hide sections they deliberately turned off.
+  describe('#802 text section upgrade path', () => {
+    const PRE_FIX_MAP_SECTIONS: FilterSection[] = [
+      'timeline',
+      'people',
+      'location',
+      'camera',
+      'tags',
+      'rating',
+      'media',
+      'favorites',
+      'albums',
+    ];
+
+    it('reveals the newly introduced text section to a user with a pre-fix stored set', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ selected: [...PRE_FIX_MAP_SECTIONS], known: [...PRE_FIX_MAP_SECTIONS] }),
+      );
+
+      renderPanel([...ALL_FILTER_SECTIONS]);
+
+      expect(screen.getByTestId('filter-section-text')).toBeTruthy();
+    });
+
+    it('reveals the text section without un-hiding sections the user deliberately hid', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ selected: ['timeline', 'people'], known: [...PRE_FIX_MAP_SECTIONS] }),
+      );
+
+      renderPanel([...ALL_FILTER_SECTIONS]);
+
+      expect(screen.getByTestId('filter-section-text')).toBeTruthy();
+      expect(screen.getByTestId('filter-section-people')).toBeTruthy();
+      expect(screen.queryByTestId('filter-section-camera')).toBeNull();
+      expect(screen.queryByTestId('filter-section-albums')).toBeNull();
+    });
+
+    it('shows every section to a user who has never opened the panel', () => {
+      renderPanel([...ALL_FILTER_SECTIONS]);
+
+      for (const section of ALL_FILTER_SECTIONS) {
+        expect(screen.getByTestId(`filter-section-${section}`)).toBeTruthy();
+      }
+    });
+
+    it('does not re-introduce the text section once the user has hidden it post-fix', () => {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          selected: ALL_FILTER_SECTIONS.filter((section) => section !== 'text'),
+          known: [...ALL_FILTER_SECTIONS],
+        }),
+      );
+
+      renderPanel([...ALL_FILTER_SECTIONS]);
+
+      expect(screen.queryByTestId('filter-section-text')).toBeNull();
+    });
   });
 
   // Test 23

--- a/web/src/lib/components/filter-panel/filter-panel.ts
+++ b/web/src/lib/components/filter-panel/filter-panel.ts
@@ -43,6 +43,27 @@ export type FilterSection =
   | 'albums'
   | 'text';
 
+/**
+ * The canonical filter sections, in render order — the single source of truth every surface
+ * derives its section list from (#802: the Map view had silently drifted to 9 of 10 sections).
+ *
+ * A surface may only drop a section when the server physically cannot honour it there, and the
+ * omission must be justified in `filter-section-parity.spec.ts`. Adding a section here makes it
+ * appear on every surface at once, which is the point.
+ */
+export const ALL_FILTER_SECTIONS: readonly FilterSection[] = [
+  'timeline',
+  'people',
+  'location',
+  'camera',
+  'tags',
+  'rating',
+  'media',
+  'favorites',
+  'albums',
+  'text',
+] as const;
+
 export interface PersonOption {
   id: string;
   name: string;
@@ -192,6 +213,33 @@ function dateOnlyToExclusiveUtcEnd(value: string | undefined): string | undefine
 
   date.setUTCDate(date.getUTCDate() + 1);
   return date.toISOString();
+}
+
+/**
+ * Forward the three fields the `text` filter section produces onto a request payload, trimmed,
+ * omitting any that are blank. Shared by every surface's option builder so the map, album and
+ * photos views cannot drift apart again (#802).
+ */
+export function applyTextFilters(
+  base: Record<string, unknown>,
+  filters: Pick<FilterState, 'description' | 'originalFileName' | 'ocr'>,
+): Record<string, unknown> {
+  const description = filters.description?.trim();
+  if (description) {
+    base.description = description;
+  }
+
+  const originalFileName = filters.originalFileName?.trim();
+  if (originalFileName) {
+    base.originalFileName = originalFileName;
+  }
+
+  const ocr = filters.ocr?.trim();
+  if (ocr) {
+    base.ocr = ocr;
+  }
+
+  return base;
 }
 
 export function buildFilterContext(

--- a/web/src/lib/utils/__tests__/album-filter-config.spec.ts
+++ b/web/src/lib/utils/__tests__/album-filter-config.spec.ts
@@ -27,6 +27,8 @@ beforeEach(() => {
 describe('buildAlbumDetailFilterConfig', () => {
   it('keeps the album filter sections in plan order', () => {
     const config = buildAlbumDetailFilterConfig('album-1');
+    // 'albums' is deliberately absent: the server drops isInAlbum/isNotInAlbum when scoped to a
+    // single album, so the controls would do nothing. See filter-section-parity.spec.ts.
     expect(config.sections).toEqual([
       'timeline',
       'people',
@@ -36,6 +38,7 @@ describe('buildAlbumDetailFilterConfig', () => {
       'rating',
       'media',
       'favorites',
+      'text',
     ]);
   });
 
@@ -177,6 +180,7 @@ describe('buildAlbumDetailFilterConfig', () => {
 describe('buildAlbumAssetPickerFilterConfig', () => {
   it('keeps the picker filter sections in plan order', () => {
     const config = buildAlbumAssetPickerFilterConfig();
+    // The picker is not album-scoped server-side, so it gets the full set including 'albums'.
     expect(config.sections).toEqual([
       'timeline',
       'people',
@@ -186,6 +190,8 @@ describe('buildAlbumAssetPickerFilterConfig', () => {
       'rating',
       'media',
       'favorites',
+      'albums',
+      'text',
     ]);
   });
 

--- a/web/src/lib/utils/__tests__/album-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/album-filter-options.spec.ts
@@ -102,3 +102,124 @@ describe('buildAlbumAssetPickerOptions', () => {
     expect(options).not.toHaveProperty('withPartners');
   });
 });
+
+/**
+ * #802 — album views were missing the "Text" filter section. Both album builders feed
+ * TimeBucketDto, which already supports description/originalFileName/ocr server-side.
+ */
+describe('text filters (#802)', () => {
+  const textFilters = {
+    ...createFilterState(),
+    description: 'birthday cake',
+    originalFileName: 'IMG_1234.jpg',
+    ocr: 'happy birthday',
+  };
+
+  describe('buildAlbumTimelineOptions', () => {
+    it('forwards description, filename and OCR text', () => {
+      expect(buildAlbumTimelineOptions('album-1', AssetOrder.Desc, textFilters)).toEqual(
+        expect.objectContaining({
+          albumId: 'album-1',
+          description: 'birthday cake',
+          originalFileName: 'IMG_1234.jpg',
+          ocr: 'happy birthday',
+        }),
+      );
+    });
+
+    it('trims surrounding whitespace before forwarding', () => {
+      const options = buildAlbumTimelineOptions('album-1', AssetOrder.Desc, {
+        ...createFilterState(),
+        description: '  birthday cake  ',
+        originalFileName: '\tIMG_1234.jpg\n',
+        ocr: ' happy birthday ',
+      });
+
+      expect(options).toEqual(
+        expect.objectContaining({
+          description: 'birthday cake',
+          originalFileName: 'IMG_1234.jpg',
+          ocr: 'happy birthday',
+        }),
+      );
+    });
+
+    it('omits text filters that are undefined', () => {
+      const options = buildAlbumTimelineOptions('album-1', AssetOrder.Desc, createFilterState());
+
+      expect(options).not.toHaveProperty('description');
+      expect(options).not.toHaveProperty('originalFileName');
+      expect(options).not.toHaveProperty('ocr');
+    });
+
+    it('omits text filters that are blank or whitespace only', () => {
+      const options = buildAlbumTimelineOptions('album-1', AssetOrder.Desc, {
+        ...createFilterState(),
+        description: '',
+        originalFileName: '   ',
+        ocr: '\t\n',
+      });
+
+      expect(options).not.toHaveProperty('description');
+      expect(options).not.toHaveProperty('originalFileName');
+      expect(options).not.toHaveProperty('ocr');
+    });
+
+    it('forwards each text field independently of the others', () => {
+      const options = buildAlbumTimelineOptions('album-1', AssetOrder.Desc, {
+        ...createFilterState(),
+        originalFileName: 'DSC_0001.arw',
+      });
+
+      expect(options).toEqual(expect.objectContaining({ originalFileName: 'DSC_0001.arw' }));
+      expect(options).not.toHaveProperty('description');
+      expect(options).not.toHaveProperty('ocr');
+    });
+  });
+
+  describe('buildAlbumAssetPickerOptions', () => {
+    it('forwards description, filename and OCR text', () => {
+      expect(buildAlbumAssetPickerOptions('album-1', textFilters)).toEqual(
+        expect.objectContaining({
+          timelineAlbumId: 'album-1',
+          description: 'birthday cake',
+          originalFileName: 'IMG_1234.jpg',
+          ocr: 'happy birthday',
+        }),
+      );
+    });
+
+    it('forwards the album membership filters the picker can actually use', () => {
+      // The picker is not album-scoped server-side, so isInAlbum/isNotInAlbum are meaningful here
+      // and are the natural way to surface un-filed photos to add.
+      expect(buildAlbumAssetPickerOptions('album-1', { ...createFilterState(), isNotInAlbum: true })).toEqual(
+        expect.objectContaining({ isNotInAlbum: true }),
+      );
+      expect(buildAlbumAssetPickerOptions('album-1', { ...createFilterState(), isInAlbum: true })).toEqual(
+        expect.objectContaining({ isInAlbum: true }),
+      );
+    });
+
+    it('omits album membership filters when they are false', () => {
+      const options = buildAlbumAssetPickerOptions('album-1', {
+        ...createFilterState(),
+        isNotInAlbum: false,
+        isInAlbum: false,
+      });
+
+      expect(options).not.toHaveProperty('isNotInAlbum');
+      expect(options).not.toHaveProperty('isInAlbum');
+    });
+
+    it('omits blank text filters', () => {
+      const options = buildAlbumAssetPickerOptions('album-1', {
+        ...createFilterState(),
+        description: '  ',
+        ocr: '',
+      });
+
+      expect(options).not.toHaveProperty('description');
+      expect(options).not.toHaveProperty('ocr');
+    });
+  });
+});

--- a/web/src/lib/utils/__tests__/filter-section-parity.spec.ts
+++ b/web/src/lib/utils/__tests__/filter-section-parity.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ALL_FILTER_SECTIONS, type FilterSection } from '$lib/components/filter-panel/filter-panel';
+import { buildAlbumAssetPickerFilterConfig, buildAlbumDetailFilterConfig } from '$lib/utils/album-filter-config';
+import { buildMapFilterConfig } from '$lib/utils/map-filter-config';
+
+vi.mock('@immich/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@immich/sdk')>();
+  return {
+    ...actual,
+    getFilterSuggestions: vi.fn().mockResolvedValue({
+      countries: [],
+      cameraMakes: [],
+      tags: [],
+      people: [],
+      ratings: [],
+      mediaTypes: [],
+      hasUnnamedPeople: false,
+    }),
+    getSearchSuggestions: vi.fn().mockResolvedValue([]),
+  };
+});
+
+/**
+ * Regression guard for #802 — "Filter panel options differ between views".
+ *
+ * Every surface renders the same filter sections in the same order, derived from the single
+ * `ALL_FILTER_SECTIONS` source of truth. A surface may only drop a section when the server
+ * physically cannot honour it there; each such exclusion is listed below with its reason, so a
+ * new divergence has to be argued for in code review rather than appearing by omission.
+ */
+const DOCUMENTED_EXCLUSIONS: Record<string, { sections: FilterSection[]; reason: string }> = {
+  'album detail': {
+    sections: ['albums'],
+    // asset.repository.ts guards both isInAlbum and isNotInAlbum with `&& !options.albumId`, so
+    // inside a single album they are silently dropped by the server. isInAlbum would be a
+    // tautology and isNotInAlbum an always-empty set — rendering them would be a dead control.
+    reason: 'server drops isInAlbum/isNotInAlbum when scoped to one album',
+  },
+};
+
+describe('filter section parity (#802)', () => {
+  it('exposes every section on the map view', () => {
+    expect(buildMapFilterConfig().sections).toEqual([...ALL_FILTER_SECTIONS]);
+  });
+
+  it('exposes every section on the map view when scoped to a space', () => {
+    expect(buildMapFilterConfig('space-1').sections).toEqual([...ALL_FILTER_SECTIONS]);
+  });
+
+  it('exposes every section on the album asset picker', () => {
+    // The picker is NOT album-scoped server-side: `timelineAlbumId` is stripped from the request
+    // (timeline-manager/internal/request-options.ts), so isInAlbum/isNotInAlbum work here and are
+    // in fact the most useful way to find un-filed photos to add.
+    expect(buildAlbumAssetPickerFilterConfig().sections).toEqual([...ALL_FILTER_SECTIONS]);
+  });
+
+  it('exposes every section except the documented exclusion on album detail', () => {
+    const excluded = new Set(DOCUMENTED_EXCLUSIONS['album detail'].sections);
+
+    expect(buildAlbumDetailFilterConfig('album-1').sections).toEqual(
+      ALL_FILTER_SECTIONS.filter((section) => !excluded.has(section)),
+    );
+  });
+
+  it('includes the text section on every surface that is not documented as excluding it', () => {
+    // The concrete #802 report: Map showed 9 sections, Photos showed 10 — "Text" was missing.
+    for (const sections of [
+      buildMapFilterConfig().sections,
+      buildMapFilterConfig('space-1').sections,
+      buildAlbumDetailFilterConfig('album-1').sections,
+      buildAlbumAssetPickerFilterConfig().sections,
+    ]) {
+      expect(sections).toContain('text');
+    }
+  });
+
+  it('keeps every surface ordered consistently with the canonical list', () => {
+    for (const sections of [
+      buildMapFilterConfig().sections,
+      buildAlbumDetailFilterConfig('album-1').sections,
+      buildAlbumAssetPickerFilterConfig().sections,
+    ]) {
+      const canonicalPositions = sections.map((section) => ALL_FILTER_SECTIONS.indexOf(section));
+
+      expect(canonicalPositions).toEqual([...canonicalPositions].sort((a, b) => a - b));
+      expect(canonicalPositions).not.toContain(-1);
+    }
+  });
+
+  it('never lets a surface invent a section outside the canonical list', () => {
+    const canonical = new Set<string>(ALL_FILTER_SECTIONS);
+
+    for (const sections of [
+      buildMapFilterConfig().sections,
+      buildAlbumDetailFilterConfig('album-1').sections,
+      buildAlbumAssetPickerFilterConfig().sections,
+    ]) {
+      for (const section of sections) {
+        expect(canonical.has(section)).toBe(true);
+      }
+    }
+  });
+});

--- a/web/src/lib/utils/__tests__/filter-section-parity.spec.ts
+++ b/web/src/lib/utils/__tests__/filter-section-parity.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { ALL_FILTER_SECTIONS, type FilterSection } from '$lib/components/filter-panel/filter-panel';
 import { buildAlbumAssetPickerFilterConfig, buildAlbumDetailFilterConfig } from '$lib/utils/album-filter-config';
 import { buildMapFilterConfig } from '$lib/utils/map-filter-config';
+import { buildRecentlyAddedFilterConfig } from '$lib/utils/recently-added-filter-config';
 
 vi.mock('@immich/sdk', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@immich/sdk')>();
@@ -54,6 +55,12 @@ describe('filter section parity (#802)', () => {
     expect(buildAlbumAssetPickerFilterConfig().sections).toEqual([...ALL_FILTER_SECTIONS]);
   });
 
+  it('exposes every section on the Recently Added view', () => {
+    // Recently Added (#805) landed after this guard was written; it is own+partner scoped but
+    // otherwise unrestricted, so it carries the full list like Photos does.
+    expect(buildRecentlyAddedFilterConfig().sections).toEqual([...ALL_FILTER_SECTIONS]);
+  });
+
   it('exposes every section except the documented exclusion on album detail', () => {
     const excluded = new Set(DOCUMENTED_EXCLUSIONS['album detail'].sections);
 
@@ -69,6 +76,7 @@ describe('filter section parity (#802)', () => {
       buildMapFilterConfig('space-1').sections,
       buildAlbumDetailFilterConfig('album-1').sections,
       buildAlbumAssetPickerFilterConfig().sections,
+      buildRecentlyAddedFilterConfig().sections,
     ]) {
       expect(sections).toContain('text');
     }
@@ -79,6 +87,7 @@ describe('filter section parity (#802)', () => {
       buildMapFilterConfig().sections,
       buildAlbumDetailFilterConfig('album-1').sections,
       buildAlbumAssetPickerFilterConfig().sections,
+      buildRecentlyAddedFilterConfig().sections,
     ]) {
       const canonicalPositions = sections.map((section) => ALL_FILTER_SECTIONS.indexOf(section));
 
@@ -94,6 +103,7 @@ describe('filter section parity (#802)', () => {
       buildMapFilterConfig().sections,
       buildAlbumDetailFilterConfig('album-1').sections,
       buildAlbumAssetPickerFilterConfig().sections,
+      buildRecentlyAddedFilterConfig().sections,
     ]) {
       for (const section of sections) {
         expect(canonical.has(section)).toBe(true);

--- a/web/src/lib/utils/__tests__/map-filter-config.spec.ts
+++ b/web/src/lib/utils/__tests__/map-filter-config.spec.ts
@@ -37,6 +37,7 @@ describe('buildMapFilterConfig', () => {
       'media',
       'favorites',
       'albums',
+      'text',
     ]);
   });
 

--- a/web/src/lib/utils/__tests__/map-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/map-filter-options.spec.ts
@@ -218,3 +218,170 @@ describe('buildMapTimelineOptions', () => {
     expect(options).not.toHaveProperty('isFavorite');
   });
 });
+
+/**
+ * #802 — the Map view was missing the "Text" filter section entirely. These cover the option
+ * builders forwarding the three text fields the section produces. The map timeline hits
+ * TimeBucketDto (which already supports them); markers hit FilteredMapMarkerDto.
+ */
+describe('text filters (#802)', () => {
+  const textFilters = {
+    ...createFilterState(),
+    description: 'birthday cake',
+    originalFileName: 'IMG_1234.jpg',
+    ocr: 'happy birthday',
+  };
+
+  describe('buildMapMarkerOptions', () => {
+    it('forwards description, filename and OCR text to map markers', () => {
+      expect(buildMapMarkerOptions(textFilters)).toEqual(
+        expect.objectContaining({
+          description: 'birthday cake',
+          originalFileName: 'IMG_1234.jpg',
+          ocr: 'happy birthday',
+        }),
+      );
+    });
+
+    it('forwards text filters when scoped to a space', () => {
+      expect(buildMapMarkerOptions(textFilters, 'space-1')).toEqual(
+        expect.objectContaining({
+          spaceId: 'space-1',
+          description: 'birthday cake',
+          originalFileName: 'IMG_1234.jpg',
+          ocr: 'happy birthday',
+        }),
+      );
+    });
+
+    it('trims surrounding whitespace before forwarding', () => {
+      const filters = {
+        ...createFilterState(),
+        description: '  birthday cake  ',
+        originalFileName: '\tIMG_1234.jpg\n',
+        ocr: '  happy birthday ',
+      };
+
+      expect(buildMapMarkerOptions(filters)).toEqual(
+        expect.objectContaining({
+          description: 'birthday cake',
+          originalFileName: 'IMG_1234.jpg',
+          ocr: 'happy birthday',
+        }),
+      );
+    });
+
+    it('omits text filters that are undefined', () => {
+      const options = buildMapMarkerOptions(createFilterState());
+
+      expect(options).not.toHaveProperty('description');
+      expect(options).not.toHaveProperty('originalFileName');
+      expect(options).not.toHaveProperty('ocr');
+    });
+
+    it('omits text filters that are empty strings', () => {
+      const options = buildMapMarkerOptions({
+        ...createFilterState(),
+        description: '',
+        originalFileName: '',
+        ocr: '',
+      });
+
+      expect(options).not.toHaveProperty('description');
+      expect(options).not.toHaveProperty('originalFileName');
+      expect(options).not.toHaveProperty('ocr');
+    });
+
+    it('omits text filters that are whitespace only', () => {
+      const options = buildMapMarkerOptions({
+        ...createFilterState(),
+        description: '   ',
+        originalFileName: '\t\n',
+        ocr: ' ',
+      });
+
+      expect(options).not.toHaveProperty('description');
+      expect(options).not.toHaveProperty('originalFileName');
+      expect(options).not.toHaveProperty('ocr');
+    });
+
+    it('forwards each text field independently of the others', () => {
+      const options = buildMapMarkerOptions({ ...createFilterState(), ocr: 'receipt total' });
+
+      expect(options).toEqual(expect.objectContaining({ ocr: 'receipt total' }));
+      expect(options).not.toHaveProperty('description');
+      expect(options).not.toHaveProperty('originalFileName');
+    });
+  });
+
+  describe('buildMapTimeBucketOptions', () => {
+    it('forwards description, filename and OCR text', () => {
+      expect(buildMapTimeBucketOptions(textFilters)).toEqual(
+        expect.objectContaining({
+          description: 'birthday cake',
+          originalFileName: 'IMG_1234.jpg',
+          ocr: 'happy birthday',
+        }),
+      );
+    });
+
+    it('forwards text filters when scoped to a space', () => {
+      expect(buildMapTimeBucketOptions(textFilters, 'space-1')).toEqual(
+        expect.objectContaining({
+          spaceId: 'space-1',
+          description: 'birthday cake',
+          ocr: 'happy birthday',
+        }),
+      );
+    });
+
+    it('omits blank text filters', () => {
+      const options = buildMapTimeBucketOptions({ ...createFilterState(), description: '  ', ocr: '' });
+
+      expect(options).not.toHaveProperty('description');
+      expect(options).not.toHaveProperty('ocr');
+    });
+  });
+
+  describe('buildMapTimelineOptions', () => {
+    it('forwards description, filename and OCR text', () => {
+      expect(buildMapTimelineOptions(textFilters, '1,2,3,4', new Set())).toEqual(
+        expect.objectContaining({
+          description: 'birthday cake',
+          originalFileName: 'IMG_1234.jpg',
+          ocr: 'happy birthday',
+        }),
+      );
+    });
+
+    it('forwards text filters when scoped to a space', () => {
+      expect(buildMapTimelineOptions(textFilters, '1,2,3,4', new Set(), 'space-1')).toEqual(
+        expect.objectContaining({
+          spaceId: 'space-1',
+          description: 'birthday cake',
+          ocr: 'happy birthday',
+        }),
+      );
+    });
+
+    it('omits text filters when the filter state is undefined', () => {
+      const options = buildMapTimelineOptions(undefined, '1,2,3,4', new Set());
+
+      expect(options).not.toHaveProperty('description');
+      expect(options).not.toHaveProperty('originalFileName');
+      expect(options).not.toHaveProperty('ocr');
+    });
+
+    it('omits blank text filters', () => {
+      const options = buildMapTimelineOptions(
+        { ...createFilterState(), description: '   ', originalFileName: '', ocr: '\t' },
+        '1,2,3,4',
+        new Set(),
+      );
+
+      expect(options).not.toHaveProperty('description');
+      expect(options).not.toHaveProperty('originalFileName');
+      expect(options).not.toHaveProperty('ocr');
+    });
+  });
+});

--- a/web/src/lib/utils/album-filter-config.ts
+++ b/web/src/lib/utils/album-filter-config.ts
@@ -1,12 +1,26 @@
 import { AssetTypeEnum, getFilterSuggestions, getSearchSuggestions, SearchSuggestionType } from '@immich/sdk';
 import {
+  ALL_FILTER_SECTIONS,
   buildFilterContext,
   type FilterPanelConfig,
   type FilterState,
 } from '$lib/components/filter-panel/filter-panel';
 import { getPhotosPersonFilterId, getPhotosPersonFilterThumbnailUrl } from '$lib/utils/photos-filter-options';
 
-const sections = ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites'] as const;
+/**
+ * Album *detail* is scoped to a single album, and asset.repository.ts guards both `isInAlbum` and
+ * `isNotInAlbum` with `&& !options.albumId` — inside an album the former is a tautology and the
+ * latter an always-empty set, so the server drops them. Rendering the section would give the user
+ * two controls that do nothing. Every other section is shared with the rest of the app (#802).
+ */
+const albumDetailSections = ALL_FILTER_SECTIONS.filter((section) => section !== 'albums');
+
+/**
+ * The asset *picker* is not album-scoped server-side — `timelineAlbumId` is stripped from the
+ * request before it leaves the timeline manager — so the album-membership filters do work here,
+ * and "not in any album" is the natural way to find un-filed photos to add.
+ */
+const albumPickerSections = ALL_FILTER_SECTIONS;
 
 function mapSuggestions(response: Awaited<ReturnType<typeof getFilterSuggestions>>) {
   return {
@@ -48,7 +62,7 @@ function toSuggestionRequest(filters: FilterState) {
 
 export function buildAlbumDetailFilterConfig(albumId: string): FilterPanelConfig {
   return {
-    sections: [...sections],
+    sections: [...albumDetailSections],
     suggestionsProvider: async (filters) =>
       mapSuggestions(await getFilterSuggestions({ albumId, ...toSuggestionRequest(filters) })),
     providers: {
@@ -62,7 +76,7 @@ export function buildAlbumDetailFilterConfig(albumId: string): FilterPanelConfig
 
 export function buildAlbumAssetPickerFilterConfig(): FilterPanelConfig {
   return {
-    sections: [...sections],
+    sections: [...albumPickerSections],
     suggestionsProvider: async (filters) => mapSuggestions(await getFilterSuggestions(toSuggestionRequest(filters))),
     providers: {
       cities: (country, context) => getSearchSuggestions({ $type: SearchSuggestionType.City, country, ...context }),

--- a/web/src/lib/utils/album-filter-options.ts
+++ b/web/src/lib/utils/album-filter-options.ts
@@ -1,5 +1,5 @@
 import { AssetTypeEnum, AssetVisibility, type AssetOrder } from '@immich/sdk';
-import { buildFilterContext, type FilterState } from '$lib/components/filter-panel/filter-panel';
+import { applyTextFilters, buildFilterContext, type FilterState } from '$lib/components/filter-panel/filter-panel';
 
 function applyCommonFilterFields(base: Record<string, unknown>, filters: FilterState): Record<string, unknown> {
   if (filters.personIds.length > 0) {
@@ -26,6 +26,15 @@ function applyCommonFilterFields(base: Record<string, unknown>, filters: FilterS
   if (filters.isFavorite !== undefined) {
     base.isFavorite = filters.isFavorite;
   }
+  // Only meaningful for the asset picker — the server drops both when `albumId` is set, so album
+  // detail (which does not render the section anyway) is unaffected.
+  if (filters.isNotInAlbum === true) {
+    base.isNotInAlbum = true;
+  }
+  if (filters.isInAlbum === true) {
+    base.isInAlbum = true;
+  }
+  applyTextFilters(base, filters);
   if (filters.mediaType !== 'all') {
     base.$type = filters.mediaType === 'image' ? AssetTypeEnum.Image : AssetTypeEnum.Video;
   }

--- a/web/src/lib/utils/map-filter-config.ts
+++ b/web/src/lib/utils/map-filter-config.ts
@@ -6,6 +6,7 @@ import {
   type FilterSuggestionsPersonDto,
 } from '@immich/sdk';
 import {
+  ALL_FILTER_SECTIONS,
   buildFilterContext,
   type FilterPanelConfig,
   type FilterState,
@@ -14,18 +15,6 @@ import { createUrl } from '$lib/utils';
 import { getPhotosPersonFilterId, getPhotosPersonFilterThumbnailUrl } from '$lib/utils/photos-filter-options';
 
 export function buildMapFilterConfig(spaceId?: string): FilterPanelConfig {
-  const sections = [
-    'timeline',
-    'people',
-    'location',
-    'camera',
-    'tags',
-    'rating',
-    'media',
-    'favorites',
-    'albums',
-  ] as const;
-
   const suggestionsProvider = async (filters: FilterState) => {
     const context = buildFilterContext(filters);
     const response = await getFilterSuggestions({
@@ -67,7 +56,7 @@ export function buildMapFilterConfig(spaceId?: string): FilterPanelConfig {
   };
 
   return {
-    sections: [...sections],
+    sections: [...ALL_FILTER_SECTIONS],
     suggestionsProvider,
     providers: {
       cities: (country: string, context) =>

--- a/web/src/lib/utils/map-filter-options.ts
+++ b/web/src/lib/utils/map-filter-options.ts
@@ -1,5 +1,5 @@
 import { AssetTypeEnum, AssetVisibility, MapMediaType } from '@immich/sdk';
-import { buildFilterContext, type FilterState } from '$lib/components/filter-panel/filter-panel';
+import { applyTextFilters, buildFilterContext, type FilterState } from '$lib/components/filter-panel/filter-panel';
 
 type MapTimelineSettings = {
   onlyFavorites?: boolean;
@@ -37,6 +37,8 @@ function applyCommonMapFilters(base: Record<string, unknown>, filters: FilterSta
   if (filters.country) {
     base.country = filters.country;
   }
+
+  applyTextFilters(base, filters);
 
   const context = buildFilterContext(filters);
   if (context?.takenAfter) {

--- a/web/src/lib/utils/photos-filter-options.ts
+++ b/web/src/lib/utils/photos-filter-options.ts
@@ -1,6 +1,6 @@
 import { AssetOrder, AssetTypeEnum, AssetVisibility, type FilterSuggestionsPersonDto } from '@immich/sdk';
 import type { FilterState } from '$lib/components/filter-panel/filter-panel';
-import { buildFilterContext } from '$lib/components/filter-panel/filter-panel';
+import { applyTextFilters, buildFilterContext } from '$lib/components/filter-panel/filter-panel';
 import { createUrl } from '$lib/utils';
 import { clearTimelineTemporalFilter } from '$lib/utils/timeline-temporal-filters';
 
@@ -37,15 +37,7 @@ export function buildPhotosTimelineOptions(filters: FilterState): Record<string,
   if (filters.model) {
     base.model = filters.model;
   }
-  if (filters.description?.trim()) {
-    base.description = filters.description.trim();
-  }
-  if (filters.originalFileName?.trim()) {
-    base.originalFileName = filters.originalFileName.trim();
-  }
-  if (filters.ocr?.trim()) {
-    base.ocr = filters.ocr.trim();
-  }
+  applyTextFilters(base, filters);
   if (filters.tagIds.length > 0) {
     base.tagIds = filters.tagIds;
   }

--- a/web/src/lib/utils/recently-added-filter-config.ts
+++ b/web/src/lib/utils/recently-added-filter-config.ts
@@ -5,28 +5,11 @@ import {
   SearchSuggestionType,
   type SmartSearchFacetsResponseDto,
 } from '@immich/sdk';
+import { ALL_FILTER_SECTIONS } from '$lib/components/filter-panel/filter-panel';
 import type { FilterPanelConfig, FilterState } from '$lib/components/filter-panel/filter-panel';
 import { getPhotosPersonFilterId, getPhotosPersonFilterThumbnailUrl } from '$lib/utils/photos-filter-options';
 import { buildRecentlyAddedSuggestionRequest } from '$lib/utils/recently-added-filter-options';
 import { buildSmartSearchFacetsParams, mapSmartSearchFacetsToFilterSuggestions } from '$lib/utils/space-search';
-
-/**
- * All ten filter sections. `'text'` renders as `<TextFilter>`, editing the description /
- * originalFileName / ocr metadata filters — those already round-trip through the URL and through
- * `buildRecentlyAddedTimelineOptions`, independent of the query/smart-search path below.
- */
-const sections = [
-  'timeline',
-  'people',
-  'location',
-  'camera',
-  'tags',
-  'rating',
-  'media',
-  'favorites',
-  'albums',
-  'text',
-] as const;
 
 function mapSuggestions(response: Awaited<ReturnType<typeof getFilterSuggestions>>) {
   return {
@@ -83,7 +66,11 @@ export function buildRecentlyAddedFilterConfig(
   };
 
   return {
-    sections: [...sections],
+    // Derived from the canonical list (#802) so this view cannot drift from the others. `'text'`
+    // renders as `<TextFilter>`, editing the description / originalFileName / ocr metadata
+    // filters — those already round-trip through the URL and through
+    // `buildRecentlyAddedTimelineOptions`, independent of the query/smart-search path below.
+    sections: [...ALL_FILTER_SECTIONS],
     suggestionsProvider: async (filters) => {
       const context = activeSearch();
       if (!context) {

--- a/web/src/lib/utils/space-filter-options.ts
+++ b/web/src/lib/utils/space-filter-options.ts
@@ -1,5 +1,5 @@
 import { AssetOrder, AssetTypeEnum } from '@immich/sdk';
-import { buildFilterContext, type FilterState } from '$lib/components/filter-panel/filter-panel';
+import { applyTextFilters, buildFilterContext, type FilterState } from '$lib/components/filter-panel/filter-panel';
 import { clearTimelineTemporalFilter } from '$lib/utils/timeline-temporal-filters';
 
 export function buildSpaceTimelineOptions(spaceId: string, filters: FilterState): Record<string, unknown> {
@@ -20,15 +20,7 @@ export function buildSpaceTimelineOptions(spaceId: string, filters: FilterState)
   if (filters.model) {
     base.model = filters.model;
   }
-  if (filters.description?.trim()) {
-    base.description = filters.description.trim();
-  }
-  if (filters.originalFileName?.trim()) {
-    base.originalFileName = filters.originalFileName.trim();
-  }
-  if (filters.ocr?.trim()) {
-    base.ocr = filters.ocr.trim();
-  }
+  applyTextFilters(base, filters);
   if (filters.tagIds.length > 0) {
     base.tagIds = filters.tagIds;
   }

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts
@@ -120,13 +120,33 @@ describe('Map page query intersection', () => {
     });
   });
 
-  it('exposes has-no-album in the map filter panel', () => {
+  it('exposes the full canonical section set in the map filter panel', () => {
+    // #802 — the Map panel used to stop at 'albums', one section short of every other view.
     renderPage();
 
     expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute(
       'data-sections',
-      'timeline,people,location,camera,tags,rating,media,favorites,albums',
+      'timeline,people,location,camera,tags,rating,media,favorites,albums,text',
     );
+  });
+
+  // #802 — the Text section is only a real fix if the value actually reaches the marker query.
+  // Before this change FilteredMapMarkerDto had no text fields at all, so the pins would have
+  // kept showing assets the timeline had already filtered out.
+  it('passes text filters to filtered map markers when set', async () => {
+    renderPage();
+    await fireEvent.click(screen.getByTestId('filter-panel-set-text'));
+    await flushQueryDebounce();
+
+    await waitFor(() => {
+      expect(sdkMock.getFilteredMapMarkers).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: 'birthday cake',
+          originalFileName: 'IMG_1234.jpg',
+          ocr: 'happy birthday',
+        }),
+      );
+    });
   });
 
   it('passes has-no-album to filtered map markers when selected', async () => {

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -7,6 +7,7 @@
   import FilterToolbar from '$lib/components/filter-panel/filter-toolbar.svelte';
   import SmartSearchResults from '$lib/components/search/smart-search-results.svelte';
   import {
+    ALL_FILTER_SECTIONS,
     buildFilterContext,
     clearFilters,
     createFilterState,
@@ -283,7 +284,7 @@
   };
 
   const filterConfig: FilterPanelConfig = {
-    sections: ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites', 'albums', 'text'],
+    sections: [...ALL_FILTER_SECTIONS],
     suggestionsProvider: async (nextFilters: FilterState) => {
       if (!showSearchResults) {
         return loadPhotoFilterSuggestions(nextFilters);

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -5,6 +5,7 @@
   import ActiveFiltersBar from '$lib/components/filter-panel/active-filters-bar.svelte';
   import FilterToolbar from '$lib/components/filter-panel/filter-toolbar.svelte';
   import {
+    ALL_FILTER_SECTIONS,
     buildFilterContext,
     createFilterState,
     clearFilters,
@@ -301,7 +302,7 @@
   };
 
   const filterConfig: FilterPanelConfig = {
-    sections: ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites', 'albums', 'text'],
+    sections: [...ALL_FILTER_SECTIONS],
     suggestionsProvider: async (nextFilters: FilterState) => {
       if (!showSearchResults) {
         return loadSpaceFilterSuggestions(nextFilters);

--- a/web/src/test-data/mocks/bindable-filter-panel.stub.svelte
+++ b/web/src/test-data/mocks/bindable-filter-panel.stub.svelte
@@ -105,6 +105,22 @@
   <button type="button" data-testid="select-favorites-filter" onclick={selectFavorites}>Favorites</button>
   <button type="button" data-testid="select-has-no-album-filter" onclick={selectHasNoAlbum}>Has no album</button>
   <button type="button" data-testid="select-has-album-filter" onclick={selectHasAlbum}>Has album</button>
+  <button
+    type="button"
+    data-testid="filter-panel-set-text"
+    onclick={() => {
+      if (filters) {
+        updateFilters({
+          ...filters,
+          description: 'birthday cake',
+          originalFileName: 'IMG_1234.jpg',
+          ocr: 'happy birthday',
+        });
+      }
+    }}
+  >
+    Set text filters
+  </button>
   <button type="button" data-testid="load-city-suggestions" onclick={loadCitySuggestions}>Load cities</button>
   <button type="button" data-testid="load-camera-model-suggestions" onclick={loadCameraModelSuggestions}>
     Load camera models


### PR DESCRIPTION
Fixes #802.

## The report

The filter panel showed a different set of sections depending on which view you were in. Photos offered 10 sections; Map offered 9, missing **Text** entirely.

## Root cause

Each surface hardcoded its own `sections` array, and they had drifted apart:

| Surface | Before | After |
|---|---|---|
| Photos, Spaces | 10 (all) | 10 (all) |
| Map (`map-filter-config.ts`) | 9 — no `text` | **10** |
| Album detail (`album-filter-config.ts`) | 8 — no `text`, no `albums` | **9** (`albums` intentionally excluded) |
| Album asset picker | 8 — shared the album-detail list | **10** |

`ALL_FILTER_SECTIONS` is now the single source of truth every surface derives from, so a section added in one place appears everywhere. Exclusions must be justified in `filter-section-parity.spec.ts`.

## Deliberate exclusion: `albums` on album detail

The reporter noted some divergence may be intentional, and this is the one case. `asset.repository.ts:369,374` guards both `isInAlbum` and `isNotInAlbum` with `&& !options.albumId` — scoped to a single album, the former is a tautology and the latter an always-empty set, and the server drops them. Rendering the section would give two controls that do nothing.

The asset **picker** is the opposite case and gains both `albums` and `text`: it isn't album-scoped server-side (`timelineAlbumId` is stripped in `timeline-manager/internal/request-options.ts`), so "not in any album" works there and is the natural way to find un-filed photos to add.

## Server change: map markers

Adding `text` to the Map panel client-side alone would have been worse than the bug. The map *timeline* hits `TimeBucketDto`, which already supports `description`/`originalFileName`/`ocr` — but map *markers* go through `FilteredMapMarkerDto`, which had none of them. The pins would have kept showing assets the timeline had already filtered out.

`searchAssetBuilder` already implements all three predicates (`database.ts:862,869,874`), so this is three DTO fields plus three lines of pass-through — no join or index work.

## Drive-by: rating parity

Found while tracing. `getFilteredMapMarkers` passed `rating` but never `ratingIsMinimum`, so `searchAssetBuilder` fell to its `=` branch — map markers matched **exact** ratings while every other surface matched `>=`, despite the DTO documenting the field as "Minimum star rating". Fixed here at Pierre's request, with its own tests.

## Tests

TDD throughout — every test was watched failing first, including a temporary revert of `ALL_FILTER_SECTIONS` to confirm the localStorage upgrade-path tests were meaningful.

- `filter-section-parity.spec.ts` (new) — the regression guard: canonical set, per-surface exclusions with documented reasons, consistent ordering, no invented sections.
- `map-filter-options` / `album-filter-options` — text forwarding across all five builders, with edge cases: trimming, `undefined`, empty string, whitespace-only, each field independently, space-scoped variants, and `buildMapTimelineOptions(undefined, ...)`.
- `filter-panel.spec.ts` — the **upgrade path**, which decides whether existing users actually see the fix: a returning Map user with a pre-fix stored section set gets `text` revealed, without un-hiding sections they deliberately hid, and without re-introducing it once they hide it post-fix.
- `map-page.spec.ts` — end-to-end: setting a text filter reaches `getFilteredMapMarkers` with all three fields.
- `gallery-map.dto.spec.ts` — the three fields via `describe.each`: plain strings, regex/wildcard characters verbatim, empty string, absent, non-string rejection.
- `shared-space.service.spec.ts` — pass-through (global + space-scoped + absent) and both `ratingIsMinimum` cases.

## Verification

| Gate | Result |
|---|---|
| `server` unit | 5114 passed, 9 skipped |
| `web` unit | 3689 passed, 2 skipped, 8 todo |
| `server` tsc / eslint / prettier | clean |
| `web` tsc / prettier | clean |
| `web` eslint | 0 errors (613 pre-existing tailwind warnings) |

OpenAPI + SDK + Dart client regenerated; the diff is confined to the map-markers endpoint.

## Not included

`FilterSuggestionsRequestDto` still has no text fields, so suggestion lists are computed over a wider set than the grid shows. That is pre-existing and already true on Photos, so it's consistent rather than a regression — worth a separate issue if we want suggestions to narrow by text.

## Docs

`map-filtering.md` listed neither Albums nor Text, and its closing section claimed the map has no location filter — the map config has included `location` for some time.