### PR TITLE
feat(web): filters + item count for the Recently Added view (#805)

### DIFF
--- a/docs/superpowers/plans/2026-07-19-recently-added-filters-slice-1.md
+++ b/docs/superpowers/plans/2026-07-19-recently-added-filters-slice-1.md
@@ -1,0 +1,398 @@
+# Recently Added — Slice 1: Header item count — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show a live "N items" count in the Recently Added page header, sourced from `TimelineManager.assetCount`, hidden while the library is empty/loading.
+
+**Architecture:** The visibility decision is extracted into a pure, unit-tested function in a new `web/src/lib/utils/recently-added-filter-options.ts` module (which later slices extend with the timeline-options and suggestion-request builders). The route is thin glue: it derives the count from the already-bound `timelineManager` and passes the formatted label to `UserPageLayout`'s existing `description` prop. No new i18n keys, no server/API change, no changes to `Timeline` / `UserPageLayout` / the Photos page.
+
+**Tech Stack:** SvelteKit + Svelte 5 runes, TypeScript (strict), `svelte-i18n` (`$t` + ICU plural), Vitest (web unit tests), Playwright (`e2e/` web suite).
+
+## Global Constraints
+
+Copied verbatim from the spec (`docs/superpowers/specs/2026-07-19-recently-added-filters-design.md`) — these apply to every task:
+
+- **Scope:** Web only. No server / API / mobile changes.
+- **Do not modify** the Photos page or the shared `filter-panel` / `Timeline` / `UserPageLayout` components.
+- Recently Added is an **own + partner** surface, **never shared spaces** (Slice 1 changes no data path, but do not introduce one).
+- Recently Added stays ordered/day-grouped by **added** date — the existing `orderBy: AssetOrderBy.CreatedAt` in `options` must remain untouched.
+- No i18n additions: reuse the existing `items_count` key — `"{count, plural, one {# item} other {# items}}"` (`i18n/en.json:1760`).
+- The `AssetSelectControlBar` block in the route stays unchanged.
+- Code style: Prettier (120 char, single quotes, trailing commas, semicolons); no relative imports in web — use the `$lib/` alias.
+- ESLint: **no new errors**. Web's `pnpm lint` does not pass `--max-warnings 0`, and ~640 pre-existing Tailwind warnings are expected — do not halt on them (see the command reference below).
+
+## Task order and why
+
+Tasks run **unit test → e2e test (red) → implementation (green)**. The e2e spec is written *before* the route change so its red state is genuine: at Task 2 the route genuinely lacks the feature, so the count scenarios genuinely fail. Do not reorder.
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `web/src/lib/utils/recently-added-filter-options.ts` | **Create** (Task 1) | Pure decision/builder functions for the Recently Added view. This slice adds only `shouldShowRecentlyAddedCount`. |
+| `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts` | **Create** (Task 1) | Unit tests for the above. (`__tests__/` is the established location for the filter-options/filter-config spec family — see `album-filter-config.spec.ts`, `photos-filter-options.spec.ts`.) |
+| `e2e/src/specs/web/recently-added-filters.e2e-spec.ts` | **Create** (Task 2) | BDD acceptance scenarios for the header count. Extended in Slices 2–3. |
+| `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte` | **Modify** (Task 3) | Derive the count, format the label, pass `description=` to `UserPageLayout`. |
+
+## Reference: commands used in this slice
+
+Web unit tests (`web/package.json` has `"test": "vitest"` — watch by default, so `--run` is required):
+```bash
+cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-options.spec.ts
+```
+
+E2E web suite. **Do not use `:2283`** — see the trap below.
+
+**Preferred — the dedicated e2e stack** (Playwright's own defaults; no env vars, no hacks). It serves the built web app on `:2285` and runs Postgres on `5435`, which is the port `utils.resetDatabase()` hardcodes:
+```bash
+cd e2e && docker compose up --build -d          # once, if not already up
+cd e2e && pnpm exec playwright test --project=web src/specs/web/recently-added-filters.e2e-spec.ts
+```
+
+**Fallback — against a running `mise dev` stack**, which needs two corrections:
+```bash
+socat TCP-LISTEN:5435,fork,reuseaddr TCP:127.0.0.1:5432 &   # resetDatabase() hardcodes 5435; dev Postgres is on 5432
+cd e2e && PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 PLAYWRIGHT_DISABLE_WEBSERVER=1 \
+  pnpm exec playwright test --project=web src/specs/web/recently-added-filters.e2e-spec.ts
+kill %1                                                      # tear the forward down afterwards
+```
+
+**Trap (verified 2026-07-19, pre-existing repo bug):** the `make e2e-web-dev` target and CLAUDE.md both point web Playwright projects at `PLAYWRIGHT_BASE_URL=http://127.0.0.1:2283`. Against a `mise dev` stack that URL returns **HTTP 200 with a 0-byte body** for every page route — the dev `immich_server` container has no `/build/www`, so its SSR fallback silently serves empty HTML. Tests then fail with "element not found" for reasons that have nothing to do with the code. The dev stack's real web app is the Vite container on **`:3000`**. (`make e2e-web-dev` also runs the entire web suite and accepts no arguments.)
+
+Note: `cd web && pnpm lint` is `eslint . --concurrency 6` — it does **not** auto-fix and does **not** pass `--max-warnings 0`. ~640 pre-existing Tailwind warnings are expected; judge it on **errors only**. Prettier is a **separate CI gate** from ESLint, so always run `prettier --check` on touched files too.
+
+---
+
+## Task 1: `shouldShowRecentlyAddedCount` pure function
+
+**Files:**
+- Create: `web/src/lib/utils/recently-added-filter-options.ts`
+- Test: `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing (first task, new module).
+- Produces: `export function shouldShowRecentlyAddedCount(count: number, hasActiveFilters: boolean): boolean` — imported by the route in Task 3, and reused unchanged by Slice 2 (which starts passing a real `hasActiveFilters`).
+
+**Why the `hasActiveFilters` arm exists in Slice 1:** the route always passes `false` this slice, but the function is written and tested complete so Slice 2 needs no change to it. Do **not** simplify it to a one-arg function.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { shouldShowRecentlyAddedCount } from '$lib/utils/recently-added-filter-options';
+
+describe('shouldShowRecentlyAddedCount', () => {
+  it('hides the count while loading or for an empty account', () => {
+    // No buckets loaded yet (assetCount is transiently 0) and no filters: showing
+    // "0 items" would flash a wrong count. The EmptyPlaceholder communicates emptiness.
+    expect(shouldShowRecentlyAddedCount(0, false)).toBe(false);
+  });
+
+  it('shows "0 items" when a filter matched nothing', () => {
+    // Informative: tells the user their filter matched nothing, rather than
+    // looking like an empty account.
+    expect(shouldShowRecentlyAddedCount(0, true)).toBe(true);
+  });
+
+  it('shows the count for a populated view without filters', () => {
+    expect(shouldShowRecentlyAddedCount(5, false)).toBe(true);
+  });
+
+  it('shows the count for a populated filtered view', () => {
+    expect(shouldShowRecentlyAddedCount(5, true)).toBe(true);
+  });
+
+  it('shows the count at the singular boundary (plural wording is left to i18n)', () => {
+    expect(shouldShowRecentlyAddedCount(1, false)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-options.spec.ts
+```
+Expected: **FAIL** — the module does not exist, so the import fails. Vitest reports a resolution error such as `Failed to resolve import "$lib/utils/recently-added-filter-options"`. Do not proceed until you have seen a real failure; paste the output into your report.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `web/src/lib/utils/recently-added-filter-options.ts`:
+
+```ts
+/**
+ * Whether the Recently Added header should display an item count.
+ *
+ * Hidden only when there is nothing to show *and* no filter is active: that state is either
+ * "buckets have not loaded yet" or "empty account", and both are better served by the
+ * EmptyPlaceholder than by a transient "0 items". With a filter active, "0 items" is
+ * informative — it says the filter matched nothing.
+ */
+export function shouldShowRecentlyAddedCount(count: number, hasActiveFilters: boolean): boolean {
+  return count > 0 || hasActiveFilters;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-options.spec.ts
+```
+Expected: **PASS** — 5 passed. Paste the output into your report.
+
+- [ ] **Step 5: Refactor**
+
+None expected — the function is a single expression. Do not add abstraction.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/lib/utils/recently-added-filter-options.ts web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts
+git commit -m "test(web): shouldShowRecentlyAddedCount for the Recently Added header count (#805)"
+```
+
+---
+
+## Task 2: BDD acceptance scenarios (Playwright e2e), written red-first
+
+**Files:**
+- Create: `e2e/src/specs/web/recently-added-filters.e2e-spec.ts`
+
+**Interfaces:**
+- Consumes: the page header markup rendered by `UserPageLayout` — the count will appear at `[data-testid="page-header-description"]` and the title at `[data-testid="page-header"]` (`web/src/lib/components/layouts/UserPageLayout.svelte:86-93` and `:82`). Neither the count nor the route change exists yet — that is the point of this task.
+- Produces: the spec file that Slices 2 and 3 append their scenarios to. Keep the outer `test.describe` name generic (`Recently Added`) so later slices nest their own describes inside it.
+
+**Context the implementer needs:**
+
+- Template to mirror: `e2e/src/specs/web/photos-filter-panel.e2e-spec.ts`.
+- Helpers, all from `e2e/src/utils.ts`: `utils.initSdk()`, `utils.resetDatabase()`, `utils.adminSetup()` → `LoginResponseDto`, `utils.userSetup(accessToken, dto)` → `LoginResponseDto` (creates **and** logs in; `UserAdminCreateDto` requires exactly `email` / `name` / `password`), `utils.createAsset(accessToken, dto)`, `utils.setAuthCookies(context, accessToken)`.
+- A per-spec `resetDatabase()` in `beforeAll` is the established pattern and is safe: the `web` Playwright project runs `workers: 1` (`e2e/playwright.config.ts`), so it cannot race other web specs.
+- The empty-library scenario uses a **second user that owns no assets**. Non-admin `userSetup` → `setAuthCookies` → `goto` has precedent in `global-search.e2e-spec.ts:527`, so expect no onboarding redirect.
+- **Multi-select selector** — the timeline exposes a data attribute, *not* a testid. There is no `asset-container` testid anywhere in `web/src`. Use the shared helper `thumbnailUtils` from `src/ui/specs/timeline/utils` (`thumbnailUtils.locator(page)` → `page.locator('[data-thumbnail-focus-container]')`), and **hover first** — the checkbox overlay only renders on hover. Pattern lifted from `e2e/src/specs/web/timeline-add-to-collection.e2e-spec.ts:26-38`.
+- The count fills in as timeline buckets load — always assert with Playwright's auto-retrying `expect(locator).toHaveText(...)` / `.toHaveCount(...)`, never a bare `textContent()` read.
+
+- [ ] **Step 1: Write the e2e spec**
+
+Create `e2e/src/specs/web/recently-added-filters.e2e-spec.ts`:
+
+```ts
+import type { LoginResponseDto } from '@immich/sdk';
+import { expect, test } from '@playwright/test';
+import { thumbnailUtils } from 'src/ui/specs/timeline/utils';
+import { utils } from 'src/utils';
+
+test.describe('Recently Added', () => {
+  let admin: LoginResponseDto;
+  let emptyUser: LoginResponseDto;
+
+  const ASSET_COUNT = 12;
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+
+    // Seed a populated library for the admin: 12 assets on distinct days.
+    for (let i = 0; i < ASSET_COUNT; i++) {
+      const day = String(i + 1).padStart(2, '0');
+      await utils.createAsset(admin.accessToken, {
+        fileCreatedAt: `2023-08-${day}T10:00:00.000Z`,
+        fileModifiedAt: `2023-08-${day}T10:00:00.000Z`,
+      });
+    }
+
+    // A second user with an empty library, for the empty-state scenario.
+    emptyUser = await utils.userSetup(admin.accessToken, {
+      email: 'recently-added-empty@immich.cloud',
+      name: 'Empty Library',
+      password: 'password',
+    });
+  });
+
+  // Scenario: Count shown for a populated library
+  test('shows the item count in the header for a populated library', async ({ context, page }) => {
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('/recently-added');
+
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${ASSET_COUNT} items`);
+  });
+
+  // Scenario: Count hidden for an empty library
+  test('hides the item count and shows the placeholder for an empty library', async ({ context, page }) => {
+    await utils.setAuthCookies(context, emptyUser.accessToken);
+    await page.goto('/recently-added');
+
+    // The empty-state placeholder confirms the timeline finished loading with no assets.
+    // Copy comes from i18n/en.json `no_assets_message`.
+    await expect(page.getByText('Click to upload your first photo')).toBeVisible();
+    await expect(page.getByTestId('page-header-description')).toHaveCount(0);
+  });
+
+  // Scenario: Count is not shown while selecting
+  test('replaces the header with the selection bar during multi-select', async ({ context, page }) => {
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('/recently-added');
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${ASSET_COUNT} items`);
+
+    // Enter multi-select: hover a thumbnail so its checkbox overlay renders, then click it.
+    const thumb = thumbnailUtils.locator(page).first();
+    await expect(thumb).toBeVisible();
+    await thumb.hover();
+    await thumb.locator('button[role="checkbox"]').click();
+
+    // `hideNavbar` collapses the entire header row (title + count); the selection bar takes over.
+    await expect(page.getByTestId('page-header-description')).toHaveCount(0);
+    await expect(page.getByTestId('page-header')).toHaveCount(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the spec and verify it is RED**
+
+```bash
+cd e2e && pnpm exec playwright test --project=web src/specs/web/recently-added-filters.e2e-spec.ts
+```
+(Run it exactly as documented in the command reference near the top of this plan — **not** against `:2283`.)
+
+Expected: **2 failed, 1 passed.**
+- "populated library" → **FAIL**: `page-header-description` resolves to 0 elements; the route does not pass `description` yet.
+- "during multi-select" → **FAIL** at its first assertion, for the same reason.
+- "empty library" → **PASS** even now, because it asserts *absence*. That is expected and correct; it becomes a real regression guard once Task 3 lands.
+
+Paste the failure output into your report. If instead all three pass, stop — something is wrong (most likely a stale web stack; see the traps below).
+
+Two known traps in this repo:
+- The e2e stack (`immich-e2e` project, `immich-server:latest`) is **machine-wide**; a concurrent session can restart it or swap the image underneath you. If results look impossible, confirm the stack is yours and current before debugging the test.
+- `reuseExistingServer` can attach to a **stale** web stack. A "UI is broken" symptom is far more often a stale image than a code bug.
+
+- [ ] **Step 3: Commit the red spec**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/recently-added-filters-805
+git add e2e/src/specs/web/recently-added-filters.e2e-spec.ts
+git commit -m "test(e2e): acceptance scenarios for the Recently Added item count (#805)"
+```
+
+---
+
+## Task 3: Wire the count into the Recently Added route (turns Task 2 green)
+
+**Files:**
+- Modify: `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte`
+
+**Interfaces:**
+- Consumes: `shouldShowRecentlyAddedCount(count: number, hasActiveFilters: boolean): boolean` from Task 1; `TimelineManager.assetCount` (a `$derived.by` live grand total summed from bucket counts — `web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts:95`); `UserPageLayout`'s existing `description?: string | undefined` prop (`web/src/lib/components/layouts/UserPageLayout.svelte:18`), rendered at lines 86–93 with `data-testid="page-header-description"`.
+- Produces: the rendered count, asserted by the Task 2 e2e scenarios.
+
+**Context the implementer needs:**
+
+- `timelineManager` is already declared and bound in this route:
+  `let timelineManager = $state<TimelineManager>() as TimelineManager;` with `bind:timelineManager` on `<Timeline>`. It is **undefined until the first bind**, so the derivation must use optional chaining + `?? 0`. This is exactly what the Photos page does (`web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte:350`: `const totalAssetCount = $derived(timelineManager?.assetCount ?? 0);`) on the identical `as TimelineManager` cast — the optional chain is correct and triggers no lint or type error here.
+- The header row only renders when `!hideNavbar && (title || buttons)` (`UserPageLayout.svelte:77`). This route already passes `hideNavbar={assetMultiSelectManager.selectionActive}` and `title={data.meta.title}`, so the count **automatically** disappears during multi-select. Do not add extra gating for that.
+- `$t` is already imported in this file (`import { t } from 'svelte-i18n';`, line 37). `$t('items_count', { values: { count } })` is the repo-standard call shape (12 existing call sites, e.g. `AlbumCard.svelte:79`).
+- The existing `const options = { ... }` object (lines 47–52) and the whole `AssetSelectControlBar` block must remain **byte-identical**.
+
+- [ ] **Step 1: Add the import**
+
+In the `<script lang="ts">` block, add the import alongside the other `$lib/utils/` imports (`prettier-plugin-organize-imports` settles final ordering — run the formatter in Step 4):
+
+```ts
+import { shouldShowRecentlyAddedCount } from '$lib/utils/recently-added-filter-options';
+```
+
+- [ ] **Step 2: Add the derivations**
+
+Immediately after the existing `const options = { ... };` block, add:
+
+```ts
+  const assetCount = $derived(timelineManager?.assetCount ?? 0);
+  // Slice 1 has no filters yet, so `hasActiveFilters` is always false here; Slice 2 replaces
+  // the literal with `getActiveFilterCount(filters) > 0`.
+  const countLabel = $derived(
+    shouldShowRecentlyAddedCount(assetCount, false)
+      ? $t('items_count', { values: { count: assetCount } })
+      : undefined,
+  );
+```
+
+- [ ] **Step 3: Pass the label to the layout**
+
+Change the opening `UserPageLayout` tag (line 92) from:
+
+```svelte
+<UserPageLayout hideNavbar={assetMultiSelectManager.selectionActive} title={data.meta.title} scrollbar={false}>
+```
+
+to:
+
+```svelte
+<UserPageLayout
+  hideNavbar={assetMultiSelectManager.selectionActive}
+  title={data.meta.title}
+  description={countLabel}
+  scrollbar={false}
+>
+```
+
+- [ ] **Step 4: Verify the e2e spec is now GREEN**
+
+```bash
+cd e2e && pnpm exec playwright test --project=web src/specs/web/recently-added-filters.e2e-spec.ts
+```
+(Run it exactly as documented in the command reference near the top of this plan — **not** against `:2283`.)
+Expected: **3 passed** (the two that failed in Task 2 Step 2 now pass). Paste the output into your report.
+
+Note: the web dev stack serves the route from source, so no rebuild is needed between the red and green runs.
+
+- [ ] **Step 5: Run the web gate**
+
+```bash
+cd web && pnpm check:typescript && pnpm check:svelte && pnpm lint && pnpm test -- --run
+```
+Expected: type check clean, svelte-check clean, ESLint reports **no errors** (pre-existing Tailwind warnings are fine), all unit tests pass including Task 1's 5.
+
+Then the separate Prettier gate:
+```bash
+cd web && pnpm exec prettier --check "src/routes/(user)/recently-added/**/*.svelte" "src/lib/utils/recently-added-filter-options.ts" "src/lib/utils/__tests__/recently-added-filter-options.spec.ts"
+cd ../e2e && pnpm exec prettier --check src/specs/web/recently-added-filters.e2e-spec.ts
+```
+Expected: all report as formatted. If not, rerun with `--write` and re-check.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte"
+git commit -m "feat(web): item count in Recently Added header (#805)"
+```
+
+---
+
+## Slice 1 Done Gate
+
+All of the following must hold before the slice is complete:
+
+- [ ] `cd web && pnpm check:typescript` — clean
+- [ ] `cd web && pnpm check:svelte` — clean
+- [ ] `cd web && pnpm lint` — no **errors**
+- [ ] `cd web && pnpm test -- --run` — all pass, including the 5 new unit tests
+- [ ] `cd e2e && pnpm exec playwright test --project=web src/specs/web/recently-added-filters.e2e-spec.ts` (see command reference for stack setup) — **3 passed**
+- [ ] Prettier `--check` clean on all touched files (separate CI gate from ESLint)
+- [ ] Recorded red→green evidence: Task 1 Step 2 (red) / Step 4 (green); Task 2 Step 2 (2 failed, 1 passed) → Task 3 Step 4 (3 passed)
+- [ ] The Photos page, `filter-panel/`, `Timeline`, and `UserPageLayout` are **unmodified** — verify with `git diff --stat main...HEAD`
+- [ ] The route's `options` object and `AssetSelectControlBar` block are unchanged — verify with `git diff` on the route
+- [ ] Three commits made as specified above
+
+## Coverage check against the spec
+
+| Spec edge case (§Slice 1) | Covered by |
+|---|---|
+| Buckets not yet loaded (`assetCount` 0 transiently) → no "0 items" flash | Task 1 unit `shouldShowRecentlyAddedCount(0, false) === false` |
+| Empty account → count hidden, placeholder shown | Task 1 unit + Task 2 e2e "empty library" |
+| Multi-select active (`hideNavbar`) → header + count hidden | Task 2 e2e "during multi-select" |
+| Plural vs singular ("1 item") | `items_count` ICU plural (i18n, not this code); boundary case `(1, false)` asserted in Task 1 |
+| Count shown for a populated library | Task 2 e2e "populated library" |
+| `hasActiveFilters` arm (unused this slice, needed by Slice 2) | Task 1 units `(0, true)` and `(5, true)` |

--- a/docs/superpowers/plans/2026-07-19-recently-added-filters-slice-1.md
+++ b/docs/superpowers/plans/2026-07-19-recently-added-filters-slice-1.md
@@ -23,22 +23,23 @@ Copied verbatim from the spec (`docs/superpowers/specs/2026-07-19-recently-added
 
 ## Task order and why
 
-Tasks run **unit test → e2e test (red) → implementation (green)**. The e2e spec is written *before* the route change so its red state is genuine: at Task 2 the route genuinely lacks the feature, so the count scenarios genuinely fail. Do not reorder.
+Tasks run **unit test → e2e test (red) → implementation (green)**. The e2e spec is written _before_ the route change so its red state is genuine: at Task 2 the route genuinely lacks the feature, so the count scenarios genuinely fail. Do not reorder.
 
 ---
 
 ## File Structure
 
-| File | Status | Responsibility |
-|---|---|---|
-| `web/src/lib/utils/recently-added-filter-options.ts` | **Create** (Task 1) | Pure decision/builder functions for the Recently Added view. This slice adds only `shouldShowRecentlyAddedCount`. |
-| `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts` | **Create** (Task 1) | Unit tests for the above. (`__tests__/` is the established location for the filter-options/filter-config spec family — see `album-filter-config.spec.ts`, `photos-filter-options.spec.ts`.) |
-| `e2e/src/specs/web/recently-added-filters.e2e-spec.ts` | **Create** (Task 2) | BDD acceptance scenarios for the header count. Extended in Slices 2–3. |
-| `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte` | **Modify** (Task 3) | Derive the count, format the label, pass `description=` to `UserPageLayout`. |
+| File                                                                                 | Status              | Responsibility                                                                                                                                                                              |
+| ------------------------------------------------------------------------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `web/src/lib/utils/recently-added-filter-options.ts`                                 | **Create** (Task 1) | Pure decision/builder functions for the Recently Added view. This slice adds only `shouldShowRecentlyAddedCount`.                                                                           |
+| `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts`                  | **Create** (Task 1) | Unit tests for the above. (`__tests__/` is the established location for the filter-options/filter-config spec family — see `album-filter-config.spec.ts`, `photos-filter-options.spec.ts`.) |
+| `e2e/src/specs/web/recently-added-filters.e2e-spec.ts`                               | **Create** (Task 2) | BDD acceptance scenarios for the header count. Extended in Slices 2–3.                                                                                                                      |
+| `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte` | **Modify** (Task 3) | Derive the count, format the label, pass `description=` to `UserPageLayout`.                                                                                                                |
 
 ## Reference: commands used in this slice
 
 Web unit tests (`web/package.json` has `"test": "vitest"` — watch by default, so `--run` is required):
+
 ```bash
 cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-options.spec.ts
 ```
@@ -46,12 +47,14 @@ cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-optio
 E2E web suite. **Do not use `:2283`** — see the trap below.
 
 **Preferred — the dedicated e2e stack** (Playwright's own defaults; no env vars, no hacks). It serves the built web app on `:2285` and runs Postgres on `5435`, which is the port `utils.resetDatabase()` hardcodes:
+
 ```bash
 cd e2e && docker compose up --build -d          # once, if not already up
 cd e2e && pnpm exec playwright test --project=web src/specs/web/recently-added-filters.e2e-spec.ts
 ```
 
 **Fallback — against a running `mise dev` stack**, which needs two corrections:
+
 ```bash
 socat TCP-LISTEN:5435,fork,reuseaddr TCP:127.0.0.1:5432 &   # resetDatabase() hardcodes 5435; dev Postgres is on 5432
 cd e2e && PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 PLAYWRIGHT_DISABLE_WEBSERVER=1 \
@@ -68,10 +71,12 @@ Note: `cd web && pnpm lint` is `eslint . --concurrency 6` — it does **not** au
 ## Task 1: `shouldShowRecentlyAddedCount` pure function
 
 **Files:**
+
 - Create: `web/src/lib/utils/recently-added-filter-options.ts`
 - Test: `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts`
 
 **Interfaces:**
+
 - Consumes: nothing (first task, new module).
 - Produces: `export function shouldShowRecentlyAddedCount(count: number, hasActiveFilters: boolean): boolean` — imported by the route in Task 3, and reused unchanged by Slice 2 (which starts passing a real `hasActiveFilters`).
 
@@ -117,6 +122,7 @@ describe('shouldShowRecentlyAddedCount', () => {
 ```bash
 cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-options.spec.ts
 ```
+
 Expected: **FAIL** — the module does not exist, so the import fails. Vitest reports a resolution error such as `Failed to resolve import "$lib/utils/recently-added-filter-options"`. Do not proceed until you have seen a real failure; paste the output into your report.
 
 - [ ] **Step 3: Write the minimal implementation**
@@ -142,6 +148,7 @@ export function shouldShowRecentlyAddedCount(count: number, hasActiveFilters: bo
 ```bash
 cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-options.spec.ts
 ```
+
 Expected: **PASS** — 5 passed. Paste the output into your report.
 
 - [ ] **Step 5: Refactor**
@@ -160,9 +167,11 @@ git commit -m "test(web): shouldShowRecentlyAddedCount for the Recently Added he
 ## Task 2: BDD acceptance scenarios (Playwright e2e), written red-first
 
 **Files:**
+
 - Create: `e2e/src/specs/web/recently-added-filters.e2e-spec.ts`
 
 **Interfaces:**
+
 - Consumes: the page header markup rendered by `UserPageLayout` — the count will appear at `[data-testid="page-header-description"]` and the title at `[data-testid="page-header"]` (`web/src/lib/components/layouts/UserPageLayout.svelte:86-93` and `:82`). Neither the count nor the route change exists yet — that is the point of this task.
 - Produces: the spec file that Slices 2 and 3 append their scenarios to. Keep the outer `test.describe` name generic (`Recently Added`) so later slices nest their own describes inside it.
 
@@ -172,7 +181,7 @@ git commit -m "test(web): shouldShowRecentlyAddedCount for the Recently Added he
 - Helpers, all from `e2e/src/utils.ts`: `utils.initSdk()`, `utils.resetDatabase()`, `utils.adminSetup()` → `LoginResponseDto`, `utils.userSetup(accessToken, dto)` → `LoginResponseDto` (creates **and** logs in; `UserAdminCreateDto` requires exactly `email` / `name` / `password`), `utils.createAsset(accessToken, dto)`, `utils.setAuthCookies(context, accessToken)`.
 - A per-spec `resetDatabase()` in `beforeAll` is the established pattern and is safe: the `web` Playwright project runs `workers: 1` (`e2e/playwright.config.ts`), so it cannot race other web specs.
 - The empty-library scenario uses a **second user that owns no assets**. Non-admin `userSetup` → `setAuthCookies` → `goto` has precedent in `global-search.e2e-spec.ts:527`, so expect no onboarding redirect.
-- **Multi-select selector** — the timeline exposes a data attribute, *not* a testid. There is no `asset-container` testid anywhere in `web/src`. Use the shared helper `thumbnailUtils` from `src/ui/specs/timeline/utils` (`thumbnailUtils.locator(page)` → `page.locator('[data-thumbnail-focus-container]')`), and **hover first** — the checkbox overlay only renders on hover. Pattern lifted from `e2e/src/specs/web/timeline-add-to-collection.e2e-spec.ts:26-38`.
+- **Multi-select selector** — the timeline exposes a data attribute, _not_ a testid. There is no `asset-container` testid anywhere in `web/src`. Use the shared helper `thumbnailUtils` from `src/ui/specs/timeline/utils` (`thumbnailUtils.locator(page)` → `page.locator('[data-thumbnail-focus-container]')`), and **hover first** — the checkbox overlay only renders on hover. Pattern lifted from `e2e/src/specs/web/timeline-add-to-collection.e2e-spec.ts:26-38`.
 - The count fills in as timeline buckets load — always assert with Playwright's auto-retrying `expect(locator).toHaveText(...)` / `.toHaveCount(...)`, never a bare `textContent()` read.
 
 - [ ] **Step 1: Write the e2e spec**
@@ -256,16 +265,19 @@ test.describe('Recently Added', () => {
 ```bash
 cd e2e && pnpm exec playwright test --project=web src/specs/web/recently-added-filters.e2e-spec.ts
 ```
+
 (Run it exactly as documented in the command reference near the top of this plan — **not** against `:2283`.)
 
 Expected: **2 failed, 1 passed.**
+
 - "populated library" → **FAIL**: `page-header-description` resolves to 0 elements; the route does not pass `description` yet.
 - "during multi-select" → **FAIL** at its first assertion, for the same reason.
-- "empty library" → **PASS** even now, because it asserts *absence*. That is expected and correct; it becomes a real regression guard once Task 3 lands.
+- "empty library" → **PASS** even now, because it asserts _absence_. That is expected and correct; it becomes a real regression guard once Task 3 lands.
 
 Paste the failure output into your report. If instead all three pass, stop — something is wrong (most likely a stale web stack; see the traps below).
 
 Two known traps in this repo:
+
 - The e2e stack (`immich-e2e` project, `immich-server:latest`) is **machine-wide**; a concurrent session can restart it or swap the image underneath you. If results look impossible, confirm the stack is yours and current before debugging the test.
 - `reuseExistingServer` can attach to a **stale** web stack. A "UI is broken" symptom is far more often a stale image than a code bug.
 
@@ -282,9 +294,11 @@ git commit -m "test(e2e): acceptance scenarios for the Recently Added item count
 ## Task 3: Wire the count into the Recently Added route (turns Task 2 green)
 
 **Files:**
+
 - Modify: `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte`
 
 **Interfaces:**
+
 - Consumes: `shouldShowRecentlyAddedCount(count: number, hasActiveFilters: boolean): boolean` from Task 1; `TimelineManager.assetCount` (a `$derived.by` live grand total summed from bucket counts — `web/src/lib/managers/timeline-manager/timeline-manager.svelte.ts:95`); `UserPageLayout`'s existing `description?: string | undefined` prop (`web/src/lib/components/layouts/UserPageLayout.svelte:18`), rendered at lines 86–93 with `data-testid="page-header-description"`.
 - Produces: the rendered count, asserted by the Task 2 e2e scenarios.
 
@@ -309,14 +323,12 @@ import { shouldShowRecentlyAddedCount } from '$lib/utils/recently-added-filter-o
 Immediately after the existing `const options = { ... };` block, add:
 
 ```ts
-  const assetCount = $derived(timelineManager?.assetCount ?? 0);
-  // Slice 1 has no filters yet, so `hasActiveFilters` is always false here; Slice 2 replaces
-  // the literal with `getActiveFilterCount(filters) > 0`.
-  const countLabel = $derived(
-    shouldShowRecentlyAddedCount(assetCount, false)
-      ? $t('items_count', { values: { count: assetCount } })
-      : undefined,
-  );
+const assetCount = $derived(timelineManager?.assetCount ?? 0);
+// Slice 1 has no filters yet, so `hasActiveFilters` is always false here; Slice 2 replaces
+// the literal with `getActiveFilterCount(filters) > 0`.
+const countLabel = $derived(
+  shouldShowRecentlyAddedCount(assetCount, false) ? $t('items_count', { values: { count: assetCount } }) : undefined,
+);
 ```
 
 - [ ] **Step 3: Pass the label to the layout**
@@ -343,6 +355,7 @@ to:
 ```bash
 cd e2e && pnpm exec playwright test --project=web src/specs/web/recently-added-filters.e2e-spec.ts
 ```
+
 (Run it exactly as documented in the command reference near the top of this plan — **not** against `:2283`.)
 Expected: **3 passed** (the two that failed in Task 2 Step 2 now pass). Paste the output into your report.
 
@@ -353,13 +366,16 @@ Note: the web dev stack serves the route from source, so no rebuild is needed be
 ```bash
 cd web && pnpm check:typescript && pnpm check:svelte && pnpm lint && pnpm test -- --run
 ```
+
 Expected: type check clean, svelte-check clean, ESLint reports **no errors** (pre-existing Tailwind warnings are fine), all unit tests pass including Task 1's 5.
 
 Then the separate Prettier gate:
+
 ```bash
 cd web && pnpm exec prettier --check "src/routes/(user)/recently-added/**/*.svelte" "src/lib/utils/recently-added-filter-options.ts" "src/lib/utils/__tests__/recently-added-filter-options.spec.ts"
 cd ../e2e && pnpm exec prettier --check src/specs/web/recently-added-filters.e2e-spec.ts
 ```
+
 Expected: all report as formatted. If not, rerun with `--write` and re-check.
 
 - [ ] **Step 6: Commit**
@@ -388,11 +404,11 @@ All of the following must hold before the slice is complete:
 
 ## Coverage check against the spec
 
-| Spec edge case (§Slice 1) | Covered by |
-|---|---|
-| Buckets not yet loaded (`assetCount` 0 transiently) → no "0 items" flash | Task 1 unit `shouldShowRecentlyAddedCount(0, false) === false` |
-| Empty account → count hidden, placeholder shown | Task 1 unit + Task 2 e2e "empty library" |
-| Multi-select active (`hideNavbar`) → header + count hidden | Task 2 e2e "during multi-select" |
-| Plural vs singular ("1 item") | `items_count` ICU plural (i18n, not this code); boundary case `(1, false)` asserted in Task 1 |
-| Count shown for a populated library | Task 2 e2e "populated library" |
-| `hasActiveFilters` arm (unused this slice, needed by Slice 2) | Task 1 units `(0, true)` and `(5, true)` |
+| Spec edge case (§Slice 1)                                                | Covered by                                                                                    |
+| ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| Buckets not yet loaded (`assetCount` 0 transiently) → no "0 items" flash | Task 1 unit `shouldShowRecentlyAddedCount(0, false) === false`                                |
+| Empty account → count hidden, placeholder shown                          | Task 1 unit + Task 2 e2e "empty library"                                                      |
+| Multi-select active (`hideNavbar`) → header + count hidden               | Task 2 e2e "during multi-select"                                                              |
+| Plural vs singular ("1 item")                                            | `items_count` ICU plural (i18n, not this code); boundary case `(1, false)` asserted in Task 1 |
+| Count shown for a populated library                                      | Task 2 e2e "populated library"                                                                |
+| `hasActiveFilters` arm (unused this slice, needed by Slice 2)            | Task 1 units `(0, true)` and `(5, true)`                                                      |

--- a/docs/superpowers/plans/2026-07-19-recently-added-filters-slice-2.md
+++ b/docs/superpowers/plans/2026-07-19-recently-added-filters-slice-2.md
@@ -1244,9 +1244,25 @@ git commit -m "test(e2e): acceptance scenarios for Recently Added browse filters
 **Concrete adaptations:**
 - `const options = $derived({ ...buildRecentlyAddedTimelineOptions(filters), grouping: timelineGrouping });` — this **replaces** the static `const options = {...}`. That is the one sanctioned change to it.
 - `const filterConfig = withNameCapture(buildRecentlyAddedFilterConfig(), personNames, tagNames);` — `withNameCapture(config: FilterPanelConfig, personNames: Map<string, string>, tagNames: Map<string, string>): FilterPanelConfig` from `$lib/utils/filter-name-capture` (verified signature; real call site: `spaces/[spaceId]/albums/[albumId=id]/…/+page.svelte:110`). This is what lets chips render person/tag names.
-- `syncFilterUrl` passes a literal empty query — there is no search this slice:
-  `const nextUrl = buildSearchablePageUrl(page.url, '', nextFilters.sortOrder, nextFilters);`
-  Drop Photos' `relevance` fallback branch (query-mode only).
+- `syncFilterUrl` passes a literal empty query — there is no search this slice. **You must keep an equivalent of Photos' `relevance` fallback**, or every filter URL gains a spurious `sort=desc`:
+
+  ```ts
+  function syncFilterUrl(nextFilters: FilterState) {
+    const currentSearchState = getSearchablePageState(page.url);
+    // `buildSearchablePageUrl` writes an explicit `sort=` param whenever it is handed a literal
+    // 'asc' | 'desc'; only 'relevance' clears it. `createFilterState()` defaults sortOrder to
+    // 'desc', so passing it straight through would stamp `sort=desc` onto every filter URL the
+    // user never asked for. Convert the *implicit* default to 'relevance' (= "no explicit sort")
+    // and pass through anything the user actually chose. Photos does the same thing; its extra
+    // `!committedQuery.trim()` condition is query-mode-only and drops out here.
+    const sortOrder =
+      nextFilters.sortOrder === 'desc' && !currentSearchState.hasExplicitSort ? 'relevance' : nextFilters.sortOrder;
+    const nextUrl = buildSearchablePageUrl(page.url, '', sortOrder, nextFilters);
+    …
+  }
+  ```
+
+  Expected URL shapes, which Task 4's route spec asserts exactly: applying a country filter gives `/recently-added?country=Germany` (no `sort`), and clearing all filters gives bare `/recently-added`. If you see `sort=desc` in either, this conversion is missing.
 - `<FilterPanel … storageKey="gallery-filter-visible-sections-recently-added" timeBuckets={timelineBuckets} hidden={isTimelineEmpty} />` — view-specific storage key.
 - `<ActiveFiltersBar embedded {filters} {personNames} {tagNames} onRemoveFilter={handleRemoveActiveFilter} onClearAll={handleClearAllFilters} />` — **no** `resultCount`, **no** `onAddAllToCollection`, **no** `searchQuery` / `onClearSearch`.
 - `<FilterToolbar … showGrouping={!assetMultiSelectManager.selectionActive} showFilters={hasActiveFilters} filters={recentlyAddedFiltersBar} showFilterButton={filterCollapsed && !isTimelineEmpty && !assetMultiSelectManager.selectionActive} filterActive={getActiveFilterCount(filters) > 0} onExpandFilters={() => (filterCollapsed = false)} />` — drops Photos' `!showSearchResults`.

--- a/docs/superpowers/plans/2026-07-19-recently-added-filters-slice-2.md
+++ b/docs/superpowers/plans/2026-07-19-recently-added-filters-slice-2.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Give the Recently Added view the 9-section metadata filter panel (Timeline-date, People, Location, Camera, Tags, Rating, Media type, Favorites, Albums) with chips, URL persistence, and a header count that reflects the filtered set — while never surfacing shared-space assets and always ordering/grouping by *added* date.
+**Goal:** Give the Recently Added view the 9-section metadata filter panel (Timeline-date, People, Location, Camera, Tags, Rating, Media type, Favorites, Albums) with chips, URL persistence, and a header count that reflects the filtered set — while never surfacing shared-space assets and always ordering/grouping by _added_ date.
 
 **Architecture:** Pure modules carry the decision logic under exhaustive unit tests: `recently-added-filter-options.ts` (extended from Slice 1) gains `buildRecentlyAddedTimelineOptions` and `buildRecentlyAddedSuggestionRequest`; a new `recently-added-filter-config.ts` builds the `FilterPanelConfig`. A prerequisite change registers `/recently-added` as a URL-persisting page without granting it query support. The route mirrors the Photos page minus everything search-related, and is covered both by a route-level vitest spec and by Playwright acceptance scenarios.
 
@@ -43,21 +43,26 @@ Do not reorder — Tasks 4 and 5 are only genuinely red before Task 6.
 ## Reference: commands used in this slice
 
 Web unit tests (`"test": "vitest"` is watch-mode by default, so `--run` is required):
+
 ```bash
 cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-options.spec.ts
 ```
+
 Note: in this repo's vitest workspace setup the path argument does not always isolate to one file — the whole project suite may run. That is expected; find your file's results in the output.
 
 E2E web suite — **never use `:2283`** (a `mise dev` stack returns HTTP 200 with a 0-byte body for page routes there, producing bogus "element not found" failures; the dev stack's real web app is the Vite container on `:3000`).
 
 **Preferred — the dedicated e2e stack** (Playwright defaults; serves the built web app on `:2285` with Postgres on `5435`, the port `utils.resetDatabase()` hardcodes):
+
 ```bash
 cd e2e && docker compose up --build -d     # rebuild after any web source change — the app is baked into the image
 cd e2e && pnpm exec playwright test --project=web --retries=0 src/specs/web/recently-added-filters.e2e-spec.ts
 ```
+
 Pass `--retries=0` on the deliberate red runs — the `web` project sets `retries: 4`, which would otherwise multiply every expected 30s `waitForSelector` timeout by five.
 
 **Fallback — against a running `mise dev` stack** (serves from source via Vite HMR, no rebuild between runs):
+
 ```bash
 socat TCP-LISTEN:5435,fork,reuseaddr TCP:127.0.0.1:5432 &   # resetDatabase() hardcodes 5435; dev Postgres is on 5432
 cd e2e && PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 PLAYWRIGHT_DISABLE_WEBSERVER=1 \
@@ -71,27 +76,29 @@ Prettier is a **separate CI gate** from ESLint — always `prettier --check` tou
 
 ## File Structure
 
-| File | Status | Responsibility |
-|---|---|---|
-| `web/src/lib/utils/searchable-page-search.ts` | **Modify** (Task 1) | Register `/recently-added` as a URL-persisting page; split `isSearchable` from `basePath`. |
-| `web/src/lib/utils/__tests__/searchable-page-search.spec.ts` | **Modify** (Task 1) | Cases for the new path and the split flag. |
-| `web/src/lib/utils/recently-added-filter-options.ts` | **Modify** (Task 2) | Add `buildRecentlyAddedTimelineOptions`, `buildRecentlyAddedSuggestionRequest`. |
-| `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts` | **Modify** (Task 2) | Exhaustive cases for both builders. |
-| `web/src/lib/utils/recently-added-filter-config.ts` | **Create** (Task 3) | `buildRecentlyAddedFilterConfig(): FilterPanelConfig`. |
-| `web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts` | **Create** (Task 3) | Config unit tests, mirroring `album-filter-config.spec.ts`. |
-| `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts` | **Create** (Task 4) | Route-level component spec, mirroring `photos-page.spec.ts`. |
-| `e2e/src/specs/web/recently-added-filters.e2e-spec.ts` | **Modify** (Task 5) | Append the browse-filter acceptance scenarios. |
-| `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte` | **Modify** (Task 6) | Host the filter panel, toolbar, chips, URL sync; count reflects filters. |
+| File                                                                                                | Status              | Responsibility                                                                             |
+| --------------------------------------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------ |
+| `web/src/lib/utils/searchable-page-search.ts`                                                       | **Modify** (Task 1) | Register `/recently-added` as a URL-persisting page; split `isSearchable` from `basePath`. |
+| `web/src/lib/utils/__tests__/searchable-page-search.spec.ts`                                        | **Modify** (Task 1) | Cases for the new path and the split flag.                                                 |
+| `web/src/lib/utils/recently-added-filter-options.ts`                                                | **Modify** (Task 2) | Add `buildRecentlyAddedTimelineOptions`, `buildRecentlyAddedSuggestionRequest`.            |
+| `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts`                                 | **Modify** (Task 2) | Exhaustive cases for both builders.                                                        |
+| `web/src/lib/utils/recently-added-filter-config.ts`                                                 | **Create** (Task 3) | `buildRecentlyAddedFilterConfig(): FilterPanelConfig`.                                     |
+| `web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts`                                  | **Create** (Task 3) | Config unit tests, mirroring `album-filter-config.spec.ts`.                                |
+| `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts` | **Create** (Task 4) | Route-level component spec, mirroring `photos-page.spec.ts`.                               |
+| `e2e/src/specs/web/recently-added-filters.e2e-spec.ts`                                              | **Modify** (Task 5) | Append the browse-filter acceptance scenarios.                                             |
+| `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte`                | **Modify** (Task 6) | Host the filter panel, toolbar, chips, URL sync; count reflects filters.                   |
 
 ---
 
 ## Task 1: Register `/recently-added` for URL persistence, without granting query support
 
 **Files:**
+
 - Modify: `web/src/lib/utils/searchable-page-search.ts`
 - Test: `web/src/lib/utils/__tests__/searchable-page-search.spec.ts`
 
 **Interfaces:**
+
 - Produces: `getSearchablePageBasePath('/recently-added…')` → `'/recently-added'`, which makes `buildSearchablePageUrl` return a real URL for this route (Task 6 depends on it); and `getSearchablePageState(url).isSearchable === false` for that same path.
 
 **Why this task exists.** `buildSearchablePageUrl` bails to `null` when `getSearchablePageBasePath` does not recognise the pathname (`searchable-page-search.ts:115-118`), and today it recognises only `/photos` and `/spaces/…`:
@@ -110,7 +117,7 @@ export function getSearchablePageBasePath(pathname: string): string | null {
 }
 ```
 
-Without registering the path, every filter change on Recently Added would update the grid but never the URL — the write path fails silently. (The *read* path already works: `getSearchablePageFilterState` parses `searchParams` with no basePath check, which is why deep links would appear to half-work.)
+Without registering the path, every filter change on Recently Added would update the grid but never the URL — the write path fails silently. (The _read_ path already works: `getSearchablePageFilterState` parses `searchParams` with no basePath check, which is why deep links would appear to half-work.)
 
 But `getSearchablePageState` currently derives the query capability from the same fact:
 
@@ -206,6 +213,7 @@ Add any imports the file does not already have (`getSearchablePageBasePath`, `ge
 ```bash
 cd web && pnpm test -- --run src/lib/utils/__tests__/searchable-page-search.spec.ts
 ```
+
 Expected: **FAIL** — `getSearchablePageBasePath('/recently-added')` returns `null`, `buildSearchablePageUrl` returns `null`, and `isSearchable` is `false` only because `basePath` is null (so that one case may pass for the wrong reason — the first two failures are the real signal). Paste the output.
 
 - [ ] **Step 3: Implement**
@@ -213,9 +221,9 @@ Expected: **FAIL** — `getSearchablePageBasePath('/recently-added')` returns `n
 In `web/src/lib/utils/searchable-page-search.ts`, add the path to `getSearchablePageBasePath`, immediately after the `/photos` branch:
 
 ```ts
-  if (pathname.startsWith('/recently-added')) {
-    return '/recently-added';
-  }
+if (pathname.startsWith('/recently-added')) {
+  return '/recently-added';
+}
 ```
 
 Add the capability predicate above `getSearchablePageState`, and enforce it in **both** places below:
@@ -237,24 +245,24 @@ function isQueryCapablePage(basePath: string): boolean {
 Enforcement 1 — `getSearchablePageState` reports the capability:
 
 ```ts
-  return {
-    basePath,
-    isSearchable: isQueryCapablePage(basePath),
-    query,
-    hasExplicitSort: rawSort === 'asc' || rawSort === 'desc',
-    sortOrder: getSortOrder(query, rawSort),
-  };
+return {
+  basePath,
+  isSearchable: isQueryCapablePage(basePath),
+  query,
+  hasExplicitSort: rawSort === 'asc' || rawSort === 'desc',
+  sortOrder: getSortOrder(query, rawSort),
+};
 ```
 
-Enforcement 2 — `buildSearchablePageUrl` refuses to *write* a query for such a page. Insert this immediately after the existing `const trimmedQuery = query.trim();` line (which currently sits just below the `basePath` null check):
+Enforcement 2 — `buildSearchablePageUrl` refuses to _write_ a query for such a page. Insert this immediately after the existing `const trimmedQuery = query.trim();` line (which currently sits just below the `basePath` null check):
 
 ```ts
-  // A page that persists filters in the URL is not necessarily able to answer a `?q=`.
-  // Returning null here keeps global-search-manager's buildSearchDestination falling back to
-  // /photos, instead of stranding a query on a route that would silently ignore it.
-  if (trimmedQuery && !isQueryCapablePage(basePath)) {
-    return null;
-  }
+// A page that persists filters in the URL is not necessarily able to answer a `?q=`.
+// Returning null here keeps global-search-manager's buildSearchDestination falling back to
+// /photos, instead of stranding a query on a route that would silently ignore it.
+if (trimmedQuery && !isQueryCapablePage(basePath)) {
+  return null;
+}
 ```
 
 Filter-only calls (empty query) are unaffected, which is exactly what this slice's `syncFilterUrl` needs.
@@ -264,6 +272,7 @@ Filter-only calls (empty query) are unaffected, which is exactly what this slice
 ```bash
 cd web && pnpm test -- --run src/lib/utils/__tests__/searchable-page-search.spec.ts
 ```
+
 Expected: **PASS** — the new cases and every pre-existing case in the file. The pre-existing ones passing is the proof that Photos and Spaces are unaffected. Paste the output.
 
 - [ ] **Step 5: Format and commit**
@@ -279,10 +288,12 @@ git commit -m "feat(web): persist Recently Added filters in the URL without enab
 ## Task 2: Timeline-options and suggestion-request builders
 
 **Files:**
+
 - Modify: `web/src/lib/utils/recently-added-filter-options.ts`
 - Test: `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts`
 
 **Interfaces:**
+
 - Produces:
   - `export function buildRecentlyAddedTimelineOptions(filters: FilterState): Record<string, unknown>`
   - `export function buildRecentlyAddedSuggestionRequest(filters: FilterState)` (inferred object return)
@@ -292,6 +303,7 @@ git commit -m "feat(web): persist Recently Added filters in the URL without enab
 **Facts about the code you build on:**
 
 `buildPhotosTimelineOptions` (`web/src/lib/utils/photos-filter-options.ts`) starts from:
+
 ```ts
 const includeSharedTimelineAssets = filters.isFavorite === undefined;
 const base: Record<string, unknown> = {
@@ -300,6 +312,7 @@ const base: Record<string, unknown> = {
   ...(includeSharedTimelineAssets ? { withPartners: true, withSharedSpaces: true } : {}),
 };
 ```
+
 then conditionally sets `personIds`, `city`, `country`, `make`, `model`, trimmed `description`/`originalFileName`/`ocr`, `tagIds`, `rating`, `isFavorite`, `isNotInAlbum` (true only), `isInAlbum` (true only), `$type` (when `mediaType !== 'all'`), always sets `order` (`AssetOrder.Asc` for `sortOrder === 'asc'`, else `AssetOrder.Desc`), and adds `takenAfter`/`takenBefore` from `buildFilterContext(filters)`.
 
 `withPartners` and `withSharedSpaces` are added **together**, gated only on `filters.isFavorite === undefined`. Stripping `withSharedSpaces` therefore leaves `withPartners` for non-favorite filters and drops both under Favorites — exactly the intended behavior.
@@ -379,7 +392,9 @@ describe('buildRecentlyAddedTimelineOptions', () => {
 
   it('maps sortOrder to order without touching orderBy', () => {
     expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), sortOrder: 'asc' }).order).toBe(AssetOrder.Asc);
-    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), sortOrder: 'desc' }).order).toBe(AssetOrder.Desc);
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), sortOrder: 'desc' }).order).toBe(
+      AssetOrder.Desc,
+    );
     expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), sortOrder: 'relevance' }).order).toBe(
       AssetOrder.Desc,
     );
@@ -571,6 +586,7 @@ describe('buildRecentlyAddedSuggestionRequest', () => {
 ```bash
 cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-options.spec.ts
 ```
+
 Expected: **FAIL** — the module does not export the two new builders, so the import fails (`does not provide an export named 'buildRecentlyAddedTimelineOptions'`). Paste the output.
 
 - [ ] **Step 3: Implement both builders**
@@ -636,6 +652,7 @@ export function buildRecentlyAddedSuggestionRequest(filters: FilterState) {
 ```bash
 cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-options.spec.ts
 ```
+
 Expected: **PASS**, all three describes. Paste the output.
 
 - [ ] **Step 5: Format and commit**
@@ -651,10 +668,12 @@ git commit -m "feat(web): Recently Added timeline options and suggestion request
 ## Task 3: The filter-panel config
 
 **Files:**
+
 - Create: `web/src/lib/utils/recently-added-filter-config.ts`
 - Test: `web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts`
 
 **Interfaces:**
+
 - Consumes: `buildRecentlyAddedSuggestionRequest` (Task 2); `getPhotosPersonFilterId` / `getPhotosPersonFilterThumbnailUrl` from `$lib/utils/photos-filter-options`; `FilterPanelConfig` from `$lib/components/filter-panel/filter-panel`.
 - Produces: `export function buildRecentlyAddedFilterConfig(): FilterPanelConfig` — used by Task 6, extended in Slice 3.
 
@@ -852,6 +871,7 @@ describe('buildRecentlyAddedFilterConfig', () => {
 ```bash
 cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-config.spec.ts
 ```
+
 Expected: **FAIL** — `Failed to resolve import "$lib/utils/recently-added-filter-config"`. Paste the output.
 
 - [ ] **Step 3: Implement**
@@ -921,6 +941,7 @@ This is deliberately near-identical to `buildAlbumAssetPickerFilterConfig` (diff
 ```bash
 cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-config.spec.ts
 ```
+
 Expected: **PASS** — all 7 cases. Paste the output.
 
 - [ ] **Step 5: Format and commit**
@@ -936,9 +957,11 @@ git commit -m "feat(web): Recently Added filter-panel config (#805)"
 ## Task 4: Route-level component spec (red-first for the wiring)
 
 **Files:**
+
 - Create: `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts`
 
 **Interfaces:**
+
 - Consumes: the route component. Asserts the wiring Task 6 must produce.
 - Produces: fast, deterministic coverage of the URL-sync and options-derivation behavior that Playwright can only verify slowly.
 
@@ -982,6 +1005,7 @@ Create the file following the template above. Set `mockPage.url` to `new URL('ht
 ```bash
 cd web && pnpm test -- --run "src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts"
 ```
+
 Expected: **FAIL** — the route renders no filter panel, so the stub receives nothing and no `goto` is called. Confirm the failures are assertion failures about missing filter wiring, **not** mock/setup errors (an unresolved stub import or a missing manager mock means your harness is wrong, not the route). Paste the output.
 
 - [ ] **Step 3: Commit the red spec**
@@ -996,29 +1020,34 @@ git commit -m "test(web): route-level spec for Recently Added filters (#805)"
 ## Task 5: BDD acceptance scenarios (red-first)
 
 **Files:**
+
 - Modify: `e2e/src/specs/web/recently-added-filters.e2e-spec.ts`
 
 **Interfaces:**
+
 - Consumes: filter-panel testids already exercised by `e2e/src/specs/web/photos-filter-panel.e2e-spec.ts` — `discovery-panel`, `filter-toggle-btn`, `collapse-panel-btn`, `filter-section-<name>` (the template is `data-testid="filter-section-{testId}"` in `filter-section.svelte:25`, fed `testId={section}` from `filter-panel.svelte:754`, so every section emits one), `media-type-image` / `media-type-video`, `rating-star-5`, `active-filters-bar`, `active-chip`, `clear-all-btn`. The header count is `page-header-description`.
 - Produces: the scenarios Task 6 turns green. Slice 3 appends search scenarios to the same file.
 
 **Structure:** keep Slice 1's `test.describe('Recently Added', …)` exactly as-is and add a **sibling** `test.describe('Recently Added filters', …)` with its own `beforeAll`. The `web` Playwright project is `fullyParallel: false` with `workers: 1`, and Playwright runs `beforeAll` lazily per describe, so a second resetting `beforeAll` is safe.
 
 **Video seeding — verified, use this.** `utils.createAsset(accessToken, dto?)` accepts `assetData?: { bytes?: Buffer; filename: string }`, and the server derives asset type from the **filename extension** (`mimeTypes.assetType(file.originalPath)`), so no real video fixture is needed. Existing precedent — `e2e/src/specs/server/api/shared-space-album-timeline.e2e-spec.ts:561`:
+
 ```ts
 const videoAsset = await utils.createAsset(owner.accessToken, { assetData: { filename: 'example.mp4' } });
 ```
 
-**URL parameters — verified** against `SEARCHABLE_PAGE_FILTER_PARAMS` (`web/src/lib/utils/searchable-page-search.ts:5-21`): rating is `rating`, camera make is `make`, and media type is **`type`** (e.g. `type=video`) — *not* `mediaType`.
+**URL parameters — verified** against `SEARCHABLE_PAGE_FILTER_PARAMS` (`web/src/lib/utils/searchable-page-search.ts:5-21`): rating is `rating`, camera make is `make`, and media type is **`type`** (e.g. `type=video`) — _not_ `mediaType`.
 
 - [ ] **Step 1: Write the scenarios**
 
 Extend the file's imports (Slice 1's version has none of these):
+
 ```ts
 import { updateAsset } from '@immich/sdk';
 import { thumbnailUtils } from 'src/ui/specs/timeline/utils';
 import { asBearerAuth, utils } from 'src/utils';
 ```
+
 (`thumbnailUtils` import path matches `e2e/src/specs/web/timeline-grouping.e2e-spec.ts:3`.)
 
 Append:
@@ -1216,15 +1245,18 @@ git commit -m "test(e2e): acceptance scenarios for Recently Added browse filters
 ## Task 6: Wire the filter panel into the route (turns Tasks 4 and 5 green)
 
 **Files:**
+
 - Modify: `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte`
 
 **Interfaces:**
+
 - Consumes: `buildRecentlyAddedTimelineOptions` (Task 2), `buildRecentlyAddedFilterConfig` (Task 3), `shouldShowRecentlyAddedCount` (Slice 1), and the URL registration from Task 1.
 - Produces: the rendered filter UI asserted by Tasks 4 and 5.
 
 **The template is the Photos page** — `web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte`. Copy its structure, then delete every search-related part. Do not modify the Photos page itself.
 
 **Take from Photos (line refs):**
+
 - filter state seeding (`:105-124`), `filtersBeforePanelChange` + its `$effect` (`:116-140`)
 - `timelineGrouping` / `temporalAnchor` (`:125-126`), `pendingFilterUrlSync` (`:129-131`)
 - `personNames` / `tagNames` `SvelteMap`s + `consumeTypedSearchNamesInto` (`:141-143`)
@@ -1234,6 +1266,7 @@ git commit -m "test(e2e): acceptance scenarios for Recently Added browse filters
 - the layout shell (`:556-641`): `<div class="flex h-full">` → `<FilterPanel>` → `<div class="flex flex-1 flex-col overflow-hidden pl-4">` → filters-bar snippet → `<FilterToolbar>` → `<Timeline>`
 
 **OMIT (all Slice 3 territory):**
+
 - `committedQuery`, `showSearchResults`, `isLoading`, `clearSearch`, and the query parts of `lastHandledSearchState`
 - `smartFacets`, `smartFacetKey`, `smartFacetInFlight`, `loadPhotoSmartFacets`, `smartFacetBuckets`, `smartFacetTotal`, and the `buildSmartSearchFacetKey` / `buildSmartSearchFacetsParams` / `mapSmartSearchFacetsToFilterSuggestions` imports
 - `<SmartSearchResults>` and the `{#if showSearchResults}` branch — render `<Timeline>` unconditionally
@@ -1242,6 +1275,7 @@ git commit -m "test(e2e): acceptance scenarios for Recently Added browse filters
 - the memories `ImageCarousel`, and `registerSelectionContext` (not in this route today — do not add it)
 
 **Concrete adaptations:**
+
 - `const options = $derived({ ...buildRecentlyAddedTimelineOptions(filters), grouping: timelineGrouping });` — this **replaces** the static `const options = {...}`. That is the one sanctioned change to it.
 - `const filterConfig = withNameCapture(buildRecentlyAddedFilterConfig(), personNames, tagNames);` — `withNameCapture(config: FilterPanelConfig, personNames: Map<string, string>, tagNames: Map<string, string>): FilterPanelConfig` from `$lib/utils/filter-name-capture` (verified signature; real call site: `spaces/[spaceId]/albums/[albumId=id]/…/+page.svelte:110`). This is what lets chips render person/tag names.
 - `syncFilterUrl` passes a literal empty query — there is no search this slice. **You must keep an equivalent of Photos' `relevance` fallback**, or every filter URL gains a spurious `sort=desc`:
@@ -1263,6 +1297,7 @@ git commit -m "test(e2e): acceptance scenarios for Recently Added browse filters
   ```
 
   Expected URL shapes, which Task 4's route spec asserts exactly: applying a country filter gives `/recently-added?country=Germany` (no `sort`), and clearing all filters gives bare `/recently-added`. If you see `sort=desc` in either, this conversion is missing.
+
 - `<FilterPanel … storageKey="gallery-filter-visible-sections-recently-added" timeBuckets={timelineBuckets} hidden={isTimelineEmpty} />` — view-specific storage key.
 - `<ActiveFiltersBar embedded {filters} {personNames} {tagNames} onRemoveFilter={handleRemoveActiveFilter} onClearAll={handleClearAllFilters} />` — **no** `resultCount`, **no** `onAddAllToCollection`, **no** `searchQuery` / `onClearSearch`.
 - `<FilterToolbar … showGrouping={!assetMultiSelectManager.selectionActive} showFilters={hasActiveFilters} filters={recentlyAddedFiltersBar} showFilterButton={filterCollapsed && !isTimelineEmpty && !assetMultiSelectManager.selectionActive} filterActive={getActiveFilterCount(filters) > 0} onExpandFilters={() => (filterCollapsed = false)} />` — drops Photos' `!showSearchResults`.
@@ -1282,6 +1317,7 @@ Work with the Photos file open beside you; copy its handler code exactly rather 
 ```bash
 cd web && pnpm test -- --run "src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts"
 ```
+
 Expected: **PASS** — all six cases from Task 4. This is your fast feedback loop — get it green before touching Playwright. Paste the output.
 
 - [ ] **Step 3: Type-check and lint**
@@ -1289,6 +1325,7 @@ Expected: **PASS** — all six cases from Task 4. This is your fast feedback loo
 ```bash
 cd web && pnpm check:typescript && pnpm lint
 ```
+
 Fix errors before running e2e. (`check:svelte` reports 0 files locally — a known no-op; CI is authoritative. Run it anyway.)
 
 - [ ] **Step 4: Turn the e2e spec GREEN**
@@ -1342,23 +1379,23 @@ git commit -m "feat(web): browse filters for Recently Added (#805)"
 
 ## Coverage check against the spec
 
-| Spec item (§Slice 2) | Covered by |
-|---|---|
-| URL persistence works at all (spec §3.1.1 prerequisite) | Task 1 units; Task 4 route-spec URL-sync case; Task 5 e2e reload/deep-link |
-| Filter matches zero assets → panel stays open, "0 items" | Task 5 e2e "matches nothing"; Slice 1 unit `shouldShowRecentlyAddedCount(0, true)` |
-| `withSharedSpaces` leakage in any path | Task 2 options `toEqual` + `not.toHaveProperty` ×2 + suggestion-request unit; Task 3 config unit (all 3 request types); Done-Gate grep |
-| Future stray key from `buildPhotosTimelineOptions` | Task 2 default-case `toEqual` (exact shape) |
-| Favorites filter → own-only | Task 2 "drops partner assets under a favorites filter" |
-| Any filter combination keeps `orderBy: CreatedAt` | Task 2 "keeps orderBy CreatedAt under every filter combination" + multi-filter case; Task 5 e2e "stays ordered by added date" |
-| Sort asc/desc flips `order`, not `orderBy` | Task 2 "maps sortOrder to order without touching orderBy" |
-| All predicate passthroughs + date ranges (year, year+month, custom, from-only, to-only) | Task 2 predicate / mediaType / text-trim / album-flag / date cases |
-| Suggestion request omits shared/album/space scope | Task 2 "never scopes to shared spaces, albums, or spaces" |
-| Config = 9 sections, correct suggestion/provider calls | Task 3, all 7 cases |
-| BDD 1: media type updates grid, URL, count | Task 5 "filtering by media type…" |
-| BDD 2: removing a chip restores the full view | Task 5 "removing the media-type chip…" (chip control, not clear-all) + "clear all removes every active filter" |
-| BDD 3: filter matching nothing → 0 items | Task 5 "matches nothing" |
-| BDD 4: filters survive a reload | Task 5 "filters survive a reload" |
-| BDD 5: stays ordered by added date under a filter | Task 5 "stays ordered by added date under a filter" |
-| Count flicker on apply | Accepted + documented (spec §5.5); e2e asserts the settled count via auto-retrying assertions |
-| Grouping day↔month | Copied `handleTimelineGroupingChange` / `FilterToolbar` wiring; manual smoke |
-| Suggestion fetch failure | `FilterPanel`'s own AbortController path — no new handling, matching `album-filter-config.ts` |
+| Spec item (§Slice 2)                                                                    | Covered by                                                                                                                             |
+| --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| URL persistence works at all (spec §3.1.1 prerequisite)                                 | Task 1 units; Task 4 route-spec URL-sync case; Task 5 e2e reload/deep-link                                                             |
+| Filter matches zero assets → panel stays open, "0 items"                                | Task 5 e2e "matches nothing"; Slice 1 unit `shouldShowRecentlyAddedCount(0, true)`                                                     |
+| `withSharedSpaces` leakage in any path                                                  | Task 2 options `toEqual` + `not.toHaveProperty` ×2 + suggestion-request unit; Task 3 config unit (all 3 request types); Done-Gate grep |
+| Future stray key from `buildPhotosTimelineOptions`                                      | Task 2 default-case `toEqual` (exact shape)                                                                                            |
+| Favorites filter → own-only                                                             | Task 2 "drops partner assets under a favorites filter"                                                                                 |
+| Any filter combination keeps `orderBy: CreatedAt`                                       | Task 2 "keeps orderBy CreatedAt under every filter combination" + multi-filter case; Task 5 e2e "stays ordered by added date"          |
+| Sort asc/desc flips `order`, not `orderBy`                                              | Task 2 "maps sortOrder to order without touching orderBy"                                                                              |
+| All predicate passthroughs + date ranges (year, year+month, custom, from-only, to-only) | Task 2 predicate / mediaType / text-trim / album-flag / date cases                                                                     |
+| Suggestion request omits shared/album/space scope                                       | Task 2 "never scopes to shared spaces, albums, or spaces"                                                                              |
+| Config = 9 sections, correct suggestion/provider calls                                  | Task 3, all 7 cases                                                                                                                    |
+| BDD 1: media type updates grid, URL, count                                              | Task 5 "filtering by media type…"                                                                                                      |
+| BDD 2: removing a chip restores the full view                                           | Task 5 "removing the media-type chip…" (chip control, not clear-all) + "clear all removes every active filter"                         |
+| BDD 3: filter matching nothing → 0 items                                                | Task 5 "matches nothing"                                                                                                               |
+| BDD 4: filters survive a reload                                                         | Task 5 "filters survive a reload"                                                                                                      |
+| BDD 5: stays ordered by added date under a filter                                       | Task 5 "stays ordered by added date under a filter"                                                                                    |
+| Count flicker on apply                                                                  | Accepted + documented (spec §5.5); e2e asserts the settled count via auto-retrying assertions                                          |
+| Grouping day↔month                                                                      | Copied `handleTimelineGroupingChange` / `FilterToolbar` wiring; manual smoke                                                           |
+| Suggestion fetch failure                                                                | `FilterPanel`'s own AbortController path — no new handling, matching `album-filter-config.ts`                                          |

--- a/docs/superpowers/plans/2026-07-19-recently-added-filters-slice-2.md
+++ b/docs/superpowers/plans/2026-07-19-recently-added-filters-slice-2.md
@@ -1,0 +1,1348 @@
+# Recently Added — Slice 2: Browse filter panel (9 metadata sections) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the Recently Added view the 9-section metadata filter panel (Timeline-date, People, Location, Camera, Tags, Rating, Media type, Favorites, Albums) with chips, URL persistence, and a header count that reflects the filtered set — while never surfacing shared-space assets and always ordering/grouping by *added* date.
+
+**Architecture:** Pure modules carry the decision logic under exhaustive unit tests: `recently-added-filter-options.ts` (extended from Slice 1) gains `buildRecentlyAddedTimelineOptions` and `buildRecentlyAddedSuggestionRequest`; a new `recently-added-filter-config.ts` builds the `FilterPanelConfig`. A prerequisite change registers `/recently-added` as a URL-persisting page without granting it query support. The route mirrors the Photos page minus everything search-related, and is covered both by a route-level vitest spec and by Playwright acceptance scenarios.
+
+**Tech Stack:** SvelteKit + Svelte 5 runes, TypeScript (strict), Vitest + @testing-library/svelte, Playwright.
+
+## Global Constraints
+
+From the spec (`docs/superpowers/specs/2026-07-19-recently-added-filters-design.md`) — these bind every task:
+
+- **Scope:** Web only. No server / API / mobile / DTO changes.
+- **Do not modify** the Photos page or the shared `filter-panel/` / `Timeline` / `UserPageLayout` components. (`searchable-page-search.ts` **is** modified this slice — see Task 1 — but in a way that leaves Photos and Spaces behaviour bit-for-bit unchanged.)
+- **The single scope invariant:** Recently Added is an **own + partner** surface, **never shared spaces**. `withSharedSpaces` must never appear in timeline options, filter-suggestion requests, or provider requests.
+- **`orderBy: AssetOrderBy.CreatedAt` always** — under every filter combination. The defining trait of the view.
+- **No free-text / smart search in this slice.** Nothing may reference `committedQuery`, `SmartSearchResults`, `searchSmartFacets`, or smart facets. The `'text'` section arrives in Slice 3 with its search path, so the text input is never present without a working submit. `isSearchable` must stay **false** for `/recently-added` this slice.
+- **No `resultCount` and no `onAddAllToCollection`** on `ActiveFiltersBar` — the header carries the single count (spec §5.2).
+- No i18n additions: reuse the existing `items_count` key.
+- The `AssetSelectControlBar` block in the route stays unchanged, as does the `{#snippet empty()}` / `EmptyPlaceholder` block (Slice 1's e2e asserts its copy).
+- Code style: Prettier (120 char, single quotes, trailing commas, semicolons); no relative imports in web — use `$lib/`.
+- ESLint: **no new errors and no new warnings**. Web's `pnpm lint` does not pass `--max-warnings 0`, and ~640 pre-existing Tailwind warnings are expected — but do not add to them.
+
+## Baseline: what Slice 1 delivered (do not redo)
+
+Committed on this branch: `recently-added-filter-options.ts` exporting `shouldShowRecentlyAddedCount(count, hasActiveFilters)`; its spec; `e2e/src/specs/web/recently-added-filters.e2e-spec.ts` with 3 passing scenarios; and the route deriving `assetCount` + `countLabel` and passing `description={countLabel}` to `UserPageLayout`. This slice extends all four.
+
+## Task order and why
+
+1. URL-persistence prerequisite (unit TDD) — without it every filter→URL step downstream silently no-ops.
+2. Options builders (unit TDD).
+3. Filter config (unit TDD).
+4. Route-level vitest spec (red).
+5. E2E acceptance scenarios (red).
+6. Route wiring (turns 4 and 5 green).
+
+Do not reorder — Tasks 4 and 5 are only genuinely red before Task 6.
+
+---
+
+## Reference: commands used in this slice
+
+Web unit tests (`"test": "vitest"` is watch-mode by default, so `--run` is required):
+```bash
+cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-options.spec.ts
+```
+Note: in this repo's vitest workspace setup the path argument does not always isolate to one file — the whole project suite may run. That is expected; find your file's results in the output.
+
+E2E web suite — **never use `:2283`** (a `mise dev` stack returns HTTP 200 with a 0-byte body for page routes there, producing bogus "element not found" failures; the dev stack's real web app is the Vite container on `:3000`).
+
+**Preferred — the dedicated e2e stack** (Playwright defaults; serves the built web app on `:2285` with Postgres on `5435`, the port `utils.resetDatabase()` hardcodes):
+```bash
+cd e2e && docker compose up --build -d     # rebuild after any web source change — the app is baked into the image
+cd e2e && pnpm exec playwright test --project=web --retries=0 src/specs/web/recently-added-filters.e2e-spec.ts
+```
+Pass `--retries=0` on the deliberate red runs — the `web` project sets `retries: 4`, which would otherwise multiply every expected 30s `waitForSelector` timeout by five.
+
+**Fallback — against a running `mise dev` stack** (serves from source via Vite HMR, no rebuild between runs):
+```bash
+socat TCP-LISTEN:5435,fork,reuseaddr TCP:127.0.0.1:5432 &   # resetDatabase() hardcodes 5435; dev Postgres is on 5432
+cd e2e && PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 PLAYWRIGHT_DISABLE_WEBSERVER=1 \
+  pnpm exec playwright test --project=web --retries=0 src/specs/web/recently-added-filters.e2e-spec.ts
+kill %1
+```
+
+Prettier is a **separate CI gate** from ESLint — always `prettier --check` touched files. A `**/*.svelte` glob does not match inside the `[[…]]` route directory; use the concrete escaped path.
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `web/src/lib/utils/searchable-page-search.ts` | **Modify** (Task 1) | Register `/recently-added` as a URL-persisting page; split `isSearchable` from `basePath`. |
+| `web/src/lib/utils/__tests__/searchable-page-search.spec.ts` | **Modify** (Task 1) | Cases for the new path and the split flag. |
+| `web/src/lib/utils/recently-added-filter-options.ts` | **Modify** (Task 2) | Add `buildRecentlyAddedTimelineOptions`, `buildRecentlyAddedSuggestionRequest`. |
+| `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts` | **Modify** (Task 2) | Exhaustive cases for both builders. |
+| `web/src/lib/utils/recently-added-filter-config.ts` | **Create** (Task 3) | `buildRecentlyAddedFilterConfig(): FilterPanelConfig`. |
+| `web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts` | **Create** (Task 3) | Config unit tests, mirroring `album-filter-config.spec.ts`. |
+| `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts` | **Create** (Task 4) | Route-level component spec, mirroring `photos-page.spec.ts`. |
+| `e2e/src/specs/web/recently-added-filters.e2e-spec.ts` | **Modify** (Task 5) | Append the browse-filter acceptance scenarios. |
+| `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte` | **Modify** (Task 6) | Host the filter panel, toolbar, chips, URL sync; count reflects filters. |
+
+---
+
+## Task 1: Register `/recently-added` for URL persistence, without granting query support
+
+**Files:**
+- Modify: `web/src/lib/utils/searchable-page-search.ts`
+- Test: `web/src/lib/utils/__tests__/searchable-page-search.spec.ts`
+
+**Interfaces:**
+- Produces: `getSearchablePageBasePath('/recently-added…')` → `'/recently-added'`, which makes `buildSearchablePageUrl` return a real URL for this route (Task 6 depends on it); and `getSearchablePageState(url).isSearchable === false` for that same path.
+
+**Why this task exists.** `buildSearchablePageUrl` bails to `null` when `getSearchablePageBasePath` does not recognise the pathname (`searchable-page-search.ts:115-118`), and today it recognises only `/photos` and `/spaces/…`:
+
+```ts
+export function getSearchablePageBasePath(pathname: string): string | null {
+  if (pathname.startsWith('/photos')) {
+    return '/photos';
+  }
+
+  const parts = pathname.split('/').filter(Boolean);
+  if (parts[0] !== 'spaces' || parts[1] === undefined) {
+    return null;
+  }
+  …
+}
+```
+
+Without registering the path, every filter change on Recently Added would update the grid but never the URL — the write path fails silently. (The *read* path already works: `getSearchablePageFilterState` parses `searchParams` with no basePath check, which is why deep links would appear to half-work.)
+
+But `getSearchablePageState` currently derives the query capability from the same fact:
+
+```ts
+return {
+  basePath,
+  isSearchable: true,
+  …
+};
+```
+
+and consumers key off `isSearchable`: `global-search-input-trigger.svelte:10` (`showSearchSortControl`) and `global-search-manager.svelte.ts:663` / `:670` (typed display text).
+
+**The dangerous consumer is not gated by that flag at all.** `buildSearchDestination` (`global-search-manager.svelte.ts:1540-1543`) branches purely on `buildSearchablePageUrl` returning non-null:
+
+```ts
+private buildSearchDestination(text: string, filters?: FilterState): string {
+  const searchablePageUrl = buildSearchablePageUrl(page.url, text, this.searchSortOrder, filters);
+  if (searchablePageUrl) {
+    return searchablePageUrl;
+  }
+  …
+  return buildSearchablePageUrl(new URL('/photos', page.url), text, this.searchSortOrder, filters) ?? '/photos';
+}
+```
+
+It is reached from `activateSearch` (`:1692-1694`) — the ordinary type-a-query-and-press-Enter path. Today on `/recently-added` the first call returns `null`, so the search runs on `/photos` and works. The moment we register the base path, it returns a real URL and `buildSearchablePageUrl:130-131` sets `q`, landing the user on `/recently-added?q=beach`: a route with no query handling until Slice 3. Unfiltered grid, stale `q`, no error — a silent regression against working behavior. `isSearchable: false` does **not** prevent it (it only suppresses pre-filling the box; nothing stops the user typing).
+
+**So the predicate must be enforced where the query is written, not only where it is advertised** — in `buildSearchablePageUrl` itself, which keeps `buildSearchDestination`'s `/photos` fallback intact.
+
+Accepted, deliberate consequence: `global-search-manager.svelte.ts:1594` (`applyFilters`) now sees a non-null base path and keeps filter application on Recently Added instead of redirecting to `/photos`. That is benign — it passes a literal `''` query, so it writes filter params only, which is exactly this slice's own behavior. Two other newly-reachable consumers are no-ops: `:1601` (`applySearchSort`) is unreachable because its control is `isSearchable`-gated, and `:1632` (`activateSearch('')`) passes no `filters`, so the built URL equals the current one.
+
+One further newly-reachable path is intentional, not a bug: `navigateToFieldResults` (`:1595`) also passes a literal `''`, so the guard correctly lets it through. Field searches from global search (filename / description / OCR) will now write `?filename=…` / `?description=…` / `?ocr=…` onto `/recently-added` instead of redirecting to `/photos`. That works end to end this slice — the params are parsed by `getSearchablePageFilterState`, consumed by `buildRecentlyAddedTimelineOptions`, rendered as chips by `active-filters-bar.svelte:151-157`, and removable via `handlePhotosRemoveFilter`. The only rough edge is that the panel has no `'text'` section yet, so such a chip is visible and removable but not editable in the panel until Slice 3. Do not "fix" this.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `web/src/lib/utils/__tests__/searchable-page-search.spec.ts` (keep the existing `/photos` and `/spaces/…` cases untouched — they are the regression guard that this change is behaviour-preserving elsewhere):
+
+```ts
+describe('recently added page', () => {
+  it('resolves the base path so filter changes can be written to the URL', () => {
+    expect(getSearchablePageBasePath('/recently-added')).toBe('/recently-added');
+    expect(getSearchablePageBasePath('/recently-added/photos')).toBe('/recently-added');
+  });
+
+  it('builds a filter URL for the recently added page', () => {
+    const url = buildSearchablePageUrl(new URL('https://gallery.test/recently-added'), '', 'desc', {
+      ...createFilterState(),
+      rating: 5,
+    });
+
+    expect(url).not.toBeNull();
+    expect(url).toContain('rating=5');
+  });
+
+  it('is not query-capable until the text slice lands', () => {
+    // Slice 3 flips this to true together with the text section and the search path, so the
+    // global search UI never offers a query this page cannot answer.
+    const state = getSearchablePageState(new URL('https://gallery.test/recently-added'));
+
+    expect(state.basePath).toBe('/recently-added');
+    expect(state.isSearchable).toBe(false);
+  });
+
+  it('refuses to build a query URL for a page that cannot answer one', () => {
+    // This is the load-bearing case. global-search-manager's buildSearchDestination falls back to
+    // /photos only when this returns null, so returning a URL here would strand a `?q=` on a route
+    // with no query handling.
+    expect(buildSearchablePageUrl(new URL('https://gallery.test/recently-added'), 'beach')).toBeNull();
+  });
+
+  it('still builds a filter-only URL for the same page', () => {
+    const url = buildSearchablePageUrl(new URL('https://gallery.test/recently-added'), '', 'desc', {
+      ...createFilterState(),
+      rating: 5,
+    });
+
+    expect(url).toContain('rating=5');
+  });
+
+  it('leaves photos and spaces query-capable', () => {
+    expect(getSearchablePageState(new URL('https://gallery.test/photos')).isSearchable).toBe(true);
+    expect(getSearchablePageState(new URL('https://gallery.test/spaces/space-1')).isSearchable).toBe(true);
+    expect(buildSearchablePageUrl(new URL('https://gallery.test/photos'), 'beach')).toContain('q=beach');
+  });
+});
+```
+
+Add any imports the file does not already have (`getSearchablePageBasePath`, `getSearchablePageState`, `buildSearchablePageUrl`, `createFilterState`) — read the file's existing import block first and extend it rather than duplicating.
+
+- [ ] **Step 2: Run to verify RED**
+
+```bash
+cd web && pnpm test -- --run src/lib/utils/__tests__/searchable-page-search.spec.ts
+```
+Expected: **FAIL** — `getSearchablePageBasePath('/recently-added')` returns `null`, `buildSearchablePageUrl` returns `null`, and `isSearchable` is `false` only because `basePath` is null (so that one case may pass for the wrong reason — the first two failures are the real signal). Paste the output.
+
+- [ ] **Step 3: Implement**
+
+In `web/src/lib/utils/searchable-page-search.ts`, add the path to `getSearchablePageBasePath`, immediately after the `/photos` branch:
+
+```ts
+  if (pathname.startsWith('/recently-added')) {
+    return '/recently-added';
+  }
+```
+
+Add the capability predicate above `getSearchablePageState`, and enforce it in **both** places below:
+
+```ts
+/**
+ * Query (free-text) support is a separate capability from URL filter persistence.
+ *
+ * Recently Added persists its filters in the URL but cannot answer a `?q=` yet — its text
+ * section and smart-search path arrive together in the text slice. Until then it must not
+ * advertise itself as searchable, or the global search UI would offer a query that silently
+ * does nothing. Remove this exclusion in the same change that adds the search path.
+ */
+function isQueryCapablePage(basePath: string): boolean {
+  return basePath !== '/recently-added';
+}
+```
+
+Enforcement 1 — `getSearchablePageState` reports the capability:
+
+```ts
+  return {
+    basePath,
+    isSearchable: isQueryCapablePage(basePath),
+    query,
+    hasExplicitSort: rawSort === 'asc' || rawSort === 'desc',
+    sortOrder: getSortOrder(query, rawSort),
+  };
+```
+
+Enforcement 2 — `buildSearchablePageUrl` refuses to *write* a query for such a page. Insert this immediately after the existing `const trimmedQuery = query.trim();` line (which currently sits just below the `basePath` null check):
+
+```ts
+  // A page that persists filters in the URL is not necessarily able to answer a `?q=`.
+  // Returning null here keeps global-search-manager's buildSearchDestination falling back to
+  // /photos, instead of stranding a query on a route that would silently ignore it.
+  if (trimmedQuery && !isQueryCapablePage(basePath)) {
+    return null;
+  }
+```
+
+Filter-only calls (empty query) are unaffected, which is exactly what this slice's `syncFilterUrl` needs.
+
+- [ ] **Step 4: Run to verify GREEN**
+
+```bash
+cd web && pnpm test -- --run src/lib/utils/__tests__/searchable-page-search.spec.ts
+```
+Expected: **PASS** — the new cases and every pre-existing case in the file. The pre-existing ones passing is the proof that Photos and Spaces are unaffected. Paste the output.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+cd web && pnpm exec prettier --check src/lib/utils/searchable-page-search.ts src/lib/utils/__tests__/searchable-page-search.spec.ts
+cd .. && git add web/src/lib/utils/searchable-page-search.ts web/src/lib/utils/__tests__/searchable-page-search.spec.ts
+git commit -m "feat(web): persist Recently Added filters in the URL without enabling query mode (#805)"
+```
+
+---
+
+## Task 2: Timeline-options and suggestion-request builders
+
+**Files:**
+- Modify: `web/src/lib/utils/recently-added-filter-options.ts`
+- Test: `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts`
+
+**Interfaces:**
+- Produces:
+  - `export function buildRecentlyAddedTimelineOptions(filters: FilterState): Record<string, unknown>`
+  - `export function buildRecentlyAddedSuggestionRequest(filters: FilterState)` (inferred object return)
+
+  Task 3 imports the suggestion request; Task 6 imports the timeline options.
+
+**Facts about the code you build on:**
+
+`buildPhotosTimelineOptions` (`web/src/lib/utils/photos-filter-options.ts`) starts from:
+```ts
+const includeSharedTimelineAssets = filters.isFavorite === undefined;
+const base: Record<string, unknown> = {
+  visibility: AssetVisibility.Timeline,
+  withStacked: true,
+  ...(includeSharedTimelineAssets ? { withPartners: true, withSharedSpaces: true } : {}),
+};
+```
+then conditionally sets `personIds`, `city`, `country`, `make`, `model`, trimmed `description`/`originalFileName`/`ocr`, `tagIds`, `rating`, `isFavorite`, `isNotInAlbum` (true only), `isInAlbum` (true only), `$type` (when `mediaType !== 'all'`), always sets `order` (`AssetOrder.Asc` for `sortOrder === 'asc'`, else `AssetOrder.Desc`), and adds `takenAfter`/`takenBefore` from `buildFilterContext(filters)`.
+
+`withPartners` and `withSharedSpaces` are added **together**, gated only on `filters.isFavorite === undefined`. Stripping `withSharedSpaces` therefore leaves `withPartners` for non-favorite filters and drops both under Favorites — exactly the intended behavior.
+
+`createFilterState()` returns `{ personIds: [], tagIds: [], mediaType: 'all', sortOrder: 'desc' }`, and `buildFilterContext` returns `undefined` for it (no date keys).
+
+**ESLint note — use a bare underscore.** `web/eslint.config.js` sets `varsIgnorePattern: '^_$'`, which matches **only** the literal `_`, and typescript-eslint defaults `ignoreRestSiblings` to `false`. A name like `_omitSharedSpaces` would raise a new warning. The repo convention is the bare `_` — see `web/src/lib/utils/space-search.ts:92`: `const { order: _, ...params } = buildSmartSearchParams(args);`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Update the existing import at the top of `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts` to:
+
+```ts
+import {
+  buildRecentlyAddedSuggestionRequest,
+  buildRecentlyAddedTimelineOptions,
+  shouldShowRecentlyAddedCount,
+} from '$lib/utils/recently-added-filter-options';
+```
+
+and add these imports:
+
+```ts
+import { AssetOrder, AssetOrderBy, AssetTypeEnum, AssetVisibility } from '@immich/sdk';
+import { createFilterState } from '$lib/components/filter-panel/filter-panel';
+```
+
+Then append (keep the existing `shouldShowRecentlyAddedCount` describe as-is):
+
+```ts
+describe('buildRecentlyAddedTimelineOptions', () => {
+  it('returns the own+partner added-date shape by default', () => {
+    // Exact shape on purpose: if buildPhotosTimelineOptions ever grows a new shared-scope key,
+    // this fails rather than silently leaking it into Recently Added.
+    expect(buildRecentlyAddedTimelineOptions(createFilterState())).toEqual({
+      visibility: AssetVisibility.Timeline,
+      withStacked: true,
+      withPartners: true,
+      order: AssetOrder.Desc,
+      orderBy: AssetOrderBy.CreatedAt,
+    });
+  });
+
+  it('never sends withSharedSpaces under a metadata filter', () => {
+    const options = buildRecentlyAddedTimelineOptions({ ...createFilterState(), country: 'Germany' });
+    expect(options).not.toHaveProperty('withSharedSpaces');
+    expect(options.country).toBe('Germany');
+  });
+
+  it('never sends withSharedSpaces under a favorites filter', () => {
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), isFavorite: true })).not.toHaveProperty(
+      'withSharedSpaces',
+    );
+  });
+
+  it('keeps orderBy CreatedAt under every filter combination', () => {
+    const cases = [
+      createFilterState(),
+      { ...createFilterState(), country: 'Germany' },
+      { ...createFilterState(), isFavorite: true },
+      { ...createFilterState(), sortOrder: 'asc' as const },
+    ];
+    for (const filters of cases) {
+      expect(buildRecentlyAddedTimelineOptions(filters).orderBy).toBe(AssetOrderBy.CreatedAt);
+    }
+  });
+
+  it('keeps partner assets for a non-favorite filter', () => {
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), rating: 4 }).withPartners).toBe(true);
+  });
+
+  it('drops partner assets under a favorites filter (favorites are personal)', () => {
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), isFavorite: true })).not.toHaveProperty(
+      'withPartners',
+    );
+  });
+
+  it('maps sortOrder to order without touching orderBy', () => {
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), sortOrder: 'asc' }).order).toBe(AssetOrder.Asc);
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), sortOrder: 'desc' }).order).toBe(AssetOrder.Desc);
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), sortOrder: 'relevance' }).order).toBe(
+      AssetOrder.Desc,
+    );
+  });
+
+  it('passes metadata predicates through', () => {
+    const options = buildRecentlyAddedTimelineOptions({
+      ...createFilterState(),
+      personIds: ['person:p1'],
+      city: 'Berlin',
+      country: 'Germany',
+      make: 'Sony',
+      model: 'A7',
+      tagIds: ['tag-1'],
+      rating: 5,
+    });
+
+    expect(options).toMatchObject({
+      personIds: ['person:p1'],
+      city: 'Berlin',
+      country: 'Germany',
+      make: 'Sony',
+      model: 'A7',
+      tagIds: ['tag-1'],
+      rating: 5,
+    });
+  });
+
+  it('maps mediaType to $type and omits it for "all"', () => {
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), mediaType: 'image' }).$type).toBe(
+      AssetTypeEnum.Image,
+    );
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), mediaType: 'video' }).$type).toBe(
+      AssetTypeEnum.Video,
+    );
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), mediaType: 'all' })).not.toHaveProperty('$type');
+  });
+
+  it('trims text predicates and omits them when blank', () => {
+    const set = buildRecentlyAddedTimelineOptions({
+      ...createFilterState(),
+      description: '  sunset  ',
+      originalFileName: '  IMG_1.jpg  ',
+      ocr: '  invoice  ',
+    });
+    expect(set).toMatchObject({ description: 'sunset', originalFileName: 'IMG_1.jpg', ocr: 'invoice' });
+
+    const blank = buildRecentlyAddedTimelineOptions({
+      ...createFilterState(),
+      description: '   ',
+      originalFileName: '   ',
+      ocr: '   ',
+    });
+    expect(blank).not.toHaveProperty('description');
+    expect(blank).not.toHaveProperty('originalFileName');
+    expect(blank).not.toHaveProperty('ocr');
+  });
+
+  it('passes album membership flags only when true', () => {
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), isNotInAlbum: true }).isNotInAlbum).toBe(true);
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), isInAlbum: true }).isInAlbum).toBe(true);
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), isNotInAlbum: false })).not.toHaveProperty(
+      'isNotInAlbum',
+    );
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), isInAlbum: false })).not.toHaveProperty(
+      'isInAlbum',
+    );
+  });
+
+  it('derives takenAfter/takenBefore from the timeline date filter', () => {
+    // Documented semantic: the date filter filters *taken* date while day-groups reflect *added*
+    // date. Intentional — no created-at range predicate exists (that would be backend work).
+    const year = buildRecentlyAddedTimelineOptions({ ...createFilterState(), selectedYear: 2024 });
+    expect(year.takenAfter).toBe('2024-01-01T00:00:00.000Z');
+    expect(year.takenBefore).toBe('2025-01-01T00:00:00.000Z');
+
+    const yearMonth = buildRecentlyAddedTimelineOptions({
+      ...createFilterState(),
+      selectedYear: 2024,
+      selectedMonth: 3,
+    });
+    expect(yearMonth.takenAfter).toBe('2024-03-01T00:00:00.000Z');
+    expect(yearMonth.takenBefore).toBe('2024-04-01T00:00:00.000Z');
+
+    const custom = buildRecentlyAddedTimelineOptions({
+      ...createFilterState(),
+      dateAfter: '2024-01-01',
+      dateBefore: '2024-12-31',
+    });
+    expect(custom.takenAfter).toBe('2024-01-01T00:00:00.000Z');
+    expect(custom.takenBefore).toBe('2025-01-01T00:00:00.000Z');
+
+    const fromOnly = buildRecentlyAddedTimelineOptions({ ...createFilterState(), dateAfter: '2024-01-01' });
+    expect(fromOnly.takenAfter).toBe('2024-01-01T00:00:00.000Z');
+    expect(fromOnly).not.toHaveProperty('takenBefore');
+
+    const toOnly = buildRecentlyAddedTimelineOptions({ ...createFilterState(), dateBefore: '2024-12-31' });
+    expect(toOnly.takenBefore).toBe('2025-01-01T00:00:00.000Z');
+    expect(toOnly).not.toHaveProperty('takenAfter');
+  });
+
+  it('holds both invariants under a multi-filter combination', () => {
+    const options = buildRecentlyAddedTimelineOptions({
+      ...createFilterState(),
+      personIds: ['person:p1'],
+      country: 'Germany',
+      tagIds: ['tag-1'],
+      mediaType: 'video',
+      sortOrder: 'asc',
+    });
+
+    expect(options.orderBy).toBe(AssetOrderBy.CreatedAt);
+    expect(options).not.toHaveProperty('withSharedSpaces');
+  });
+});
+
+describe('buildRecentlyAddedSuggestionRequest', () => {
+  it('never scopes to shared spaces, albums, or spaces', () => {
+    const request = buildRecentlyAddedSuggestionRequest(createFilterState());
+    expect(request).not.toHaveProperty('withSharedSpaces');
+    expect(request).not.toHaveProperty('albumId');
+    expect(request).not.toHaveProperty('spaceId');
+  });
+
+  it('sends undefined for empty person and tag selections', () => {
+    const request = buildRecentlyAddedSuggestionRequest(createFilterState());
+    expect(request.personIds).toBeUndefined();
+    expect(request.tagIds).toBeUndefined();
+  });
+
+  it('sends arrays when people and tags are selected', () => {
+    const request = buildRecentlyAddedSuggestionRequest({
+      ...createFilterState(),
+      personIds: ['person:p1'],
+      tagIds: ['tag-1'],
+    });
+    expect(request.personIds).toEqual(['person:p1']);
+    expect(request.tagIds).toEqual(['tag-1']);
+  });
+
+  it('maps mediaType and omits it for "all"', () => {
+    expect(buildRecentlyAddedSuggestionRequest({ ...createFilterState(), mediaType: 'image' }).mediaType).toBe(
+      AssetTypeEnum.Image,
+    );
+    expect(buildRecentlyAddedSuggestionRequest({ ...createFilterState(), mediaType: 'video' }).mediaType).toBe(
+      AssetTypeEnum.Video,
+    );
+    expect(buildRecentlyAddedSuggestionRequest({ ...createFilterState(), mediaType: 'all' }).mediaType).toBeUndefined();
+  });
+
+  it('passes isFavorite and location/camera predicates through', () => {
+    const request = buildRecentlyAddedSuggestionRequest({
+      ...createFilterState(),
+      isFavorite: true,
+      country: 'Germany',
+      city: 'Berlin',
+      make: 'Sony',
+      model: 'A7',
+      rating: 3,
+    });
+    expect(request).toMatchObject({
+      isFavorite: true,
+      country: 'Germany',
+      city: 'Berlin',
+      make: 'Sony',
+      model: 'A7',
+      rating: 3,
+    });
+  });
+
+  it('passes the date range for year and custom filters', () => {
+    const year = buildRecentlyAddedSuggestionRequest({ ...createFilterState(), selectedYear: 2024 });
+    expect(year.takenAfter).toBe('2024-01-01T00:00:00.000Z');
+    expect(year.takenBefore).toBe('2025-01-01T00:00:00.000Z');
+
+    const custom = buildRecentlyAddedSuggestionRequest({
+      ...createFilterState(),
+      dateAfter: '2024-01-01',
+      dateBefore: '2024-12-31',
+    });
+    expect(custom.takenAfter).toBe('2024-01-01T00:00:00.000Z');
+    expect(custom.takenBefore).toBe('2025-01-01T00:00:00.000Z');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify RED**
+
+```bash
+cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-options.spec.ts
+```
+Expected: **FAIL** — the module does not export the two new builders, so the import fails (`does not provide an export named 'buildRecentlyAddedTimelineOptions'`). Paste the output.
+
+- [ ] **Step 3: Implement both builders**
+
+Add to `web/src/lib/utils/recently-added-filter-options.ts` (leave `shouldShowRecentlyAddedCount` unchanged). Imports:
+
+```ts
+import { AssetOrderBy, AssetTypeEnum } from '@immich/sdk';
+import { buildFilterContext, type FilterState } from '$lib/components/filter-panel/filter-panel';
+import { buildPhotosTimelineOptions } from '$lib/utils/photos-filter-options';
+```
+
+Body:
+
+```ts
+/**
+ * Timeline query for the Recently Added view.
+ *
+ * Reuses Photos' predicate mapping, then applies the two invariants that define this view:
+ *  1. never surface shared-space assets — `withSharedSpaces` is stripped in every case, so the
+ *     view stays own + partner (and own-only under a Favorites filter, which Photos treats as
+ *     a personal flag);
+ *  2. always order and day-group by *added* date.
+ *
+ * Note the date filter still filters *taken* date (there is no created-at range predicate);
+ * day-groups reflect added date. That mismatch is intentional — e.g. old photos just imported.
+ */
+export function buildRecentlyAddedTimelineOptions(filters: FilterState): Record<string, unknown> {
+  const { withSharedSpaces: _, ...base } = buildPhotosTimelineOptions(filters);
+  return { ...base, orderBy: AssetOrderBy.CreatedAt };
+}
+
+/**
+ * Filter-suggestion request for the Recently Added panel. Deliberately carries no
+ * `withSharedSpaces` / `albumId` / `spaceId` — suggestions must describe the same own+partner
+ * set the timeline shows.
+ */
+export function buildRecentlyAddedSuggestionRequest(filters: FilterState) {
+  const context = buildFilterContext(filters);
+  return {
+    personIds: filters.personIds.length > 0 ? filters.personIds : undefined,
+    country: filters.country,
+    city: filters.city,
+    make: filters.make,
+    model: filters.model,
+    tagIds: filters.tagIds.length > 0 ? filters.tagIds : undefined,
+    rating: filters.rating,
+    isFavorite: filters.isFavorite,
+    mediaType:
+      filters.mediaType === 'all'
+        ? undefined
+        : filters.mediaType === 'image'
+          ? AssetTypeEnum.Image
+          : AssetTypeEnum.Video,
+    takenAfter: context?.takenAfter,
+    takenBefore: context?.takenBefore,
+  };
+}
+```
+
+- [ ] **Step 4: Run to verify GREEN**
+
+```bash
+cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-options.spec.ts
+```
+Expected: **PASS**, all three describes. Paste the output.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+cd web && pnpm exec prettier --check src/lib/utils/recently-added-filter-options.ts src/lib/utils/__tests__/recently-added-filter-options.spec.ts
+cd .. && git add web/src/lib/utils/recently-added-filter-options.ts web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts
+git commit -m "feat(web): Recently Added timeline options and suggestion request builders (#805)"
+```
+
+---
+
+## Task 3: The filter-panel config
+
+**Files:**
+- Create: `web/src/lib/utils/recently-added-filter-config.ts`
+- Test: `web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts`
+
+**Interfaces:**
+- Consumes: `buildRecentlyAddedSuggestionRequest` (Task 2); `getPhotosPersonFilterId` / `getPhotosPersonFilterThumbnailUrl` from `$lib/utils/photos-filter-options`; `FilterPanelConfig` from `$lib/components/filter-panel/filter-panel`.
+- Produces: `export function buildRecentlyAddedFilterConfig(): FilterPanelConfig` — used by Task 6, extended in Slice 3.
+
+**Template:** `web/src/lib/utils/album-filter-config.ts` + `__tests__/album-filter-config.spec.ts`. Differences: nine of the ten `FilterSection` values (Recently Added adds `'albums'`; `'text'` waits for Slice 3), and no `albumId` scoping anywhere.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts`:
+
+```ts
+import { AssetTypeEnum, getFilterSuggestions, getSearchSuggestions, Type } from '@immich/sdk';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFilterState } from '$lib/components/filter-panel/filter-panel';
+import { buildRecentlyAddedFilterConfig } from '$lib/utils/recently-added-filter-config';
+
+vi.mock('@immich/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@immich/sdk')>();
+  return {
+    ...actual,
+    getFilterSuggestions: vi.fn().mockResolvedValue({
+      countries: ['Germany'],
+      cameraMakes: ['Sony'],
+      tags: [{ id: 'tag-1', value: 'Vacation' }],
+      people: [{ id: 'person-1', name: 'Alice' }],
+      ratings: [5],
+      mediaTypes: ['IMAGE'],
+      hasUnnamedPeople: false,
+    }),
+    getSearchSuggestions: vi.fn().mockResolvedValue(['Berlin']),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('buildRecentlyAddedFilterConfig', () => {
+  it('exposes the nine metadata sections in plan order', () => {
+    // 'text' is deliberately absent — it arrives in Slice 3 with the search path, so the input
+    // is never rendered without a working submit.
+    expect(buildRecentlyAddedFilterConfig().sections).toEqual([
+      'timeline',
+      'people',
+      'location',
+      'camera',
+      'tags',
+      'rating',
+      'media',
+      'favorites',
+      'albums',
+    ]);
+  });
+
+  it('never scopes suggestions to shared spaces, albums, or spaces', async () => {
+    const config = buildRecentlyAddedFilterConfig();
+
+    await config.suggestionsProvider!(createFilterState());
+    await config.providers!.cities!('Germany');
+    await config.providers!.cameraModels!('Sony');
+
+    const filterRequest = vi.mocked(getFilterSuggestions).mock.calls[0][0];
+    const cityRequest = vi.mocked(getSearchSuggestions).mock.calls[0][0];
+    const cameraRequest = vi.mocked(getSearchSuggestions).mock.calls[1][0];
+
+    for (const request of [filterRequest, cityRequest, cameraRequest]) {
+      expect(request).not.toHaveProperty('withSharedSpaces');
+      expect(request).not.toHaveProperty('albumId');
+      expect(request).not.toHaveProperty('spaceId');
+    }
+  });
+
+  it('maps tags and people suggestions', async () => {
+    vi.mocked(getFilterSuggestions).mockResolvedValueOnce({
+      countries: ['Germany'],
+      cameraMakes: ['Sony'],
+      tags: [{ id: 'tag-1', value: 'Vacation' }],
+      people: [{ id: 'person-1', name: 'Alice' }],
+      ratings: [5],
+      mediaTypes: ['IMAGE'],
+      hasUnnamedPeople: true,
+    } as never);
+
+    const result = await buildRecentlyAddedFilterConfig().suggestionsProvider!(createFilterState());
+
+    expect(result.tags).toEqual([{ id: 'tag-1', name: 'Vacation' }]);
+    expect(result.people).toEqual([
+      expect.objectContaining({
+        id: 'person-1',
+        name: 'Alice',
+        thumbnailUrl: expect.stringContaining('/people/person-1/thumbnail'),
+      }),
+    ]);
+    expect(result.hasUnnamedPeople).toBe(true);
+    expect(result.countries).toEqual(['Germany']);
+    expect(result.cameraMakes).toEqual(['Sony']);
+    expect(result.ratings).toEqual([5]);
+  });
+
+  it('resolves a space-person suggestion to its shared-space thumbnail', async () => {
+    // A shared-space person can still be *suggested* (they may appear on an own asset); only the
+    // asset scope is restricted. The thumbnail must route to the space endpoint, because the
+    // space-person id has no row in the owner-only person table.
+    vi.mocked(getFilterSuggestions).mockResolvedValueOnce({
+      countries: [],
+      cameraMakes: [],
+      tags: [],
+      people: [
+        {
+          id: 'space-person:space-person-1',
+          name: 'Space Person',
+          primaryProfile: { type: Type.SpacePerson, id: 'space-person-1', spaceId: 'space-1' },
+        },
+      ],
+      ratings: [],
+      mediaTypes: [],
+      hasUnnamedPeople: false,
+    } as never);
+
+    const result = await buildRecentlyAddedFilterConfig().suggestionsProvider!(createFilterState());
+
+    expect(result.people).toEqual([
+      expect.objectContaining({
+        id: 'space-person:space-person-1',
+        thumbnailUrl: '/api/shared-spaces/space-1/people/space-person-1/thumbnail',
+      }),
+    ]);
+  });
+
+  it('maps people suggestions by scoped filter id', async () => {
+    vi.mocked(getFilterSuggestions).mockResolvedValueOnce({
+      countries: [],
+      cameraMakes: [],
+      tags: [],
+      people: [
+        {
+          id: 'identity-group-1',
+          filterId: 'person:person-1',
+          name: 'Alice',
+          primaryProfile: { type: Type.UserPerson, id: 'person-1' },
+        },
+      ],
+      ratings: [],
+      mediaTypes: [],
+      hasUnnamedPeople: false,
+    } as never);
+
+    const result = await buildRecentlyAddedFilterConfig().suggestionsProvider!(createFilterState());
+
+    expect(result.people[0]).toEqual(expect.objectContaining({ id: 'person:person-1', name: 'Alice' }));
+  });
+
+  it('forwards the active filters to the suggestion request', async () => {
+    await buildRecentlyAddedFilterConfig().suggestionsProvider!({
+      ...createFilterState(),
+      personIds: ['person:p1'],
+      tagIds: ['tag-1'],
+      mediaType: 'image',
+      isFavorite: true,
+      dateAfter: '2024-01-01',
+      dateBefore: '2024-12-31',
+    });
+
+    expect(getFilterSuggestions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        personIds: ['person:p1'],
+        tagIds: ['tag-1'],
+        mediaType: AssetTypeEnum.Image,
+        isFavorite: true,
+        takenAfter: '2024-01-01T00:00:00.000Z',
+        takenBefore: '2025-01-01T00:00:00.000Z',
+      }),
+    );
+  });
+
+  it('passes the dependent-provider arguments and context through', async () => {
+    const config = buildRecentlyAddedFilterConfig();
+
+    await config.providers!.cities!('Germany', { takenAfter: '2024-01-01T00:00:00.000Z' });
+    await config.providers!.cameraModels!('Sony', { takenBefore: '2024-12-31T00:00:00.000Z' });
+
+    expect(getSearchSuggestions).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ country: 'Germany', takenAfter: '2024-01-01T00:00:00.000Z' }),
+    );
+    expect(getSearchSuggestions).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ make: 'Sony', takenBefore: '2024-12-31T00:00:00.000Z' }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify RED**
+
+```bash
+cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-config.spec.ts
+```
+Expected: **FAIL** — `Failed to resolve import "$lib/utils/recently-added-filter-config"`. Paste the output.
+
+- [ ] **Step 3: Implement**
+
+Create `web/src/lib/utils/recently-added-filter-config.ts`:
+
+```ts
+import { getFilterSuggestions, getSearchSuggestions, SearchSuggestionType } from '@immich/sdk';
+import type { FilterPanelConfig } from '$lib/components/filter-panel/filter-panel';
+import { getPhotosPersonFilterId, getPhotosPersonFilterThumbnailUrl } from '$lib/utils/photos-filter-options';
+import { buildRecentlyAddedSuggestionRequest } from '$lib/utils/recently-added-filter-options';
+
+/**
+ * Nine of the ten filter sections. `'text'` is intentionally absent until Slice 3 adds the
+ * smart-search path alongside it, so the text input is never rendered without a working submit.
+ */
+const sections = [
+  'timeline',
+  'people',
+  'location',
+  'camera',
+  'tags',
+  'rating',
+  'media',
+  'favorites',
+  'albums',
+] as const;
+
+function mapSuggestions(response: Awaited<ReturnType<typeof getFilterSuggestions>>) {
+  return {
+    countries: response.countries,
+    cameraMakes: response.cameraMakes,
+    tags: response.tags.map((tag) => ({ id: tag.id, name: tag.value })),
+    people: response.people.map((person) => ({
+      id: getPhotosPersonFilterId(person),
+      name: person.name,
+      thumbnailUrl: getPhotosPersonFilterThumbnailUrl(person),
+    })),
+    ratings: response.ratings,
+    mediaTypes: response.mediaTypes,
+    hasUnnamedPeople: response.hasUnnamedPeople,
+  };
+}
+
+/**
+ * Filter-panel config for the Recently Added view: own + partner scope only, so nothing here
+ * carries `withSharedSpaces` / `albumId` / `spaceId`.
+ */
+export function buildRecentlyAddedFilterConfig(): FilterPanelConfig {
+  return {
+    sections: [...sections],
+    suggestionsProvider: async (filters) =>
+      mapSuggestions(await getFilterSuggestions(buildRecentlyAddedSuggestionRequest(filters))),
+    providers: {
+      cities: (country, context) => getSearchSuggestions({ $type: SearchSuggestionType.City, country, ...context }),
+      cameraModels: (make, context) =>
+        getSearchSuggestions({ $type: SearchSuggestionType.CameraModel, make, ...context }),
+    },
+  };
+}
+```
+
+This is deliberately near-identical to `buildAlbumAssetPickerFilterConfig` (differing only by the `'albums'` section). The spec sanctions mirroring `album-filter-config.ts` rather than extracting a shared helper; do not refactor the album module in this slice.
+
+- [ ] **Step 4: Run to verify GREEN**
+
+```bash
+cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-config.spec.ts
+```
+Expected: **PASS** — all 7 cases. Paste the output.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+cd web && pnpm exec prettier --check src/lib/utils/recently-added-filter-config.ts src/lib/utils/__tests__/recently-added-filter-config.spec.ts
+cd .. && git add web/src/lib/utils/recently-added-filter-config.ts web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts
+git commit -m "feat(web): Recently Added filter-panel config (#805)"
+```
+
+---
+
+## Task 4: Route-level component spec (red-first for the wiring)
+
+**Files:**
+- Create: `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts`
+
+**Interfaces:**
+- Consumes: the route component. Asserts the wiring Task 6 must produce.
+- Produces: fast, deterministic coverage of the URL-sync and options-derivation behavior that Playwright can only verify slowly.
+
+**Template — read it first and mirror its mocking setup exactly:** `web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts` (989 lines). It hoists `mockPage`, `mockAssetMultiSelectManager`, `mockAuthManager`, `mockRegisterSearchablePageFilters`; mocks `$app/navigation` (`goto`), `$app/state` (`page`), and swaps heavy components for stubs from `@test-data/mocks/` (`bindable-filter-panel.stub.svelte`, `active-filters-bar-actions.stub.svelte`, `noop-component.svelte`) plus the shared mock timeline wrapper. Reuse those same stubs. `web/src/routes/(user)/spaces/…` has a second example.
+
+Copy only the mocks this route actually needs — the Recently Added route has **no** `SmartSearchResults`, no memories carousel, and no `registerSelectionContext`, so omit those mocks.
+
+**How to assert — the two mechanisms `photos-page.spec.ts` uses.** Do not invent a third:
+
+1. **The timeline stub renders its received options as JSON under a testid.** Assert against its text content, e.g. (`photos-page.spec.ts:670`, `:685`, `:688`):
+   ```ts
+   expect(screen.getByTestId('timeline-options')).toHaveTextContent('"grouping":"day"');
+   ```
+2. **Spy on the options builder module** to assert what the route passed it (`photos-page.spec.ts:202-203` does this for `$lib/utils/photos-filter-options`). The Recently Added equivalent spies on `$lib/utils/recently-added-filter-options`:
+   ```ts
+   vi.mock('$lib/utils/recently-added-filter-options', async (importOriginal) => {
+     const actual = await importOriginal<typeof import('$lib/utils/recently-added-filter-options')>();
+     return { ...actual, buildRecentlyAddedTimelineOptions: vi.fn(actual.buildRecentlyAddedTimelineOptions) };
+   });
+   ```
+
+URL assertions go against the mocked `goto` from `$app/navigation`. Follow the structure of `photos-page.spec.ts`'s `'syncs the URL when a location typed filter is cleared from the filter panel'` and `'clears typed filter URL params and q when clearing all active filters'`.
+
+Write these **six** cases (Task 6 Step 2 checks for six passing):
+
+```
+1. derives timeline options from the filters — orderBy CreatedAt, no withSharedSpaces
+2. seeds filter state from the URL on load (deep link, e.g. ?rating=5)
+3. writes filter changes to the URL via goto  ← the case that would have caught the Task 1 no-op
+4. clearing all filters removes the filter params from the URL
+5. registers its filters with globalSearchManager (registerSearchablePageFilters called)
+6. passes the nine sections to the filter panel, and no 'text' section
+```
+
+- [ ] **Step 1: Write the spec**
+
+Create the file following the template above. Set `mockPage.url` to `new URL('https://gallery.test/recently-added')` and `mockPage.route.id` to `'/(user)/recently-added/[[photos=photos]]/[[assetId=id]]'`.
+
+- [ ] **Step 2: Run to verify RED**
+
+```bash
+cd web && pnpm test -- --run "src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts"
+```
+Expected: **FAIL** — the route renders no filter panel, so the stub receives nothing and no `goto` is called. Confirm the failures are assertion failures about missing filter wiring, **not** mock/setup errors (an unresolved stub import or a missing manager mock means your harness is wrong, not the route). Paste the output.
+
+- [ ] **Step 3: Commit the red spec**
+
+```bash
+git add "web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts"
+git commit -m "test(web): route-level spec for Recently Added filters (#805)"
+```
+
+---
+
+## Task 5: BDD acceptance scenarios (red-first)
+
+**Files:**
+- Modify: `e2e/src/specs/web/recently-added-filters.e2e-spec.ts`
+
+**Interfaces:**
+- Consumes: filter-panel testids already exercised by `e2e/src/specs/web/photos-filter-panel.e2e-spec.ts` — `discovery-panel`, `filter-toggle-btn`, `collapse-panel-btn`, `filter-section-<name>` (the template is `data-testid="filter-section-{testId}"` in `filter-section.svelte:25`, fed `testId={section}` from `filter-panel.svelte:754`, so every section emits one), `media-type-image` / `media-type-video`, `rating-star-5`, `active-filters-bar`, `active-chip`, `clear-all-btn`. The header count is `page-header-description`.
+- Produces: the scenarios Task 6 turns green. Slice 3 appends search scenarios to the same file.
+
+**Structure:** keep Slice 1's `test.describe('Recently Added', …)` exactly as-is and add a **sibling** `test.describe('Recently Added filters', …)` with its own `beforeAll`. The `web` Playwright project is `fullyParallel: false` with `workers: 1`, and Playwright runs `beforeAll` lazily per describe, so a second resetting `beforeAll` is safe.
+
+**Video seeding — verified, use this.** `utils.createAsset(accessToken, dto?)` accepts `assetData?: { bytes?: Buffer; filename: string }`, and the server derives asset type from the **filename extension** (`mimeTypes.assetType(file.originalPath)`), so no real video fixture is needed. Existing precedent — `e2e/src/specs/server/api/shared-space-album-timeline.e2e-spec.ts:561`:
+```ts
+const videoAsset = await utils.createAsset(owner.accessToken, { assetData: { filename: 'example.mp4' } });
+```
+
+**URL parameters — verified** against `SEARCHABLE_PAGE_FILTER_PARAMS` (`web/src/lib/utils/searchable-page-search.ts:5-21`): rating is `rating`, camera make is `make`, and media type is **`type`** (e.g. `type=video`) — *not* `mediaType`.
+
+- [ ] **Step 1: Write the scenarios**
+
+Extend the file's imports (Slice 1's version has none of these):
+```ts
+import { updateAsset } from '@immich/sdk';
+import { thumbnailUtils } from 'src/ui/specs/timeline/utils';
+import { asBearerAuth, utils } from 'src/utils';
+```
+(`thumbnailUtils` import path matches `e2e/src/specs/web/timeline-grouping.e2e-spec.ts:3`.)
+
+Append:
+
+```ts
+test.describe('Recently Added filters', () => {
+  let admin: LoginResponseDto;
+  const videos: Awaited<ReturnType<typeof utils.createAsset>>[] = [];
+
+  const TOTAL = 20;
+  const VIDEOS = 5;
+  const RATED = 3;
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+
+    // Seed with *taken* dates deliberately unrelated to upload order, so "ordered by added date"
+    // is a meaningful assertion: taken dates run backwards while added order runs forwards.
+    const images = [];
+    for (let i = 0; i < TOTAL - VIDEOS; i++) {
+      const day = String(TOTAL - VIDEOS - i).padStart(2, '0');
+      images.push(
+        await utils.createAsset(admin.accessToken, {
+          fileCreatedAt: `2023-09-${day}T10:00:00.000Z`,
+          fileModifiedAt: `2023-09-${day}T10:00:00.000Z`,
+        }),
+      );
+    }
+
+    // Videos' taken dates run *opposite* to their upload order, so within the video-filtered set
+    // "newest added first" and "newest taken first" disagree. That disagreement is the whole point
+    // of the ordering scenario below — seeding them ascending would make the test pass equally
+    // against orderBy: TakenAt, i.e. unable to detect the bug it exists to catch.
+    for (let i = 0; i < VIDEOS; i++) {
+      videos.push(
+        await utils.createAsset(admin.accessToken, {
+          fileCreatedAt: `2023-10-0${VIDEOS - i}T10:00:00.000Z`,
+          fileModifiedAt: `2023-10-0${VIDEOS - i}T10:00:00.000Z`,
+          assetData: { filename: `example-${i}.mp4` },
+        }),
+      );
+    }
+
+    for (const asset of images.slice(0, RATED)) {
+      await updateAsset({ id: asset.id, updateAssetDto: { rating: 5 } }, { headers: asBearerAuth(admin.accessToken) });
+    }
+  });
+
+  async function gotoRecentlyAdded(
+    context: import('@playwright/test').BrowserContext,
+    page: import('@playwright/test').Page,
+    search = '',
+  ) {
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('/recently-added');
+    // Panel collapse is persisted in localStorage — start every test from a clean state.
+    await page.evaluate(() => localStorage.clear());
+    await page.goto(`/recently-added${search}`);
+    await page.waitForSelector('[data-testid="discovery-panel"], [data-testid="filter-toggle-btn"]');
+  }
+
+  test('renders the nine metadata filter sections and no text section', async ({ context, page }) => {
+    await gotoRecentlyAdded(context, page);
+
+    await expect(page.getByTestId('discovery-panel')).toBeVisible();
+    for (const section of [
+      'timeline',
+      'people',
+      'location',
+      'camera',
+      'tags',
+      'rating',
+      'media',
+      'favorites',
+      'albums',
+    ]) {
+      await expect(page.getByTestId(`filter-section-${section}`)).toBeVisible();
+    }
+    // Slice 3 adds this; it must not exist yet.
+    await expect(page.getByTestId('filter-section-text')).toHaveCount(0);
+  });
+
+  // Spec scenario: Filtering by media type updates grid, URL, and count
+  test('filtering by media type updates the count and the URL', async ({ context, page }) => {
+    await gotoRecentlyAdded(context, page);
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${TOTAL} items`);
+
+    const bucketResponse = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
+    await page.getByTestId('media-type-video').click();
+    await bucketResponse;
+
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${VIDEOS} items`);
+    await expect(page).toHaveURL(/type=video/);
+  });
+
+  // Spec scenario: Removing a filter chip restores the full view
+  test('removing the media-type chip restores the full view', async ({ context, page }) => {
+    await gotoRecentlyAdded(context, page);
+
+    const filtered = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
+    await page.getByTestId('media-type-video').click();
+    await filtered;
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${VIDEOS} items`);
+
+    // Collapse the panel so the ActiveFiltersBar and its chips are shown.
+    await page.getByTestId('collapse-panel-btn').click();
+    await expect(page.getByTestId('active-filters-bar')).toBeVisible();
+    const chip = page.getByTestId('active-chip').first();
+    await expect(chip).toBeVisible();
+
+    const restored = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
+    // Remove the chip itself (exercises handleRemoveActiveFilter), not "clear all".
+    // dispatchEvent avoids the UserPageLayout absolute header overlaying the control,
+    // the same workaround photos-filter-panel.e2e-spec.ts uses.
+    await chip.getByRole('button').last().dispatchEvent('click');
+    await restored;
+
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${TOTAL} items`);
+    await expect(page).not.toHaveURL(/type=video/);
+  });
+
+  test('clear all removes every active filter', async ({ context, page }) => {
+    await gotoRecentlyAdded(context, page, '?rating=5');
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${RATED} items`);
+
+    await page.getByTestId('collapse-panel-btn').click();
+    await expect(page.getByTestId('active-filters-bar')).toBeVisible();
+
+    const cleared = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
+    await page.getByTestId('clear-all-btn').dispatchEvent('click');
+    await cleared;
+
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${TOTAL} items`);
+  });
+
+  // Spec scenario: A filter matching nothing shows a zero count, not an empty account
+  test('a filter that matches nothing shows "0 items" and keeps the panel open', async ({ context, page }) => {
+    await gotoRecentlyAdded(context, page, '?make=NoSuchCameraMake');
+
+    await expect(page.getByTestId('page-header-description')).toHaveText('0 items');
+    // The panel must stay mounted so the user can change the filter.
+    await expect(page.getByTestId('discovery-panel')).toBeVisible();
+  });
+
+  // Spec scenario: Filters survive a reload (URL is source of truth)
+  test('filters survive a reload', async ({ context, page }) => {
+    await gotoRecentlyAdded(context, page, '?rating=5');
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${RATED} items`);
+
+    await page.reload();
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${RATED} items`);
+    await expect(page).toHaveURL(/rating=5/);
+  });
+
+  // Spec scenario: Recently Added stays ordered by added date under a filter
+  test('stays ordered by added date under a filter', async ({ context, page }) => {
+    // Within the video-filtered set, added order and taken order run opposite (see the seeding),
+    // so this scenario can tell the two ordering bases apart. Applying a filter must not change
+    // the basis: the grid stays ordered by *added* date, newest first.
+    await gotoRecentlyAdded(context, page);
+
+    const filtered = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
+    await page.getByTestId('media-type-video').click();
+    await filtered;
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${VIDEOS} items`);
+
+    // The LAST-UPLOADED video must lead the grid. Its taken date is the *oldest* of the five, so
+    // this assertion fails if the view ever orders by taken date instead of added date.
+    const first = thumbnailUtils.locator(page).first();
+    await expect(first).toBeVisible();
+    await expect(first).toHaveAttribute('data-asset', videos.at(-1)!.id);
+  });
+});
+```
+
+Note the final assertion must be the exact-id form above. A looser `toHaveAttribute('data-asset', /.+/)` is tautological — `thumbnailUtils.locator` selects `[data-thumbnail-focus-container]`, which always carries `data-asset` — and would leave BDD 5 covered in name only.
+
+- [ ] **Step 2: Run to verify RED**
+
+Run the spec with `--retries=0` (see the command reference). Expected: the 3 Slice-1 scenarios still **pass**; the 7 new ones **fail** because the route renders no filter panel — `gotoRecentlyAdded`'s `waitForSelector` times out. That timeout is the expected red signal.
+
+Confirm the failure reason is the missing panel, not a seeding error, import error, or auth failure. Paste the output.
+
+- [ ] **Step 3: Commit the red spec**
+
+```bash
+git add e2e/src/specs/web/recently-added-filters.e2e-spec.ts
+git commit -m "test(e2e): acceptance scenarios for Recently Added browse filters (#805)"
+```
+
+---
+
+## Task 6: Wire the filter panel into the route (turns Tasks 4 and 5 green)
+
+**Files:**
+- Modify: `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte`
+
+**Interfaces:**
+- Consumes: `buildRecentlyAddedTimelineOptions` (Task 2), `buildRecentlyAddedFilterConfig` (Task 3), `shouldShowRecentlyAddedCount` (Slice 1), and the URL registration from Task 1.
+- Produces: the rendered filter UI asserted by Tasks 4 and 5.
+
+**The template is the Photos page** — `web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte`. Copy its structure, then delete every search-related part. Do not modify the Photos page itself.
+
+**Take from Photos (line refs):**
+- filter state seeding (`:105-124`), `filtersBeforePanelChange` + its `$effect` (`:116-140`)
+- `timelineGrouping` / `temporalAnchor` (`:125-126`), `pendingFilterUrlSync` (`:129-131`)
+- `personNames` / `tagNames` `SvelteMap`s + `consumeTypedSearchNamesInto` (`:141-143`)
+- `globalSearchManager.registerSearchablePageFilters` effect (`:144`)
+- `filterCollapsed` (`:349`), `isTimelineEmpty` (`:373`) — copy its explanatory comment too
+- `syncFilterUrl` (`:438-456`), `handleFiltersChange` (`:458-470`), `handleTimelineBucketActivate` (`:472-484`), `handleTimelineGroupingChange` (`:486-490`), `handleRemoveActiveFilter` (`:492-499`), `handleClearAllFilters` (`:501-508`), the URL→filters `$effect` (`:510-543`)
+- the layout shell (`:556-641`): `<div class="flex h-full">` → `<FilterPanel>` → `<div class="flex flex-1 flex-col overflow-hidden pl-4">` → filters-bar snippet → `<FilterToolbar>` → `<Timeline>`
+
+**OMIT (all Slice 3 territory):**
+- `committedQuery`, `showSearchResults`, `isLoading`, `clearSearch`, and the query parts of `lastHandledSearchState`
+- `smartFacets`, `smartFacetKey`, `smartFacetInFlight`, `loadPhotoSmartFacets`, `smartFacetBuckets`, `smartFacetTotal`, and the `buildSmartSearchFacetKey` / `buildSmartSearchFacetsParams` / `mapSmartSearchFacetsToFilterSuggestions` imports
+- `<SmartSearchResults>` and the `{#if showSearchResults}` branch — render `<Timeline>` unconditionally
+- the `{#key}` wrapper around `<FilterPanel>` (it exists only to remount on query/lang change)
+- `handleAddAllToCollection`, `SearchAddAllToCollectionModal`, `filterStateToSearchTerms`, and the `resultCount` / `onAddAllToCollection` props on `<ActiveFiltersBar>`
+- the memories `ImageCarousel`, and `registerSelectionContext` (not in this route today — do not add it)
+
+**Concrete adaptations:**
+- `const options = $derived({ ...buildRecentlyAddedTimelineOptions(filters), grouping: timelineGrouping });` — this **replaces** the static `const options = {...}`. That is the one sanctioned change to it.
+- `const filterConfig = withNameCapture(buildRecentlyAddedFilterConfig(), personNames, tagNames);` — `withNameCapture(config: FilterPanelConfig, personNames: Map<string, string>, tagNames: Map<string, string>): FilterPanelConfig` from `$lib/utils/filter-name-capture` (verified signature; real call site: `spaces/[spaceId]/albums/[albumId=id]/…/+page.svelte:110`). This is what lets chips render person/tag names.
+- `syncFilterUrl` passes a literal empty query — there is no search this slice:
+  `const nextUrl = buildSearchablePageUrl(page.url, '', nextFilters.sortOrder, nextFilters);`
+  Drop Photos' `relevance` fallback branch (query-mode only).
+- `<FilterPanel … storageKey="gallery-filter-visible-sections-recently-added" timeBuckets={timelineBuckets} hidden={isTimelineEmpty} />` — view-specific storage key.
+- `<ActiveFiltersBar embedded {filters} {personNames} {tagNames} onRemoveFilter={handleRemoveActiveFilter} onClearAll={handleClearAllFilters} />` — **no** `resultCount`, **no** `onAddAllToCollection`, **no** `searchQuery` / `onClearSearch`.
+- `<FilterToolbar … showGrouping={!assetMultiSelectManager.selectionActive} showFilters={hasActiveFilters} filters={recentlyAddedFiltersBar} showFilterButton={filterCollapsed && !isTimelineEmpty && !assetMultiSelectManager.selectionActive} filterActive={getActiveFilterCount(filters) > 0} onExpandFilters={() => (filterCollapsed = false)} />` — drops Photos' `!showSearchResults`.
+- `const hasActiveFilters = $derived(getActiveFilterCount(filters) > 0);` — no `|| showSearchResults`.
+- Count now reflects filters: `shouldShowRecentlyAddedCount(assetCount, hasActiveFilters)`. **Replace the Slice-1 literal `false`** and delete the now-stale comment above it that predicted this change.
+- `const timelineBuckets = $derived(getTimelineManagerTimeBuckets(timelineManager));` from `$lib/utils/timeline-zoom-navigation` (takes `TemporalBucketSource | undefined`).
+- Keep `<Timeline>`'s existing props and add, mirroring Photos: `onTimelineBucketActivate`, `{temporalAnchor}`, `onTemporalAnchorResolved`, `grouping={timelineGrouping}`, `onGroupingChange`.
+- **Keep the existing `{#snippet empty()}` / `EmptyPlaceholder` block** — Slice 1's e2e asserts its copy.
+- The `AssetSelectControlBar` block stays **byte-identical**.
+
+- [ ] **Step 1: Implement the route**
+
+Work with the Photos file open beside you; copy its handler code exactly rather than paraphrasing, so behavior matches.
+
+- [ ] **Step 2: Turn the route-level spec GREEN**
+
+```bash
+cd web && pnpm test -- --run "src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts"
+```
+Expected: **PASS** — all six cases from Task 4. This is your fast feedback loop — get it green before touching Playwright. Paste the output.
+
+- [ ] **Step 3: Type-check and lint**
+
+```bash
+cd web && pnpm check:typescript && pnpm lint
+```
+Fix errors before running e2e. (`check:svelte` reports 0 files locally — a known no-op; CI is authoritative. Run it anyway.)
+
+- [ ] **Step 4: Turn the e2e spec GREEN**
+
+Run the spec (rebuild the e2e stack image first if you use `:2285`).
+Expected: **10 passed** — 3 from Slice 1 plus the 7 from Task 5. Paste the output.
+
+If a scenario fails, fix the **route**, not the test — unless the test encodes a genuinely wrong expectation about the shared filter-panel components, in which case explain the discrepancy in your report before changing it.
+
+- [ ] **Step 5: Full slice gate**
+
+```bash
+cd web && pnpm check:typescript && pnpm check:svelte && pnpm lint && pnpm test -- --run
+cd web && pnpm exec prettier --check \
+  "src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte" \
+  "src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts" \
+  src/lib/utils/recently-added-filter-options.ts \
+  src/lib/utils/recently-added-filter-config.ts \
+  src/lib/utils/searchable-page-search.ts \
+  src/lib/utils/__tests__/recently-added-filter-options.spec.ts \
+  src/lib/utils/__tests__/recently-added-filter-config.spec.ts \
+  src/lib/utils/__tests__/searchable-page-search.spec.ts
+cd ../e2e && pnpm exec prettier --check src/specs/web/recently-added-filters.e2e-spec.ts
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte"
+git commit -m "feat(web): browse filters for Recently Added (#805)"
+```
+
+---
+
+## Slice 2 Done Gate
+
+- [ ] `cd web && pnpm check:typescript` — clean
+- [ ] `cd web && pnpm check:svelte` — clean
+- [ ] `cd web && pnpm lint` — no **errors**, and no **new** warnings
+- [ ] `cd web && pnpm test -- --run` — all pass, including the new searchable-page, options, config, and route-level cases
+- [ ] E2E `recently-added-filters.e2e-spec.ts` — **10 passed**
+- [ ] Prettier `--check` clean on all touched files
+- [ ] Red→green evidence recorded for Tasks 1, 2, 3 (unit), 4→6 (route spec), 5→6 (e2e)
+- [ ] Photos page, `filter-panel/`, `Timeline`, `UserPageLayout` unmodified — `git diff --stat main...HEAD`
+- [ ] Photos/Spaces search behaviour unchanged — the pre-existing `searchable-page-search.spec.ts` cases still pass untouched
+- [ ] `AssetSelectControlBar` block and the `{#snippet empty()}` block byte-identical — `git diff` on the route
+- [ ] **No search leakage:** `grep -rn "committedQuery\|SmartSearchResults\|searchSmartFacets\|smartFacet" "web/src/routes/(user)/recently-added/" web/src/lib/utils/recently-added-filter-*.ts` returns nothing
+- [ ] **`isSearchable` still false for this route:** the Task 1 unit case asserts it; confirm no code sets it otherwise
+- [ ] **No shared-space leakage:** `grep -rn "withSharedSpaces" web/src/lib/utils/recently-added-filter-*.ts` returns only the destructured-and-discarded `_` in the options builder
+- [ ] Six commits made as specified
+
+## Coverage check against the spec
+
+| Spec item (§Slice 2) | Covered by |
+|---|---|
+| URL persistence works at all (spec §3.1.1 prerequisite) | Task 1 units; Task 4 route-spec URL-sync case; Task 5 e2e reload/deep-link |
+| Filter matches zero assets → panel stays open, "0 items" | Task 5 e2e "matches nothing"; Slice 1 unit `shouldShowRecentlyAddedCount(0, true)` |
+| `withSharedSpaces` leakage in any path | Task 2 options `toEqual` + `not.toHaveProperty` ×2 + suggestion-request unit; Task 3 config unit (all 3 request types); Done-Gate grep |
+| Future stray key from `buildPhotosTimelineOptions` | Task 2 default-case `toEqual` (exact shape) |
+| Favorites filter → own-only | Task 2 "drops partner assets under a favorites filter" |
+| Any filter combination keeps `orderBy: CreatedAt` | Task 2 "keeps orderBy CreatedAt under every filter combination" + multi-filter case; Task 5 e2e "stays ordered by added date" |
+| Sort asc/desc flips `order`, not `orderBy` | Task 2 "maps sortOrder to order without touching orderBy" |
+| All predicate passthroughs + date ranges (year, year+month, custom, from-only, to-only) | Task 2 predicate / mediaType / text-trim / album-flag / date cases |
+| Suggestion request omits shared/album/space scope | Task 2 "never scopes to shared spaces, albums, or spaces" |
+| Config = 9 sections, correct suggestion/provider calls | Task 3, all 7 cases |
+| BDD 1: media type updates grid, URL, count | Task 5 "filtering by media type…" |
+| BDD 2: removing a chip restores the full view | Task 5 "removing the media-type chip…" (chip control, not clear-all) + "clear all removes every active filter" |
+| BDD 3: filter matching nothing → 0 items | Task 5 "matches nothing" |
+| BDD 4: filters survive a reload | Task 5 "filters survive a reload" |
+| BDD 5: stays ordered by added date under a filter | Task 5 "stays ordered by added date under a filter" |
+| Count flicker on apply | Accepted + documented (spec §5.5); e2e asserts the settled count via auto-retrying assertions |
+| Grouping day↔month | Copied `handleTimelineGroupingChange` / `FilterToolbar` wiring; manual smoke |
+| Suggestion fetch failure | `FilterPanel`'s own AbortController path — no new handling, matching `album-filter-config.ts` |

--- a/docs/superpowers/plans/2026-07-19-recently-added-filters-slice-3.md
+++ b/docs/superpowers/plans/2026-07-19-recently-added-filters-slice-3.md
@@ -512,7 +512,23 @@ Scenario: Text search stays within own + partner scope
 
 **Seeding notes.** Smart search is ML-backed and its ranking is not deterministic in e2e — do **not** assert on which assets match semantically. Assert on the **mode switch, the count source, and the scope**.
 
-**Scenario 3 needs a positive control, or it is unfalsifiable.** Asserting only that a shared-space asset is *absent* passes for a dozen unrelated reasons: never indexed, matched nothing semantically, the member never opted the space into their timeline, or the seeding silently failed. The test must prove the asset *would* have been found:
+**Scenario 3 must assert the REQUEST, not the results — the e2e stack has no ML.** (Discovered during implementation: `e2e/docker-compose.yml` has no `machine-learning` service and `IMMICH_MACHINE_LEARNING_ENABLED=false`, so `searchSmart` errors and `smart-search-results.svelte` falls back to an empty list for *every* query. `photos-search.e2e-spec.ts:88-91` documents the same limitation.) A result-based scope test is therefore untestable here: nothing is ever found, so absence proves nothing and no positive control can succeed.
+
+Assert what the client **sends** instead. `smart-search-results.svelte:46-52` posts `buildSmartSearchParams({ …, withSharedSpaces, … })` to `POST /api/search/smart`, and `buildSmartSearchParams` sets `withSharedSpaces: true` only when truthy. So intercept the request with Playwright and assert:
+
+- on `/recently-added?q=…` the payload **has no `withSharedSpaces`** (own + partner);
+- **positive control:** on `/photos?q=…` the payload **does** carry `withSharedSpaces: true`.
+
+This is deterministic, ML-independent, and tests the invariant directly. Capture with `page.waitForRequest` / `route.request().postDataJSON()`.
+
+It is also genuinely red before Task 5: the unwired route never enters query mode, so no `/api/search/smart` request is issued at all from `/recently-added` and the wait times out.
+
+The shared-space seeding below is no longer needed for scenario 3 — drop it. (Keep it only if you also want a result-level assertion, which cannot pass in this environment.)
+
+<details>
+<summary>Superseded: the result-based approach and its seeding requirements (kept for context)</summary>
+
+Asserting only that a shared-space asset is *absent* passes for a dozen unrelated reasons: never indexed, matched nothing semantically, the member never opted the space into their timeline, or the seeding silently failed. It would have needed:
 
 1. A **second user** owns the asset and adds it to a space the test actor is a member of (this direction, not the reverse).
 2. Set the **member-level** timeline opt-in explicitly (`updateMemberTimeline`, imported straight from `@immich/sdk` and called with the **member's own** token — see `space-map-markers.e2e-spec.ts:62-63`), so it is a controlled variable rather than an accidental confound. Note this is *not* the album-level `showInTimeline` toggle; the two are not interchangeable (`spaces-albums-timeline.e2e-spec.ts:19-23`).
@@ -522,6 +538,8 @@ Scenario: Text search stays within own + partner scope
 Helpers (all in `e2e/src/utils.ts`): `utils.userSetup`, `utils.createSpace(accessToken, dto)` (`:367`), `utils.addSpaceMember(accessToken, spaceId, { userId, role })` (`:370`), `utils.addSpaceAssets(accessToken, spaceId, assetIds)` (`:373`). Closest precedent: `e2e/src/specs/web/space-map-markers.e2e-spec.ts:26-55` — note it calls the SDK directly for the per-member timeline opt-in, because that endpoint needs the **member's own** token, not admin's.
 
 This third `describe` must call `utils.resetDatabase()` in its own `beforeAll` and build its own fixture — it cannot inherit from either existing block, both of which reset the database themselves.
+
+</details>
 
 **Do not try to make the semantic match deterministic — you do not need to, and the obvious workaround does not exist.** The mode switch is guaranteed by the URL carrying `?q=`, whatever it matches; the assertion is that one specific shared-space asset id is absent from the rendered results; and the `/photos` positive control is precisely what proves the query *can* find it. If the query matches nothing even on `/photos`, the positive control fails loudly — which is the correct outcome, turning semantic non-determinism into a visible failure rather than a silent pass.
 

--- a/docs/superpowers/plans/2026-07-19-recently-added-filters-slice-3.md
+++ b/docs/superpowers/plans/2026-07-19-recently-added-filters-slice-3.md
@@ -1,0 +1,604 @@
+# Recently Added — Slice 3: Text / smart-search section — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the tenth (`text`) filter section and the browse↔query mode switch to Recently Added, completing all-10 parity with Photos — with `withSharedSpaces` forced `false` on every search path.
+
+**Architecture:** The filter config gains a query-mode branch, selected by a search-context accessor the route supplies (keeping the config a pure, unit-testable module). The Slice-2 query-capability exclusion is removed, so `/recently-added` becomes genuinely searchable — and because that exclusion is enforced in two places, removing it in one predicate turns both on together. The route mirrors Photos' smart-facet plumbing (AbortController + key cache) with `withSharedSpaces` pinned false.
+
+**Tech Stack:** SvelteKit + Svelte 5 runes, TypeScript (strict), Vitest + @testing-library/svelte, Playwright.
+
+## Global Constraints
+
+- **Scope:** Web only. No server / API / mobile / DTO changes.
+- **Do not modify** the Photos page or the shared `filter-panel/` / `Timeline` / `UserPageLayout` / `SmartSearchResults` components.
+- **`withSharedSpaces: false` on every search path** — Recently Added stays own + partner in query mode exactly as in browse mode. This is the slice's headline invariant.
+- **`orderBy: AssetOrderBy.CreatedAt`** still governs browse mode; nothing here may change it.
+- No i18n additions — reuse the search keys Photos already uses.
+- The `AssetSelectControlBar` block and the `{#snippet empty()}` block stay unchanged.
+- Code style: Prettier (120 char, single quotes, trailing commas, semicolons); no relative imports — use `$lib/`.
+- ESLint: no new errors AND no new warnings.
+
+## Baseline: what Slices 1–2 delivered
+
+Committed: the header count; `shouldShowRecentlyAddedCount`; `buildRecentlyAddedTimelineOptions` / `buildRecentlyAddedSuggestionRequest`; `buildRecentlyAddedFilterConfig` (9 sections); `/recently-added` registered in `getSearchablePageBasePath` with query support deliberately withheld by `isQueryCapablePage`; the wired browse filter panel; a route-level spec (6 cases) and 10 passing Playwright scenarios.
+
+## The `'relevance'` sort question — resolved here
+
+Slice 2's review flagged this and deferred it to this slice. `getSortOrder(query, rawSort)` returns `'relevance'` whenever a non-empty `q` is present without an explicit `sort`. Until now that was unreachable on this route.
+
+**Resolution — no special handling needed, and this is deliberate:**
+- **In query mode**, results come from `<SmartSearchResults>`, which does its own relevance ordering. `'relevance'` is meaningful there, exactly as on Photos.
+- **In browse mode**, `buildRecentlyAddedTimelineOptions` already maps `'relevance'` → `AssetOrder.Desc` (asserted by a Slice-2 unit test: *"maps sortOrder to order without touching orderBy"*), and `orderBy` stays `CreatedAt`. So a stale `relevance` degrades to "newest added first" — the view's natural default.
+
+Task 1 adds a regression test pinning this, so the behaviour is asserted rather than incidental.
+
+---
+
+## Reference: commands
+
+```bash
+cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-config.spec.ts
+cd web && pnpm test -- --run "src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts"
+```
+(`"test": "vitest"` is watch-mode; `--run` is mandatory. The path argument may not isolate to one file — expected.)
+
+E2E — **never use `PLAYWRIGHT_BASE_URL=http://127.0.0.1:2283`** (serves 0-byte page bodies; produces meaningless failures). Use the dedicated e2e stack on `:2285`, which **bakes the web app into its image** — rebuild after any web source change:
+```bash
+cd e2e && docker compose up --build -d
+cd e2e && pnpm exec playwright test --project=web --retries=0 src/specs/web/recently-added-filters.e2e-spec.ts
+```
+Use `--retries=0` on deliberate red runs (the `web` project sets `retries: 4`).
+
+Prettier is a separate CI gate. A `**/*.svelte` glob does not match inside the `[[…]]` route directory — use the concrete escaped path.
+
+**CI is the only gate that type-checks `.svelte` templates** (`tsc --noEmit` skips them; local `check:svelte` reports 0 FILES). Watch the CI Lint/Test Web run.
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `web/src/lib/utils/recently-added-filter-config.ts` | **Modify** (Task 1) | Append `'text'`; add the query-mode branch to `suggestionsProvider` and the two dependent providers. |
+| `web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts` | **Modify** (Task 1) | Bump to 10 sections; add search-branch cases. |
+| `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts` | **Modify** (Task 1) | Add the `'relevance'`-in-browse-mode regression case. |
+| `web/src/lib/utils/searchable-page-search.ts` | **Modify** (Task 2) | Remove the `/recently-added` exclusion — the route becomes query-capable. |
+| `web/src/lib/utils/__tests__/searchable-page-search.spec.ts` | **Modify** (Task 2) | Flip the Slice-2 assertions to the query-capable end state. |
+| `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts` | **Modify** (Tasks 1 & 3) | Task 1 updates the sections case to ten (or the repo lands red); Task 3 adds the query-mode cases. |
+| `e2e/src/specs/web/recently-added-filters.e2e-spec.ts` | **Modify** (Task 4) | Search acceptance scenarios (red). |
+| `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte` | **Modify** (Task 5) | Query state, smart facets, mode switch (green). |
+
+## Task order
+
+1. Config + `'relevance'` regression (unit TDD).
+2. Flip query capability (unit TDD).
+3. Route-level spec for query mode (red).
+4. E2E search scenarios (red).
+5. Route wiring (turns 3 and 4 green).
+
+Tasks 3 and 4 are only genuinely red before Task 5. Do not reorder.
+
+---
+
+## Task 1: Config gains the `text` section and a query-mode branch
+
+**Files:**
+- Modify: `web/src/lib/utils/recently-added-filter-config.ts`
+- Test: `web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts`, `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts`
+
+**Interfaces:**
+- Produces: `buildRecentlyAddedFilterConfig(getSearchContext?: () => RecentlyAddedSearchContext | undefined): FilterPanelConfig`, and `export type RecentlyAddedSearchContext = { query: string; language: string; filters: FilterState };`
+
+**Design — why an accessor rather than a plain argument.** The panel's providers are called *later*, during user interaction, and must see the query **and the live filters** as they are at call time. Values captured when the config is built would go stale the moment the user edits either. Photos solves this by defining its config inline in the route, closing over reactive state; keeping ours in a module means the route passes a thunk instead. The parameter is optional and defaults to `() => undefined`, so a caller that never searches keeps exactly the Slice-2 browse behaviour (verified: the route's current bare call site stays correct).
+
+**The context must carry `filters`, not just the query.** Photos builds its dependent-provider facet payloads from the *live* `FilterState` (`photos/+page.svelte:318`, `:336`):
+```ts
+filters: { ...filters, country },
+```
+Do **not** reconstruct a `FilterState` from the panel-supplied `FilterContext`. They are different types: `FilterContext` has no `city` / `make` / `model` / `mediaType` / `description` / `originalFileName` / `ocr` / `sortOrder`, and it carries dates as `takenAfter`/`takenBefore` whereas `buildSmartSearchParams` derives dates by calling `buildFilterContext(filters)` on `dateAfter` / `dateBefore` / `selectedYear`. A `{ ...createFilterState(), ...filterContext }` spread **type-checks but silently drops most of the filter scope**, including all dates — so the city/camera dropdowns would be scoped differently from Photos with nothing to catch it.
+
+**`withSharedSpaces: false` produces NO key.** `buildSmartSearchParams` only sets it when truthy (`space-search.ts:38-40`: `if (withSharedSpaces) { params.withSharedSpaces = true; }`). So assert its **absence** — `expect(dto).not.toHaveProperty('withSharedSpaces')`. An `expect.objectContaining({ withSharedSpaces: false })` can never pass, and chasing it would mean breaking the shared `space-search.ts`. Photos' own spec uses the absence form (`photos-page.spec.ts:528`).
+
+**Facts you need:**
+- `buildSmartSearchFacetsParams(args: SmartSearchParamsArgs): SmartSearchFacetsDto` and `mapSmartSearchFacetsToFilterSuggestions(facets, options?)` live in `$lib/utils/space-search`. `mapSmartSearchFacetsToFilterSuggestions` with **no** `spaceId` option resolves people via `getPhotosPersonFilterId` / `getPhotosPersonFilterThumbnailUrl` — which is what we want (no space scoping).
+- `searchSmartFacets({ smartSearchFacetsDto }, opts?)` is the SDK call.
+- `SmartSearchParamsArgs` takes `{ query, filters, withSharedSpaces, language }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `recently-added-filter-config.spec.ts`, **change** the sections case to expect ten:
+
+```ts
+  it('exposes all ten filter sections in plan order', () => {
+    expect(buildRecentlyAddedFilterConfig().sections).toEqual([
+      'timeline',
+      'people',
+      'location',
+      'camera',
+      'tags',
+      'rating',
+      'media',
+      'favorites',
+      'albums',
+      'text',
+    ]);
+  });
+```
+
+Add `searchSmartFacets` to the `@immich/sdk` mock:
+
+```ts
+    searchSmartFacets: vi.fn().mockResolvedValue({
+      countries: ['Germany'],
+      cities: ['Berlin'],
+      cameraMakes: ['Sony'],
+      cameraModels: ['A7'],
+      tags: [{ id: 'tag-1', value: 'Vacation' }],
+      people: [{ id: 'person-1', name: 'Alice' }],
+      ratings: [5],
+      mediaTypes: ['IMAGE'],
+      hasUnnamedPeople: false,
+      total: 7,
+      timeBuckets: [],
+    }),
+```
+
+Append the search-branch describe (keep every existing browse case — they are the regression guard that the browse path is untouched):
+
+```ts
+describe('buildRecentlyAddedFilterConfig in query mode', () => {
+  const searchContext = () => ({ query: 'beach', language: 'en', filters: createFilterState() });
+
+  it('routes suggestions through smart facets, never shared spaces', async () => {
+    const config = buildRecentlyAddedFilterConfig(searchContext);
+
+    await config.suggestionsProvider!(createFilterState());
+
+    expect(getFilterSuggestions).not.toHaveBeenCalled();
+    expect(searchSmartFacets).toHaveBeenCalledWith(
+      expect.objectContaining({ smartSearchFacetsDto: expect.objectContaining({ query: 'beach' }) }),
+    );
+    // Absence, not `false` — buildSmartSearchParams only sets the key when truthy.
+    expect(vi.mocked(searchSmartFacets).mock.calls[0][0].smartSearchFacetsDto).not.toHaveProperty('withSharedSpaces');
+  });
+
+  it('maps smart facets to filter suggestions', async () => {
+    const result = await buildRecentlyAddedFilterConfig(searchContext).suggestionsProvider!(createFilterState());
+
+    expect(result.tags).toEqual([{ id: 'tag-1', name: 'Vacation' }]);
+    expect(result.people[0]).toEqual(expect.objectContaining({ id: 'person-1', name: 'Alice' }));
+    expect(result.countries).toEqual(['Germany']);
+  });
+
+  it('routes the dependent providers through smart facets without shared spaces', async () => {
+    const config = buildRecentlyAddedFilterConfig(searchContext);
+
+    const cities = await config.providers!.cities!('Germany');
+    const cameraModels = await config.providers!.cameraModels!('Sony');
+
+    expect(getSearchSuggestions).not.toHaveBeenCalled();
+    expect(cities).toEqual(['Berlin']);
+    expect(cameraModels).toEqual(['A7']);
+    for (const call of vi.mocked(searchSmartFacets).mock.calls) {
+      expect(call[0].smartSearchFacetsDto).not.toHaveProperty('withSharedSpaces');
+    }
+  });
+
+  it('scopes the dependent providers by the live filters, not just the dependent value', async () => {
+    // Regression pin: reconstructing a FilterState from the panel's FilterContext type-checks but
+    // silently drops city/make/model/mediaType/text filters AND all dates (buildSmartSearchParams
+    // derives dates from dateAfter/dateBefore/selectedYear, not takenAfter/takenBefore).
+    const config = buildRecentlyAddedFilterConfig(() => ({
+      query: 'beach',
+      language: 'en',
+      filters: { ...createFilterState(), make: 'Sony', rating: 4, selectedYear: 2024 },
+    }));
+
+    await config.providers!.cities!('Germany');
+
+    expect(vi.mocked(searchSmartFacets).mock.calls[0][0].smartSearchFacetsDto).toEqual(
+      expect.objectContaining({
+        country: 'Germany',
+        make: 'Sony',
+        rating: 4,
+        takenAfter: '2024-01-01T00:00:00.000Z',
+      }),
+    );
+  });
+
+  it('reads the query and filters at call time, not at build time', async () => {
+    // The panel calls providers during interaction; values captured at build time would go stale
+    // the moment the user edits the query or another filter.
+    let context = { query: 'beach', language: 'en', filters: createFilterState() };
+    const config = buildRecentlyAddedFilterConfig(() => context);
+
+    await config.suggestionsProvider!(createFilterState());
+    context = { query: 'sunset', language: 'en', filters: { ...createFilterState(), rating: 5 } };
+    await config.suggestionsProvider!(createFilterState());
+
+    expect(vi.mocked(searchSmartFacets).mock.calls[1][0].smartSearchFacetsDto).toEqual(
+      expect.objectContaining({ query: 'sunset' }),
+    );
+  });
+
+  it('falls back to the browse path when the query is blank', async () => {
+    const config = buildRecentlyAddedFilterConfig(() => ({
+      query: '   ',
+      language: 'en',
+      filters: createFilterState(),
+    }));
+
+    await config.suggestionsProvider!(createFilterState());
+
+    expect(searchSmartFacets).not.toHaveBeenCalled();
+    expect(getFilterSuggestions).toHaveBeenCalled();
+  });
+});
+```
+
+Import `searchSmartFacets` from `@immich/sdk` at the top of the spec.
+
+**You must also update the route-level spec in this task**, or this commit lands the repo red. `recently-added-page.spec.ts:256-266` currently pins the Slice-2 state:
+
+```ts
+  it("passes the nine sections to the filter panel, and no 'text' section", async () => {
+    …
+    expect(panel).toHaveAttribute('data-sections', 'timeline,people,location,camera,tags,rating,media,favorites,albums');
+    expect(panel.dataset.sections).not.toContain('text');
+  });
+```
+
+Rewrite it to the ten-section end state:
+
+```ts
+  it('passes all ten sections to the filter panel', async () => {
+    …
+    expect(panel).toHaveAttribute(
+      'data-sections',
+      'timeline,people,location,camera,tags,rating,media,favorites,albums,text',
+    );
+  });
+```
+
+and include `recently-added-page.spec.ts` in this task's commit. (Task 3 then genuinely starts from 6 passing / 4 failing.)
+
+In `recently-added-filter-options.spec.ts`, append to the `buildRecentlyAddedTimelineOptions` describe:
+
+```ts
+  it('degrades a relevance sort to newest-added-first in browse mode', () => {
+    // A `?q=` in the URL resolves sortOrder to 'relevance'. Browse mode has no relevance ranking,
+    // so it must fall back to the view's natural default rather than producing an invalid order.
+    const options = buildRecentlyAddedTimelineOptions({ ...createFilterState(), sortOrder: 'relevance' });
+
+    expect(options.order).toBe(AssetOrder.Desc);
+    expect(options.orderBy).toBe(AssetOrderBy.CreatedAt);
+  });
+```
+
+- [ ] **Step 2: Run to verify RED**
+
+Run both spec files. Expected: the sections case fails (9 vs 10), and the query-mode cases fail because `buildRecentlyAddedFilterConfig` takes no argument and never calls `searchSmartFacets`. The `'relevance'` case may already pass — Slice 2's implementation covers it; that is fine and expected, it is a pin, not a new behaviour. Paste the output and say which cases were red.
+
+- [ ] **Step 3: Implement**
+
+In `recently-added-filter-config.ts`:
+
+```ts
+import {
+  getFilterSuggestions,
+  getSearchSuggestions,
+  searchSmartFacets,
+  SearchSuggestionType,
+  type SmartSearchFacetsResponseDto,
+} from '@immich/sdk';
+import type { FilterPanelConfig, FilterState } from '$lib/components/filter-panel/filter-panel';
+import { getPhotosPersonFilterId, getPhotosPersonFilterThumbnailUrl } from '$lib/utils/photos-filter-options';
+import { buildRecentlyAddedSuggestionRequest } from '$lib/utils/recently-added-filter-options';
+import { buildSmartSearchFacetsParams, mapSmartSearchFacetsToFilterSuggestions } from '$lib/utils/space-search';
+```
+
+Append `'text'` to `sections` (last, tenth).
+
+Add the search context type and the facet fetcher:
+
+```ts
+/**
+ * The route's live search state, read at provider call time so it never goes stale.
+ * `filters` must be the route's live FilterState — the dependent providers scope their facet
+ * query by it, exactly as the Photos page does.
+ */
+export type RecentlyAddedSearchContext = { query: string; language: string; filters: FilterState };
+
+function fetchFacets(context: RecentlyAddedSearchContext, filters: FilterState): Promise<SmartSearchFacetsResponseDto> {
+  return searchSmartFacets({
+    smartSearchFacetsDto: buildSmartSearchFacetsParams({
+      query: context.query.trim(),
+      filters,
+      // Recently Added is own + partner in query mode exactly as in browse mode.
+      withSharedSpaces: false,
+      language: context.language,
+    }),
+  });
+}
+```
+
+Change the exported builder to take the accessor and branch on it. Resolve the context **inside** each provider:
+
+```ts
+export function buildRecentlyAddedFilterConfig(
+  getSearchContext: () => RecentlyAddedSearchContext | undefined = () => undefined,
+): FilterPanelConfig {
+  // Resolved per call, not per build: the panel invokes these during interaction.
+  const activeSearch = (): RecentlyAddedSearchContext | undefined => {
+    const context = getSearchContext();
+    return context && context.query.trim() ? context : undefined;
+  };
+
+  return {
+    sections: [...sections],
+    suggestionsProvider: async (filters) => {
+      const context = activeSearch();
+      if (!context) {
+        return mapSuggestions(await getFilterSuggestions(buildRecentlyAddedSuggestionRequest(filters)));
+      }
+      return mapSmartSearchFacetsToFilterSuggestions(await fetchFacets(context, filters));
+    },
+    providers: {
+      cities: async (country, filterContext) => {
+        const context = activeSearch();
+        if (!context) {
+          return getSearchSuggestions({ $type: SearchSuggestionType.City, country, ...filterContext });
+        }
+        // Scope by the LIVE filters (mirroring Photos' `filters: { ...filters, country }`), not by
+        // the panel's FilterContext — see the design note above.
+        return (await fetchFacets(context, { ...context.filters, country })).cities;
+      },
+      cameraModels: async (make, filterContext) => {
+        const context = activeSearch();
+        if (!context) {
+          return getSearchSuggestions({ $type: SearchSuggestionType.CameraModel, make, ...filterContext });
+        }
+        return (await fetchFacets(context, { ...context.filters, make })).cameraModels;
+      },
+    },
+  };
+}
+```
+
+Also update the module's stale doc block (`recently-added-filter-config.ts:6-9`), which currently says "Nine of the ten filter sections… `'text'` is intentionally absent until Slice 3 adds the smart-search path alongside it, so the text input is never rendered without a working submit." That rationale is factually wrong: `filter-panel.svelte` renders `'text'` as `<TextFilter>` editing the **description / originalFileName / ocr metadata filters**, which already round-trip through the URL and through `buildRecentlyAddedTimelineOptions`. Replace it with an accurate description of the ten sections.
+
+- [ ] **Step 4: Run to verify GREEN**
+
+Run both spec files. Expected: all cases pass, **including every pre-existing browse case** — that is the proof the browse path is unchanged. Paste the output.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+cd web && pnpm exec prettier --check src/lib/utils/recently-added-filter-config.ts src/lib/utils/__tests__/recently-added-filter-config.spec.ts src/lib/utils/__tests__/recently-added-filter-options.spec.ts "src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts"
+cd .. && git add web/src/lib/utils/recently-added-filter-config.ts web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts "web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts"
+git commit -m "feat(web): text section and smart-facet suggestions for Recently Added (#805)"
+```
+
+Before committing, run the **full** unit suite (`cd web && pnpm test -- --run`) and confirm it is green — this task touches a spec the route already satisfies, so a red repo here means the section update above was missed.
+
+---
+
+## Task 2: Make `/recently-added` query-capable
+
+**Files:**
+- Modify: `web/src/lib/utils/searchable-page-search.ts`
+- Test: `web/src/lib/utils/__tests__/searchable-page-search.spec.ts`
+
+**Why now.** Slice 2 registered the base path but withheld query support via `isQueryCapablePage`, precisely so the text input never existed without a working submit. Task 1 has now added the search path, so the exclusion comes out. Because Slice 2 enforced the predicate in **two** places (`getSearchablePageState`'s `isSearchable`, and `buildSearchablePageUrl`'s refusal to write a `q=`), removing the single exclusion turns both on together — that was the design intent.
+
+- [ ] **Step 1: Update the tests (they invert)**
+
+In `searchable-page-search.spec.ts`, replace the two Slice-2 cases that pinned the withheld state:
+
+```ts
+  it('is query-capable now that the text section and search path exist', () => {
+    const state = getSearchablePageState(new URL('https://gallery.test/recently-added'));
+
+    expect(state.basePath).toBe('/recently-added');
+    expect(state.isSearchable).toBe(true);
+  });
+
+  it('builds a query URL for the recently added page', () => {
+    expect(buildSearchablePageUrl(new URL('https://gallery.test/recently-added'), 'beach')).toContain('q=beach');
+  });
+```
+
+(These replace `'is not query-capable until the text slice lands'` and `'refuses to build a query URL for a page that cannot answer one'`. Leave every other case — including the filter-only URL case and the Photos/Spaces regression cases — untouched.)
+
+- [ ] **Step 2: Run to verify RED**
+
+```bash
+cd web && pnpm test -- --run src/lib/utils/__tests__/searchable-page-search.spec.ts
+```
+Expected: the two updated cases fail (`isSearchable` is false; the query URL is null). Paste the output.
+
+- [ ] **Step 3: Implement**
+
+Delete the `isQueryCapablePage` function and its two call sites, restoring the original shapes:
+- `getSearchablePageState` → `isSearchable: true`
+- `buildSearchablePageUrl` → remove the `if (trimmedQuery && !isQueryCapablePage(basePath)) { return null; }` guard.
+
+Delete the whole predicate rather than leaving it always-true — its doc comment explicitly says to remove it in the change that adds the search path.
+
+- [ ] **Step 4: Run to verify GREEN**
+
+Same command. Expected: all cases pass, including the untouched Photos/Spaces regression cases. Paste the output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd web && pnpm exec prettier --check src/lib/utils/searchable-page-search.ts src/lib/utils/__tests__/searchable-page-search.spec.ts
+cd .. && git add web/src/lib/utils/searchable-page-search.ts web/src/lib/utils/__tests__/searchable-page-search.spec.ts
+git commit -m "feat(web): enable query mode for Recently Added (#805)"
+```
+
+---
+
+## Task 3: Route-level spec for query mode (red-first)
+
+**Files:**
+- Modify: `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts`
+
+Keep the six existing cases unchanged (Task 1 already updated the sections one) — they are the browse-mode regression guard. Append a `describe` for query mode with these **six** cases (Task 5 Step 2 checks for twelve passing total):
+
+```
+1. renders SmartSearchResults instead of the timeline when the URL carries ?q=
+2. does not send shared-space scope to SmartSearchResults
+3. stays in browse mode for a blank/whitespace-only query
+4. the header count uses the search total in query mode, not timelineManager.assetCount
+5. a failed facet fetch falls back to the previous facets (count survives)
+6. re-rendering with an unchanged query+filters does not refetch facets (key cache)
+```
+
+Cases 5 and 6 transplant almost verbatim from `photos-page.spec.ts` — the rejection fallback at `:581-597` (`sdkMock.searchSmartFacets.mockRejectedValueOnce(...)` → `data-total` still `'12'`) and the call-count dedup at `:517-528` / `:572-577`. Copy them rather than inventing equivalents.
+
+**Harness setup you must add** (case 4 and 5 need a resolved facets payload, or they fail as harness errors rather than assertion failures). The spec already imports `sdkMock` from `$lib/__mocks__/sdk.mock`; seed it, copying `photos-page.spec.ts:244-256`:
+
+```ts
+sdkMock.searchSmartFacets.mockResolvedValue({
+  total: 12,
+  timeBuckets: [{ timeBucket: '2024-01-01', count: 12 }],
+  countries: ['Germany'], cities: ['Berlin'], cameraMakes: ['Sony'], cameraModels: ['A7'],
+  tags: [{ id: 'tag-1', value: 'Travel' }], people: [{ id: 'person-1', name: 'Ada' }],
+  ratings: [4], mediaTypes: [AssetTypeEnum.Image], hasUnnamedPeople: false,
+});
+```
+
+Mock `$lib/components/search/smart-search-results.svelte` with the existing `@test-data/mocks/smart-search-results.stub.svelte` (the one `photos-page.spec.ts` uses). It exposes received props as `data-*` attributes — `data-total`, `data-with-shared-spaces`, `data-search-query`, `data-language`. Assert against those; do not invent a mechanism.
+
+Note for case 2: the route passes `withSharedSpaces={false}`, so the stub's `data-with-shared-spaces` will read `"false"` — assert that exact value (this is the component prop, unlike the facets DTO where the key is simply absent).
+
+Drive query mode by setting `mockPage.url` to `new URL('https://gallery.test/recently-added?q=beach')`.
+
+- [ ] **Step 1: Write the cases**
+- [ ] **Step 2: Run to verify RED** — expected: 6 passed, 6 failed. The six must fail as ASSERTION failures about missing query wiring (no SmartSearchResults rendered, count still from assetCount), **not** harness errors. If you get mock/setup errors, your harness is wrong — fix it and re-run. Paste the output and state the distinction explicitly.
+- [ ] **Step 3: Commit** — `test(web): route-level spec for Recently Added query mode (#805)`
+
+---
+
+## Task 4: E2E search scenarios (red-first)
+
+**Files:**
+- Modify: `e2e/src/specs/web/recently-added-filters.e2e-spec.ts`
+
+Keep the existing 10 scenarios unchanged. Append a sibling `test.describe('Recently Added text search', …)` with its own `beforeAll`, covering the spec's three BDD scenarios:
+
+```gherkin
+Scenario: A text query switches to search results with a total count
+  Given the Recently Added view
+  When I open it with a text query in the URL (?q=…)
+  Then search results are shown instead of the added-date timeline
+  And the header shows the search-result total as "N items"
+
+Scenario: Clearing the query returns to the added-date timeline
+  Given the Recently Added view showing text-search results
+  When I clear the text query
+  Then the added-date timeline is shown again with its item count
+
+Scenario: Text search stays within own + partner scope
+  Given a shared-space asset that the same query DOES find on /photos
+  When I run that text search in Recently Added
+  Then search results are shown (not the added-date timeline)
+  And the shared-space asset is not among those results
+```
+
+**Drive the query via `?q=` deep-link or the navbar global search — NOT "the text filter".** The panel's `'text'` section is `<TextFilter>` editing the description / originalFileName / ocr **metadata** filters; it is not a smart-search box and cannot submit a query. The smart query reaches the route only through the URL or the global search bar. Scenario 1's wording above is corrected accordingly: *"When I open the view with a text query in the URL"*.
+
+**Seeding notes.** Smart search is ML-backed and its ranking is not deterministic in e2e — do **not** assert on which assets match semantically. Assert on the **mode switch, the count source, and the scope**.
+
+**Scenario 3 needs a positive control, or it is unfalsifiable.** Asserting only that a shared-space asset is *absent* passes for a dozen unrelated reasons: never indexed, matched nothing semantically, the member never opted the space into their timeline, or the seeding silently failed. The test must prove the asset *would* have been found:
+
+1. A **second user** owns the asset and adds it to a space the test actor is a member of (this direction, not the reverse).
+2. Set the **member-level** timeline opt-in explicitly (`updateMemberTimeline`, imported straight from `@immich/sdk` and called with the **member's own** token — see `space-map-markers.e2e-spec.ts:62-63`), so it is a controlled variable rather than an accidental confound. Note this is *not* the album-level `showInTimeline` toggle; the two are not interchangeable (`spaces-albums-timeline.e2e-spec.ts:19-23`).
+3. **Positive control:** run the identical query on `/photos` (which *is* `withSharedSpaces: true`) in the same test and assert the asset **is** present there. Only then assert its absence on `/recently-added`.
+4. **Assert the mode switch before asserting absence.** On `/recently-added`, first assert that search results are rendered rather than the timeline, *then* assert the asset is absent **from those results**. Without this the scenario passes before Task 5 too — the unwired route renders an own+partner timeline from which the asset is trivially absent — and it would never demonstrate the invariant it names. With it, Task 4's red gate is genuinely **10 passed, 3 failed**.
+
+Helpers (all in `e2e/src/utils.ts`): `utils.userSetup`, `utils.createSpace(accessToken, dto)` (`:367`), `utils.addSpaceMember(accessToken, spaceId, { userId, role })` (`:370`), `utils.addSpaceAssets(accessToken, spaceId, assetIds)` (`:373`). Closest precedent: `e2e/src/specs/web/space-map-markers.e2e-spec.ts:26-55` — note it calls the SDK directly for the per-member timeline opt-in, because that endpoint needs the **member's own** token, not admin's.
+
+This third `describe` must call `utils.resetDatabase()` in its own `beforeAll` and build its own fixture — it cannot inherit from either existing block, both of which reset the database themselves.
+
+**Do not try to make the semantic match deterministic — you do not need to, and the obvious workaround does not exist.** The mode switch is guaranteed by the URL carrying `?q=`, whatever it matches; the assertion is that one specific shared-space asset id is absent from the rendered results; and the `/photos` positive control is precisely what proves the query *can* find it. If the query matches nothing even on `/photos`, the positive control fails loudly — which is the correct outcome, turning semantic non-determinism into a visible failure rather than a silent pass.
+
+(For the record, swapping in an `originalFileName` / `description` / `ocr` filter as a "deterministic discriminator" is not an option: those three are metadata-only. `buildSmartSearchParams` never reads them — grep `space-search.ts`, zero occurrences — so they are silently dropped from the smart-search DTO. And dropping `?q=` would put the page back in browse mode, making the mandated mode-switch assertion unsatisfiable.)
+
+- [ ] **Step 1: Write the scenarios**
+- [ ] **Step 2: Run to verify RED** (with `--retries=0`) — expected: 10 passed, 3 failed, failing because the route ignores `?q=` and still renders the timeline. Confirm the failure reason is the missing query wiring, not seeding/auth/stack problems. Paste the output.
+- [ ] **Step 3: Commit** — `test(e2e): acceptance scenarios for Recently Added text search (#805)`
+
+---
+
+## Task 5: Wire query mode into the route (turns Tasks 3 and 4 green)
+
+**Files:**
+- Modify: `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte`
+
+**Template:** the Photos page's search plumbing — `photos/[[assetId=id]]/+page.svelte` lines `:127-133` (`committedQuery`, `showSearchResults`), `:145-157` (facet state + derived buckets/total), `:216-266` (`loadPhotoSmartFacets` — the AbortController + key-cache loader), `:429-436` (`clearSearch`), the query parts of the URL→filters `$effect` (`:510-543`), and the render switch (`:598-607`).
+
+**Adaptations:**
+- `withSharedSpaces` is **`false` everywhere** — in `buildSmartSearchFacetsParams`, in the facet cache key, and on `<SmartSearchResults withSharedSpaces={false}>`. Photos computes `filters.isFavorite === undefined`; we do not. This is the slice's headline invariant.
+- Pass the search context into the config — **including `filters`**, which the dependent providers scope their facet query by:
+  ```ts
+  const filterConfig = withNameCapture(
+    buildRecentlyAddedFilterConfig(() => ({ query: committedQuery, language: $lang, filters })),
+    personNames,
+    tagNames,
+  );
+  ```
+  A thunk, so it reads live state. Omitting `filters` re-opens the silently-dropped-scope defect that Task 1's "scopes the dependent providers by the live filters" case exists to prevent — and because this lives in a `.svelte` `<script>` block, **neither `tsc --noEmit` nor local `check:svelte` would catch it**; it would surface only in CI, or not at all.
+- `syncFilterUrl` must now pass `committedQuery` instead of the literal `''`, and restore Photos' full sort conversion (`!committedQuery.trim() && …`) — the Slice-2 simplification assumed no query could exist. Copy Photos' version. **Also rewrite the now-false comment above it** (`+page.svelte:184-185`), which currently ends "…its extra free-text-query guard is query-mode-only and drops out here (this view has no query yet)" — this task is precisely what restores that guard.
+- Count: `const count = $derived(showSearchResults ? (smartFacetTotal ?? 0) : (timelineManager?.assetCount ?? 0));` and `hasActiveFilters` becomes `getActiveFilterCount(filters) > 0 || showSearchResults`.
+- `timeBuckets` on `<FilterPanel>` becomes `showSearchResults ? (smartFacets?.timeBuckets ?? []) : timelineBuckets`.
+- Restore the `{#key}` wrapper around `<FilterPanel>` (Photos `:558`) so the panel remounts on query/lang change.
+- Restore `showGrouping={!showSearchResults && !assetMultiSelectManager.selectionActive}` on `<FilterToolbar>`, and give `<ActiveFiltersBar>` `searchQuery={committedQuery}` + `onClearSearch={clearSearch}`. Still **no** `resultCount` / `onAddAllToCollection` — the header keeps the single count.
+- Facet-fetch errors: catch → `console.error` → fall back to the last good facets (Photos `:252-257`).
+- The `AssetSelectControlBar` and `{#snippet empty()}` blocks stay unchanged.
+
+- [ ] **Step 1: Implement the wiring**
+- [ ] **Step 2: Route spec GREEN** — `pnpm test -- --run "…/recently-added-page.spec.ts"` → **12 passed** (6 browse + 6 query). Fast loop; do this before Playwright. Paste output.
+- [ ] **Step 3: `cd web && pnpm check:typescript && pnpm lint`** — clean.
+- [ ] **Step 4: E2E GREEN** — rebuild the stack (`cd e2e && docker compose up --build -d`), then run the spec → **13 passed**. Paste output.
+- [ ] **Step 5: Full gate**
+
+```bash
+cd web && pnpm check:typescript && pnpm check:svelte && pnpm lint && pnpm test -- --run
+cd web && pnpm exec prettier --check "src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte"
+cd ../e2e && pnpm exec prettier --check src/specs/web/recently-added-filters.e2e-spec.ts
+```
+
+- [ ] **Step 6: Commit** — `feat(web): text/smart-search filter for Recently Added (#805)`
+
+---
+
+## Slice 3 Done Gate
+
+- [ ] `check:typescript`, `check:svelte`, `lint` (no errors, no new warnings), full unit suite — all clean
+- [ ] Route spec — **12 passed**
+- [ ] E2E — **13 passed**
+- [ ] Prettier clean on all touched files
+- [ ] Red→green evidence for Tasks 1, 2 (unit), 3→5 (route), 4→5 (e2e). The `'relevance'` case is a characterization pin, already green — do NOT count it as red→green evidence.
+- [ ] Photos page, `filter-panel/`, `Timeline`, `UserPageLayout`, `SmartSearchResults` unmodified
+- [ ] Photos/Spaces search behaviour unchanged — their `searchable-page-search.spec.ts` cases still pass untouched
+- [ ] **`withSharedSpaces` is `false`, never `true`, on every search path:** `grep -rn "withSharedSpaces" web/src/lib/utils/recently-added-filter-*.ts "web/src/routes/(user)/recently-added/"` shows only `false` literals and the discarded `_` in the options builder. (The facet DTO simply omits the key — `buildSmartSearchParams` sets it only when truthy — so assert absence in tests, never `false`.)
+- [ ] `isQueryCapablePage` is fully deleted, not left always-true
+- [ ] Five commits as specified
+
+## Coverage check against the spec
+
+| Spec item (§Slice 3) | Covered by |
+|---|---|
+| Config = 10 sections incl. text | Task 1 sections case |
+| Query-mode provider calls `searchSmartFacets` with `withSharedSpaces: false` | Task 1 query-mode cases (suggestions + both dependent providers) |
+| Browse-mode provider unchanged | Task 1 — every pre-existing browse case retained and passing |
+| Text query → search results + search-total count | Task 3 cases 1 & 4; Task 4 scenario 1 (driven via `?q=`) |
+| Clear query → back to added-date timeline | Task 4 scenario 2 |
+| Search stays own + partner | Task 1 unit (DTO lacks `withSharedSpaces`) + Task 3 case 2 + Task 4 scenario 3 **with its `/photos` positive control** |
+| Empty query submitted → stays browse | Task 1 blank-query fallback case; Task 3 case 3 |
+| Smart-facet fetch failure → console.error + fall back to prior facets | Task 3 case 5 (route-level, copied from Photos `:581-597`) |
+| Query then filter change → refetch keyed by query+filters | Task 3 case 6 (key-cache dedup, copied from Photos `:517-528`); Task 1 read-at-call-time case. **Abort-in-flight is not separately asserted** — it is carried by the copied Photos loader; dedup ≠ abort. |
+| `'relevance'` sort on an added-date timeline | Task 1 regression case (browse degrades to newest-added-first); query mode ranks in `SmartSearchResults` |

--- a/docs/superpowers/plans/2026-07-19-recently-added-filters-slice-3.md
+++ b/docs/superpowers/plans/2026-07-19-recently-added-filters-slice-3.md
@@ -28,8 +28,9 @@ Committed: the header count; `shouldShowRecentlyAddedCount`; `buildRecentlyAdded
 Slice 2's review flagged this and deferred it to this slice. `getSortOrder(query, rawSort)` returns `'relevance'` whenever a non-empty `q` is present without an explicit `sort`. Until now that was unreachable on this route.
 
 **Resolution — no special handling needed, and this is deliberate:**
+
 - **In query mode**, results come from `<SmartSearchResults>`, which does its own relevance ordering. `'relevance'` is meaningful there, exactly as on Photos.
-- **In browse mode**, `buildRecentlyAddedTimelineOptions` already maps `'relevance'` → `AssetOrder.Desc` (asserted by a Slice-2 unit test: *"maps sortOrder to order without touching orderBy"*), and `orderBy` stays `CreatedAt`. So a stale `relevance` degrades to "newest added first" — the view's natural default.
+- **In browse mode**, `buildRecentlyAddedTimelineOptions` already maps `'relevance'` → `AssetOrder.Desc` (asserted by a Slice-2 unit test: _"maps sortOrder to order without touching orderBy"_), and `orderBy` stays `CreatedAt`. So a stale `relevance` degrades to "newest added first" — the view's natural default.
 
 Task 1 adds a regression test pinning this, so the behaviour is asserted rather than incidental.
 
@@ -41,13 +42,16 @@ Task 1 adds a regression test pinning this, so the behaviour is asserted rather 
 cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-config.spec.ts
 cd web && pnpm test -- --run "src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts"
 ```
+
 (`"test": "vitest"` is watch-mode; `--run` is mandatory. The path argument may not isolate to one file — expected.)
 
 E2E — **never use `PLAYWRIGHT_BASE_URL=http://127.0.0.1:2283`** (serves 0-byte page bodies; produces meaningless failures). Use the dedicated e2e stack on `:2285`, which **bakes the web app into its image** — rebuild after any web source change:
+
 ```bash
 cd e2e && docker compose up --build -d
 cd e2e && pnpm exec playwright test --project=web --retries=0 src/specs/web/recently-added-filters.e2e-spec.ts
 ```
+
 Use `--retries=0` on deliberate red runs (the `web` project sets `retries: 4`).
 
 Prettier is a separate CI gate. A `**/*.svelte` glob does not match inside the `[[…]]` route directory — use the concrete escaped path.
@@ -58,16 +62,16 @@ Prettier is a separate CI gate. A `**/*.svelte` glob does not match inside the `
 
 ## File Structure
 
-| File | Status | Responsibility |
-|---|---|---|
-| `web/src/lib/utils/recently-added-filter-config.ts` | **Modify** (Task 1) | Append `'text'`; add the query-mode branch to `suggestionsProvider` and the two dependent providers. |
-| `web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts` | **Modify** (Task 1) | Bump to 10 sections; add search-branch cases. |
-| `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts` | **Modify** (Task 1) | Add the `'relevance'`-in-browse-mode regression case. |
-| `web/src/lib/utils/searchable-page-search.ts` | **Modify** (Task 2) | Remove the `/recently-added` exclusion — the route becomes query-capable. |
-| `web/src/lib/utils/__tests__/searchable-page-search.spec.ts` | **Modify** (Task 2) | Flip the Slice-2 assertions to the query-capable end state. |
-| `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts` | **Modify** (Tasks 1 & 3) | Task 1 updates the sections case to ten (or the repo lands red); Task 3 adds the query-mode cases. |
-| `e2e/src/specs/web/recently-added-filters.e2e-spec.ts` | **Modify** (Task 4) | Search acceptance scenarios (red). |
-| `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte` | **Modify** (Task 5) | Query state, smart facets, mode switch (green). |
+| File                                                                                                | Status                   | Responsibility                                                                                       |
+| --------------------------------------------------------------------------------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `web/src/lib/utils/recently-added-filter-config.ts`                                                 | **Modify** (Task 1)      | Append `'text'`; add the query-mode branch to `suggestionsProvider` and the two dependent providers. |
+| `web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts`                                  | **Modify** (Task 1)      | Bump to 10 sections; add search-branch cases.                                                        |
+| `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts`                                 | **Modify** (Task 1)      | Add the `'relevance'`-in-browse-mode regression case.                                                |
+| `web/src/lib/utils/searchable-page-search.ts`                                                       | **Modify** (Task 2)      | Remove the `/recently-added` exclusion — the route becomes query-capable.                            |
+| `web/src/lib/utils/__tests__/searchable-page-search.spec.ts`                                        | **Modify** (Task 2)      | Flip the Slice-2 assertions to the query-capable end state.                                          |
+| `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts` | **Modify** (Tasks 1 & 3) | Task 1 updates the sections case to ten (or the repo lands red); Task 3 adds the query-mode cases.   |
+| `e2e/src/specs/web/recently-added-filters.e2e-spec.ts`                                              | **Modify** (Task 4)      | Search acceptance scenarios (red).                                                                   |
+| `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte`                | **Modify** (Task 5)      | Query state, smart facets, mode switch (green).                                                      |
 
 ## Task order
 
@@ -84,23 +88,28 @@ Tasks 3 and 4 are only genuinely red before Task 5. Do not reorder.
 ## Task 1: Config gains the `text` section and a query-mode branch
 
 **Files:**
+
 - Modify: `web/src/lib/utils/recently-added-filter-config.ts`
 - Test: `web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts`, `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts`
 
 **Interfaces:**
+
 - Produces: `buildRecentlyAddedFilterConfig(getSearchContext?: () => RecentlyAddedSearchContext | undefined): FilterPanelConfig`, and `export type RecentlyAddedSearchContext = { query: string; language: string; filters: FilterState };`
 
-**Design — why an accessor rather than a plain argument.** The panel's providers are called *later*, during user interaction, and must see the query **and the live filters** as they are at call time. Values captured when the config is built would go stale the moment the user edits either. Photos solves this by defining its config inline in the route, closing over reactive state; keeping ours in a module means the route passes a thunk instead. The parameter is optional and defaults to `() => undefined`, so a caller that never searches keeps exactly the Slice-2 browse behaviour (verified: the route's current bare call site stays correct).
+**Design — why an accessor rather than a plain argument.** The panel's providers are called _later_, during user interaction, and must see the query **and the live filters** as they are at call time. Values captured when the config is built would go stale the moment the user edits either. Photos solves this by defining its config inline in the route, closing over reactive state; keeping ours in a module means the route passes a thunk instead. The parameter is optional and defaults to `() => undefined`, so a caller that never searches keeps exactly the Slice-2 browse behaviour (verified: the route's current bare call site stays correct).
 
-**The context must carry `filters`, not just the query.** Photos builds its dependent-provider facet payloads from the *live* `FilterState` (`photos/+page.svelte:318`, `:336`):
+**The context must carry `filters`, not just the query.** Photos builds its dependent-provider facet payloads from the _live_ `FilterState` (`photos/+page.svelte:318`, `:336`):
+
 ```ts
 filters: { ...filters, country },
 ```
+
 Do **not** reconstruct a `FilterState` from the panel-supplied `FilterContext`. They are different types: `FilterContext` has no `city` / `make` / `model` / `mediaType` / `description` / `originalFileName` / `ocr` / `sortOrder`, and it carries dates as `takenAfter`/`takenBefore` whereas `buildSmartSearchParams` derives dates by calling `buildFilterContext(filters)` on `dateAfter` / `dateBefore` / `selectedYear`. A `{ ...createFilterState(), ...filterContext }` spread **type-checks but silently drops most of the filter scope**, including all dates — so the city/camera dropdowns would be scoped differently from Photos with nothing to catch it.
 
 **`withSharedSpaces: false` produces NO key.** `buildSmartSearchParams` only sets it when truthy (`space-search.ts:38-40`: `if (withSharedSpaces) { params.withSharedSpaces = true; }`). So assert its **absence** — `expect(dto).not.toHaveProperty('withSharedSpaces')`. An `expect.objectContaining({ withSharedSpaces: false })` can never pass, and chasing it would mean breaking the shared `space-search.ts`. Photos' own spec uses the absence form (`photos-page.spec.ts:528`).
 
 **Facts you need:**
+
 - `buildSmartSearchFacetsParams(args: SmartSearchParamsArgs): SmartSearchFacetsDto` and `mapSmartSearchFacetsToFilterSuggestions(facets, options?)` live in `$lib/utils/space-search`. `mapSmartSearchFacetsToFilterSuggestions` with **no** `spaceId` option resolves people via `getPhotosPersonFilterId` / `getPhotosPersonFilterThumbnailUrl` — which is what we want (no space scoping).
 - `searchSmartFacets({ smartSearchFacetsDto }, opts?)` is the SDK call.
 - `SmartSearchParamsArgs` takes `{ query, filters, withSharedSpaces, language }`.
@@ -110,20 +119,20 @@ Do **not** reconstruct a `FilterState` from the panel-supplied `FilterContext`. 
 In `recently-added-filter-config.spec.ts`, **change** the sections case to expect ten:
 
 ```ts
-  it('exposes all ten filter sections in plan order', () => {
-    expect(buildRecentlyAddedFilterConfig().sections).toEqual([
-      'timeline',
-      'people',
-      'location',
-      'camera',
-      'tags',
-      'rating',
-      'media',
-      'favorites',
-      'albums',
-      'text',
-    ]);
-  });
+it('exposes all ten filter sections in plan order', () => {
+  expect(buildRecentlyAddedFilterConfig().sections).toEqual([
+    'timeline',
+    'people',
+    'location',
+    'camera',
+    'tags',
+    'rating',
+    'media',
+    'favorites',
+    'albums',
+    'text',
+  ]);
+});
 ```
 
 Add `searchSmartFacets` to the `@immich/sdk` mock:
@@ -266,14 +275,14 @@ and include `recently-added-page.spec.ts` in this task's commit. (Task 3 then ge
 In `recently-added-filter-options.spec.ts`, append to the `buildRecentlyAddedTimelineOptions` describe:
 
 ```ts
-  it('degrades a relevance sort to newest-added-first in browse mode', () => {
-    // A `?q=` in the URL resolves sortOrder to 'relevance'. Browse mode has no relevance ranking,
-    // so it must fall back to the view's natural default rather than producing an invalid order.
-    const options = buildRecentlyAddedTimelineOptions({ ...createFilterState(), sortOrder: 'relevance' });
+it('degrades a relevance sort to newest-added-first in browse mode', () => {
+  // A `?q=` in the URL resolves sortOrder to 'relevance'. Browse mode has no relevance ranking,
+  // so it must fall back to the view's natural default rather than producing an invalid order.
+  const options = buildRecentlyAddedTimelineOptions({ ...createFilterState(), sortOrder: 'relevance' });
 
-    expect(options.order).toBe(AssetOrder.Desc);
-    expect(options.orderBy).toBe(AssetOrderBy.CreatedAt);
-  });
+  expect(options.order).toBe(AssetOrder.Desc);
+  expect(options.orderBy).toBe(AssetOrderBy.CreatedAt);
+});
 ```
 
 - [ ] **Step 2: Run to verify RED**
@@ -387,6 +396,7 @@ Before committing, run the **full** unit suite (`cd web && pnpm test -- --run`) 
 ## Task 2: Make `/recently-added` query-capable
 
 **Files:**
+
 - Modify: `web/src/lib/utils/searchable-page-search.ts`
 - Test: `web/src/lib/utils/__tests__/searchable-page-search.spec.ts`
 
@@ -397,16 +407,16 @@ Before committing, run the **full** unit suite (`cd web && pnpm test -- --run`) 
 In `searchable-page-search.spec.ts`, replace the two Slice-2 cases that pinned the withheld state:
 
 ```ts
-  it('is query-capable now that the text section and search path exist', () => {
-    const state = getSearchablePageState(new URL('https://gallery.test/recently-added'));
+it('is query-capable now that the text section and search path exist', () => {
+  const state = getSearchablePageState(new URL('https://gallery.test/recently-added'));
 
-    expect(state.basePath).toBe('/recently-added');
-    expect(state.isSearchable).toBe(true);
-  });
+  expect(state.basePath).toBe('/recently-added');
+  expect(state.isSearchable).toBe(true);
+});
 
-  it('builds a query URL for the recently added page', () => {
-    expect(buildSearchablePageUrl(new URL('https://gallery.test/recently-added'), 'beach')).toContain('q=beach');
-  });
+it('builds a query URL for the recently added page', () => {
+  expect(buildSearchablePageUrl(new URL('https://gallery.test/recently-added'), 'beach')).toContain('q=beach');
+});
 ```
 
 (These replace `'is not query-capable until the text slice lands'` and `'refuses to build a query URL for a page that cannot answer one'`. Leave every other case — including the filter-only URL case and the Photos/Spaces regression cases — untouched.)
@@ -416,11 +426,13 @@ In `searchable-page-search.spec.ts`, replace the two Slice-2 cases that pinned t
 ```bash
 cd web && pnpm test -- --run src/lib/utils/__tests__/searchable-page-search.spec.ts
 ```
+
 Expected: the two updated cases fail (`isSearchable` is false; the query URL is null). Paste the output.
 
 - [ ] **Step 3: Implement**
 
 Delete the `isQueryCapablePage` function and its two call sites, restoring the original shapes:
+
 - `getSearchablePageState` → `isSearchable: true`
 - `buildSearchablePageUrl` → remove the `if (trimmedQuery && !isQueryCapablePage(basePath)) { return null; }` guard.
 
@@ -443,6 +455,7 @@ git commit -m "feat(web): enable query mode for Recently Added (#805)"
 ## Task 3: Route-level spec for query mode (red-first)
 
 **Files:**
+
 - Modify: `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts`
 
 Keep the six existing cases unchanged (Task 1 already updated the sections one) — they are the browse-mode regression guard. Append a `describe` for query mode with these **six** cases (Task 5 Step 2 checks for twelve passing total):
@@ -464,9 +477,15 @@ Cases 5 and 6 transplant almost verbatim from `photos-page.spec.ts` — the reje
 sdkMock.searchSmartFacets.mockResolvedValue({
   total: 12,
   timeBuckets: [{ timeBucket: '2024-01-01', count: 12 }],
-  countries: ['Germany'], cities: ['Berlin'], cameraMakes: ['Sony'], cameraModels: ['A7'],
-  tags: [{ id: 'tag-1', value: 'Travel' }], people: [{ id: 'person-1', name: 'Ada' }],
-  ratings: [4], mediaTypes: [AssetTypeEnum.Image], hasUnnamedPeople: false,
+  countries: ['Germany'],
+  cities: ['Berlin'],
+  cameraMakes: ['Sony'],
+  cameraModels: ['A7'],
+  tags: [{ id: 'tag-1', value: 'Travel' }],
+  people: [{ id: 'person-1', name: 'Ada' }],
+  ratings: [4],
+  mediaTypes: [AssetTypeEnum.Image],
+  hasUnnamedPeople: false,
 });
 ```
 
@@ -485,6 +504,7 @@ Drive query mode by setting `mockPage.url` to `new URL('https://gallery.test/rec
 ## Task 4: E2E search scenarios (red-first)
 
 **Files:**
+
 - Modify: `e2e/src/specs/web/recently-added-filters.e2e-spec.ts`
 
 Keep the existing 10 scenarios unchanged. Append a sibling `test.describe('Recently Added text search', …)` with its own `beforeAll`, covering the spec's three BDD scenarios:
@@ -508,11 +528,11 @@ Scenario: Text search stays within own + partner scope
   And the shared-space asset is not among those results
 ```
 
-**Drive the query via `?q=` deep-link or the navbar global search — NOT "the text filter".** The panel's `'text'` section is `<TextFilter>` editing the description / originalFileName / ocr **metadata** filters; it is not a smart-search box and cannot submit a query. The smart query reaches the route only through the URL or the global search bar. Scenario 1's wording above is corrected accordingly: *"When I open the view with a text query in the URL"*.
+**Drive the query via `?q=` deep-link or the navbar global search — NOT "the text filter".** The panel's `'text'` section is `<TextFilter>` editing the description / originalFileName / ocr **metadata** filters; it is not a smart-search box and cannot submit a query. The smart query reaches the route only through the URL or the global search bar. Scenario 1's wording above is corrected accordingly: _"When I open the view with a text query in the URL"_.
 
 **Seeding notes.** Smart search is ML-backed and its ranking is not deterministic in e2e — do **not** assert on which assets match semantically. Assert on the **mode switch, the count source, and the scope**.
 
-**Scenario 3 must assert the REQUEST, not the results — the e2e stack has no ML.** (Discovered during implementation: `e2e/docker-compose.yml` has no `machine-learning` service and `IMMICH_MACHINE_LEARNING_ENABLED=false`, so `searchSmart` errors and `smart-search-results.svelte` falls back to an empty list for *every* query. `photos-search.e2e-spec.ts:88-91` documents the same limitation.) A result-based scope test is therefore untestable here: nothing is ever found, so absence proves nothing and no positive control can succeed.
+**Scenario 3 must assert the REQUEST, not the results — the e2e stack has no ML.** (Discovered during implementation: `e2e/docker-compose.yml` has no `machine-learning` service and `IMMICH_MACHINE_LEARNING_ENABLED=false`, so `searchSmart` errors and `smart-search-results.svelte` falls back to an empty list for _every_ query. `photos-search.e2e-spec.ts:88-91` documents the same limitation.) A result-based scope test is therefore untestable here: nothing is ever found, so absence proves nothing and no positive control can succeed.
 
 Assert what the client **sends** instead. `smart-search-results.svelte:46-52` posts `buildSmartSearchParams({ …, withSharedSpaces, … })` to `POST /api/search/smart`, and `buildSmartSearchParams` sets `withSharedSpaces: true` only when truthy. So intercept the request with Playwright and assert:
 
@@ -528,12 +548,12 @@ The shared-space seeding below is no longer needed for scenario 3 — drop it. (
 <details>
 <summary>Superseded: the result-based approach and its seeding requirements (kept for context)</summary>
 
-Asserting only that a shared-space asset is *absent* passes for a dozen unrelated reasons: never indexed, matched nothing semantically, the member never opted the space into their timeline, or the seeding silently failed. It would have needed:
+Asserting only that a shared-space asset is _absent_ passes for a dozen unrelated reasons: never indexed, matched nothing semantically, the member never opted the space into their timeline, or the seeding silently failed. It would have needed:
 
 1. A **second user** owns the asset and adds it to a space the test actor is a member of (this direction, not the reverse).
-2. Set the **member-level** timeline opt-in explicitly (`updateMemberTimeline`, imported straight from `@immich/sdk` and called with the **member's own** token — see `space-map-markers.e2e-spec.ts:62-63`), so it is a controlled variable rather than an accidental confound. Note this is *not* the album-level `showInTimeline` toggle; the two are not interchangeable (`spaces-albums-timeline.e2e-spec.ts:19-23`).
-3. **Positive control:** run the identical query on `/photos` (which *is* `withSharedSpaces: true`) in the same test and assert the asset **is** present there. Only then assert its absence on `/recently-added`.
-4. **Assert the mode switch before asserting absence.** On `/recently-added`, first assert that search results are rendered rather than the timeline, *then* assert the asset is absent **from those results**. Without this the scenario passes before Task 5 too — the unwired route renders an own+partner timeline from which the asset is trivially absent — and it would never demonstrate the invariant it names. With it, Task 4's red gate is genuinely **10 passed, 3 failed**.
+2. Set the **member-level** timeline opt-in explicitly (`updateMemberTimeline`, imported straight from `@immich/sdk` and called with the **member's own** token — see `space-map-markers.e2e-spec.ts:62-63`), so it is a controlled variable rather than an accidental confound. Note this is _not_ the album-level `showInTimeline` toggle; the two are not interchangeable (`spaces-albums-timeline.e2e-spec.ts:19-23`).
+3. **Positive control:** run the identical query on `/photos` (which _is_ `withSharedSpaces: true`) in the same test and assert the asset **is** present there. Only then assert its absence on `/recently-added`.
+4. **Assert the mode switch before asserting absence.** On `/recently-added`, first assert that search results are rendered rather than the timeline, _then_ assert the asset is absent **from those results**. Without this the scenario passes before Task 5 too — the unwired route renders an own+partner timeline from which the asset is trivially absent — and it would never demonstrate the invariant it names. With it, Task 4's red gate is genuinely **10 passed, 3 failed**.
 
 Helpers (all in `e2e/src/utils.ts`): `utils.userSetup`, `utils.createSpace(accessToken, dto)` (`:367`), `utils.addSpaceMember(accessToken, spaceId, { userId, role })` (`:370`), `utils.addSpaceAssets(accessToken, spaceId, assetIds)` (`:373`). Closest precedent: `e2e/src/specs/web/space-map-markers.e2e-spec.ts:26-55` — note it calls the SDK directly for the per-member timeline opt-in, because that endpoint needs the **member's own** token, not admin's.
 
@@ -541,7 +561,7 @@ This third `describe` must call `utils.resetDatabase()` in its own `beforeAll` a
 
 </details>
 
-**Do not try to make the semantic match deterministic — you do not need to, and the obvious workaround does not exist.** The mode switch is guaranteed by the URL carrying `?q=`, whatever it matches; the assertion is that one specific shared-space asset id is absent from the rendered results; and the `/photos` positive control is precisely what proves the query *can* find it. If the query matches nothing even on `/photos`, the positive control fails loudly — which is the correct outcome, turning semantic non-determinism into a visible failure rather than a silent pass.
+**Do not try to make the semantic match deterministic — you do not need to, and the obvious workaround does not exist.** The mode switch is guaranteed by the URL carrying `?q=`, whatever it matches; the assertion is that one specific shared-space asset id is absent from the rendered results; and the `/photos` positive control is precisely what proves the query _can_ find it. If the query matches nothing even on `/photos`, the positive control fails loudly — which is the correct outcome, turning semantic non-determinism into a visible failure rather than a silent pass.
 
 (For the record, swapping in an `originalFileName` / `description` / `ocr` filter as a "deterministic discriminator" is not an option: those three are metadata-only. `buildSmartSearchParams` never reads them — grep `space-search.ts`, zero occurrences — so they are silently dropped from the smart-search DTO. And dropping `?q=` would put the page back in browse mode, making the mandated mode-switch assertion unsatisfiable.)
 
@@ -554,11 +574,13 @@ This third `describe` must call `utils.resetDatabase()` in its own `beforeAll` a
 ## Task 5: Wire query mode into the route (turns Tasks 3 and 4 green)
 
 **Files:**
+
 - Modify: `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte`
 
 **Template:** the Photos page's search plumbing — `photos/[[assetId=id]]/+page.svelte` lines `:127-133` (`committedQuery`, `showSearchResults`), `:145-157` (facet state + derived buckets/total), `:216-266` (`loadPhotoSmartFacets` — the AbortController + key-cache loader), `:429-436` (`clearSearch`), the query parts of the URL→filters `$effect` (`:510-543`), and the render switch (`:598-607`).
 
 **Adaptations:**
+
 - `withSharedSpaces` is **`false` everywhere** — in `buildSmartSearchFacetsParams`, in the facet cache key, and on `<SmartSearchResults withSharedSpaces={false}>`. Photos computes `filters.isFavorite === undefined`; we do not. This is the slice's headline invariant.
 - Pass the search context into the config — **including `filters`**, which the dependent providers scope their facet query by:
   ```ts
@@ -608,15 +630,15 @@ cd ../e2e && pnpm exec prettier --check src/specs/web/recently-added-filters.e2e
 
 ## Coverage check against the spec
 
-| Spec item (§Slice 3) | Covered by |
-|---|---|
-| Config = 10 sections incl. text | Task 1 sections case |
-| Query-mode provider calls `searchSmartFacets` with `withSharedSpaces: false` | Task 1 query-mode cases (suggestions + both dependent providers) |
-| Browse-mode provider unchanged | Task 1 — every pre-existing browse case retained and passing |
-| Text query → search results + search-total count | Task 3 cases 1 & 4; Task 4 scenario 1 (driven via `?q=`) |
-| Clear query → back to added-date timeline | Task 4 scenario 2 |
-| Search stays own + partner | Task 1 unit (DTO lacks `withSharedSpaces`) + Task 3 case 2 + Task 4 scenario 3 **with its `/photos` positive control** |
-| Empty query submitted → stays browse | Task 1 blank-query fallback case; Task 3 case 3 |
-| Smart-facet fetch failure → console.error + fall back to prior facets | Task 3 case 5 (route-level, copied from Photos `:581-597`) |
-| Query then filter change → refetch keyed by query+filters | Task 3 case 6 (key-cache dedup, copied from Photos `:517-528`); Task 1 read-at-call-time case. **Abort-in-flight is not separately asserted** — it is carried by the copied Photos loader; dedup ≠ abort. |
-| `'relevance'` sort on an added-date timeline | Task 1 regression case (browse degrades to newest-added-first); query mode ranks in `SmartSearchResults` |
+| Spec item (§Slice 3)                                                         | Covered by                                                                                                                                                                                                |
+| ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Config = 10 sections incl. text                                              | Task 1 sections case                                                                                                                                                                                      |
+| Query-mode provider calls `searchSmartFacets` with `withSharedSpaces: false` | Task 1 query-mode cases (suggestions + both dependent providers)                                                                                                                                          |
+| Browse-mode provider unchanged                                               | Task 1 — every pre-existing browse case retained and passing                                                                                                                                              |
+| Text query → search results + search-total count                             | Task 3 cases 1 & 4; Task 4 scenario 1 (driven via `?q=`)                                                                                                                                                  |
+| Clear query → back to added-date timeline                                    | Task 4 scenario 2                                                                                                                                                                                         |
+| Search stays own + partner                                                   | Task 1 unit (DTO lacks `withSharedSpaces`) + Task 3 case 2 + Task 4 scenario 3 **with its `/photos` positive control**                                                                                    |
+| Empty query submitted → stays browse                                         | Task 1 blank-query fallback case; Task 3 case 3                                                                                                                                                           |
+| Smart-facet fetch failure → console.error + fall back to prior facets        | Task 3 case 5 (route-level, copied from Photos `:581-597`)                                                                                                                                                |
+| Query then filter change → refetch keyed by query+filters                    | Task 3 case 6 (key-cache dedup, copied from Photos `:517-528`); Task 1 read-at-call-time case. **Abort-in-flight is not separately asserted** — it is carried by the copied Photos loader; dedup ≠ abort. |
+| `'relevance'` sort on an added-date timeline                                 | Task 1 regression case (browse degrades to newest-added-first); query mode ranks in `SmartSearchResults`                                                                                                  |

--- a/docs/superpowers/specs/2026-07-19-recently-added-filters-design.md
+++ b/docs/superpowers/specs/2026-07-19-recently-added-filters-design.md
@@ -73,18 +73,30 @@ and today it recognises only `/photos` and `/spaces/…`. On `/recently-added` t
 would therefore **silently no-op** — filters would apply to the grid but never reach the URL, breaking
 "URL is the source of truth", deep links, and survive-a-reload.
 
-Registering the path is necessary but not sufficient: `getSearchablePageState()` derives
-`isSearchable` directly from `basePath !== null`, and three consumers key off that flag
-(`global-search-input-trigger.svelte`'s sort control, and `global-search-manager`'s typed-display
-text plus its "which page do I apply a filter to" base — which today redirects to `/photos`).
-Flipping it on in Slice 2 would make global search stay on Recently Added and write a `?q=` that
-nothing handles until Slice 3.
+Registering the path is necessary but not sufficient, and the flag is not where the risk lives.
+`global-search-manager`'s `buildSearchDestination()` branches purely on whether
+`buildSearchablePageUrl()` returns non-null — it never consults `isSearchable`:
 
-**Decision:** separate the two capabilities. Slice 2 registers `/recently-added` in
-`getSearchablePageBasePath()` (so URL persistence works) while computing `isSearchable` from a
-separate query-capable predicate that excludes `/recently-added`. Slice 3 removes that exclusion
-together with the text section and the search path, so query support arrives complete. Photos and
-Spaces behaviour is unchanged throughout.
+```ts
+const searchablePageUrl = buildSearchablePageUrl(page.url, text, this.searchSortOrder, filters);
+if (searchablePageUrl) { return searchablePageUrl; }
+…
+return buildSearchablePageUrl(new URL('/photos', page.url), text, …) ?? '/photos';
+```
+
+Today a global search typed on Recently Added falls through to `/photos` and works. The moment the
+base path resolves, that fallback stops firing and the user lands on `/recently-added?q=beach` — a
+route with no query handling until Slice 3. Unfiltered grid, stale `q`, no error. Setting
+`isSearchable: false` does not prevent this: it only suppresses pre-filling the search box.
+
+**Decision:** separate the two capabilities, and enforce the separation where the query is
+*written*, not merely where it is advertised. Slice 2 registers `/recently-added` in
+`getSearchablePageBasePath()` (so filter URL persistence works) and adds a query-capable predicate
+that excludes `/recently-added`. That predicate is enforced in **two** places: `getSearchablePageState()`
+reports `isSearchable: false`, and `buildSearchablePageUrl()` returns `null` when asked to build a
+URL carrying a non-empty query for a non-query-capable page — which keeps `buildSearchDestination`'s
+`/photos` fallback intact. Slice 3 deletes the exclusion in one place, and the text section, the
+search path, and query support all land together. Photos and Spaces behaviour is unchanged throughout.
 
 ### 3.2 Decision logic lives in pure, unit-tested functions
 

--- a/docs/superpowers/specs/2026-07-19-recently-added-filters-design.md
+++ b/docs/superpowers/specs/2026-07-19-recently-added-filters-design.md
@@ -6,15 +6,18 @@
 - **Approach:** Mirror the existing per-view filter integration pattern (Photos), adding two new
   `web/src/lib/utils/` modules and wiring them into the Recently Added route. Do **not** modify the
   Photos page or the shared `filter-panel` / `Timeline` components.
+- **Delivery:** three impl-loop slices (§Slice 1–3). Each slice is independently shippable, TDD-first
+  (unit red→green→refactor), with BDD acceptance scenarios for user-facing behavior, and ends green on
+  the repo gate + a commit.
 
 ## 1. Goal
 
-Give the web **Recently Added** view (`/recently-added`) two things the discussion asks for:
+Give the web **Recently Added** view (`/recently-added`) the two things the discussion asks for:
 
-1. **Filter navigation** — the same 10-section Filter panel used by Photos
-   (Timeline, People, Location, Camera, Tags, Rating, Media type, Favorites, Albums, Text).
-2. **A visible item count** — "N items" in the page header, reflecting what is currently shown and
+1. **A visible item count** — "N items" in the page header, reflecting what is currently shown and
    updating live as filters change.
+2. **Filter navigation** — the same 10-section Filter panel used by Photos
+   (Timeline, People, Location, Camera, Tags, Rating, Media type, Favorites, Albums, Text).
 
 …while preserving what makes the view "recently added": assets are **ordered and day-grouped by
 *added* date** (`orderBy: AssetOrderBy.CreatedAt`) and the view stays scoped to **own + partner**
@@ -27,6 +30,12 @@ assets (never shared spaces).
   `options = { visibility: Timeline, withStacked: true, withPartners: true, orderBy: CreatedAt }`.
   It has a header **title** ("Recently Added") via `UserPageLayout` but **no count and no filters**.
   It shares the multi-select bulk-action machinery (`AssetSelectControlBar`) with Photos.
+
+- **`UserPageLayout`** (`web/src/lib/components/layouts/UserPageLayout.svelte`) exposes a
+  `description?: string` prop rendered next to the title (line 86–92), inside the header row that only
+  shows when `!hideNavbar && (title || buttons)`. The current route already passes
+  `hideNavbar={assetMultiSelectManager.selectionActive}`, so the count naturally hides during
+  multi-select (the selection bar shows its own count instead).
 
 - **The Filter panel** `web/src/lib/components/filter-panel/` is reusable. Each host view supplies a
   `FilterPanelConfig` (which `sections` to show + suggestion providers) and converts the panel's
@@ -42,41 +51,179 @@ assets (never shared spaces).
   free-text is entered.
 
 - **The count is free client-side.** `TimelineManager.assetCount` is a live grand total (time buckets
-  carry per-bucket counts) available once buckets load. There is **no** photos/videos split without
-  backend work. The `items_count` i18n key already exists:
-  `"{count, plural, one {# item} other {# items}}"`.
+  carry per-bucket counts) available once buckets load. No photos/videos split without backend work.
+  The `items_count` i18n key already exists: `"{count, plural, one {# item} other {# items}}"`.
 
 - **Scope subtlety in `buildPhotosTimelineOptions`:** `withPartners` and `withSharedSpaces` are only
   added when `filters.isFavorite === undefined` (favorites are treated as strictly personal). Recently
-  Added must never add `withSharedSpaces` — see §4.
+  Added must never add `withSharedSpaces` — see §Slice 2.
 
-## 3. New & modified files
+## 3. Architecture
 
-### New (source)
+### 3.1 The single scope invariant
 
-| File | Responsibility |
-|---|---|
-| `web/src/lib/utils/recently-added-filter-options.ts` | Pure functions: `buildRecentlyAddedTimelineOptions(filters)`, `buildRecentlyAddedSuggestionRequest(filters)`, `shouldShowRecentlyAddedCount(count, hasActiveFilters)`. |
-| `web/src/lib/utils/recently-added-filter-config.ts` | `buildRecentlyAddedFilterConfig()` → `FilterPanelConfig` (browse-mode suggestions, own+partners scope). Phase 2 extends its `suggestionsProvider` for query mode. |
+Recently Added is an **own + partner** surface, **never shared spaces**. This holds in every data path:
+timeline options (Slice 2), filter suggestions (Slice 2), and smart search (Slice 3). It is the one rule
+distinguishing Recently Added from Photos.
 
-### New (tests)
+### 3.2 Decision logic lives in pure, unit-tested functions
 
-| File | Covers |
-|---|---|
-| `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts` | The three pure functions above. |
-| `web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts` | The config (sections list + suggestion/provider requests), mirroring `album-filter-config.spec.ts`. |
-| `e2e/src/specs/web/recently-added-filters.e2e-spec.ts` (mirrors the existing `photos-filter-panel.e2e-spec.ts`) | End-to-end: filter panel present, apply/remove a filter, count updates, URL round-trips. Flagged optional-but-recommended. |
+To keep the route thin (a full `+page.svelte` with all managers is impractical to mount in vitest), all
+branching logic is extracted into pure functions that get exhaustive TDD unit coverage. The route is glue
+whose behavior is verified by BDD e2e acceptance scenarios.
 
-### Modified
+| Pure function | Module | Slice |
+|---|---|---|
+| `shouldShowRecentlyAddedCount(count, hasActiveFilters)` | `recently-added-filter-options.ts` | 1 |
+| `buildRecentlyAddedTimelineOptions(filters)` | `recently-added-filter-options.ts` | 2 |
+| `buildRecentlyAddedSuggestionRequest(filters)` | `recently-added-filter-options.ts` | 2 |
+| `buildRecentlyAddedFilterConfig()` | `recently-added-filter-config.ts` | 2 (extended in 3) |
 
-| File | Change |
-|---|---|
-| `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte` | Add filter state seeded from the URL, the filter config, `<FilterPanel>` / `<ActiveFiltersBar>` / `<FilterToolbar>`, browse/query mode switch, header count. Keep the existing title and the entire bulk-action `AssetSelectControlBar` block unchanged. |
+### 3.3 Testing strategy: TDD + BDD
 
-No i18n changes are required for Phase 1 (`items_count` exists). Phase 2 reuses existing search keys
+- **TDD (example-based)** for the pure functions — the right tool for input→output logic. Each is built
+  red→green→refactor with concrete failing-test commands and expected red output (per slice).
+- **BDD (Given/When/Then)** for user-facing behavior — the count display, applying/removing filters, and
+  search. These become Playwright e2e specs under `e2e/src/specs/web/`, written **red-first** (the feature
+  is absent → scenario fails), then made green by the route wiring. BDD is deliberately *not* forced onto
+  the pure functions, where example tables are clearer.
+
+### 3.4 Files (whole feature)
+
+**New source:**
+
+| File | Responsibility | Slice |
+|---|---|---|
+| `web/src/lib/utils/recently-added-filter-options.ts` | `shouldShowRecentlyAddedCount`, `buildRecentlyAddedTimelineOptions`, `buildRecentlyAddedSuggestionRequest` | 1, 2 |
+| `web/src/lib/utils/recently-added-filter-config.ts` | `buildRecentlyAddedFilterConfig()` → `FilterPanelConfig` | 2, 3 |
+
+**New tests:**
+
+| File | Covers | Slice |
+|---|---|---|
+| `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts` | the three pure functions | 1, 2 |
+| `web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts` | the config (mirrors `album-filter-config.spec.ts`) | 2, 3 |
+| `e2e/src/specs/web/recently-added-filters.e2e-spec.ts` (mirrors `photos-filter-panel.e2e-spec.ts`) | BDD acceptance scenarios | 1, 2, 3 |
+
+**Modified:**
+
+| File | Change | Slice |
+|---|---|---|
+| `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte` | header count (1); filter panel + toolbar + chips + URL sync (2); text/search mode (3). The `AssetSelectControlBar` block stays unchanged. | 1, 2, 3 |
+
+No i18n additions: `items_count` exists (Slices 1–2); Slice 3 reuses existing search keys
 (`filter_result_count`, etc.) already used by Photos.
 
-## 4. The options builder (the load-bearing unit)
+## 4. Slice overview
+
+| Slice | Delivers (shippable) | Depends on |
+|---|---|---|
+| **1 — Header item count** | "N items" in the header for the (unfiltered) view; hides on empty/loading. Half of #805, ships alone. | — |
+| **2 — Browse filter panel (9 sections)** | Full metadata filtering (People, Location, Camera, Tags, Rating, Media type, Favorites, Albums, Timeline-date) with chips, URL persistence, and the count reflecting the filtered set. The bulk of #805. | 1 |
+| **3 — Text / smart-search (10th section)** | Free-text search → `SmartSearchResults`, search-total count; completes all-10 parity. | 2 |
+
+---
+
+## Slice 1 — Header item count
+
+**Goal:** show "N items" in the Recently Added header, sourced from `timelineManager.assetCount`, with
+sensible visibility. No filter panel yet; the `<Timeline>` body is unchanged.
+
+**Files:** `recently-added-filter-options.ts` (new, `shouldShowRecentlyAddedCount` only),
+its spec (new), the route (add header count), the e2e spec (new).
+
+### The pure function
+
+```ts
+// recently-added-filter-options.ts
+export function shouldShowRecentlyAddedCount(count: number, hasActiveFilters: boolean): boolean {
+  return count > 0 || hasActiveFilters;
+}
+```
+
+Rationale for each rule (each is a test row below):
+
+- `count === 0` & no filters → **hidden**: no "0 items" flash before buckets load; the `EmptyPlaceholder`
+  already communicates an empty account.
+- `count === 0` & filters active → **"0 items"**: informative ("your filter matched nothing"). (The
+  `hasActiveFilters` arm is always `false` in Slice 1 but the function is written and tested complete so
+  Slice 2 needs no change.)
+- `count > 0` → **"N items"**, live-updating as buckets load.
+
+### TDD steps
+
+1. **Red.** Create `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts` with the
+   `shouldShowRecentlyAddedCount` cases (below). Run:
+   `cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-options.spec.ts`
+   Expected red: `does not provide an export named 'shouldShowRecentlyAddedCount'` (import fails).
+2. **Green.** Add the one-line function to `recently-added-filter-options.ts`. Re-run → all pass.
+3. **Refactor.** None expected (single expression).
+
+### Unit tests (exhaustive)
+
+```
+shouldShowRecentlyAddedCount:
+  (0, false) → false   // loading / empty account: hidden
+  (0, true)  → true    // filter matched nothing: "0 items"
+  (5, false) → true    // normal: "5 items"
+  (5, true)  → true    // filtered result
+  (1, false) → true    // plural boundary handled by i18n, not this fn
+```
+
+### Route change
+
+- `const count = $derived(timelineManager?.assetCount ?? 0);`
+- `const countLabel = $derived(shouldShowRecentlyAddedCount(count, false) ? $t('items_count', { values: { count } }) : undefined);`
+- Pass `description={countLabel}` to the existing `<UserPageLayout ... title={data.meta.title}>`.
+
+### BDD acceptance scenarios (e2e, red-first)
+
+```gherkin
+Feature: Recently Added item count
+
+  Scenario: Count shown for a populated library
+    Given my library has 12 assets in the timeline
+    When I open the Recently Added view
+    Then the header shows "12 items"
+
+  Scenario: Count hidden for an empty library
+    Given my library has no assets
+    When I open the Recently Added view
+    Then no item count is shown in the header
+    And the empty-state placeholder is shown
+
+  Scenario: Count is not shown while selecting
+    Given the Recently Added view with assets
+    When I enter multi-select and select an asset
+    Then the header (title + count) is replaced by the selection bar
+```
+
+### Edge cases
+
+| Edge case | Expected | Verified by |
+|---|---|---|
+| Buckets not yet loaded (`assetCount` 0 transiently) | No "0 items" flash | `shouldShowRecentlyAddedCount(0,false)=false` |
+| Empty account | Count hidden; placeholder shown | unit + e2e "empty library" |
+| Multi-select active (`hideNavbar`) | Header + count hidden; selection bar shown | e2e "while selecting" |
+| Plural vs singular ("1 item") | Handled by `items_count` ICU plural | rendered by i18n (not this fn) |
+
+### Done gate
+
+`cd web && pnpm check:typescript && pnpm check:svelte && pnpm lint && pnpm test`; commit
+`feat(web): item count in Recently Added header (#805)`.
+
+---
+
+## Slice 2 — Browse filter panel (9 metadata sections)
+
+**Goal:** add the Filter panel with the 9 metadata sections, chips, URL persistence, grouping control,
+and make the Slice-1 count reflect the filtered set. **No free-text/search mode** (that is Slice 3);
+nothing in this slice references `committedQuery`/`SmartSearchResults`/smart facets.
+
+**Files:** `recently-added-filter-options.ts` (add two builders), `recently-added-filter-config.ts`
+(new), their specs, the route (restructure body to host the panel), the e2e spec (add scenarios).
+
+### The options builder
 
 ```ts
 // recently-added-filter-options.ts
@@ -93,28 +240,25 @@ export function buildRecentlyAddedTimelineOptions(filters: FilterState): Record<
 }
 ```
 
-**Why this exact shape:**
+**Invariants (each a test row):**
 
-- **`orderBy: AssetOrderBy.CreatedAt` always.** This is the defining trait of Recently Added and must
-  hold under every filter combination. (`buildPhotosTimelineOptions` never sets `orderBy`, so Photos
-  defaults to taken-at; we override.)
-- **`withSharedSpaces` stripped always.** Recently Added is an own+partner surface; adding shared-space
-  assets would silently broaden what appears. Stripping is safe whether or not the key is present
-  (it is absent when a favorites filter is active).
-- **`withPartners` inherited from `buildPhotosTimelineOptions` unchanged.** That means:
-  - No favorites filter → `withPartners: true` (own + partners — matches today's static options).
-  - Favorites filter active → `withPartners` absent (own-only). This matches Photos' semantics
-    (a favorite is a *personal* flag; a partner's favorite is not yours) and is a *new* behavior for a
-    *new* capability (there is no pre-existing favorites-filtering in Recently Added to regress).
-- **`order` (asc/desc) inherited** from `filters.sortOrder`; default desc = newest-added first.
-- **Date filters map to `takenAfter`/`takenBefore`** (inherited). Documented semantic: the **Timeline**
-  date filter filters on *taken* date, while day-groups ("Today") reflect *added* date. This is
-  intentional and useful (e.g. old photos just imported); we do not remap to created-at (no created-at
-  range predicate exists on the timeline query — that would be backend work, a non-goal).
+- **`orderBy: CreatedAt` always** — the defining trait; holds under every filter combination.
+- **`withSharedSpaces` never present** — asserted by exact-shape `toEqual` on the default case (so a
+  *future* new shared-scope key added by `buildPhotosTimelineOptions` would fail the test), plus explicit
+  `not.toHaveProperty('withSharedSpaces')` under a filter and under favorites.
+- **`withPartners` inherited** — `true` by default / non-favorite filters (own+partners, matching today's
+  static options); **absent** under a Favorites filter (own-only, matching Photos: a favorite is a
+  personal flag). New behavior for a new capability → no regression.
+- **`order`** inherited from `filters.sortOrder`; default `Desc` = newest-added first.
+- **Date filters → `takenAfter`/`takenBefore`** (inherited). Documented semantic: the Timeline date
+  filter filters *taken* date while day-groups reflect *added* date — intentional (e.g. old photos just
+  imported); not remapped to created-at (no created-at range predicate exists; that is backend work,
+  a non-goal).
 
-### Suggestion request payload
+### The suggestion request
 
 ```ts
+// recently-added-filter-options.ts
 export function buildRecentlyAddedSuggestionRequest(filters: FilterState) {
   const context = buildFilterContext(filters);
   return {
@@ -132,22 +276,21 @@ export function buildRecentlyAddedSuggestionRequest(filters: FilterState) {
         : filters.mediaType === 'image' ? AssetTypeEnum.Image : AssetTypeEnum.Video,
     takenAfter: context?.takenAfter,
     takenBefore: context?.takenBefore,
-    // NOTE: no withSharedSpaces, no albumId, no spaceId — own+partners scope only.
+    // no withSharedSpaces / albumId / spaceId — own+partners scope only
   };
 }
 ```
 
-This mirrors `album-filter-config.ts`'s private `toSuggestionRequest` (which likewise omits
-`withSharedSpaces`), so suggestion lists stay scoped to the same asset set the timeline shows.
+Mirrors `album-filter-config.ts`'s private `toSuggestionRequest` (which likewise omits `withSharedSpaces`).
 
-## 5. The filter config
+### The filter config
 
 ```ts
-// recently-added-filter-config.ts — Phase 1 (browse mode), mirrors album-filter-config.ts
+// recently-added-filter-config.ts (mirrors album-filter-config.ts)
 export function buildRecentlyAddedFilterConfig(): FilterPanelConfig {
   return {
-    // Phase 1: 9 metadata sections. 'text' is appended in Phase 2 together with its search path (§7),
-    // so the text input is never present without a working submit.
+    // 9 metadata sections. 'text' is appended in Slice 3 together with its search path, so the text
+    // input is never present without a working submit.
     sections: ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites', 'albums'],
     suggestionsProvider: async (filters) =>
       mapSuggestions(await getFilterSuggestions(buildRecentlyAddedSuggestionRequest(filters))),
@@ -159,228 +302,276 @@ export function buildRecentlyAddedFilterConfig(): FilterPanelConfig {
 }
 ```
 
-- `sections` is 9 in Phase 1; Phase 2 appends `'text'` for the full 10 (same plan order Photos uses).
-- `mapSuggestions` = the same mapping album/photos use (`getPhotosPersonFilterId` /
-  `getPhotosPersonFilterThumbnailUrl` for people, `{id, value}`→`{id, name}` for tags). Reuse the
-  exported helpers from `photos-filter-options.ts`; the small mapping wrapper is local to this file
-  (consistent with album-filter-config).
-- The page wraps this config with `withNameCapture(config, personNames, tagNames)` so `ActiveFiltersBar`
-  can label person/tag chips (same as the album/space pages).
-- **Phase 2** extends `suggestionsProvider` to branch on an active free-text query and pull
-  `searchSmartFacets` results (with `withSharedSpaces: false`), mirroring Photos' inline provider — see §7.
+`mapSuggestions` uses the exported `getPhotosPersonFilterId` / `getPhotosPersonFilterThumbnailUrl` from
+`photos-filter-options.ts` (as album-filter-config does) and maps tags `{id, value}`→`{id, name}`. The
+route wraps the config with `withNameCapture(config, personNames, tagNames)` so chips can be labelled.
 
-## 6. Page wiring (browse mode + count) — Phase 1
+### TDD steps
 
-Mirror the Photos page, dropping Photos-only extras (memories `ImageCarousel`/`memoryManager`, and the
-`RotateAction` which the current Recently Added page does not include). Keep the existing
-`AssetSelectControlBar` block verbatim.
+1. **Red (options).** Add `buildRecentlyAddedTimelineOptions` + `buildRecentlyAddedSuggestionRequest`
+   cases to the existing options spec. Run
+   `cd web && pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-options.spec.ts`
+   → red (`does not provide an export named 'buildRecentlyAddedTimelineOptions'`).
+2. **Green (options).** Implement both functions → re-run → pass.
+3. **Red (config).** Create `web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts`
+   (mock `@immich/sdk`, mirror `album-filter-config.spec.ts`). Run
+   `pnpm test -- --run src/lib/utils/__tests__/recently-added-filter-config.spec.ts`
+   → red (`buildRecentlyAddedFilterConfig` not exported).
+4. **Green (config).** Implement `recently-added-filter-config.ts` → re-run → pass.
+5. **Refactor.** De-dup any local mapping; keep functions pure.
+6. **Wire the route** (glue): seed `filters` from the URL (`getSearchablePageFilterState`/`State`);
+   `options = $derived({ ...buildRecentlyAddedTimelineOptions(filters), grouping: timelineGrouping })`;
+   restructure the body to `‹div flex›‹FilterPanel/›‹div›‹FilterToolbar/›‹Timeline/›‹/div›‹/div›` inside
+   the existing header; add `<ActiveFiltersBar>`; reuse the exported `handlePhotosRemoveFilter`;
+   `syncFilterUrl(nextFilters)` calls `buildSearchablePageUrl(page.url, '', nextFilters.sortOrder, nextFilters)`
+   (literal `''` query — no search in this slice); URL→filters `$effect` (filter-only variant of Photos');
+   register with `globalSearchManager.registerSearchablePageFilters`. Update the count:
+   `hasActiveFilters = $derived(getActiveFilterCount(filters) > 0)`, and
+   `countLabel = shouldShowRecentlyAddedCount(count, hasActiveFilters) ? … : undefined`.
+   Verify against the e2e scenarios (red before wiring → green after).
 
-**State & derivations** (mirroring Photos §102–156, minus smart-facet state in Phase 1):
+### Count derivations added this slice
 
-- `filters = $state<FilterState>()` seeded from the URL via `getSearchablePageFilterState` /
-  `getSearchablePageState`, exactly as Photos seeds it.
-- `timelineGrouping = $state<TimelineGrouping>('day')`, `temporalAnchor`, `committedQuery = ''`
-  (search unreachable in Phase 1 — no `text` submission path yet), and the URL-sync bookkeeping
-  (`lastHandledSearchState`, `pendingFilterUrlSync`).
-- `options = $derived({ ...buildRecentlyAddedTimelineOptions(filters), grouping: timelineGrouping })`
-  → `<Timeline {options}>`.
-- `$effect(() => globalSearchManager.registerSearchablePageFilters(() => filters))`.
+- `storageKey="gallery-filter-visible-sections-recently-added"` on `<FilterPanel>`.
+- `isTimelineEmpty = $derived(!!timelineManager?.isEmptyForOptions(options) && !hasActiveFilters)`
+  (verbatim from Photos) → `hidden` on the panel and toolbar gating.
+- **Single count, no duplicate:** pass `<ActiveFiltersBar>` **no** `resultCount` and **no**
+  `onAddAllToCollection`; the header remains the one count. (Chips + "Clear all" still work.
+  "Add all to collection" is intentionally omitted — see §5 decisions.)
 
-**Handlers** — reuse Photos' logic and its **exported** helper `handlePhotosRemoveFilter`
-(operates on `FilterState`, view-agnostic):
-
-- `syncFilterUrl`, `handleFiltersChange`, `handleRemoveActiveFilter` (→ `handlePhotosRemoveFilter`),
-  `handleClearAllFilters`, `handleTimelineGroupingChange`, and the URL→filters `$effect`.
-
-**Markup** — replicate Photos' body structure *inside* the existing `UserPageLayout` header:
-
-```svelte
-<UserPageLayout hideNavbar={assetMultiSelectManager.selectionActive} title={data.meta.title} description={countLabel} scrollbar={false}>
-  <div class="flex h-full">
-    <FilterPanel bind:filters bind:collapsed={filterCollapsed} externalToggle config={filterConfig}
-      timeBuckets={timelineBuckets} storageKey="gallery-filter-visible-sections-recently-added"
-      hidden={isTimelineEmpty} {personNames} {tagNames} onFiltersChange={handleFiltersChange} />
-    <div class="flex flex-1 flex-col overflow-hidden pl-4">
-      <FilterToolbar ... showFilters={hasActiveFilters} filters={activeFiltersBarSnippet} ... />
-      <Timeline enableRouting bind:timelineManager {options} assetInteraction={assetMultiSelectManager}
-        removeAction={AssetAction.ARCHIVE} onEscape={handleEscape} grouping={timelineGrouping}
-        onGroupingChange={handleTimelineGroupingChange} {temporalAnchor}
-        onTemporalAnchorResolved={() => (temporalAnchor = undefined)}
-        onTimelineBucketActivate={handleTimelineBucketActivate} withStacked>
-        {#snippet empty()}<EmptyPlaceholder text={$t('no_assets_message')} onClick={() => openFileUploadDialog()} .../>{/snippet}
-      </Timeline>
-    </div>
-  </div>
-</UserPageLayout>
-<!-- existing {#if selectionActive} AssetSelectControlBar … {/if} unchanged -->
-```
-
-### The count
-
-- `storageKey="gallery-filter-visible-sections-recently-added"` (its own per-view persisted section set).
-- `hasActiveFilters = $derived(getActiveFilterCount(filters) > 0)` (Phase 1; `|| showSearchResults` in Phase 2).
-- `count = $derived(timelineManager?.assetCount ?? 0)` (Phase 1; `showSearchResults ? smartFacetTotal : assetCount` in Phase 2).
-- `countLabel = $derived(shouldShowRecentlyAddedCount(count, hasActiveFilters) ? $t('items_count', { values: { count } }) : undefined)`,
-  passed as `description` to `UserPageLayout` — it renders next to the "Recently Added" title.
-- `isTimelineEmpty = $derived(!!timelineManager?.isEmptyForOptions(options) && !hasActiveFilters)` — reused
-  verbatim from Photos for `hidden`/toolbar gating (avoids the panel unmounting for a tick when clearing a
-  zero-result filter).
-
-```ts
-// pure — fully unit-tested
-export function shouldShowRecentlyAddedCount(count: number, hasActiveFilters: boolean): boolean {
-  return count > 0 || hasActiveFilters;
-}
-```
-
-Rationale for `shouldShowRecentlyAddedCount`:
-
-- Before buckets load (`count === 0`, no filters) → **hidden**: no "0 items" flash on entry.
-- Genuinely empty account (`count === 0`, no filters) → **hidden**: the `EmptyPlaceholder` already
-  communicates emptiness.
-- A filter that matches nothing (`count === 0`, filters active) → **"0 items"**: informative.
-- Any non-empty result → **"N items"**, live-updating as buckets load / filters change.
-
-### Single count, no duplicate
-
-`ActiveFiltersBar` can render its own `resultCount` (via `filter_result_count`) and an "Add all N to
-collection" button. To keep **one** unambiguous count (the header), Phase 1 passes the bar **no**
-`resultCount` and **no** `onAddAllToCollection`. Chips + "Clear all" still work.
-
-> **Default decision (open to override at review):** "Add all to collection" is **omitted** from Recently
-> Added to avoid a second count. It is an additive follow-up if wanted (pass `resultCount` +
-> `onAddAllToCollection`, and suppress the header count while filters are active to avoid duplication).
-
-## 7. Phase 2 — the Text / smart-search section
-
-The `text` section switches the view to query mode. Because a text query is inherently
-relevance-ordered, this mode is (as in Photos) indistinguishable from Photos search — it abandons the
-added-date ordering. It requires the most page-coupled, least-unit-testable plumbing, so it is a
-**separate, later slice** (the sections array only really needs `text` once this lands; until then the
-panel shows the other 9). End state = all 10 sections.
-
-Phase 2 mirrors Photos' inline search wiring **with `withSharedSpaces` forced to `false`** everywhere:
-
-- `committedQuery` from the URL; `showSearchResults = committedQuery.trim().length > 0`.
-- `smartFacets` state + `loadSmartFacets(filters)` via `searchSmartFacets({ ...buildSmartSearchFacetsParams({ query, filters, withSharedSpaces: false, language }) })`, with AbortController cancellation and the key-cache, exactly like Photos `§216–266` but `withSharedSpaces` pinned false.
-- `suggestionsProvider` branches: browse → `getFilterSuggestions` (§5); query → map `searchSmartFacets` facets.
-- Render `<SmartSearchResults searchQuery={committedQuery} {filters} withSharedSpaces={false} total={smartFacetTotal} />` in the `{#if showSearchResults}` branch; `<Timeline>` otherwise.
-- `timeBuckets={showSearchResults ? (smartFacets?.timeBuckets ?? []) : timelineBuckets}`.
-- Header count uses `smartFacetTotal` in query mode; `hasActiveFilters` also true whenever `showSearchResults`.
-- `clearSearch` / the query-clearing paths mirror Photos.
-
-**Scope invariant:** own+partners, never shared spaces — enforced in all three data paths (timeline
-options §4, browse suggestions §5, smart search here). This is the single rule distinguishing Recently
-Added from Photos.
-
-## 8. Development process — TDD
-
-Every pure unit is built **red → green → refactor** using `superpowers:test-driven-development`.
-Order (each step: write failing spec, run, implement, run, refactor):
-
-1. `shouldShowRecentlyAddedCount` — smallest; pins the count-visibility rules.
-2. `buildRecentlyAddedTimelineOptions` — the invariants (`orderBy` always CreatedAt; `withSharedSpaces`
-   never present; `withPartners` inherited) + predicate passthrough.
-3. `buildRecentlyAddedSuggestionRequest` — own+partners payload shape.
-4. `buildRecentlyAddedFilterConfig` — sections list + suggestion/provider requests (mock `@immich/sdk`,
-   mirror `album-filter-config.spec.ts`).
-5. Page wiring — landed behind the tested units; verified by the e2e spec (§9) and manual smoke, since a
-   full SvelteKit `+page.svelte` with all managers is impractical to mount in vitest. All *decision logic*
-   is already in the pure units above, so the page is thin glue.
-6. Phase 2 (Text) — config search-branch unit tests where the provider is separable; otherwise e2e.
-
-Gate before "done" (per repo conventions): `cd web && pnpm check:typescript && pnpm check:svelte && pnpm lint && pnpm test`
-plus the e2e web run for the new spec.
-
-## 9. Test plan & edge cases
-
-### Unit — `recently-added-filter-options.spec.ts`
+### Unit tests (exhaustive)
 
 `buildRecentlyAddedTimelineOptions`:
 
-- **default** → `toEqual({ visibility: Timeline, withStacked: true, withPartners: true, order: Desc, orderBy: CreatedAt })`.
-- **never has `withSharedSpaces`** — default; with a non-favorite filter (`country`); with `isFavorite: true`.
-- **`orderBy` is always `CreatedAt`** — default; with `country`; with `isFavorite: true`; with `sortOrder: 'asc'`.
-- **`withPartners` inherited** — present (`true`) with a non-favorite filter; **absent** when `isFavorite: true`.
-- **`order`** — `Desc` for default/`relevance`, `Asc` for `sortOrder: 'asc'`.
+- **default** → `toEqual({ visibility: Timeline, withStacked: true, withPartners: true, order: Desc, orderBy: CreatedAt })`
+  (exact shape — catches any future stray key).
+- **`withSharedSpaces` never present** — default (via `toEqual`); with a `country` filter
+  (`not.toHaveProperty`); with `isFavorite: true` (`not.toHaveProperty`).
+- **`orderBy` always `CreatedAt`** — default; `country`; `isFavorite: true`; `sortOrder: 'asc'`.
+- **`withPartners`** — `true` with a non-favorite filter; **absent** with `isFavorite: true`.
+- **`order`** — `Desc` for default and `sortOrder: 'relevance'`; `Asc` for `sortOrder: 'asc'`.
 - **predicate passthrough** — `personIds`, `city`+`country`, `make`+`model`, `tagIds`, `rating`,
   `mediaType`→`$type` (image/video) and omitted for `all`, trimmed `description`/`originalFileName`/`ocr`
   and omitted when blank, `isNotInAlbum`/`isInAlbum` true-only, `takenAfter`/`takenBefore` for year /
-  year+month / custom-bounded / from-only / to-only ranges.
-- **multi-filter** case with `orderBy` still `CreatedAt` and no `withSharedSpaces`.
+  year+month / custom-bounded / from-only / to-only.
+- **multi-filter** combo with `orderBy` still `CreatedAt` and no `withSharedSpaces`.
 
 `buildRecentlyAddedSuggestionRequest`:
 
 - omits `withSharedSpaces`, `albumId`, `spaceId` (always).
-- maps `mediaType`; passes `takenAfter`/`takenBefore`, `isFavorite`, `personIds`/`tagIds` (undefined when empty).
+- maps `mediaType`; passes `takenAfter`/`takenBefore` (year & custom), `isFavorite`; `personIds`/`tagIds`
+  `undefined` when empty, arrays when set.
 
-`shouldShowRecentlyAddedCount`:
+`buildRecentlyAddedFilterConfig` (mirror `album-filter-config.spec.ts`):
 
-- `(0, false) → false`; `(0, true) → true`; `(5, false) → true`; `(5, true) → true`.
-
-### Unit — `recently-added-filter-config.spec.ts` (mirror `album-filter-config.spec.ts`)
-
-- `sections` equals the 9 metadata sections in plan order (Phase 1); the assertion is updated to the full
-  10 (with `'text'`) when Phase 2 lands.
+- `sections` equals the **9** metadata sections in plan order.
 - `suggestionsProvider` calls `getFilterSuggestions` **without** `withSharedSpaces`/`albumId`/`spaceId`;
-  maps tags (`{id, name}`), people (scoped id via `getPhotosPersonFilterId`, incl. a space-primary
-  thumbnail case), `hasUnnamedPeople`; passes custom dates and `isFavorite`.
+  maps tags (`{id, name}`) and people (scoped id via `getPhotosPersonFilterId`, incl. a space-primary
+  thumbnail case), passes `hasUnnamedPeople`, custom dates, `isFavorite`, mapped `mediaType`.
 - `providers.cities` / `cameraModels` call `getSearchSuggestions` without `withSharedSpaces`/`albumId`/`spaceId`.
 
-### E2E — `recently-added.e2e-spec.ts` (Playwright, `--project=web`)
+### BDD acceptance scenarios (e2e)
 
-- `/recently-added` renders the Filter panel and the header count.
-- Applying **Media type = Video** narrows the grid, updates the URL (filter param present), and updates
-  the header count; a person/tag chip appears in `ActiveFiltersBar`.
-- **Remove** the chip / **Clear all** restores the full view and count.
-- **Deep-link** to `/recently-added?...` with a filter param seeds the panel state on load.
-- Reload preserves filters (URL is source of truth).
-- *(Phase 2)* Typing a text query shows `SmartSearchResults` and a search-total count; clearing returns to browse.
+```gherkin
+Feature: Recently Added filters
 
-### Edge cases (each has a test above or an explicit e2e assertion)
+  Scenario: Filtering by media type updates grid, URL, and count
+    Given the Recently Added view with 20 assets, 5 of them videos
+    When I open the filter panel and set Media type = Video
+    Then the grid shows 5 assets
+    And the header shows "5 items"
+    And the URL carries the media-type filter parameter
+
+  Scenario: Removing a filter chip restores the full view
+    Given the Recently Added view filtered to Media type = Video
+    When I remove the media-type chip
+    Then the grid shows all 20 assets
+    And the header shows "20 items"
+
+  Scenario: A filter matching nothing shows a zero count, not an empty account
+    Given the Recently Added view
+    When I apply a Rating = 5 filter that matches no asset
+    Then the header shows "0 items"
+    And the filter panel stays open so I can change the filter
+
+  Scenario: Filters survive a reload (URL is source of truth)
+    Given the Recently Added view filtered to a specific person
+    When I reload the page
+    Then the person filter is still applied and reflected in the count
+
+  Scenario: Recently Added stays ordered by added date under a filter
+    Given assets whose *added* order differs from their *taken* order
+    When I apply any metadata filter
+    Then the results remain grouped/ordered by added date (newest added first)
+```
+
+### Edge cases
 
 | Edge case | Expected | Verified by |
 |---|---|---|
-| Empty account (no assets) | Empty placeholder; count hidden; panel hidden (`isEmptyForOptions && !hasActiveFilters`) | `shouldShowRecentlyAddedCount(0,false)=false` + e2e |
-| Filter matches zero assets | Panel/chips stay visible; count shows "0 items"; user can clear | `shouldShowRecentlyAddedCount(0,true)=true` + e2e |
-| Initial load, buckets not yet counted | No "0 items" flash | `shouldShowRecentlyAddedCount(0,false)=false` |
-| `withSharedSpaces` leakage | Never sent in options, suggestions, or search | options + config unit tests |
-| Favorites filter | Own-only (partners excluded), consistent with Photos | options unit test |
-| Any filter combination | `orderBy` stays `CreatedAt` | options unit tests |
-| Sort asc/desc | `order` flips; `orderBy` unchanged | options unit tests |
-| Deep-link / reload with filter params | Filters seeded from URL | e2e |
-| Multi-select active | Header (title+count) hidden; selection bar shown; Escape clears selection | existing behavior preserved (unchanged block) + e2e smoke |
-| Grouping day↔month via toolbar | Grouping changes; temporal anchor preserved | mirrors Photos (manual/e2e) |
-| Suggestion fetch failure | Panel handles via its AbortController path; no uncaught throw | mirrors album/Photos (no new handling) |
-| *(Phase 2)* Smart-facet fetch failure | Caught, `console.error`, falls back to prior facets | mirrors Photos |
+| Filter matches zero assets | Panel stays open; count "0 items" | config/options units + e2e "matching nothing" |
+| `withSharedSpaces` leakage (any path) | Never sent in options or suggestions | options `toEqual` + config unit |
+| Future stray key from `buildPhotosTimelineOptions` | Caught | options default `toEqual` |
+| Favorites filter | Own-only (partners excluded) | options unit |
+| Any filter combination | `orderBy` stays `CreatedAt` | options units + e2e "ordered by added date" |
+| Sort asc/desc | `order` flips; `orderBy` unchanged | options units |
+| Count flicker on filter apply (`assetCount`→0→N) | Accept: momentary "0 items"→"N items" reflects the reload; not gated further (added date, own+partners; extra gating would risk the panel-unmount race Photos avoids with `isEmptyForOptions`). Documented, not hidden. | e2e observes final count; noted decision |
+| Deep-link with filter params | Filters seeded from URL on load | e2e "survive a reload" / deep-link |
+| Grouping day↔month via toolbar | Grouping changes; temporal anchor preserved | mirrors Photos (manual/e2e smoke) |
+| Suggestion fetch failure | `FilterPanel`'s own AbortController path; no uncaught throw | mirrors album/Photos (no new handling) |
 
-## 10. Error handling
+### Done gate
 
-- **Filter-suggestion fetch:** the browse `suggestionsProvider` does not add its own try/catch (matching
+Repo gate as Slice 1 **plus** the e2e web run for `recently-added-filters.e2e-spec.ts`; commit
+`feat(web): browse filters for Recently Added (#805)`.
+
+---
+
+## Slice 3 — Text / smart-search section (completes all-10 parity)
+
+**Goal:** add the 10th (`text`) section and the browse↔query mode switch, mirroring Photos'
+smart-search wiring, with **`withSharedSpaces` forced `false`** everywhere.
+
+**Files:** `recently-added-filter-config.ts` (append `text` + a query-mode `suggestionsProvider` branch),
+its spec (bump to 10 sections + search-branch), the route (add `committedQuery`, `showSearchResults`,
+`SmartSearchResults`, smart-facet state), the e2e spec (add search scenarios).
+
+### Changes
+
+- Config `sections` → append `'text'` (now 10, plan order). `suggestionsProvider` branches: browse →
+  `getFilterSuggestions` (Slice 2); query → map `searchSmartFacets` facets. `providers.cities`/`cameraModels`
+  gain the same browse/query branch.
+- Route: `committedQuery` from the URL; `showSearchResults = committedQuery.trim().length > 0`;
+  `smartFacets` state + `loadSmartFacets` via `searchSmartFacets({ ...buildSmartSearchFacetsParams({ query, filters, withSharedSpaces: false, language }) })`
+  with AbortController cancellation + key-cache (mirror Photos §216–266, `withSharedSpaces` pinned false).
+- Render `{#if showSearchResults}<SmartSearchResults searchQuery={committedQuery} {filters} withSharedSpaces={false} total={smartFacetTotal}/>{:else}<Timeline .../>{/if}`.
+- `timeBuckets={showSearchResults ? (smartFacets?.timeBuckets ?? []) : timelineBuckets}` on the panel.
+- Count: `count = showSearchResults ? (smartFacetTotal ?? 0) : (timelineManager?.assetCount ?? 0)`;
+  `hasActiveFilters` also true whenever `showSearchResults`. `clearSearch` mirrors Photos.
+
+### TDD steps
+
+1. **Red (config).** Update the config spec: `sections` now 10; add a search-branch case asserting the
+   query-mode provider calls `searchSmartFacets` with `withSharedSpaces: false`. Run the config spec → red.
+2. **Green (config).** Append `'text'` and the query branch → pass.
+3. **Wire the route** search mode; verify the search e2e scenarios (red-first → green).
+4. **Refactor.** Extract the smart-facet loader as a small named function for readability.
+
+### Unit tests
+
+`buildRecentlyAddedFilterConfig`:
+
+- `sections` equals the full **10** in plan order.
+- browse-mode provider unchanged (Slice-2 assertions still pass).
+- query-mode provider (given an active query) calls `searchSmartFacets` with `withSharedSpaces: false`
+  and maps facets to suggestions. (Where the provider needs page state, cover the separable payload
+  builder; the rest is e2e.)
+
+### BDD acceptance scenarios (e2e)
+
+```gherkin
+Feature: Recently Added text search
+
+  Scenario: A text query switches to search results with a total count
+    Given the Recently Added view
+    When I type "beach" into the text filter and submit
+    Then search results are shown
+    And the header shows the search-result total as "N items"
+
+  Scenario: Clearing the query returns to the added-date timeline
+    Given the Recently Added view showing text-search results
+    When I clear the text query
+    Then the added-date timeline is shown again with its item count
+
+  Scenario: Text search stays within own + partner scope
+    Given a shared-space asset that would match "invoice"
+    When I run a text search for "invoice" in Recently Added
+    Then the shared-space asset is not included in the results
+```
+
+### Edge cases
+
+| Edge case | Expected | Verified by |
+|---|---|---|
+| Empty query submitted | Stays in browse mode (`showSearchResults` false) | route logic + e2e |
+| Smart-facet fetch failure | Caught, `console.error`, falls back to prior facets | mirrors Photos §252–257 |
+| `withSharedSpaces` in search path | Forced `false` (own+partners) | config search-branch unit + e2e "own+partner scope" |
+| Query then filter change | Facets refetch (keyed by query+filters); abort in-flight | mirrors Photos key-cache |
+| Count in query mode | Uses `smartFacetTotal`, not `assetCount` | route derivation + e2e |
+
+### Done gate
+
+Repo gate + e2e web run; commit `feat(web): text/smart-search filter for Recently Added (#805)`.
+
+---
+
+## 5. Cross-cutting
+
+### Error handling
+
+- **Filter-suggestion fetch (browse):** the config's `suggestionsProvider` adds no try/catch (matching
   `album-filter-config.ts`); `FilterPanel` owns debouncing + `AbortController` cancellation.
-- **Smart-facet fetch (Phase 2):** catch → `console.error` → fall back to the last good facets (mirror
-  Photos `§252–257`).
+- **Smart-facet fetch (Slice 3):** catch → `console.error` → fall back to the last good facets (mirror
+  Photos §252–257).
 - **URL navigation:** mirror Photos — `goto(..., { replaceState, keepFocus, noScroll })`; no special handling.
 
-## 11. Non-goals
+### Decisions taken (open to override)
 
-- Any server / API / DTO change.
-- Photos/videos count breakdown (needs a server stats change — `/search/statistics` returns total only;
-  `/assets/statistics` lacks the filters).
-- Per-day-group counts in the timeline day headers (would edit the shared `Timeline` component → affects
-  all timeline views).
-- Mobile parity (separate filter stack).
-- Extracting a shared `<FilteredTimelinePage>` component or shared logic helpers (Approaches B/C — a
-  cross-cutting refactor of all filter surfaces, out of scope here).
-- Fixing the pre-existing cross-view filter-parity issues #802 / #797 / #796.
-
-## 12. Decisions taken (flagged for review)
-
-1. **Text/smart-search is Phase 2**, sequenced after the browse filters + count, to isolate the risky,
-   page-coupled, least-unit-testable plumbing. End state still includes all 10 sections.
-2. **"Add all to collection" omitted** from Recently Added's `ActiveFiltersBar` so the header carries the
-   single count. Easy to add back later.
-3. **Favorites filter excludes partner assets** (own-only), matching Photos, rather than forcing
-   `withPartners` on. It is new behavior for a new capability, so no regression.
+1. **Text/smart-search is the last slice** — isolates the risky, page-coupled, least-unit-testable
+   plumbing. End state still includes all 10 sections.
+2. **"Add all to collection" omitted** from Recently Added's `ActiveFiltersBar`, so the header carries the
+   single count. Additive later if wanted (pass `resultCount` + `onAddAllToCollection`, and suppress the
+   header count while filters are active to avoid duplication).
+3. **Favorites filter excludes partner assets** (own-only), matching Photos — new behavior for a new
+   capability, so no regression.
 4. **The Timeline date filter filters taken-at** while day-grouping reflects added-at; kept as-is (no
    created-at range predicate exists; adding one is backend work / non-goal).
+5. **Count flicker on filter apply** ("0 items" for a tick before the filtered count loads) is accepted
+   and documented rather than gated with extra state that would risk the panel-unmount race Photos
+   guards against.
+
+### Non-goals
+
+- Any server / API / DTO change.
+- Photos/videos count breakdown (needs a server stats change).
+- Per-day-group counts in the timeline day headers (would edit the shared `Timeline` component).
+- Mobile parity (separate filter stack).
+- Extracting a shared `<FilteredTimelinePage>` component / shared logic helpers (Approaches B/C).
+- Fixing the pre-existing cross-view filter-parity issues #802 / #797 / #796.
+
+## 6. Coverage matrix (every edge case → slice → test)
+
+| # | Edge case / behavior | Slice | Test |
+|---|---|---|---|
+| 1 | Count hidden while loading / empty account | 1 | unit `shouldShowRecentlyAddedCount(0,false)`; e2e empty library |
+| 2 | Count shown for populated library | 1 | e2e populated |
+| 3 | Count hidden during multi-select | 1 | e2e selecting |
+| 4 | Plural/singular wording | 1 | i18n `items_count` (ICU) |
+| 5 | `orderBy` always CreatedAt | 2 | options units; e2e "ordered by added date" |
+| 6 | `withSharedSpaces` never in options | 2 | options `toEqual` + `not.toHaveProperty` |
+| 7 | Future stray key regression | 2 | options default `toEqual` |
+| 8 | `withPartners` inherited / dropped on favorites | 2 | options units |
+| 9 | `order` asc/desc | 2 | options units |
+| 10 | All predicate passthroughs + date ranges | 2 | options units |
+| 11 | Suggestion request omits shared/album/space scope | 2 | options unit |
+| 12 | Config = 9 sections, correct suggestion/provider calls | 2 | config unit |
+| 13 | Filter matches nothing → "0 items", panel stays | 2 | e2e "matching nothing" |
+| 14 | Filters persist via URL / deep-link / reload | 2 | e2e reload |
+| 15 | Chip removal / clear all | 2 | e2e remove chip |
+| 16 | Count flicker on apply | 2 | documented decision; e2e final count |
+| 17 | Grouping day↔month | 2 | e2e/manual smoke |
+| 18 | Config = 10 sections incl. text | 3 | config unit |
+| 19 | Text query → search results + search-total count | 3 | e2e search |
+| 20 | Clear query → back to added-date timeline | 3 | e2e clear |
+| 21 | Search stays own+partner (no shared spaces) | 3 | config search-branch unit + e2e scope |
+| 22 | Empty query submitted → stays browse | 3 | route logic + e2e |
+| 23 | Smart-facet fetch failure fallback | 3 | mirrors Photos (manual/e2e) |
+
+## 7. Process notes for impl-loop
+
+- Slice plans are saved to `docs/superpowers/plans/2026-07-19-recently-added-filters-slice-<n>.md`.
+- Each slice: pure-function TDD (red→green with the commands above) → route wiring → e2e acceptance
+  (red-first) → repo gate (`check:typescript`, `check:svelte`, `lint`, `test`) + e2e web run → commit → push.
+- Slices are independent increments: Slice 1 ships the count alone; Slice 2 adds browse filters; Slice 3
+  completes all-10 parity. A later slice may modify an earlier slice's file only for that slice's feature
+  (e.g., Slice 3 appends `'text'` to the config from Slice 2).

--- a/docs/superpowers/specs/2026-07-19-recently-added-filters-design.md
+++ b/docs/superpowers/specs/2026-07-19-recently-added-filters-design.md
@@ -1,0 +1,386 @@
+# Filters + item count for the "Recently Added" view (#805)
+
+- **Discussion:** https://github.com/open-noodle/gallery/discussions/805
+- **Date:** 2026-07-19
+- **Scope:** Web only. No server / API / mobile changes.
+- **Approach:** Mirror the existing per-view filter integration pattern (Photos), adding two new
+  `web/src/lib/utils/` modules and wiring them into the Recently Added route. Do **not** modify the
+  Photos page or the shared `filter-panel` / `Timeline` components.
+
+## 1. Goal
+
+Give the web **Recently Added** view (`/recently-added`) two things the discussion asks for:
+
+1. **Filter navigation** — the same 10-section Filter panel used by Photos
+   (Timeline, People, Location, Camera, Tags, Rating, Media type, Favorites, Albums, Text).
+2. **A visible item count** — "N items" in the page header, reflecting what is currently shown and
+   updating live as filters change.
+
+…while preserving what makes the view "recently added": assets are **ordered and day-grouped by
+*added* date** (`orderBy: AssetOrderBy.CreatedAt`) and the view stays scoped to **own + partner**
+assets (never shared spaces).
+
+## 2. Background: how the pieces work today
+
+- **The route** `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte`
+  renders the shared `<Timeline {options}>` with a static
+  `options = { visibility: Timeline, withStacked: true, withPartners: true, orderBy: CreatedAt }`.
+  It has a header **title** ("Recently Added") via `UserPageLayout` but **no count and no filters**.
+  It shares the multi-select bulk-action machinery (`AssetSelectControlBar`) with Photos.
+
+- **The Filter panel** `web/src/lib/components/filter-panel/` is reusable. Each host view supplies a
+  `FilterPanelConfig` (which `sections` to show + suggestion providers) and converts the panel's
+  `FilterState` into a timeline query via a per-view **options builder**
+  (`buildPhotosTimelineOptions`, `buildSpaceTimelineOptions`, `buildAlbumTimelineOptions`,
+  `buildMapTimelineOptions`). The **URL is the source of truth** for filter state
+  (`web/src/lib/utils/searchable-page-search.ts`).
+
+- **Photos is the full template** (`web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte`):
+  it seeds `FilterState` from the URL, builds an all-10-section config, feeds
+  `buildPhotosTimelineOptions(filters)` into `<Timeline>`, renders `<ActiveFiltersBar>` + `<FilterToolbar>`,
+  and switches between **browse mode** (`<Timeline>`) and **query mode** (`<SmartSearchResults>`) when
+  free-text is entered.
+
+- **The count is free client-side.** `TimelineManager.assetCount` is a live grand total (time buckets
+  carry per-bucket counts) available once buckets load. There is **no** photos/videos split without
+  backend work. The `items_count` i18n key already exists:
+  `"{count, plural, one {# item} other {# items}}"`.
+
+- **Scope subtlety in `buildPhotosTimelineOptions`:** `withPartners` and `withSharedSpaces` are only
+  added when `filters.isFavorite === undefined` (favorites are treated as strictly personal). Recently
+  Added must never add `withSharedSpaces` — see §4.
+
+## 3. New & modified files
+
+### New (source)
+
+| File | Responsibility |
+|---|---|
+| `web/src/lib/utils/recently-added-filter-options.ts` | Pure functions: `buildRecentlyAddedTimelineOptions(filters)`, `buildRecentlyAddedSuggestionRequest(filters)`, `shouldShowRecentlyAddedCount(count, hasActiveFilters)`. |
+| `web/src/lib/utils/recently-added-filter-config.ts` | `buildRecentlyAddedFilterConfig()` → `FilterPanelConfig` (browse-mode suggestions, own+partners scope). Phase 2 extends its `suggestionsProvider` for query mode. |
+
+### New (tests)
+
+| File | Covers |
+|---|---|
+| `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts` | The three pure functions above. |
+| `web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts` | The config (sections list + suggestion/provider requests), mirroring `album-filter-config.spec.ts`. |
+| `e2e/src/specs/web/recently-added-filters.e2e-spec.ts` (mirrors the existing `photos-filter-panel.e2e-spec.ts`) | End-to-end: filter panel present, apply/remove a filter, count updates, URL round-trips. Flagged optional-but-recommended. |
+
+### Modified
+
+| File | Change |
+|---|---|
+| `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte` | Add filter state seeded from the URL, the filter config, `<FilterPanel>` / `<ActiveFiltersBar>` / `<FilterToolbar>`, browse/query mode switch, header count. Keep the existing title and the entire bulk-action `AssetSelectControlBar` block unchanged. |
+
+No i18n changes are required for Phase 1 (`items_count` exists). Phase 2 reuses existing search keys
+(`filter_result_count`, etc.) already used by Photos.
+
+## 4. The options builder (the load-bearing unit)
+
+```ts
+// recently-added-filter-options.ts
+import { AssetOrderBy } from '@immich/sdk';
+import type { FilterState } from '$lib/components/filter-panel/filter-panel';
+import { buildPhotosTimelineOptions } from '$lib/utils/photos-filter-options';
+
+export function buildRecentlyAddedTimelineOptions(filters: FilterState): Record<string, unknown> {
+  // Reuse Photos' predicate mapping, then apply the two Recently-Added invariants:
+  //   1. never surface shared-space assets (strip withSharedSpaces in every case)
+  //   2. always order/group by *added* date
+  const { withSharedSpaces: _omitShared, ...base } = buildPhotosTimelineOptions(filters);
+  return { ...base, orderBy: AssetOrderBy.CreatedAt };
+}
+```
+
+**Why this exact shape:**
+
+- **`orderBy: AssetOrderBy.CreatedAt` always.** This is the defining trait of Recently Added and must
+  hold under every filter combination. (`buildPhotosTimelineOptions` never sets `orderBy`, so Photos
+  defaults to taken-at; we override.)
+- **`withSharedSpaces` stripped always.** Recently Added is an own+partner surface; adding shared-space
+  assets would silently broaden what appears. Stripping is safe whether or not the key is present
+  (it is absent when a favorites filter is active).
+- **`withPartners` inherited from `buildPhotosTimelineOptions` unchanged.** That means:
+  - No favorites filter → `withPartners: true` (own + partners — matches today's static options).
+  - Favorites filter active → `withPartners` absent (own-only). This matches Photos' semantics
+    (a favorite is a *personal* flag; a partner's favorite is not yours) and is a *new* behavior for a
+    *new* capability (there is no pre-existing favorites-filtering in Recently Added to regress).
+- **`order` (asc/desc) inherited** from `filters.sortOrder`; default desc = newest-added first.
+- **Date filters map to `takenAfter`/`takenBefore`** (inherited). Documented semantic: the **Timeline**
+  date filter filters on *taken* date, while day-groups ("Today") reflect *added* date. This is
+  intentional and useful (e.g. old photos just imported); we do not remap to created-at (no created-at
+  range predicate exists on the timeline query — that would be backend work, a non-goal).
+
+### Suggestion request payload
+
+```ts
+export function buildRecentlyAddedSuggestionRequest(filters: FilterState) {
+  const context = buildFilterContext(filters);
+  return {
+    personIds: filters.personIds.length > 0 ? filters.personIds : undefined,
+    country: filters.country,
+    city: filters.city,
+    make: filters.make,
+    model: filters.model,
+    tagIds: filters.tagIds.length > 0 ? filters.tagIds : undefined,
+    rating: filters.rating,
+    isFavorite: filters.isFavorite,
+    mediaType:
+      filters.mediaType === 'all'
+        ? undefined
+        : filters.mediaType === 'image' ? AssetTypeEnum.Image : AssetTypeEnum.Video,
+    takenAfter: context?.takenAfter,
+    takenBefore: context?.takenBefore,
+    // NOTE: no withSharedSpaces, no albumId, no spaceId — own+partners scope only.
+  };
+}
+```
+
+This mirrors `album-filter-config.ts`'s private `toSuggestionRequest` (which likewise omits
+`withSharedSpaces`), so suggestion lists stay scoped to the same asset set the timeline shows.
+
+## 5. The filter config
+
+```ts
+// recently-added-filter-config.ts — Phase 1 (browse mode), mirrors album-filter-config.ts
+export function buildRecentlyAddedFilterConfig(): FilterPanelConfig {
+  return {
+    // Phase 1: 9 metadata sections. 'text' is appended in Phase 2 together with its search path (§7),
+    // so the text input is never present without a working submit.
+    sections: ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites', 'albums'],
+    suggestionsProvider: async (filters) =>
+      mapSuggestions(await getFilterSuggestions(buildRecentlyAddedSuggestionRequest(filters))),
+    providers: {
+      cities: (country, context) => getSearchSuggestions({ $type: SearchSuggestionType.City, country, ...context }),
+      cameraModels: (make, context) => getSearchSuggestions({ $type: SearchSuggestionType.CameraModel, make, ...context }),
+    },
+  };
+}
+```
+
+- `sections` is 9 in Phase 1; Phase 2 appends `'text'` for the full 10 (same plan order Photos uses).
+- `mapSuggestions` = the same mapping album/photos use (`getPhotosPersonFilterId` /
+  `getPhotosPersonFilterThumbnailUrl` for people, `{id, value}`→`{id, name}` for tags). Reuse the
+  exported helpers from `photos-filter-options.ts`; the small mapping wrapper is local to this file
+  (consistent with album-filter-config).
+- The page wraps this config with `withNameCapture(config, personNames, tagNames)` so `ActiveFiltersBar`
+  can label person/tag chips (same as the album/space pages).
+- **Phase 2** extends `suggestionsProvider` to branch on an active free-text query and pull
+  `searchSmartFacets` results (with `withSharedSpaces: false`), mirroring Photos' inline provider — see §7.
+
+## 6. Page wiring (browse mode + count) — Phase 1
+
+Mirror the Photos page, dropping Photos-only extras (memories `ImageCarousel`/`memoryManager`, and the
+`RotateAction` which the current Recently Added page does not include). Keep the existing
+`AssetSelectControlBar` block verbatim.
+
+**State & derivations** (mirroring Photos §102–156, minus smart-facet state in Phase 1):
+
+- `filters = $state<FilterState>()` seeded from the URL via `getSearchablePageFilterState` /
+  `getSearchablePageState`, exactly as Photos seeds it.
+- `timelineGrouping = $state<TimelineGrouping>('day')`, `temporalAnchor`, `committedQuery = ''`
+  (search unreachable in Phase 1 — no `text` submission path yet), and the URL-sync bookkeeping
+  (`lastHandledSearchState`, `pendingFilterUrlSync`).
+- `options = $derived({ ...buildRecentlyAddedTimelineOptions(filters), grouping: timelineGrouping })`
+  → `<Timeline {options}>`.
+- `$effect(() => globalSearchManager.registerSearchablePageFilters(() => filters))`.
+
+**Handlers** — reuse Photos' logic and its **exported** helper `handlePhotosRemoveFilter`
+(operates on `FilterState`, view-agnostic):
+
+- `syncFilterUrl`, `handleFiltersChange`, `handleRemoveActiveFilter` (→ `handlePhotosRemoveFilter`),
+  `handleClearAllFilters`, `handleTimelineGroupingChange`, and the URL→filters `$effect`.
+
+**Markup** — replicate Photos' body structure *inside* the existing `UserPageLayout` header:
+
+```svelte
+<UserPageLayout hideNavbar={assetMultiSelectManager.selectionActive} title={data.meta.title} description={countLabel} scrollbar={false}>
+  <div class="flex h-full">
+    <FilterPanel bind:filters bind:collapsed={filterCollapsed} externalToggle config={filterConfig}
+      timeBuckets={timelineBuckets} storageKey="gallery-filter-visible-sections-recently-added"
+      hidden={isTimelineEmpty} {personNames} {tagNames} onFiltersChange={handleFiltersChange} />
+    <div class="flex flex-1 flex-col overflow-hidden pl-4">
+      <FilterToolbar ... showFilters={hasActiveFilters} filters={activeFiltersBarSnippet} ... />
+      <Timeline enableRouting bind:timelineManager {options} assetInteraction={assetMultiSelectManager}
+        removeAction={AssetAction.ARCHIVE} onEscape={handleEscape} grouping={timelineGrouping}
+        onGroupingChange={handleTimelineGroupingChange} {temporalAnchor}
+        onTemporalAnchorResolved={() => (temporalAnchor = undefined)}
+        onTimelineBucketActivate={handleTimelineBucketActivate} withStacked>
+        {#snippet empty()}<EmptyPlaceholder text={$t('no_assets_message')} onClick={() => openFileUploadDialog()} .../>{/snippet}
+      </Timeline>
+    </div>
+  </div>
+</UserPageLayout>
+<!-- existing {#if selectionActive} AssetSelectControlBar … {/if} unchanged -->
+```
+
+### The count
+
+- `storageKey="gallery-filter-visible-sections-recently-added"` (its own per-view persisted section set).
+- `hasActiveFilters = $derived(getActiveFilterCount(filters) > 0)` (Phase 1; `|| showSearchResults` in Phase 2).
+- `count = $derived(timelineManager?.assetCount ?? 0)` (Phase 1; `showSearchResults ? smartFacetTotal : assetCount` in Phase 2).
+- `countLabel = $derived(shouldShowRecentlyAddedCount(count, hasActiveFilters) ? $t('items_count', { values: { count } }) : undefined)`,
+  passed as `description` to `UserPageLayout` — it renders next to the "Recently Added" title.
+- `isTimelineEmpty = $derived(!!timelineManager?.isEmptyForOptions(options) && !hasActiveFilters)` — reused
+  verbatim from Photos for `hidden`/toolbar gating (avoids the panel unmounting for a tick when clearing a
+  zero-result filter).
+
+```ts
+// pure — fully unit-tested
+export function shouldShowRecentlyAddedCount(count: number, hasActiveFilters: boolean): boolean {
+  return count > 0 || hasActiveFilters;
+}
+```
+
+Rationale for `shouldShowRecentlyAddedCount`:
+
+- Before buckets load (`count === 0`, no filters) → **hidden**: no "0 items" flash on entry.
+- Genuinely empty account (`count === 0`, no filters) → **hidden**: the `EmptyPlaceholder` already
+  communicates emptiness.
+- A filter that matches nothing (`count === 0`, filters active) → **"0 items"**: informative.
+- Any non-empty result → **"N items"**, live-updating as buckets load / filters change.
+
+### Single count, no duplicate
+
+`ActiveFiltersBar` can render its own `resultCount` (via `filter_result_count`) and an "Add all N to
+collection" button. To keep **one** unambiguous count (the header), Phase 1 passes the bar **no**
+`resultCount` and **no** `onAddAllToCollection`. Chips + "Clear all" still work.
+
+> **Default decision (open to override at review):** "Add all to collection" is **omitted** from Recently
+> Added to avoid a second count. It is an additive follow-up if wanted (pass `resultCount` +
+> `onAddAllToCollection`, and suppress the header count while filters are active to avoid duplication).
+
+## 7. Phase 2 — the Text / smart-search section
+
+The `text` section switches the view to query mode. Because a text query is inherently
+relevance-ordered, this mode is (as in Photos) indistinguishable from Photos search — it abandons the
+added-date ordering. It requires the most page-coupled, least-unit-testable plumbing, so it is a
+**separate, later slice** (the sections array only really needs `text` once this lands; until then the
+panel shows the other 9). End state = all 10 sections.
+
+Phase 2 mirrors Photos' inline search wiring **with `withSharedSpaces` forced to `false`** everywhere:
+
+- `committedQuery` from the URL; `showSearchResults = committedQuery.trim().length > 0`.
+- `smartFacets` state + `loadSmartFacets(filters)` via `searchSmartFacets({ ...buildSmartSearchFacetsParams({ query, filters, withSharedSpaces: false, language }) })`, with AbortController cancellation and the key-cache, exactly like Photos `§216–266` but `withSharedSpaces` pinned false.
+- `suggestionsProvider` branches: browse → `getFilterSuggestions` (§5); query → map `searchSmartFacets` facets.
+- Render `<SmartSearchResults searchQuery={committedQuery} {filters} withSharedSpaces={false} total={smartFacetTotal} />` in the `{#if showSearchResults}` branch; `<Timeline>` otherwise.
+- `timeBuckets={showSearchResults ? (smartFacets?.timeBuckets ?? []) : timelineBuckets}`.
+- Header count uses `smartFacetTotal` in query mode; `hasActiveFilters` also true whenever `showSearchResults`.
+- `clearSearch` / the query-clearing paths mirror Photos.
+
+**Scope invariant:** own+partners, never shared spaces — enforced in all three data paths (timeline
+options §4, browse suggestions §5, smart search here). This is the single rule distinguishing Recently
+Added from Photos.
+
+## 8. Development process — TDD
+
+Every pure unit is built **red → green → refactor** using `superpowers:test-driven-development`.
+Order (each step: write failing spec, run, implement, run, refactor):
+
+1. `shouldShowRecentlyAddedCount` — smallest; pins the count-visibility rules.
+2. `buildRecentlyAddedTimelineOptions` — the invariants (`orderBy` always CreatedAt; `withSharedSpaces`
+   never present; `withPartners` inherited) + predicate passthrough.
+3. `buildRecentlyAddedSuggestionRequest` — own+partners payload shape.
+4. `buildRecentlyAddedFilterConfig` — sections list + suggestion/provider requests (mock `@immich/sdk`,
+   mirror `album-filter-config.spec.ts`).
+5. Page wiring — landed behind the tested units; verified by the e2e spec (§9) and manual smoke, since a
+   full SvelteKit `+page.svelte` with all managers is impractical to mount in vitest. All *decision logic*
+   is already in the pure units above, so the page is thin glue.
+6. Phase 2 (Text) — config search-branch unit tests where the provider is separable; otherwise e2e.
+
+Gate before "done" (per repo conventions): `cd web && pnpm check:typescript && pnpm check:svelte && pnpm lint && pnpm test`
+plus the e2e web run for the new spec.
+
+## 9. Test plan & edge cases
+
+### Unit — `recently-added-filter-options.spec.ts`
+
+`buildRecentlyAddedTimelineOptions`:
+
+- **default** → `toEqual({ visibility: Timeline, withStacked: true, withPartners: true, order: Desc, orderBy: CreatedAt })`.
+- **never has `withSharedSpaces`** — default; with a non-favorite filter (`country`); with `isFavorite: true`.
+- **`orderBy` is always `CreatedAt`** — default; with `country`; with `isFavorite: true`; with `sortOrder: 'asc'`.
+- **`withPartners` inherited** — present (`true`) with a non-favorite filter; **absent** when `isFavorite: true`.
+- **`order`** — `Desc` for default/`relevance`, `Asc` for `sortOrder: 'asc'`.
+- **predicate passthrough** — `personIds`, `city`+`country`, `make`+`model`, `tagIds`, `rating`,
+  `mediaType`→`$type` (image/video) and omitted for `all`, trimmed `description`/`originalFileName`/`ocr`
+  and omitted when blank, `isNotInAlbum`/`isInAlbum` true-only, `takenAfter`/`takenBefore` for year /
+  year+month / custom-bounded / from-only / to-only ranges.
+- **multi-filter** case with `orderBy` still `CreatedAt` and no `withSharedSpaces`.
+
+`buildRecentlyAddedSuggestionRequest`:
+
+- omits `withSharedSpaces`, `albumId`, `spaceId` (always).
+- maps `mediaType`; passes `takenAfter`/`takenBefore`, `isFavorite`, `personIds`/`tagIds` (undefined when empty).
+
+`shouldShowRecentlyAddedCount`:
+
+- `(0, false) → false`; `(0, true) → true`; `(5, false) → true`; `(5, true) → true`.
+
+### Unit — `recently-added-filter-config.spec.ts` (mirror `album-filter-config.spec.ts`)
+
+- `sections` equals the 9 metadata sections in plan order (Phase 1); the assertion is updated to the full
+  10 (with `'text'`) when Phase 2 lands.
+- `suggestionsProvider` calls `getFilterSuggestions` **without** `withSharedSpaces`/`albumId`/`spaceId`;
+  maps tags (`{id, name}`), people (scoped id via `getPhotosPersonFilterId`, incl. a space-primary
+  thumbnail case), `hasUnnamedPeople`; passes custom dates and `isFavorite`.
+- `providers.cities` / `cameraModels` call `getSearchSuggestions` without `withSharedSpaces`/`albumId`/`spaceId`.
+
+### E2E — `recently-added.e2e-spec.ts` (Playwright, `--project=web`)
+
+- `/recently-added` renders the Filter panel and the header count.
+- Applying **Media type = Video** narrows the grid, updates the URL (filter param present), and updates
+  the header count; a person/tag chip appears in `ActiveFiltersBar`.
+- **Remove** the chip / **Clear all** restores the full view and count.
+- **Deep-link** to `/recently-added?...` with a filter param seeds the panel state on load.
+- Reload preserves filters (URL is source of truth).
+- *(Phase 2)* Typing a text query shows `SmartSearchResults` and a search-total count; clearing returns to browse.
+
+### Edge cases (each has a test above or an explicit e2e assertion)
+
+| Edge case | Expected | Verified by |
+|---|---|---|
+| Empty account (no assets) | Empty placeholder; count hidden; panel hidden (`isEmptyForOptions && !hasActiveFilters`) | `shouldShowRecentlyAddedCount(0,false)=false` + e2e |
+| Filter matches zero assets | Panel/chips stay visible; count shows "0 items"; user can clear | `shouldShowRecentlyAddedCount(0,true)=true` + e2e |
+| Initial load, buckets not yet counted | No "0 items" flash | `shouldShowRecentlyAddedCount(0,false)=false` |
+| `withSharedSpaces` leakage | Never sent in options, suggestions, or search | options + config unit tests |
+| Favorites filter | Own-only (partners excluded), consistent with Photos | options unit test |
+| Any filter combination | `orderBy` stays `CreatedAt` | options unit tests |
+| Sort asc/desc | `order` flips; `orderBy` unchanged | options unit tests |
+| Deep-link / reload with filter params | Filters seeded from URL | e2e |
+| Multi-select active | Header (title+count) hidden; selection bar shown; Escape clears selection | existing behavior preserved (unchanged block) + e2e smoke |
+| Grouping day↔month via toolbar | Grouping changes; temporal anchor preserved | mirrors Photos (manual/e2e) |
+| Suggestion fetch failure | Panel handles via its AbortController path; no uncaught throw | mirrors album/Photos (no new handling) |
+| *(Phase 2)* Smart-facet fetch failure | Caught, `console.error`, falls back to prior facets | mirrors Photos |
+
+## 10. Error handling
+
+- **Filter-suggestion fetch:** the browse `suggestionsProvider` does not add its own try/catch (matching
+  `album-filter-config.ts`); `FilterPanel` owns debouncing + `AbortController` cancellation.
+- **Smart-facet fetch (Phase 2):** catch → `console.error` → fall back to the last good facets (mirror
+  Photos `§252–257`).
+- **URL navigation:** mirror Photos — `goto(..., { replaceState, keepFocus, noScroll })`; no special handling.
+
+## 11. Non-goals
+
+- Any server / API / DTO change.
+- Photos/videos count breakdown (needs a server stats change — `/search/statistics` returns total only;
+  `/assets/statistics` lacks the filters).
+- Per-day-group counts in the timeline day headers (would edit the shared `Timeline` component → affects
+  all timeline views).
+- Mobile parity (separate filter stack).
+- Extracting a shared `<FilteredTimelinePage>` component or shared logic helpers (Approaches B/C — a
+  cross-cutting refactor of all filter surfaces, out of scope here).
+- Fixing the pre-existing cross-view filter-parity issues #802 / #797 / #796.
+
+## 12. Decisions taken (flagged for review)
+
+1. **Text/smart-search is Phase 2**, sequenced after the browse filters + count, to isolate the risky,
+   page-coupled, least-unit-testable plumbing. End state still includes all 10 sections.
+2. **"Add all to collection" omitted** from Recently Added's `ActiveFiltersBar` so the header carries the
+   single count. Easy to add back later.
+3. **Favorites filter excludes partner assets** (own-only), matching Photos, rather than forcing
+   `withPartners` on. It is new behavior for a new capability, so no regression.
+4. **The Timeline date filter filters taken-at** while day-grouping reflects added-at; kept as-is (no
+   created-at range predicate exists; adding one is backend work / non-goal).

--- a/docs/superpowers/specs/2026-07-19-recently-added-filters-design.md
+++ b/docs/superpowers/specs/2026-07-19-recently-added-filters-design.md
@@ -66,6 +66,26 @@ Recently Added is an **own + partner** surface, **never shared spaces**. This ho
 timeline options (Slice 2), filter suggestions (Slice 2), and smart search (Slice 3). It is the one rule
 distinguishing Recently Added from Photos.
 
+### 3.1.1 Prerequisite discovered during Slice 2 planning: `/recently-added` is not a searchable page
+
+`buildSearchablePageUrl()` returns `null` unless `getSearchablePageBasePath()` recognises the pathname,
+and today it recognises only `/photos` and `/spaces/…`. On `/recently-added` the filter→URL write path
+would therefore **silently no-op** — filters would apply to the grid but never reach the URL, breaking
+"URL is the source of truth", deep links, and survive-a-reload.
+
+Registering the path is necessary but not sufficient: `getSearchablePageState()` derives
+`isSearchable` directly from `basePath !== null`, and three consumers key off that flag
+(`global-search-input-trigger.svelte`'s sort control, and `global-search-manager`'s typed-display
+text plus its "which page do I apply a filter to" base — which today redirects to `/photos`).
+Flipping it on in Slice 2 would make global search stay on Recently Added and write a `?q=` that
+nothing handles until Slice 3.
+
+**Decision:** separate the two capabilities. Slice 2 registers `/recently-added` in
+`getSearchablePageBasePath()` (so URL persistence works) while computing `isSearchable` from a
+separate query-capable predicate that excludes `/recently-added`. Slice 3 removes that exclusion
+together with the text section and the search path, so query support arrives complete. Photos and
+Spaces behaviour is unchanged throughout.
+
 ### 3.2 Decision logic lives in pure, unit-tested functions
 
 To keep the route thin (a full `+page.svelte` with all managers is impractical to mount in vitest), all

--- a/docs/superpowers/specs/2026-07-19-recently-added-filters-design.md
+++ b/docs/superpowers/specs/2026-07-19-recently-added-filters-design.md
@@ -20,7 +20,7 @@ Give the web **Recently Added** view (`/recently-added`) the two things the disc
    (Timeline, People, Location, Camera, Tags, Rating, Media type, Favorites, Albums, Text).
 
 …while preserving what makes the view "recently added": assets are **ordered and day-grouped by
-*added* date** (`orderBy: AssetOrderBy.CreatedAt`) and the view stays scoped to **own + partner**
+_added_ date** (`orderBy: AssetOrderBy.CreatedAt`) and the view stays scoped to **own + partner**
 assets (never shared spaces).
 
 ## 2. Background: how the pieces work today
@@ -90,7 +90,7 @@ route with no query handling until Slice 3. Unfiltered grid, stale `q`, no error
 `isSearchable: false` does not prevent this: it only suppresses pre-filling the search box.
 
 **Decision:** separate the two capabilities, and enforce the separation where the query is
-*written*, not merely where it is advertised. Slice 2 registers `/recently-added` in
+_written_, not merely where it is advertised. Slice 2 registers `/recently-added` in
 `getSearchablePageBasePath()` (so filter URL persistence works) and adds a query-capable predicate
 that excludes `/recently-added`. That predicate is enforced in **two** places: `getSearchablePageState()`
 reports `isSearchable: false`, and `buildSearchablePageUrl()` returns `null` when asked to build a
@@ -104,12 +104,12 @@ To keep the route thin (a full `+page.svelte` with all managers is impractical t
 branching logic is extracted into pure functions that get exhaustive TDD unit coverage. The route is glue
 whose behavior is verified by BDD e2e acceptance scenarios.
 
-| Pure function | Module | Slice |
-|---|---|---|
-| `shouldShowRecentlyAddedCount(count, hasActiveFilters)` | `recently-added-filter-options.ts` | 1 |
-| `buildRecentlyAddedTimelineOptions(filters)` | `recently-added-filter-options.ts` | 2 |
-| `buildRecentlyAddedSuggestionRequest(filters)` | `recently-added-filter-options.ts` | 2 |
-| `buildRecentlyAddedFilterConfig()` | `recently-added-filter-config.ts` | 2 (extended in 3) |
+| Pure function                                           | Module                             | Slice             |
+| ------------------------------------------------------- | ---------------------------------- | ----------------- |
+| `shouldShowRecentlyAddedCount(count, hasActiveFilters)` | `recently-added-filter-options.ts` | 1                 |
+| `buildRecentlyAddedTimelineOptions(filters)`            | `recently-added-filter-options.ts` | 2                 |
+| `buildRecentlyAddedSuggestionRequest(filters)`          | `recently-added-filter-options.ts` | 2                 |
+| `buildRecentlyAddedFilterConfig()`                      | `recently-added-filter-config.ts`  | 2 (extended in 3) |
 
 ### 3.3 Testing strategy: TDD + BDD
 
@@ -117,30 +117,30 @@ whose behavior is verified by BDD e2e acceptance scenarios.
   red→green→refactor with concrete failing-test commands and expected red output (per slice).
 - **BDD (Given/When/Then)** for user-facing behavior — the count display, applying/removing filters, and
   search. These become Playwright e2e specs under `e2e/src/specs/web/`, written **red-first** (the feature
-  is absent → scenario fails), then made green by the route wiring. BDD is deliberately *not* forced onto
+  is absent → scenario fails), then made green by the route wiring. BDD is deliberately _not_ forced onto
   the pure functions, where example tables are clearer.
 
 ### 3.4 Files (whole feature)
 
 **New source:**
 
-| File | Responsibility | Slice |
-|---|---|---|
-| `web/src/lib/utils/recently-added-filter-options.ts` | `shouldShowRecentlyAddedCount`, `buildRecentlyAddedTimelineOptions`, `buildRecentlyAddedSuggestionRequest` | 1, 2 |
-| `web/src/lib/utils/recently-added-filter-config.ts` | `buildRecentlyAddedFilterConfig()` → `FilterPanelConfig` | 2, 3 |
+| File                                                 | Responsibility                                                                                             | Slice |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ----- |
+| `web/src/lib/utils/recently-added-filter-options.ts` | `shouldShowRecentlyAddedCount`, `buildRecentlyAddedTimelineOptions`, `buildRecentlyAddedSuggestionRequest` | 1, 2  |
+| `web/src/lib/utils/recently-added-filter-config.ts`  | `buildRecentlyAddedFilterConfig()` → `FilterPanelConfig`                                                   | 2, 3  |
 
 **New tests:**
 
-| File | Covers | Slice |
-|---|---|---|
-| `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts` | the three pure functions | 1, 2 |
-| `web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts` | the config (mirrors `album-filter-config.spec.ts`) | 2, 3 |
-| `e2e/src/specs/web/recently-added-filters.e2e-spec.ts` (mirrors `photos-filter-panel.e2e-spec.ts`) | BDD acceptance scenarios | 1, 2, 3 |
+| File                                                                                               | Covers                                             | Slice   |
+| -------------------------------------------------------------------------------------------------- | -------------------------------------------------- | ------- |
+| `web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts`                                | the three pure functions                           | 1, 2    |
+| `web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts`                                 | the config (mirrors `album-filter-config.spec.ts`) | 2, 3    |
+| `e2e/src/specs/web/recently-added-filters.e2e-spec.ts` (mirrors `photos-filter-panel.e2e-spec.ts`) | BDD acceptance scenarios                           | 1, 2, 3 |
 
 **Modified:**
 
-| File | Change | Slice |
-|---|---|---|
+| File                                                                                 | Change                                                                                                                                    | Slice   |
+| ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte` | header count (1); filter panel + toolbar + chips + URL sync (2); text/search mode (3). The `AssetSelectControlBar` block stays unchanged. | 1, 2, 3 |
 
 No i18n additions: `items_count` exists (Slices 1–2); Slice 3 reuses existing search keys
@@ -148,11 +148,11 @@ No i18n additions: `items_count` exists (Slices 1–2); Slice 3 reuses existing 
 
 ## 4. Slice overview
 
-| Slice | Delivers (shippable) | Depends on |
-|---|---|---|
-| **1 — Header item count** | "N items" in the header for the (unfiltered) view; hides on empty/loading. Half of #805, ships alone. | — |
-| **2 — Browse filter panel (9 sections)** | Full metadata filtering (People, Location, Camera, Tags, Rating, Media type, Favorites, Albums, Timeline-date) with chips, URL persistence, and the count reflecting the filtered set. The bulk of #805. | 1 |
-| **3 — Text / smart-search (10th section)** | Free-text search → `SmartSearchResults`, search-total count; completes all-10 parity. | 2 |
+| Slice                                      | Delivers (shippable)                                                                                                                                                                                     | Depends on |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| **1 — Header item count**                  | "N items" in the header for the (unfiltered) view; hides on empty/loading. Half of #805, ships alone.                                                                                                    | —          |
+| **2 — Browse filter panel (9 sections)**   | Full metadata filtering (People, Location, Camera, Tags, Rating, Media type, Favorites, Albums, Timeline-date) with chips, URL persistence, and the count reflecting the filtered set. The bulk of #805. | 1          |
+| **3 — Text / smart-search (10th section)** | Free-text search → `SmartSearchResults`, search-total count; completes all-10 parity.                                                                                                                    | 2          |
 
 ---
 
@@ -232,12 +232,12 @@ Feature: Recently Added item count
 
 ### Edge cases
 
-| Edge case | Expected | Verified by |
-|---|---|---|
-| Buckets not yet loaded (`assetCount` 0 transiently) | No "0 items" flash | `shouldShowRecentlyAddedCount(0,false)=false` |
-| Empty account | Count hidden; placeholder shown | unit + e2e "empty library" |
-| Multi-select active (`hideNavbar`) | Header + count hidden; selection bar shown | e2e "while selecting" |
-| Plural vs singular ("1 item") | Handled by `items_count` ICU plural | rendered by i18n (not this fn) |
+| Edge case                                           | Expected                                   | Verified by                                   |
+| --------------------------------------------------- | ------------------------------------------ | --------------------------------------------- |
+| Buckets not yet loaded (`assetCount` 0 transiently) | No "0 items" flash                         | `shouldShowRecentlyAddedCount(0,false)=false` |
+| Empty account                                       | Count hidden; placeholder shown            | unit + e2e "empty library"                    |
+| Multi-select active (`hideNavbar`)                  | Header + count hidden; selection bar shown | e2e "while selecting"                         |
+| Plural vs singular ("1 item")                       | Handled by `items_count` ICU plural        | rendered by i18n (not this fn)                |
 
 ### Done gate
 
@@ -276,14 +276,14 @@ export function buildRecentlyAddedTimelineOptions(filters: FilterState): Record<
 
 - **`orderBy: CreatedAt` always** — the defining trait; holds under every filter combination.
 - **`withSharedSpaces` never present** — asserted by exact-shape `toEqual` on the default case (so a
-  *future* new shared-scope key added by `buildPhotosTimelineOptions` would fail the test), plus explicit
+  _future_ new shared-scope key added by `buildPhotosTimelineOptions` would fail the test), plus explicit
   `not.toHaveProperty('withSharedSpaces')` under a filter and under favorites.
 - **`withPartners` inherited** — `true` by default / non-favorite filters (own+partners, matching today's
   static options); **absent** under a Favorites filter (own-only, matching Photos: a favorite is a
   personal flag). New behavior for a new capability → no regression.
 - **`order`** inherited from `filters.sortOrder`; default `Desc` = newest-added first.
 - **Date filters → `takenAfter`/`takenBefore`** (inherited). Documented semantic: the Timeline date
-  filter filters *taken* date while day-groups reflect *added* date — intentional (e.g. old photos just
+  filter filters _taken_ date while day-groups reflect _added_ date — intentional (e.g. old photos just
   imported); not remapped to created-at (no created-at range predicate exists; that is backend work,
   a non-goal).
 
@@ -305,7 +305,9 @@ export function buildRecentlyAddedSuggestionRequest(filters: FilterState) {
     mediaType:
       filters.mediaType === 'all'
         ? undefined
-        : filters.mediaType === 'image' ? AssetTypeEnum.Image : AssetTypeEnum.Video,
+        : filters.mediaType === 'image'
+          ? AssetTypeEnum.Image
+          : AssetTypeEnum.Video,
     takenAfter: context?.takenAfter,
     takenBefore: context?.takenBefore,
     // no withSharedSpaces / albumId / spaceId — own+partners scope only
@@ -335,7 +337,8 @@ export function buildRecentlyAddedFilterConfig(): FilterPanelConfig {
       mapSuggestions(await getFilterSuggestions(buildRecentlyAddedSuggestionRequest(filters))),
     providers: {
       cities: (country, context) => getSearchSuggestions({ $type: SearchSuggestionType.City, country, ...context }),
-      cameraModels: (make, context) => getSearchSuggestions({ $type: SearchSuggestionType.CameraModel, make, ...context }),
+      cameraModels: (make, context) =>
+        getSearchSuggestions({ $type: SearchSuggestionType.CameraModel, make, ...context }),
     },
   };
 }
@@ -446,18 +449,18 @@ Feature: Recently Added filters
 
 ### Edge cases
 
-| Edge case | Expected | Verified by |
-|---|---|---|
-| Filter matches zero assets | Panel stays open; count "0 items" | config/options units + e2e "matching nothing" |
-| `withSharedSpaces` leakage (any path) | Never sent in options or suggestions | options `toEqual` + config unit |
-| Future stray key from `buildPhotosTimelineOptions` | Caught | options default `toEqual` |
-| Favorites filter | Own-only (partners excluded) | options unit |
-| Any filter combination | `orderBy` stays `CreatedAt` | options units + e2e "ordered by added date" |
-| Sort asc/desc | `order` flips; `orderBy` unchanged | options units |
-| Count flicker on filter apply (`assetCount`→0→N) | Accept: momentary "0 items"→"N items" reflects the reload; not gated further (added date, own+partners; extra gating would risk the panel-unmount race Photos avoids with `isEmptyForOptions`). Documented, not hidden. | e2e observes final count; noted decision |
-| Deep-link with filter params | Filters seeded from URL on load | e2e "survive a reload" / deep-link |
-| Grouping day↔month via toolbar | Grouping changes; temporal anchor preserved | mirrors Photos (manual/e2e smoke) |
-| Suggestion fetch failure | `FilterPanel`'s own AbortController path; no uncaught throw | mirrors album/Photos (no new handling) |
+| Edge case                                          | Expected                                                                                                                                                                                                                | Verified by                                   |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| Filter matches zero assets                         | Panel stays open; count "0 items"                                                                                                                                                                                       | config/options units + e2e "matching nothing" |
+| `withSharedSpaces` leakage (any path)              | Never sent in options or suggestions                                                                                                                                                                                    | options `toEqual` + config unit               |
+| Future stray key from `buildPhotosTimelineOptions` | Caught                                                                                                                                                                                                                  | options default `toEqual`                     |
+| Favorites filter                                   | Own-only (partners excluded)                                                                                                                                                                                            | options unit                                  |
+| Any filter combination                             | `orderBy` stays `CreatedAt`                                                                                                                                                                                             | options units + e2e "ordered by added date"   |
+| Sort asc/desc                                      | `order` flips; `orderBy` unchanged                                                                                                                                                                                      | options units                                 |
+| Count flicker on filter apply (`assetCount`→0→N)   | Accept: momentary "0 items"→"N items" reflects the reload; not gated further (added date, own+partners; extra gating would risk the panel-unmount race Photos avoids with `isEmptyForOptions`). Documented, not hidden. | e2e observes final count; noted decision      |
+| Deep-link with filter params                       | Filters seeded from URL on load                                                                                                                                                                                         | e2e "survive a reload" / deep-link            |
+| Grouping day↔month via toolbar                     | Grouping changes; temporal anchor preserved                                                                                                                                                                             | mirrors Photos (manual/e2e smoke)             |
+| Suggestion fetch failure                           | `FilterPanel`'s own AbortController path; no uncaught throw                                                                                                                                                             | mirrors album/Photos (no new handling)        |
 
 ### Done gate
 
@@ -530,13 +533,13 @@ Feature: Recently Added text search
 
 ### Edge cases
 
-| Edge case | Expected | Verified by |
-|---|---|---|
-| Empty query submitted | Stays in browse mode (`showSearchResults` false) | route logic + e2e |
-| Smart-facet fetch failure | Caught, `console.error`, falls back to prior facets | mirrors Photos §252–257 |
-| `withSharedSpaces` in search path | Forced `false` (own+partners) | config search-branch unit + e2e "own+partner scope" |
-| Query then filter change | Facets refetch (keyed by query+filters); abort in-flight | mirrors Photos key-cache |
-| Count in query mode | Uses `smartFacetTotal`, not `assetCount` | route derivation + e2e |
+| Edge case                         | Expected                                                 | Verified by                                         |
+| --------------------------------- | -------------------------------------------------------- | --------------------------------------------------- |
+| Empty query submitted             | Stays in browse mode (`showSearchResults` false)         | route logic + e2e                                   |
+| Smart-facet fetch failure         | Caught, `console.error`, falls back to prior facets      | mirrors Photos §252–257                             |
+| `withSharedSpaces` in search path | Forced `false` (own+partners)                            | config search-branch unit + e2e "own+partner scope" |
+| Query then filter change          | Facets refetch (keyed by query+filters); abort in-flight | mirrors Photos key-cache                            |
+| Count in query mode               | Uses `smartFacetTotal`, not `assetCount`                 | route derivation + e2e                              |
 
 ### Done gate
 
@@ -580,31 +583,31 @@ Repo gate + e2e web run; commit `feat(web): text/smart-search filter for Recentl
 
 ## 6. Coverage matrix (every edge case → slice → test)
 
-| # | Edge case / behavior | Slice | Test |
-|---|---|---|---|
-| 1 | Count hidden while loading / empty account | 1 | unit `shouldShowRecentlyAddedCount(0,false)`; e2e empty library |
-| 2 | Count shown for populated library | 1 | e2e populated |
-| 3 | Count hidden during multi-select | 1 | e2e selecting |
-| 4 | Plural/singular wording | 1 | i18n `items_count` (ICU) |
-| 5 | `orderBy` always CreatedAt | 2 | options units; e2e "ordered by added date" |
-| 6 | `withSharedSpaces` never in options | 2 | options `toEqual` + `not.toHaveProperty` |
-| 7 | Future stray key regression | 2 | options default `toEqual` |
-| 8 | `withPartners` inherited / dropped on favorites | 2 | options units |
-| 9 | `order` asc/desc | 2 | options units |
-| 10 | All predicate passthroughs + date ranges | 2 | options units |
-| 11 | Suggestion request omits shared/album/space scope | 2 | options unit |
-| 12 | Config = 9 sections, correct suggestion/provider calls | 2 | config unit |
-| 13 | Filter matches nothing → "0 items", panel stays | 2 | e2e "matching nothing" |
-| 14 | Filters persist via URL / deep-link / reload | 2 | e2e reload |
-| 15 | Chip removal / clear all | 2 | e2e remove chip |
-| 16 | Count flicker on apply | 2 | documented decision; e2e final count |
-| 17 | Grouping day↔month | 2 | e2e/manual smoke |
-| 18 | Config = 10 sections incl. text | 3 | config unit |
-| 19 | Text query → search results + search-total count | 3 | e2e search |
-| 20 | Clear query → back to added-date timeline | 3 | e2e clear |
-| 21 | Search stays own+partner (no shared spaces) | 3 | config search-branch unit + e2e scope |
-| 22 | Empty query submitted → stays browse | 3 | route logic + e2e |
-| 23 | Smart-facet fetch failure fallback | 3 | mirrors Photos (manual/e2e) |
+| #   | Edge case / behavior                                   | Slice | Test                                                            |
+| --- | ------------------------------------------------------ | ----- | --------------------------------------------------------------- |
+| 1   | Count hidden while loading / empty account             | 1     | unit `shouldShowRecentlyAddedCount(0,false)`; e2e empty library |
+| 2   | Count shown for populated library                      | 1     | e2e populated                                                   |
+| 3   | Count hidden during multi-select                       | 1     | e2e selecting                                                   |
+| 4   | Plural/singular wording                                | 1     | i18n `items_count` (ICU)                                        |
+| 5   | `orderBy` always CreatedAt                             | 2     | options units; e2e "ordered by added date"                      |
+| 6   | `withSharedSpaces` never in options                    | 2     | options `toEqual` + `not.toHaveProperty`                        |
+| 7   | Future stray key regression                            | 2     | options default `toEqual`                                       |
+| 8   | `withPartners` inherited / dropped on favorites        | 2     | options units                                                   |
+| 9   | `order` asc/desc                                       | 2     | options units                                                   |
+| 10  | All predicate passthroughs + date ranges               | 2     | options units                                                   |
+| 11  | Suggestion request omits shared/album/space scope      | 2     | options unit                                                    |
+| 12  | Config = 9 sections, correct suggestion/provider calls | 2     | config unit                                                     |
+| 13  | Filter matches nothing → "0 items", panel stays        | 2     | e2e "matching nothing"                                          |
+| 14  | Filters persist via URL / deep-link / reload           | 2     | e2e reload                                                      |
+| 15  | Chip removal / clear all                               | 2     | e2e remove chip                                                 |
+| 16  | Count flicker on apply                                 | 2     | documented decision; e2e final count                            |
+| 17  | Grouping day↔month                                     | 2     | e2e/manual smoke                                                |
+| 18  | Config = 10 sections incl. text                        | 3     | config unit                                                     |
+| 19  | Text query → search results + search-total count       | 3     | e2e search                                                      |
+| 20  | Clear query → back to added-date timeline              | 3     | e2e clear                                                       |
+| 21  | Search stays own+partner (no shared spaces)            | 3     | config search-branch unit + e2e scope                           |
+| 22  | Empty query submitted → stays browse                   | 3     | route logic + e2e                                               |
+| 23  | Smart-facet fetch failure fallback                     | 3     | mirrors Photos (manual/e2e)                                     |
 
 ## 7. Process notes for impl-loop
 

--- a/docs/superpowers/specs/2026-07-19-recently-added-filters-design.md
+++ b/docs/superpowers/specs/2026-07-19-recently-added-filters-design.md
@@ -323,6 +323,13 @@ export function buildRecentlyAddedFilterConfig(): FilterPanelConfig {
   return {
     // 9 metadata sections. 'text' is appended in Slice 3 together with its search path, so the text
     // input is never present without a working submit.
+    // NOTE (corrected during Slice 3 planning): the `'text'` section is NOT a smart-search query
+    // box — `filter-panel.svelte` renders it as `<TextFilter>` editing three *metadata* filters
+    // (description / originalFileName / ocr), which already round-trip through the URL and through
+    // `buildRecentlyAddedTimelineOptions`. The smart-search query arrives only via `?q=` or the
+    // navbar global search. Deferring `'text'` to Slice 3 was therefore a conservative grouping,
+    // not a correctness requirement; the "never render a text input without a working submit"
+    // rationale below is mistaken about what the section does.
     sections: ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites', 'albums'],
     suggestionsProvider: async (filters) =>
       mapSuggestions(await getFilterSuggestions(buildRecentlyAddedSuggestionRequest(filters))),

--- a/e2e/src/specs/web/recently-added-filters.e2e-spec.ts
+++ b/e2e/src/specs/web/recently-added-filters.e2e-spec.ts
@@ -127,7 +127,12 @@ test.describe('Recently Added filters', () => {
     await page.waitForSelector('[data-testid="discovery-panel"], [data-testid="filter-toggle-btn"]');
   }
 
-  test('renders the nine metadata filter sections and no text section', async ({ context, page }) => {
+  // Slice 3 Task 1 (`recently-added-filter-config.ts`) added `text` as the tenth section; this
+  // assertion originally pinned the pre-Slice-3 nine-section, no-text state but was never updated
+  // when that section landed, leaving it stale. `recently-added-page.spec.ts`'s "passes all ten
+  // sections to the filter panel" case (unrelated to query mode, already green) is the up-to-date
+  // pin for this — ten sections, `text` included — so this scenario now matches it instead.
+  test('renders all ten metadata filter sections, including text', async ({ context, page }) => {
     await gotoRecentlyAdded(context, page);
 
     await expect(page.getByTestId('discovery-panel')).toBeVisible();
@@ -141,11 +146,10 @@ test.describe('Recently Added filters', () => {
       'media',
       'favorites',
       'albums',
+      'text',
     ]) {
       await expect(page.getByTestId(`filter-section-${section}`)).toBeVisible();
     }
-    // Slice 3 adds this; it must not exist yet.
-    await expect(page.getByTestId('filter-section-text')).toHaveCount(0);
   });
 
   // Spec scenario: Filtering by media type updates grid, URL, and count

--- a/e2e/src/specs/web/recently-added-filters.e2e-spec.ts
+++ b/e2e/src/specs/web/recently-added-filters.e2e-spec.ts
@@ -1,0 +1,69 @@
+import type { LoginResponseDto } from '@immich/sdk';
+import { expect, test } from '@playwright/test';
+import { thumbnailUtils } from 'src/ui/specs/timeline/utils';
+import { utils } from 'src/utils';
+
+test.describe('Recently Added', () => {
+  let admin: LoginResponseDto;
+  let emptyUser: LoginResponseDto;
+
+  const ASSET_COUNT = 12;
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+
+    // Seed a populated library for the admin: 12 assets on distinct days.
+    for (let i = 0; i < ASSET_COUNT; i++) {
+      const day = String(i + 1).padStart(2, '0');
+      await utils.createAsset(admin.accessToken, {
+        fileCreatedAt: `2023-08-${day}T10:00:00.000Z`,
+        fileModifiedAt: `2023-08-${day}T10:00:00.000Z`,
+      });
+    }
+
+    // A second user with an empty library, for the empty-state scenario.
+    emptyUser = await utils.userSetup(admin.accessToken, {
+      email: 'recently-added-empty@immich.cloud',
+      name: 'Empty Library',
+      password: 'password',
+    });
+  });
+
+  // Scenario: Count shown for a populated library
+  test('shows the item count in the header for a populated library', async ({ context, page }) => {
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('/recently-added');
+
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${ASSET_COUNT} items`);
+  });
+
+  // Scenario: Count hidden for an empty library
+  test('hides the item count and shows the placeholder for an empty library', async ({ context, page }) => {
+    await utils.setAuthCookies(context, emptyUser.accessToken);
+    await page.goto('/recently-added');
+
+    // The empty-state placeholder confirms the timeline finished loading with no assets.
+    // Copy comes from i18n/en.json `no_assets_message`.
+    await expect(page.getByText('Click to upload your first photo')).toBeVisible();
+    await expect(page.getByTestId('page-header-description')).toHaveCount(0);
+  });
+
+  // Scenario: Count is not shown while selecting
+  test('replaces the header with the selection bar during multi-select', async ({ context, page }) => {
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('/recently-added');
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${ASSET_COUNT} items`);
+
+    // Enter multi-select: hover a thumbnail so its checkbox overlay renders, then click it.
+    const thumb = thumbnailUtils.locator(page).first();
+    await expect(thumb).toBeVisible();
+    await thumb.hover();
+    await thumb.locator('button[role="checkbox"]').click();
+
+    // `hideNavbar` collapses the entire header row (title + count); the selection bar takes over.
+    await expect(page.getByTestId('page-header-description')).toHaveCount(0);
+    await expect(page.getByTestId('page-header')).toHaveCount(0);
+  });
+});

--- a/e2e/src/specs/web/recently-added-filters.e2e-spec.ts
+++ b/e2e/src/specs/web/recently-added-filters.e2e-spec.ts
@@ -258,6 +258,16 @@ async function expectSearchResultsMode(page: import('@playwright/test').Page) {
   });
 }
 
+// Matches the actual results-fetching POST /search/smart request, and ONLY that — NOT
+// POST /search/smart/facets, which `req.url().includes('/search/smart')` would also match. Both
+// endpoints fire on a query: FilterPanel's suggestionsProvider calls the facets endpoint at 0ms on
+// mount (filter-panel.svelte's isInitialMount branch), while SmartSearchResults' own search call
+// is behind a 250ms debounce (SEARCH_FILTER_DEBOUNCE_MS) — so an `includes` match would almost
+// always resolve to the facets request first, silently asserting against the wrong endpoint.
+function isSmartSearchRequest(req: import('@playwright/test').Request): boolean {
+  return req.method() === 'POST' && new URL(req.url()).pathname.endsWith('/search/smart');
+}
+
 test.describe('Recently Added text search', () => {
   let admin: LoginResponseDto;
 
@@ -300,7 +310,9 @@ test.describe('Recently Added text search', () => {
     // The header count now comes from the search total, not the timeline's asset count. Its exact
     // value depends on ML availability in this e2e stack (see the scope scenario below for why
     // that can't be made deterministic here) — this only pins the *shape* of the header text.
-    await expect(page.getByTestId('page-header-description')).toHaveText(/^\d+ items$/, { timeout: 15_000 });
+    // `items?` (not `items`) because `items_count` is `{count, plural, one {# item} other {# items}}`
+    // — a count of exactly 1 renders "1 item", singular.
+    await expect(page.getByTestId('page-header-description')).toHaveText(/^\d+ items?$/, { timeout: 15_000 });
   });
 
   // Scenario: Clearing the query returns to the added-date timeline
@@ -311,7 +323,9 @@ test.describe('Recently Added text search', () => {
     await page.goto('/recently-added');
 
     await expect(page.locator('#asset-grid')).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByTestId('page-header-description')).toHaveText(/^\d+ items$/, { timeout: 15_000 });
+    // Same singular/plural note as scenario 1 — harmless here (3 seeded assets, never 1), but kept
+    // consistent.
+    await expect(page.getByTestId('page-header-description')).toHaveText(/^\d+ items?$/, { timeout: 15_000 });
   });
 
   // Scenario: Text search stays within own + partner scope
@@ -340,9 +354,7 @@ test.describe('Recently Added text search', () => {
     // vacuous — it would pass even if the whole scoping mechanism were broken and neither page
     // ever sent the key.
     const [photosRequest] = await Promise.all([
-      page.waitForRequest((req) => req.url().includes('/search/smart') && req.method() === 'POST', {
-        timeout: 15_000,
-      }),
+      page.waitForRequest(isSmartSearchRequest, { timeout: 15_000 }),
       page.goto(`/photos?q=${query}`),
     ]);
     expect(photosRequest.postDataJSON()).toMatchObject({ withSharedSpaces: true });
@@ -351,9 +363,7 @@ test.describe('Recently Added text search', () => {
     // no `withSharedSpaces` key at all. Today this never even fires — the unwired route ignores
     // `?q=` and never calls /search/smart in the first place, so this wait times out.
     const [recentlyAddedRequest] = await Promise.all([
-      page.waitForRequest((req) => req.url().includes('/search/smart') && req.method() === 'POST', {
-        timeout: 15_000,
-      }),
+      page.waitForRequest(isSmartSearchRequest, { timeout: 15_000 }),
       page.goto(`/recently-added?q=${query}`),
     ]);
     expect(recentlyAddedRequest.postDataJSON()).not.toHaveProperty('withSharedSpaces');

--- a/e2e/src/specs/web/recently-added-filters.e2e-spec.ts
+++ b/e2e/src/specs/web/recently-added-filters.e2e-spec.ts
@@ -1,7 +1,8 @@
 import type { LoginResponseDto } from '@immich/sdk';
+import { updateAsset } from '@immich/sdk';
 import { expect, test } from '@playwright/test';
 import { thumbnailUtils } from 'src/ui/specs/timeline/utils';
-import { utils } from 'src/utils';
+import { asBearerAuth, utils } from 'src/utils';
 
 test.describe('Recently Added', () => {
   let admin: LoginResponseDto;
@@ -65,5 +66,176 @@ test.describe('Recently Added', () => {
     // `hideNavbar` collapses the entire header row (title + count); the selection bar takes over.
     await expect(page.getByTestId('page-header-description')).toHaveCount(0);
     await expect(page.getByTestId('page-header')).toHaveCount(0);
+  });
+});
+
+test.describe('Recently Added filters', () => {
+  let admin: LoginResponseDto;
+  const videos: Awaited<ReturnType<typeof utils.createAsset>>[] = [];
+
+  const TOTAL = 20;
+  const VIDEOS = 5;
+  const RATED = 3;
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+
+    // Seed with *taken* dates deliberately unrelated to upload order, so "ordered by added date"
+    // is a meaningful assertion: taken dates run backwards while added order runs forwards.
+    const images = [];
+    for (let i = 0; i < TOTAL - VIDEOS; i++) {
+      const day = String(TOTAL - VIDEOS - i).padStart(2, '0');
+      images.push(
+        await utils.createAsset(admin.accessToken, {
+          fileCreatedAt: `2023-09-${day}T10:00:00.000Z`,
+          fileModifiedAt: `2023-09-${day}T10:00:00.000Z`,
+        }),
+      );
+    }
+
+    // Videos' taken dates run *opposite* to their upload order, so within the video-filtered set
+    // "newest added first" and "newest taken first" disagree. That disagreement is the whole point
+    // of the ordering scenario below — seeding them ascending would make the test pass equally
+    // against orderBy: TakenAt, i.e. unable to detect the bug it exists to catch.
+    for (let i = 0; i < VIDEOS; i++) {
+      videos.push(
+        await utils.createAsset(admin.accessToken, {
+          fileCreatedAt: `2023-10-0${VIDEOS - i}T10:00:00.000Z`,
+          fileModifiedAt: `2023-10-0${VIDEOS - i}T10:00:00.000Z`,
+          assetData: { filename: `example-${i}.mp4` },
+        }),
+      );
+    }
+
+    for (const asset of images.slice(0, RATED)) {
+      await updateAsset({ id: asset.id, updateAssetDto: { rating: 5 } }, { headers: asBearerAuth(admin.accessToken) });
+    }
+  });
+
+  async function gotoRecentlyAdded(
+    context: import('@playwright/test').BrowserContext,
+    page: import('@playwright/test').Page,
+    search = '',
+  ) {
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('/recently-added');
+    // Panel collapse is persisted in localStorage — start every test from a clean state.
+    await page.evaluate(() => localStorage.clear());
+    await page.goto(`/recently-added${search}`);
+    await page.waitForSelector('[data-testid="discovery-panel"], [data-testid="filter-toggle-btn"]');
+  }
+
+  test('renders the nine metadata filter sections and no text section', async ({ context, page }) => {
+    await gotoRecentlyAdded(context, page);
+
+    await expect(page.getByTestId('discovery-panel')).toBeVisible();
+    for (const section of [
+      'timeline',
+      'people',
+      'location',
+      'camera',
+      'tags',
+      'rating',
+      'media',
+      'favorites',
+      'albums',
+    ]) {
+      await expect(page.getByTestId(`filter-section-${section}`)).toBeVisible();
+    }
+    // Slice 3 adds this; it must not exist yet.
+    await expect(page.getByTestId('filter-section-text')).toHaveCount(0);
+  });
+
+  // Spec scenario: Filtering by media type updates grid, URL, and count
+  test('filtering by media type updates the count and the URL', async ({ context, page }) => {
+    await gotoRecentlyAdded(context, page);
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${TOTAL} items`);
+
+    const bucketResponse = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
+    await page.getByTestId('media-type-video').click();
+    await bucketResponse;
+
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${VIDEOS} items`);
+    await expect(page).toHaveURL(/type=video/);
+  });
+
+  // Spec scenario: Removing a filter chip restores the full view
+  test('removing the media-type chip restores the full view', async ({ context, page }) => {
+    await gotoRecentlyAdded(context, page);
+
+    const filtered = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
+    await page.getByTestId('media-type-video').click();
+    await filtered;
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${VIDEOS} items`);
+
+    // Collapse the panel so the ActiveFiltersBar and its chips are shown.
+    await page.getByTestId('collapse-panel-btn').click();
+    await expect(page.getByTestId('active-filters-bar')).toBeVisible();
+    const chip = page.getByTestId('active-chip').first();
+    await expect(chip).toBeVisible();
+
+    const restored = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
+    // Remove the chip itself (exercises handleRemoveActiveFilter), not "clear all".
+    // dispatchEvent avoids the UserPageLayout absolute header overlaying the control,
+    // the same workaround photos-filter-panel.e2e-spec.ts uses.
+    await chip.getByRole('button').last().dispatchEvent('click');
+    await restored;
+
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${TOTAL} items`);
+    await expect(page).not.toHaveURL(/type=video/);
+  });
+
+  test('clear all removes every active filter', async ({ context, page }) => {
+    await gotoRecentlyAdded(context, page, '?rating=5');
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${RATED} items`);
+
+    await page.getByTestId('collapse-panel-btn').click();
+    await expect(page.getByTestId('active-filters-bar')).toBeVisible();
+
+    const cleared = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
+    await page.getByTestId('clear-all-btn').dispatchEvent('click');
+    await cleared;
+
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${TOTAL} items`);
+  });
+
+  // Spec scenario: A filter matching nothing shows a zero count, not an empty account
+  test('a filter that matches nothing shows "0 items" and keeps the panel open', async ({ context, page }) => {
+    await gotoRecentlyAdded(context, page, '?make=NoSuchCameraMake');
+
+    await expect(page.getByTestId('page-header-description')).toHaveText('0 items');
+    // The panel must stay mounted so the user can change the filter.
+    await expect(page.getByTestId('discovery-panel')).toBeVisible();
+  });
+
+  // Spec scenario: Filters survive a reload (URL is source of truth)
+  test('filters survive a reload', async ({ context, page }) => {
+    await gotoRecentlyAdded(context, page, '?rating=5');
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${RATED} items`);
+
+    await page.reload();
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${RATED} items`);
+    await expect(page).toHaveURL(/rating=5/);
+  });
+
+  // Spec scenario: Recently Added stays ordered by added date under a filter
+  test('stays ordered by added date under a filter', async ({ context, page }) => {
+    // Within the video-filtered set, added order and taken order run opposite (see the seeding),
+    // so this scenario can tell the two ordering bases apart. Applying a filter must not change
+    // the basis: the grid stays ordered by *added* date, newest first.
+    await gotoRecentlyAdded(context, page);
+
+    const filtered = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
+    await page.getByTestId('media-type-video').click();
+    await filtered;
+    await expect(page.getByTestId('page-header-description')).toHaveText(`${VIDEOS} items`);
+
+    // The LAST-UPLOADED video must lead the grid. Its taken date is the *oldest* of the five, so
+    // this assertion fails if the view ever orders by taken date instead of added date.
+    const first = thumbnailUtils.locator(page).first();
+    await expect(first).toBeVisible();
+    await expect(first).toHaveAttribute('data-asset', videos.at(-1)!.id);
   });
 });

--- a/e2e/src/specs/web/recently-added-filters.e2e-spec.ts
+++ b/e2e/src/specs/web/recently-added-filters.e2e-spec.ts
@@ -1,5 +1,5 @@
 import type { LoginResponseDto } from '@immich/sdk';
-import { SharedSpaceRole, updateAsset, updateMemberTimeline } from '@immich/sdk';
+import { updateAsset } from '@immich/sdk';
 import { expect, test } from '@playwright/test';
 import { thumbnailUtils } from 'src/ui/specs/timeline/utils';
 import { asBearerAuth, utils } from 'src/utils';
@@ -315,56 +315,47 @@ test.describe('Recently Added text search', () => {
   });
 
   // Scenario: Text search stays within own + partner scope
+  //
+  // This asserts the *request payload* sent to POST /search/smart, not the rendered results.
+  // Results are unusable for this: this e2e stack runs with IMMICH_MACHINE_LEARNING_ENABLED=false
+  // and has no machine-learning service in its docker-compose at all (confirmed by direct probe —
+  // even force-enabling ML via system-config still 500s, since machineLearning.urls points at a
+  // host that doesn't exist on this network), so /search/smart never returns real matches for any
+  // query and an absence-of-results assertion would be unfalsifiable either way.
+  //
+  // `buildSmartSearchParams` (space-search.ts:38-40) only sets `withSharedSpaces: true` on the
+  // outgoing DTO when the caller passes a truthy `withSharedSpaces`; when falsy, the key is
+  // omitted entirely (not sent as `false`). Recently Added always passes `withSharedSpaces={false}`
+  // (own + partner scope only — see the route-level spec's "does not send shared-space scope to
+  // SmartSearchResults"), while /photos passes `withSharedSpaces={filters.isFavorite === undefined}`,
+  // i.e. `true` by default. So the same query, run on both pages, must produce two different
+  // request bodies — that difference *is* the own+partner-vs-shared-spaces scope invariant, and
+  // it's fully deterministic (it never touches embeddings or matching).
   test('text search stays within own + partner scope', async ({ context, page }) => {
-    test.setTimeout(45_000);
-
-    // A second user OWNS the shared asset and adds it to a space our test actor (admin) is a
-    // member of — the reverse of the usual owner-is-admin shape used elsewhere in this file.
-    const ownerLogin = await utils.userSetup(admin.accessToken, {
-      email: 'recently-added-search-owner@immich.cloud',
-      name: 'Search Space Owner',
-      password: 'password',
-    });
-
-    const sharedAsset = await utils.createAsset(ownerLogin.accessToken);
-    const space = await utils.createSpace(ownerLogin.accessToken, { name: 'Search Scope Space' });
-    await utils.addSpaceMember(ownerLogin.accessToken, space.id, {
-      userId: admin.userId,
-      role: SharedSpaceRole.Viewer,
-    });
-    await utils.addSpaceAssets(ownerLogin.accessToken, space.id, [sharedAsset.id]);
-
-    // Member-level timeline opt-in — NOT the album-level `showInTimeline` toggle, the two are not
-    // interchangeable (spaces-albums-timeline.e2e-spec.ts:19-23). Self-PATCH:
-    // `/shared-spaces/{id}/members/me/timeline` requires the member's own token, not the owner's
-    // (see space-map-markers.e2e-spec.ts:62-66).
-    await updateMemberTimeline(
-      { id: space.id, sharedSpaceMemberTimelineDto: { showInTimeline: true } },
-      { headers: asBearerAuth(admin.accessToken) },
-    );
-
     const query = 'harbor';
-    const sharedThumbnail = page.locator(`img[src="/api/assets/${sharedAsset.id}/thumbnail"]`);
-
-    // Positive control: the identical query on /photos (own + partner + shared spaces — it always
-    // sends `withSharedSpaces: true`) DOES find the shared-space asset. Without this, the absence
-    // assertion below would be unfalsifiable — it would pass for a dozen unrelated reasons (never
-    // indexed, no semantic match, a missed opt-in, or a seeding bug), not because Recently Added
-    // actually enforces its narrower own+partner scope.
     await utils.setAuthCookies(context, admin.accessToken);
-    await page.goto(`/photos?q=${query}`);
-    await expect(page.locator('#asset-grid')).toHaveCount(0);
-    await expect(page.getByTestId('result-count').or(page.getByTestId('search-empty'))).toBeVisible({
-      timeout: 15_000,
-    });
-    await expect(sharedThumbnail).toBeVisible({ timeout: 15_000 });
 
-    // The real assertion: Recently Added is own + partner only, so the same query must still
-    // switch into search mode (asserted BEFORE the absence check — otherwise this would also pass
-    // against today's unwired route, whose own+partner *timeline* trivially never contains an
-    // asset it was never seeded with in the first place).
-    await page.goto(`/recently-added?q=${query}`);
-    await expectSearchResultsMode(page);
-    await expect(sharedThumbnail).toHaveCount(0);
+    // Positive control: on /photos, the identical query DOES carry `withSharedSpaces: true`.
+    // Without this, the assertion below (no `withSharedSpaces` key from Recently Added) would be
+    // vacuous — it would pass even if the whole scoping mechanism were broken and neither page
+    // ever sent the key.
+    const [photosRequest] = await Promise.all([
+      page.waitForRequest((req) => req.url().includes('/search/smart') && req.method() === 'POST', {
+        timeout: 15_000,
+      }),
+      page.goto(`/photos?q=${query}`),
+    ]);
+    expect(photosRequest.postDataJSON()).toMatchObject({ withSharedSpaces: true });
+
+    // The real assertion: Recently Added is own + partner only, so its outgoing request must carry
+    // no `withSharedSpaces` key at all. Today this never even fires — the unwired route ignores
+    // `?q=` and never calls /search/smart in the first place, so this wait times out.
+    const [recentlyAddedRequest] = await Promise.all([
+      page.waitForRequest((req) => req.url().includes('/search/smart') && req.method() === 'POST', {
+        timeout: 15_000,
+      }),
+      page.goto(`/recently-added?q=${query}`),
+    ]);
+    expect(recentlyAddedRequest.postDataJSON()).not.toHaveProperty('withSharedSpaces');
   });
 });

--- a/e2e/src/specs/web/recently-added-filters.e2e-spec.ts
+++ b/e2e/src/specs/web/recently-added-filters.e2e-spec.ts
@@ -127,11 +127,6 @@ test.describe('Recently Added filters', () => {
     await page.waitForSelector('[data-testid="discovery-panel"], [data-testid="filter-toggle-btn"]');
   }
 
-  // Slice 3 Task 1 (`recently-added-filter-config.ts`) added `text` as the tenth section; this
-  // assertion originally pinned the pre-Slice-3 nine-section, no-text state but was never updated
-  // when that section landed, leaving it stale. `recently-added-page.spec.ts`'s "passes all ten
-  // sections to the filter panel" case (unrelated to query mode, already green) is the up-to-date
-  // pin for this — ten sections, `text` included — so this scenario now matches it instead.
   test('renders all ten metadata filter sections, including text', async ({ context, page }) => {
     await gotoRecentlyAdded(context, page);
 
@@ -251,7 +246,7 @@ test.describe('Recently Added filters', () => {
 // its own fixture: it cannot inherit from either describe above, both of which reset it too.
 
 // Search-results mode never renders the browse-mode Timeline (`#asset-grid`); it renders either a
-// result count or the empty state via SpaceSearchResults — the same component /photos uses (see
+// result count or the empty state via SmartSearchResults — the same component /photos uses (see
 // photos-search.e2e-spec.ts). Asserting this MODE SWITCH first, before anything else, is what
 // makes every scenario below fail for the right reason pre-wiring: today `/recently-added` ignores
 // `?q=` entirely and keeps rendering the timeline, so this is exactly what goes red.

--- a/e2e/src/specs/web/recently-added-filters.e2e-spec.ts
+++ b/e2e/src/specs/web/recently-added-filters.e2e-spec.ts
@@ -1,5 +1,5 @@
 import type { LoginResponseDto } from '@immich/sdk';
-import { updateAsset } from '@immich/sdk';
+import { SharedSpaceRole, updateAsset, updateMemberTimeline } from '@immich/sdk';
 import { expect, test } from '@playwright/test';
 import { thumbnailUtils } from 'src/ui/specs/timeline/utils';
 import { asBearerAuth, utils } from 'src/utils';
@@ -237,5 +237,134 @@ test.describe('Recently Added filters', () => {
     const first = thumbnailUtils.locator(page).first();
     await expect(first).toBeVisible();
     await expect(first).toHaveAttribute('data-asset', videos.at(-1)!.id);
+  });
+});
+
+// Slice 3 Task 4: acceptance scenarios for the text-search path, driven exclusively through the
+// `?q=` deep link (the navbar global search commits to the same URL) — NOT through the panel's
+// `'text'` section, which is `<TextFilter>` editing description/originalFileName/ocr *metadata*
+// filters and cannot submit a smart-search query. This describe resets the database and builds
+// its own fixture: it cannot inherit from either describe above, both of which reset it too.
+
+// Search-results mode never renders the browse-mode Timeline (`#asset-grid`); it renders either a
+// result count or the empty state via SpaceSearchResults — the same component /photos uses (see
+// photos-search.e2e-spec.ts). Asserting this MODE SWITCH first, before anything else, is what
+// makes every scenario below fail for the right reason pre-wiring: today `/recently-added` ignores
+// `?q=` entirely and keeps rendering the timeline, so this is exactly what goes red.
+async function expectSearchResultsMode(page: import('@playwright/test').Page) {
+  await expect(page.locator('#asset-grid')).toHaveCount(0);
+  await expect(page.getByTestId('result-count').or(page.getByTestId('search-empty'))).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+test.describe('Recently Added text search', () => {
+  let admin: LoginResponseDto;
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+
+    // A few personal assets so the browse-mode header has a real, non-empty count to fall back to
+    // once the query is cleared (an empty library hides the count entirely — see the "Recently
+    // Added" describe above — which would make the clear-query scenario's count assertion moot).
+    await Promise.all([
+      utils.createAsset(admin.accessToken),
+      utils.createAsset(admin.accessToken),
+      utils.createAsset(admin.accessToken),
+    ]);
+  });
+
+  async function gotoRecentlyAdded(
+    context: import('@playwright/test').BrowserContext,
+    page: import('@playwright/test').Page,
+    path = '/recently-added',
+  ) {
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto(path);
+    // Panel collapse is persisted in localStorage — start every test from a clean state (same
+    // precaution as the "Recently Added filters" describe above).
+    await page.evaluate(() => localStorage.clear());
+    await page.goto(path);
+    await page.waitForSelector(
+      '[data-testid="discovery-panel"], [data-testid="collapsed-icon-strip"], [data-testid="result-count"], [data-testid="search-empty"]',
+    );
+  }
+
+  // Scenario: A text query switches to search results with a total count
+  test('a text query in the URL switches to search results with a total count', async ({ context, page }) => {
+    await gotoRecentlyAdded(context, page, '/recently-added?q=beach');
+
+    await expectSearchResultsMode(page);
+    // The header count now comes from the search total, not the timeline's asset count. Its exact
+    // value depends on ML availability in this e2e stack (see the scope scenario below for why
+    // that can't be made deterministic here) — this only pins the *shape* of the header text.
+    await expect(page.getByTestId('page-header-description')).toHaveText(/^\d+ items$/, { timeout: 15_000 });
+  });
+
+  // Scenario: Clearing the query returns to the added-date timeline
+  test('clearing the query returns to the added-date timeline', async ({ context, page }) => {
+    await gotoRecentlyAdded(context, page, '/recently-added?q=beach');
+    await expectSearchResultsMode(page);
+
+    await page.goto('/recently-added');
+
+    await expect(page.locator('#asset-grid')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('page-header-description')).toHaveText(/^\d+ items$/, { timeout: 15_000 });
+  });
+
+  // Scenario: Text search stays within own + partner scope
+  test('text search stays within own + partner scope', async ({ context, page }) => {
+    test.setTimeout(45_000);
+
+    // A second user OWNS the shared asset and adds it to a space our test actor (admin) is a
+    // member of — the reverse of the usual owner-is-admin shape used elsewhere in this file.
+    const ownerLogin = await utils.userSetup(admin.accessToken, {
+      email: 'recently-added-search-owner@immich.cloud',
+      name: 'Search Space Owner',
+      password: 'password',
+    });
+
+    const sharedAsset = await utils.createAsset(ownerLogin.accessToken);
+    const space = await utils.createSpace(ownerLogin.accessToken, { name: 'Search Scope Space' });
+    await utils.addSpaceMember(ownerLogin.accessToken, space.id, {
+      userId: admin.userId,
+      role: SharedSpaceRole.Viewer,
+    });
+    await utils.addSpaceAssets(ownerLogin.accessToken, space.id, [sharedAsset.id]);
+
+    // Member-level timeline opt-in — NOT the album-level `showInTimeline` toggle, the two are not
+    // interchangeable (spaces-albums-timeline.e2e-spec.ts:19-23). Self-PATCH:
+    // `/shared-spaces/{id}/members/me/timeline` requires the member's own token, not the owner's
+    // (see space-map-markers.e2e-spec.ts:62-66).
+    await updateMemberTimeline(
+      { id: space.id, sharedSpaceMemberTimelineDto: { showInTimeline: true } },
+      { headers: asBearerAuth(admin.accessToken) },
+    );
+
+    const query = 'harbor';
+    const sharedThumbnail = page.locator(`img[src="/api/assets/${sharedAsset.id}/thumbnail"]`);
+
+    // Positive control: the identical query on /photos (own + partner + shared spaces — it always
+    // sends `withSharedSpaces: true`) DOES find the shared-space asset. Without this, the absence
+    // assertion below would be unfalsifiable — it would pass for a dozen unrelated reasons (never
+    // indexed, no semantic match, a missed opt-in, or a seeding bug), not because Recently Added
+    // actually enforces its narrower own+partner scope.
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto(`/photos?q=${query}`);
+    await expect(page.locator('#asset-grid')).toHaveCount(0);
+    await expect(page.getByTestId('result-count').or(page.getByTestId('search-empty'))).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(sharedThumbnail).toBeVisible({ timeout: 15_000 });
+
+    // The real assertion: Recently Added is own + partner only, so the same query must still
+    // switch into search mode (asserted BEFORE the absence check — otherwise this would also pass
+    // against today's unwired route, whose own+partner *timeline* trivially never contains an
+    // asset it was never seeded with in the first place).
+    await page.goto(`/recently-added?q=${query}`);
+    await expectSearchResultsMode(page);
+    await expect(sharedThumbnail).toHaveCount(0);
   });
 });

--- a/web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts
+++ b/web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts
@@ -1,4 +1,4 @@
-import { AssetTypeEnum, getFilterSuggestions, getSearchSuggestions, Type } from '@immich/sdk';
+import { AssetTypeEnum, getFilterSuggestions, getSearchSuggestions, searchSmartFacets, Type } from '@immich/sdk';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createFilterState } from '$lib/components/filter-panel/filter-panel';
 import { buildRecentlyAddedFilterConfig } from '$lib/utils/recently-added-filter-config';
@@ -17,6 +17,19 @@ vi.mock('@immich/sdk', async (importOriginal) => {
       hasUnnamedPeople: false,
     }),
     getSearchSuggestions: vi.fn().mockResolvedValue(['Berlin']),
+    searchSmartFacets: vi.fn().mockResolvedValue({
+      countries: ['Germany'],
+      cities: ['Berlin'],
+      cameraMakes: ['Sony'],
+      cameraModels: ['A7'],
+      tags: [{ id: 'tag-1', value: 'Vacation' }],
+      people: [{ id: 'person-1', name: 'Alice' }],
+      ratings: [5],
+      mediaTypes: ['IMAGE'],
+      hasUnnamedPeople: false,
+      total: 7,
+      timeBuckets: [],
+    }),
   };
 });
 
@@ -25,9 +38,7 @@ beforeEach(() => {
 });
 
 describe('buildRecentlyAddedFilterConfig', () => {
-  it('exposes the nine metadata sections in plan order', () => {
-    // 'text' is deliberately absent — it arrives in Slice 3 with the search path, so the input
-    // is never rendered without a working submit.
+  it('exposes all ten filter sections in plan order', () => {
     expect(buildRecentlyAddedFilterConfig().sections).toEqual([
       'timeline',
       'people',
@@ -38,6 +49,7 @@ describe('buildRecentlyAddedFilterConfig', () => {
       'media',
       'favorites',
       'albums',
+      'text',
     ]);
   });
 
@@ -176,5 +188,94 @@ describe('buildRecentlyAddedFilterConfig', () => {
       2,
       expect.objectContaining({ make: 'Sony', takenBefore: '2024-12-31T00:00:00.000Z' }),
     );
+  });
+});
+
+describe('buildRecentlyAddedFilterConfig in query mode', () => {
+  const searchContext = () => ({ query: 'beach', language: 'en', filters: createFilterState() });
+
+  it('routes suggestions through smart facets, never shared spaces', async () => {
+    const config = buildRecentlyAddedFilterConfig(searchContext);
+
+    await config.suggestionsProvider!(createFilterState());
+
+    expect(getFilterSuggestions).not.toHaveBeenCalled();
+    expect(searchSmartFacets).toHaveBeenCalledWith(
+      expect.objectContaining({ smartSearchFacetsDto: expect.objectContaining({ query: 'beach' }) }),
+    );
+    // Absence, not `false` — buildSmartSearchParams only sets the key when truthy.
+    expect(vi.mocked(searchSmartFacets).mock.calls[0][0].smartSearchFacetsDto).not.toHaveProperty('withSharedSpaces');
+  });
+
+  it('maps smart facets to filter suggestions', async () => {
+    const result = await buildRecentlyAddedFilterConfig(searchContext).suggestionsProvider!(createFilterState());
+
+    expect(result.tags).toEqual([{ id: 'tag-1', name: 'Vacation' }]);
+    expect(result.people[0]).toEqual(expect.objectContaining({ id: 'person-1', name: 'Alice' }));
+    expect(result.countries).toEqual(['Germany']);
+  });
+
+  it('routes the dependent providers through smart facets without shared spaces', async () => {
+    const config = buildRecentlyAddedFilterConfig(searchContext);
+
+    const cities = await config.providers!.cities!('Germany');
+    const cameraModels = await config.providers!.cameraModels!('Sony');
+
+    expect(getSearchSuggestions).not.toHaveBeenCalled();
+    expect(cities).toEqual(['Berlin']);
+    expect(cameraModels).toEqual(['A7']);
+    for (const call of vi.mocked(searchSmartFacets).mock.calls) {
+      expect(call[0].smartSearchFacetsDto).not.toHaveProperty('withSharedSpaces');
+    }
+  });
+
+  it('scopes the dependent providers by the live filters, not just the dependent value', async () => {
+    // Regression pin: reconstructing a FilterState from the panel's FilterContext type-checks but
+    // silently drops city/make/model/mediaType/text filters AND all dates (buildSmartSearchParams
+    // derives dates from dateAfter/dateBefore/selectedYear, not takenAfter/takenBefore).
+    const config = buildRecentlyAddedFilterConfig(() => ({
+      query: 'beach',
+      language: 'en',
+      filters: { ...createFilterState(), make: 'Sony', rating: 4, selectedYear: 2024 },
+    }));
+
+    await config.providers!.cities!('Germany');
+
+    expect(vi.mocked(searchSmartFacets).mock.calls[0][0].smartSearchFacetsDto).toEqual(
+      expect.objectContaining({
+        country: 'Germany',
+        make: 'Sony',
+        rating: 4,
+        takenAfter: '2024-01-01T00:00:00.000Z',
+      }),
+    );
+  });
+
+  it('reads the query and filters at call time, not at build time', async () => {
+    // The panel calls providers during interaction; values captured at build time would go stale
+    // the moment the user edits the query or another filter.
+    let context = { query: 'beach', language: 'en', filters: createFilterState() };
+    const config = buildRecentlyAddedFilterConfig(() => context);
+
+    await config.suggestionsProvider!(createFilterState());
+    context = { query: 'sunset', language: 'en', filters: { ...createFilterState(), rating: 5 } };
+    await config.suggestionsProvider!(createFilterState());
+
+    expect(vi.mocked(searchSmartFacets).mock.calls[1][0].smartSearchFacetsDto).toEqual(
+      expect.objectContaining({ query: 'sunset' }),
+    );
+  });
+
+  it('falls back to the browse path when the query is blank', async () => {
+    const config = buildRecentlyAddedFilterConfig(() => ({
+      query: '   ',
+      language: 'en',
+      filters: createFilterState(),
+    }));
+
+    await config.suggestionsProvider!(createFilterState());
+
+    expect(searchSmartFacets).not.toHaveBeenCalled();
+    expect(getFilterSuggestions).toHaveBeenCalled();
   });
 });

--- a/web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts
+++ b/web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts
@@ -1,0 +1,180 @@
+import { AssetTypeEnum, getFilterSuggestions, getSearchSuggestions, Type } from '@immich/sdk';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createFilterState } from '$lib/components/filter-panel/filter-panel';
+import { buildRecentlyAddedFilterConfig } from '$lib/utils/recently-added-filter-config';
+
+vi.mock('@immich/sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@immich/sdk')>();
+  return {
+    ...actual,
+    getFilterSuggestions: vi.fn().mockResolvedValue({
+      countries: ['Germany'],
+      cameraMakes: ['Sony'],
+      tags: [{ id: 'tag-1', value: 'Vacation' }],
+      people: [{ id: 'person-1', name: 'Alice' }],
+      ratings: [5],
+      mediaTypes: ['IMAGE'],
+      hasUnnamedPeople: false,
+    }),
+    getSearchSuggestions: vi.fn().mockResolvedValue(['Berlin']),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('buildRecentlyAddedFilterConfig', () => {
+  it('exposes the nine metadata sections in plan order', () => {
+    // 'text' is deliberately absent — it arrives in Slice 3 with the search path, so the input
+    // is never rendered without a working submit.
+    expect(buildRecentlyAddedFilterConfig().sections).toEqual([
+      'timeline',
+      'people',
+      'location',
+      'camera',
+      'tags',
+      'rating',
+      'media',
+      'favorites',
+      'albums',
+    ]);
+  });
+
+  it('never scopes suggestions to shared spaces, albums, or spaces', async () => {
+    const config = buildRecentlyAddedFilterConfig();
+
+    await config.suggestionsProvider!(createFilterState());
+    await config.providers!.cities!('Germany');
+    await config.providers!.cameraModels!('Sony');
+
+    const filterRequest = vi.mocked(getFilterSuggestions).mock.calls[0][0];
+    const cityRequest = vi.mocked(getSearchSuggestions).mock.calls[0][0];
+    const cameraRequest = vi.mocked(getSearchSuggestions).mock.calls[1][0];
+
+    for (const request of [filterRequest, cityRequest, cameraRequest]) {
+      expect(request).not.toHaveProperty('withSharedSpaces');
+      expect(request).not.toHaveProperty('albumId');
+      expect(request).not.toHaveProperty('spaceId');
+    }
+  });
+
+  it('maps tags and people suggestions', async () => {
+    vi.mocked(getFilterSuggestions).mockResolvedValueOnce({
+      countries: ['Germany'],
+      cameraMakes: ['Sony'],
+      tags: [{ id: 'tag-1', value: 'Vacation' }],
+      people: [{ id: 'person-1', name: 'Alice' }],
+      ratings: [5],
+      mediaTypes: ['IMAGE'],
+      hasUnnamedPeople: true,
+    } as never);
+
+    const result = await buildRecentlyAddedFilterConfig().suggestionsProvider!(createFilterState());
+
+    expect(result.tags).toEqual([{ id: 'tag-1', name: 'Vacation' }]);
+    expect(result.people).toEqual([
+      expect.objectContaining({
+        id: 'person-1',
+        name: 'Alice',
+        thumbnailUrl: expect.stringContaining('/people/person-1/thumbnail'),
+      }),
+    ]);
+    expect(result.hasUnnamedPeople).toBe(true);
+    expect(result.countries).toEqual(['Germany']);
+    expect(result.cameraMakes).toEqual(['Sony']);
+    expect(result.ratings).toEqual([5]);
+  });
+
+  it('resolves a space-person suggestion to its shared-space thumbnail', async () => {
+    // A shared-space person can still be *suggested* (they may appear on an own asset); only the
+    // asset scope is restricted. The thumbnail must route to the space endpoint, because the
+    // space-person id has no row in the owner-only person table.
+    vi.mocked(getFilterSuggestions).mockResolvedValueOnce({
+      countries: [],
+      cameraMakes: [],
+      tags: [],
+      people: [
+        {
+          id: 'space-person:space-person-1',
+          name: 'Space Person',
+          primaryProfile: { type: Type.SpacePerson, id: 'space-person-1', spaceId: 'space-1' },
+        },
+      ],
+      ratings: [],
+      mediaTypes: [],
+      hasUnnamedPeople: false,
+    } as never);
+
+    const result = await buildRecentlyAddedFilterConfig().suggestionsProvider!(createFilterState());
+
+    expect(result.people).toEqual([
+      expect.objectContaining({
+        id: 'space-person:space-person-1',
+        thumbnailUrl: '/api/shared-spaces/space-1/people/space-person-1/thumbnail',
+      }),
+    ]);
+  });
+
+  it('maps people suggestions by scoped filter id', async () => {
+    vi.mocked(getFilterSuggestions).mockResolvedValueOnce({
+      countries: [],
+      cameraMakes: [],
+      tags: [],
+      people: [
+        {
+          id: 'identity-group-1',
+          filterId: 'person:person-1',
+          name: 'Alice',
+          primaryProfile: { type: Type.UserPerson, id: 'person-1' },
+        },
+      ],
+      ratings: [],
+      mediaTypes: [],
+      hasUnnamedPeople: false,
+    } as never);
+
+    const result = await buildRecentlyAddedFilterConfig().suggestionsProvider!(createFilterState());
+
+    expect(result.people[0]).toEqual(expect.objectContaining({ id: 'person:person-1', name: 'Alice' }));
+  });
+
+  it('forwards the active filters to the suggestion request', async () => {
+    await buildRecentlyAddedFilterConfig().suggestionsProvider!({
+      ...createFilterState(),
+      personIds: ['person:p1'],
+      tagIds: ['tag-1'],
+      mediaType: 'image',
+      isFavorite: true,
+      dateAfter: '2024-01-01',
+      dateBefore: '2024-12-31',
+    });
+
+    expect(getFilterSuggestions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        personIds: ['person:p1'],
+        tagIds: ['tag-1'],
+        mediaType: AssetTypeEnum.Image,
+        isFavorite: true,
+        takenAfter: '2024-01-01T00:00:00.000Z',
+        takenBefore: '2025-01-01T00:00:00.000Z',
+      }),
+    );
+  });
+
+  it('passes the dependent-provider arguments and context through', async () => {
+    const config = buildRecentlyAddedFilterConfig();
+
+    await config.providers!.cities!('Germany', { takenAfter: '2024-01-01T00:00:00.000Z' });
+    await config.providers!.cameraModels!('Sony', { takenBefore: '2024-12-31T00:00:00.000Z' });
+
+    expect(getSearchSuggestions).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ country: 'Germany', takenAfter: '2024-01-01T00:00:00.000Z' }),
+    );
+    expect(getSearchSuggestions).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ make: 'Sony', takenBefore: '2024-12-31T00:00:00.000Z' }),
+    );
+  });
+});

--- a/web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts
@@ -2,6 +2,7 @@ import { AssetOrder, AssetOrderBy, AssetTypeEnum, AssetVisibility } from '@immic
 import { describe, expect, it } from 'vitest';
 import { createFilterState } from '$lib/components/filter-panel/filter-panel';
 import {
+  buildRecentlyAddedPickerBucketOptions,
   buildRecentlyAddedSuggestionRequest,
   buildRecentlyAddedTimelineOptions,
   shouldShowRecentlyAddedCount,
@@ -207,6 +208,74 @@ describe('buildRecentlyAddedTimelineOptions', () => {
 
     expect(options.orderBy).toBe(AssetOrderBy.CreatedAt);
     expect(options).not.toHaveProperty('withSharedSpaces');
+  });
+});
+
+describe('buildRecentlyAddedPickerBucketOptions', () => {
+  it('buckets by taken date, not by added date', () => {
+    // The regression this exists to prevent: the temporal picker's year/month grid used to be
+    // sourced from the CreatedAt-ordered *timeline* buckets, so it listed **upload** years — while
+    // clicking a year emits takenAfter/takenBefore against localDateTime. A library imported in
+    // 2026 therefore showed a single "2026" chip that matched zero assets. The grid and the
+    // predicate must read the same column, and takenAt is the one the predicate uses.
+    expect(buildRecentlyAddedPickerBucketOptions(createFilterState()).orderBy).toBe(AssetOrderBy.TakenAt);
+  });
+
+  it('keeps the own+partner scope of the view it describes', () => {
+    // Same invariant as the timeline: a facet grid must never count shared-space assets the
+    // timeline below it will not show.
+    expect(buildRecentlyAddedPickerBucketOptions(createFilterState())).toEqual({
+      visibility: AssetVisibility.Timeline,
+      withStacked: true,
+      withPartners: true,
+      order: AssetOrder.Desc,
+      orderBy: AssetOrderBy.TakenAt,
+    });
+  });
+
+  it('never sends withSharedSpaces under any filter', () => {
+    const cases = [
+      { ...createFilterState(), country: 'Germany' },
+      { ...createFilterState(), isFavorite: true },
+      { ...createFilterState(), personIds: ['person:p1'] },
+    ];
+    for (const filters of cases) {
+      expect(buildRecentlyAddedPickerBucketOptions(filters)).not.toHaveProperty('withSharedSpaces');
+    }
+  });
+
+  it('keeps orderBy TakenAt under every filter combination', () => {
+    const cases = [
+      createFilterState(),
+      { ...createFilterState(), country: 'Germany' },
+      { ...createFilterState(), isFavorite: true },
+      { ...createFilterState(), sortOrder: 'asc' as const },
+      { ...createFilterState(), selectedYear: 2024 },
+    ];
+    for (const filters of cases) {
+      expect(buildRecentlyAddedPickerBucketOptions(filters).orderBy).toBe(AssetOrderBy.TakenAt);
+    }
+  });
+
+  it('scopes the grid by the other active filters', () => {
+    // The counts on each year chip must describe the set the timeline is showing, so every
+    // non-temporal predicate carries over.
+    expect(
+      buildRecentlyAddedPickerBucketOptions({
+        ...createFilterState(),
+        personIds: ['person:p1'],
+        country: 'Germany',
+        tagIds: ['tag-1'],
+        rating: 5,
+        mediaType: 'video',
+      }),
+    ).toMatchObject({
+      personIds: ['person:p1'],
+      country: 'Germany',
+      tagIds: ['tag-1'],
+      rating: 5,
+      $type: AssetTypeEnum.Video,
+    });
   });
 });
 

--- a/web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { shouldShowRecentlyAddedCount } from '$lib/utils/recently-added-filter-options';
+
+describe('shouldShowRecentlyAddedCount', () => {
+  it('hides the count while loading or for an empty account', () => {
+    // No buckets loaded yet (assetCount is transiently 0) and no filters: showing
+    // "0 items" would flash a wrong count. The EmptyPlaceholder communicates emptiness.
+    expect(shouldShowRecentlyAddedCount(0, false)).toBe(false);
+  });
+
+  it('shows "0 items" when a filter matched nothing', () => {
+    // Informative: tells the user their filter matched nothing, rather than
+    // looking like an empty account.
+    expect(shouldShowRecentlyAddedCount(0, true)).toBe(true);
+  });
+
+  it('shows the count for a populated view without filters', () => {
+    expect(shouldShowRecentlyAddedCount(5, false)).toBe(true);
+  });
+
+  it('shows the count for a populated filtered view', () => {
+    expect(shouldShowRecentlyAddedCount(5, true)).toBe(true);
+  });
+
+  it('shows the count at the singular boundary (plural wording is left to i18n)', () => {
+    expect(shouldShowRecentlyAddedCount(1, false)).toBe(true);
+  });
+});

--- a/web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts
@@ -1,5 +1,11 @@
+import { AssetOrder, AssetOrderBy, AssetTypeEnum, AssetVisibility } from '@immich/sdk';
 import { describe, expect, it } from 'vitest';
-import { shouldShowRecentlyAddedCount } from '$lib/utils/recently-added-filter-options';
+import { createFilterState } from '$lib/components/filter-panel/filter-panel';
+import {
+  buildRecentlyAddedSuggestionRequest,
+  buildRecentlyAddedTimelineOptions,
+  shouldShowRecentlyAddedCount,
+} from '$lib/utils/recently-added-filter-options';
 
 describe('shouldShowRecentlyAddedCount', () => {
   it('hides the count while loading or for an empty account', () => {
@@ -24,5 +30,242 @@ describe('shouldShowRecentlyAddedCount', () => {
 
   it('shows the count at the singular boundary (plural wording is left to i18n)', () => {
     expect(shouldShowRecentlyAddedCount(1, false)).toBe(true);
+  });
+});
+
+describe('buildRecentlyAddedTimelineOptions', () => {
+  it('returns the own+partner added-date shape by default', () => {
+    // Exact shape on purpose: if buildPhotosTimelineOptions ever grows a new shared-scope key,
+    // this fails rather than silently leaking it into Recently Added.
+    expect(buildRecentlyAddedTimelineOptions(createFilterState())).toEqual({
+      visibility: AssetVisibility.Timeline,
+      withStacked: true,
+      withPartners: true,
+      order: AssetOrder.Desc,
+      orderBy: AssetOrderBy.CreatedAt,
+    });
+  });
+
+  it('never sends withSharedSpaces under a metadata filter', () => {
+    const options = buildRecentlyAddedTimelineOptions({ ...createFilterState(), country: 'Germany' });
+    expect(options).not.toHaveProperty('withSharedSpaces');
+    expect(options.country).toBe('Germany');
+  });
+
+  it('never sends withSharedSpaces under a favorites filter', () => {
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), isFavorite: true })).not.toHaveProperty(
+      'withSharedSpaces',
+    );
+  });
+
+  it('keeps orderBy CreatedAt under every filter combination', () => {
+    const cases = [
+      createFilterState(),
+      { ...createFilterState(), country: 'Germany' },
+      { ...createFilterState(), isFavorite: true },
+      { ...createFilterState(), sortOrder: 'asc' as const },
+    ];
+    for (const filters of cases) {
+      expect(buildRecentlyAddedTimelineOptions(filters).orderBy).toBe(AssetOrderBy.CreatedAt);
+    }
+  });
+
+  it('keeps partner assets for a non-favorite filter', () => {
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), rating: 4 }).withPartners).toBe(true);
+  });
+
+  it('drops partner assets under a favorites filter (favorites are personal)', () => {
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), isFavorite: true })).not.toHaveProperty(
+      'withPartners',
+    );
+  });
+
+  it('maps sortOrder to order without touching orderBy', () => {
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), sortOrder: 'asc' }).order).toBe(AssetOrder.Asc);
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), sortOrder: 'desc' }).order).toBe(
+      AssetOrder.Desc,
+    );
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), sortOrder: 'relevance' }).order).toBe(
+      AssetOrder.Desc,
+    );
+  });
+
+  it('passes metadata predicates through', () => {
+    const options = buildRecentlyAddedTimelineOptions({
+      ...createFilterState(),
+      personIds: ['person:p1'],
+      city: 'Berlin',
+      country: 'Germany',
+      make: 'Sony',
+      model: 'A7',
+      tagIds: ['tag-1'],
+      rating: 5,
+    });
+
+    expect(options).toMatchObject({
+      personIds: ['person:p1'],
+      city: 'Berlin',
+      country: 'Germany',
+      make: 'Sony',
+      model: 'A7',
+      tagIds: ['tag-1'],
+      rating: 5,
+    });
+  });
+
+  it('maps mediaType to $type and omits it for "all"', () => {
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), mediaType: 'image' }).$type).toBe(
+      AssetTypeEnum.Image,
+    );
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), mediaType: 'video' }).$type).toBe(
+      AssetTypeEnum.Video,
+    );
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), mediaType: 'all' })).not.toHaveProperty('$type');
+  });
+
+  it('trims text predicates and omits them when blank', () => {
+    const set = buildRecentlyAddedTimelineOptions({
+      ...createFilterState(),
+      description: '  sunset  ',
+      originalFileName: '  IMG_1.jpg  ',
+      ocr: '  invoice  ',
+    });
+    expect(set).toMatchObject({ description: 'sunset', originalFileName: 'IMG_1.jpg', ocr: 'invoice' });
+
+    const blank = buildRecentlyAddedTimelineOptions({
+      ...createFilterState(),
+      description: '   ',
+      originalFileName: '   ',
+      ocr: '   ',
+    });
+    expect(blank).not.toHaveProperty('description');
+    expect(blank).not.toHaveProperty('originalFileName');
+    expect(blank).not.toHaveProperty('ocr');
+  });
+
+  it('passes album membership flags only when true', () => {
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), isNotInAlbum: true }).isNotInAlbum).toBe(true);
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), isInAlbum: true }).isInAlbum).toBe(true);
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), isNotInAlbum: false })).not.toHaveProperty(
+      'isNotInAlbum',
+    );
+    expect(buildRecentlyAddedTimelineOptions({ ...createFilterState(), isInAlbum: false })).not.toHaveProperty(
+      'isInAlbum',
+    );
+  });
+
+  it('derives takenAfter/takenBefore from the timeline date filter', () => {
+    // Documented semantic: the date filter filters *taken* date while day-groups reflect *added*
+    // date. Intentional — no created-at range predicate exists (that would be backend work).
+    const year = buildRecentlyAddedTimelineOptions({ ...createFilterState(), selectedYear: 2024 });
+    expect(year.takenAfter).toBe('2024-01-01T00:00:00.000Z');
+    expect(year.takenBefore).toBe('2025-01-01T00:00:00.000Z');
+
+    const yearMonth = buildRecentlyAddedTimelineOptions({
+      ...createFilterState(),
+      selectedYear: 2024,
+      selectedMonth: 3,
+    });
+    expect(yearMonth.takenAfter).toBe('2024-03-01T00:00:00.000Z');
+    expect(yearMonth.takenBefore).toBe('2024-04-01T00:00:00.000Z');
+
+    const custom = buildRecentlyAddedTimelineOptions({
+      ...createFilterState(),
+      dateAfter: '2024-01-01',
+      dateBefore: '2024-12-31',
+    });
+    expect(custom.takenAfter).toBe('2024-01-01T00:00:00.000Z');
+    expect(custom.takenBefore).toBe('2025-01-01T00:00:00.000Z');
+
+    const fromOnly = buildRecentlyAddedTimelineOptions({ ...createFilterState(), dateAfter: '2024-01-01' });
+    expect(fromOnly.takenAfter).toBe('2024-01-01T00:00:00.000Z');
+    expect(fromOnly).not.toHaveProperty('takenBefore');
+
+    const toOnly = buildRecentlyAddedTimelineOptions({ ...createFilterState(), dateBefore: '2024-12-31' });
+    expect(toOnly.takenBefore).toBe('2025-01-01T00:00:00.000Z');
+    expect(toOnly).not.toHaveProperty('takenAfter');
+  });
+
+  it('holds both invariants under a multi-filter combination', () => {
+    const options = buildRecentlyAddedTimelineOptions({
+      ...createFilterState(),
+      personIds: ['person:p1'],
+      country: 'Germany',
+      tagIds: ['tag-1'],
+      mediaType: 'video',
+      sortOrder: 'asc',
+    });
+
+    expect(options.orderBy).toBe(AssetOrderBy.CreatedAt);
+    expect(options).not.toHaveProperty('withSharedSpaces');
+  });
+});
+
+describe('buildRecentlyAddedSuggestionRequest', () => {
+  it('never scopes to shared spaces, albums, or spaces', () => {
+    const request = buildRecentlyAddedSuggestionRequest(createFilterState());
+    expect(request).not.toHaveProperty('withSharedSpaces');
+    expect(request).not.toHaveProperty('albumId');
+    expect(request).not.toHaveProperty('spaceId');
+  });
+
+  it('sends undefined for empty person and tag selections', () => {
+    const request = buildRecentlyAddedSuggestionRequest(createFilterState());
+    expect(request.personIds).toBeUndefined();
+    expect(request.tagIds).toBeUndefined();
+  });
+
+  it('sends arrays when people and tags are selected', () => {
+    const request = buildRecentlyAddedSuggestionRequest({
+      ...createFilterState(),
+      personIds: ['person:p1'],
+      tagIds: ['tag-1'],
+    });
+    expect(request.personIds).toEqual(['person:p1']);
+    expect(request.tagIds).toEqual(['tag-1']);
+  });
+
+  it('maps mediaType and omits it for "all"', () => {
+    expect(buildRecentlyAddedSuggestionRequest({ ...createFilterState(), mediaType: 'image' }).mediaType).toBe(
+      AssetTypeEnum.Image,
+    );
+    expect(buildRecentlyAddedSuggestionRequest({ ...createFilterState(), mediaType: 'video' }).mediaType).toBe(
+      AssetTypeEnum.Video,
+    );
+    expect(buildRecentlyAddedSuggestionRequest({ ...createFilterState(), mediaType: 'all' }).mediaType).toBeUndefined();
+  });
+
+  it('passes isFavorite and location/camera predicates through', () => {
+    const request = buildRecentlyAddedSuggestionRequest({
+      ...createFilterState(),
+      isFavorite: true,
+      country: 'Germany',
+      city: 'Berlin',
+      make: 'Sony',
+      model: 'A7',
+      rating: 3,
+    });
+    expect(request).toMatchObject({
+      isFavorite: true,
+      country: 'Germany',
+      city: 'Berlin',
+      make: 'Sony',
+      model: 'A7',
+      rating: 3,
+    });
+  });
+
+  it('passes the date range for year and custom filters', () => {
+    const year = buildRecentlyAddedSuggestionRequest({ ...createFilterState(), selectedYear: 2024 });
+    expect(year.takenAfter).toBe('2024-01-01T00:00:00.000Z');
+    expect(year.takenBefore).toBe('2025-01-01T00:00:00.000Z');
+
+    const custom = buildRecentlyAddedSuggestionRequest({
+      ...createFilterState(),
+      dateAfter: '2024-01-01',
+      dateBefore: '2024-12-31',
+    });
+    expect(custom.takenAfter).toBe('2024-01-01T00:00:00.000Z');
+    expect(custom.takenBefore).toBe('2025-01-01T00:00:00.000Z');
   });
 });

--- a/web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts
@@ -277,4 +277,15 @@ describe('buildRecentlyAddedSuggestionRequest', () => {
     expect(custom.takenAfter).toBe('2024-01-01T00:00:00.000Z');
     expect(custom.takenBefore).toBe('2025-01-01T00:00:00.000Z');
   });
+
+  it('passes album membership flags only when true', () => {
+    expect(buildRecentlyAddedSuggestionRequest({ ...createFilterState(), isNotInAlbum: true }).isNotInAlbum).toBe(true);
+    expect(buildRecentlyAddedSuggestionRequest({ ...createFilterState(), isInAlbum: true }).isInAlbum).toBe(true);
+    expect(
+      buildRecentlyAddedSuggestionRequest({ ...createFilterState(), isNotInAlbum: false }).isNotInAlbum,
+    ).toBeUndefined();
+    expect(buildRecentlyAddedSuggestionRequest({ ...createFilterState(), isInAlbum: false }).isInAlbum).toBeUndefined();
+    expect(buildRecentlyAddedSuggestionRequest(createFilterState()).isNotInAlbum).toBeUndefined();
+    expect(buildRecentlyAddedSuggestionRequest(createFilterState()).isInAlbum).toBeUndefined();
+  });
 });

--- a/web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts
+++ b/web/src/lib/utils/__tests__/recently-added-filter-options.spec.ts
@@ -90,6 +90,15 @@ describe('buildRecentlyAddedTimelineOptions', () => {
     );
   });
 
+  it('degrades a relevance sort to newest-added-first in browse mode', () => {
+    // A `?q=` in the URL resolves sortOrder to 'relevance'. Browse mode has no relevance ranking,
+    // so it must fall back to the view's natural default rather than producing an invalid order.
+    const options = buildRecentlyAddedTimelineOptions({ ...createFilterState(), sortOrder: 'relevance' });
+
+    expect(options.order).toBe(AssetOrder.Desc);
+    expect(options.orderBy).toBe(AssetOrderBy.CreatedAt);
+  });
+
   it('passes metadata predicates through', () => {
     const options = buildRecentlyAddedTimelineOptions({
       ...createFilterState(),

--- a/web/src/lib/utils/__tests__/searchable-page-search.spec.ts
+++ b/web/src/lib/utils/__tests__/searchable-page-search.spec.ts
@@ -3,6 +3,7 @@ import { createFilterState } from '$lib/components/filter-panel/filter-panel';
 import {
   buildSearchablePageUrl,
   clearSearchablePageFilterParams,
+  getSearchablePageBasePath,
   getSearchablePageFilterState,
   getSearchablePageState,
   preserveTransientTemporalFilters,
@@ -234,5 +235,53 @@ describe('text filter URL params', () => {
     expect(state.personIds).toEqual(['p1']);
     expect(state.isInAlbum).toBe(true);
     expect(state.description).toBe('beach');
+  });
+});
+
+describe('recently added page', () => {
+  it('resolves the base path so filter changes can be written to the URL', () => {
+    expect(getSearchablePageBasePath('/recently-added')).toBe('/recently-added');
+    expect(getSearchablePageBasePath('/recently-added/photos')).toBe('/recently-added');
+  });
+
+  it('builds a filter URL for the recently added page', () => {
+    const url = buildSearchablePageUrl(new URL('https://gallery.test/recently-added'), '', 'desc', {
+      ...createFilterState(),
+      rating: 5,
+    });
+
+    expect(url).not.toBeNull();
+    expect(url).toContain('rating=5');
+  });
+
+  it('is not query-capable until the text slice lands', () => {
+    // Slice 3 flips this to true together with the text section and the search path, so the
+    // global search UI never offers a query this page cannot answer.
+    const state = getSearchablePageState(new URL('https://gallery.test/recently-added'));
+
+    expect(state.basePath).toBe('/recently-added');
+    expect(state.isSearchable).toBe(false);
+  });
+
+  it('refuses to build a query URL for a page that cannot answer one', () => {
+    // This is the load-bearing case. global-search-manager's buildSearchDestination falls back to
+    // /photos only when this returns null, so returning a URL here would strand a `?q=` on a route
+    // with no query handling.
+    expect(buildSearchablePageUrl(new URL('https://gallery.test/recently-added'), 'beach')).toBeNull();
+  });
+
+  it('still builds a filter-only URL for the same page', () => {
+    const url = buildSearchablePageUrl(new URL('https://gallery.test/recently-added'), '', 'desc', {
+      ...createFilterState(),
+      rating: 5,
+    });
+
+    expect(url).toContain('rating=5');
+  });
+
+  it('leaves photos and spaces query-capable', () => {
+    expect(getSearchablePageState(new URL('https://gallery.test/photos')).isSearchable).toBe(true);
+    expect(getSearchablePageState(new URL('https://gallery.test/spaces/space-1')).isSearchable).toBe(true);
+    expect(buildSearchablePageUrl(new URL('https://gallery.test/photos'), 'beach')).toContain('q=beach');
   });
 });

--- a/web/src/lib/utils/__tests__/searchable-page-search.spec.ts
+++ b/web/src/lib/utils/__tests__/searchable-page-search.spec.ts
@@ -254,20 +254,15 @@ describe('recently added page', () => {
     expect(url).toContain('rating=5');
   });
 
-  it('is not query-capable until the text slice lands', () => {
-    // Slice 3 flips this to true together with the text section and the search path, so the
-    // global search UI never offers a query this page cannot answer.
+  it('is query-capable now that the text section and search path exist', () => {
     const state = getSearchablePageState(new URL('https://gallery.test/recently-added'));
 
     expect(state.basePath).toBe('/recently-added');
-    expect(state.isSearchable).toBe(false);
+    expect(state.isSearchable).toBe(true);
   });
 
-  it('refuses to build a query URL for a page that cannot answer one', () => {
-    // This is the load-bearing case. global-search-manager's buildSearchDestination falls back to
-    // /photos only when this returns null, so returning a URL here would strand a `?q=` on a route
-    // with no query handling.
-    expect(buildSearchablePageUrl(new URL('https://gallery.test/recently-added'), 'beach')).toBeNull();
+  it('builds a query URL for the recently added page', () => {
+    expect(buildSearchablePageUrl(new URL('https://gallery.test/recently-added'), 'beach')).toContain('q=beach');
   });
 
   it('still builds a filter-only URL for the same page', () => {

--- a/web/src/lib/utils/recently-added-filter-config.ts
+++ b/web/src/lib/utils/recently-added-filter-config.ts
@@ -1,0 +1,53 @@
+import { getFilterSuggestions, getSearchSuggestions, SearchSuggestionType } from '@immich/sdk';
+import type { FilterPanelConfig } from '$lib/components/filter-panel/filter-panel';
+import { getPhotosPersonFilterId, getPhotosPersonFilterThumbnailUrl } from '$lib/utils/photos-filter-options';
+import { buildRecentlyAddedSuggestionRequest } from '$lib/utils/recently-added-filter-options';
+
+/**
+ * Nine of the ten filter sections. `'text'` is intentionally absent until Slice 3 adds the
+ * smart-search path alongside it, so the text input is never rendered without a working submit.
+ */
+const sections = [
+  'timeline',
+  'people',
+  'location',
+  'camera',
+  'tags',
+  'rating',
+  'media',
+  'favorites',
+  'albums',
+] as const;
+
+function mapSuggestions(response: Awaited<ReturnType<typeof getFilterSuggestions>>) {
+  return {
+    countries: response.countries,
+    cameraMakes: response.cameraMakes,
+    tags: response.tags.map((tag) => ({ id: tag.id, name: tag.value })),
+    people: response.people.map((person) => ({
+      id: getPhotosPersonFilterId(person),
+      name: person.name,
+      thumbnailUrl: getPhotosPersonFilterThumbnailUrl(person),
+    })),
+    ratings: response.ratings,
+    mediaTypes: response.mediaTypes,
+    hasUnnamedPeople: response.hasUnnamedPeople,
+  };
+}
+
+/**
+ * Filter-panel config for the Recently Added view: own + partner scope only, so nothing here
+ * carries `withSharedSpaces` / `albumId` / `spaceId`.
+ */
+export function buildRecentlyAddedFilterConfig(): FilterPanelConfig {
+  return {
+    sections: [...sections],
+    suggestionsProvider: async (filters) =>
+      mapSuggestions(await getFilterSuggestions(buildRecentlyAddedSuggestionRequest(filters))),
+    providers: {
+      cities: (country, context) => getSearchSuggestions({ $type: SearchSuggestionType.City, country, ...context }),
+      cameraModels: (make, context) =>
+        getSearchSuggestions({ $type: SearchSuggestionType.CameraModel, make, ...context }),
+    },
+  };
+}

--- a/web/src/lib/utils/recently-added-filter-config.ts
+++ b/web/src/lib/utils/recently-added-filter-config.ts
@@ -1,11 +1,19 @@
-import { getFilterSuggestions, getSearchSuggestions, SearchSuggestionType } from '@immich/sdk';
-import type { FilterPanelConfig } from '$lib/components/filter-panel/filter-panel';
+import {
+  getFilterSuggestions,
+  getSearchSuggestions,
+  searchSmartFacets,
+  SearchSuggestionType,
+  type SmartSearchFacetsResponseDto,
+} from '@immich/sdk';
+import type { FilterPanelConfig, FilterState } from '$lib/components/filter-panel/filter-panel';
 import { getPhotosPersonFilterId, getPhotosPersonFilterThumbnailUrl } from '$lib/utils/photos-filter-options';
 import { buildRecentlyAddedSuggestionRequest } from '$lib/utils/recently-added-filter-options';
+import { buildSmartSearchFacetsParams, mapSmartSearchFacetsToFilterSuggestions } from '$lib/utils/space-search';
 
 /**
- * Nine of the ten filter sections. `'text'` is intentionally absent until Slice 3 adds the
- * smart-search path alongside it, so the text input is never rendered without a working submit.
+ * All ten filter sections. `'text'` renders as `<TextFilter>`, editing the description /
+ * originalFileName / ocr metadata filters — those already round-trip through the URL and through
+ * `buildRecentlyAddedTimelineOptions`, independent of the query/smart-search path below.
  */
 const sections = [
   'timeline',
@@ -17,6 +25,7 @@ const sections = [
   'media',
   'favorites',
   'albums',
+  'text',
 ] as const;
 
 function mapSuggestions(response: Awaited<ReturnType<typeof getFilterSuggestions>>) {
@@ -36,18 +45,71 @@ function mapSuggestions(response: Awaited<ReturnType<typeof getFilterSuggestions
 }
 
 /**
+ * The route's live search state, read at provider call time so it never goes stale.
+ * `filters` must be the route's live FilterState — the dependent providers scope their facet
+ * query by it, exactly as the Photos page does.
+ */
+export type RecentlyAddedSearchContext = { query: string; language: string; filters: FilterState };
+
+function fetchFacets(context: RecentlyAddedSearchContext, filters: FilterState): Promise<SmartSearchFacetsResponseDto> {
+  return searchSmartFacets({
+    smartSearchFacetsDto: buildSmartSearchFacetsParams({
+      query: context.query.trim(),
+      filters,
+      // Recently Added is own + partner in query mode exactly as in browse mode.
+      withSharedSpaces: false,
+      language: context.language,
+    }),
+  });
+}
+
+/**
  * Filter-panel config for the Recently Added view: own + partner scope only, so nothing here
  * carries `withSharedSpaces` / `albumId` / `spaceId`.
+ *
+ * `getSearchContext` is an accessor, not a plain value, because the panel's providers are called
+ * later, during user interaction, and must see the query and the live filters as they are at call
+ * time — values captured when the config is built would go stale the moment the user edits either.
+ * It defaults to `() => undefined`, so a caller that never searches keeps the Slice-2 browse
+ * behaviour unchanged.
  */
-export function buildRecentlyAddedFilterConfig(): FilterPanelConfig {
+export function buildRecentlyAddedFilterConfig(
+  getSearchContext: () => RecentlyAddedSearchContext | undefined = () => undefined,
+): FilterPanelConfig {
+  // Resolved per call, not per build: the panel invokes these during interaction.
+  const activeSearch = (): RecentlyAddedSearchContext | undefined => {
+    const context = getSearchContext();
+    return context && context.query.trim() ? context : undefined;
+  };
+
   return {
     sections: [...sections],
-    suggestionsProvider: async (filters) =>
-      mapSuggestions(await getFilterSuggestions(buildRecentlyAddedSuggestionRequest(filters))),
+    suggestionsProvider: async (filters) => {
+      const context = activeSearch();
+      if (!context) {
+        return mapSuggestions(await getFilterSuggestions(buildRecentlyAddedSuggestionRequest(filters)));
+      }
+      return mapSmartSearchFacetsToFilterSuggestions(await fetchFacets(context, filters));
+    },
     providers: {
-      cities: (country, context) => getSearchSuggestions({ $type: SearchSuggestionType.City, country, ...context }),
-      cameraModels: (make, context) =>
-        getSearchSuggestions({ $type: SearchSuggestionType.CameraModel, make, ...context }),
+      cities: async (country, filterContext) => {
+        const context = activeSearch();
+        if (!context) {
+          return getSearchSuggestions({ $type: SearchSuggestionType.City, country, ...filterContext });
+        }
+        // Scope by the LIVE filters (mirroring Photos' `filters: { ...filters, country }`), not by
+        // the panel's FilterContext — see the module design note above.
+        const facets = await fetchFacets(context, { ...context.filters, country });
+        return facets.cities;
+      },
+      cameraModels: async (make, filterContext) => {
+        const context = activeSearch();
+        if (!context) {
+          return getSearchSuggestions({ $type: SearchSuggestionType.CameraModel, make, ...filterContext });
+        }
+        const facets = await fetchFacets(context, { ...context.filters, make });
+        return facets.cameraModels;
+      },
     },
   };
 }

--- a/web/src/lib/utils/recently-added-filter-options.ts
+++ b/web/src/lib/utils/recently-added-filter-options.ts
@@ -25,10 +25,29 @@ export function shouldShowRecentlyAddedCount(count: number, hasActiveFilters: bo
  *
  * Note the date filter still filters *taken* date (there is no created-at range predicate);
  * day-groups reflect added date. That mismatch is intentional — e.g. old photos just imported.
+ * The filter panel's year/month grid must therefore be built from
+ * `buildRecentlyAddedPickerBucketOptions`, NOT from these buckets.
  */
 export function buildRecentlyAddedTimelineOptions(filters: FilterState): Record<string, unknown> {
   const { withSharedSpaces: _, ...base } = buildPhotosTimelineOptions(filters);
   return { ...base, orderBy: AssetOrderBy.CreatedAt };
+}
+
+/**
+ * Bucket query backing the filter panel's temporal picker (the year / month grid).
+ *
+ * Identical to the timeline query except that it groups by **taken** date. The picker's grid and
+ * the predicate a click on it produces have to read the same column: clicking a year emits
+ * `takenAfter` / `takenBefore`, which the server applies to `asset.localDateTime`. Deriving the
+ * grid from the timeline's `orderBy: CreatedAt` buckets instead listed *upload* years, so a
+ * library imported this year offered a single chip that matched nothing.
+ *
+ * This is also what query mode already does — smart-search facets bucket on takenAt — so browse
+ * and query mode now agree.
+ */
+export function buildRecentlyAddedPickerBucketOptions(filters: FilterState): Record<string, unknown> {
+  const { withSharedSpaces: _, ...base } = buildPhotosTimelineOptions(filters);
+  return { ...base, orderBy: AssetOrderBy.TakenAt };
 }
 
 /**

--- a/web/src/lib/utils/recently-added-filter-options.ts
+++ b/web/src/lib/utils/recently-added-filter-options.ts
@@ -1,3 +1,7 @@
+import { AssetOrderBy, AssetTypeEnum } from '@immich/sdk';
+import { buildFilterContext, type FilterState } from '$lib/components/filter-panel/filter-panel';
+import { buildPhotosTimelineOptions } from '$lib/utils/photos-filter-options';
+
 /**
  * Whether the Recently Added header should display an item count.
  *
@@ -8,4 +12,48 @@
  */
 export function shouldShowRecentlyAddedCount(count: number, hasActiveFilters: boolean): boolean {
   return count > 0 || hasActiveFilters;
+}
+
+/**
+ * Timeline query for the Recently Added view.
+ *
+ * Reuses Photos' predicate mapping, then applies the two invariants that define this view:
+ *  1. never surface shared-space assets — `withSharedSpaces` is stripped in every case, so the
+ *     view stays own + partner (and own-only under a Favorites filter, which Photos treats as
+ *     a personal flag);
+ *  2. always order and day-group by *added* date.
+ *
+ * Note the date filter still filters *taken* date (there is no created-at range predicate);
+ * day-groups reflect added date. That mismatch is intentional — e.g. old photos just imported.
+ */
+export function buildRecentlyAddedTimelineOptions(filters: FilterState): Record<string, unknown> {
+  const { withSharedSpaces: _, ...base } = buildPhotosTimelineOptions(filters);
+  return { ...base, orderBy: AssetOrderBy.CreatedAt };
+}
+
+/**
+ * Filter-suggestion request for the Recently Added panel. Deliberately carries no
+ * `withSharedSpaces` / `albumId` / `spaceId` — suggestions must describe the same own+partner
+ * set the timeline shows.
+ */
+export function buildRecentlyAddedSuggestionRequest(filters: FilterState) {
+  const context = buildFilterContext(filters);
+  return {
+    personIds: filters.personIds.length > 0 ? filters.personIds : undefined,
+    country: filters.country,
+    city: filters.city,
+    make: filters.make,
+    model: filters.model,
+    tagIds: filters.tagIds.length > 0 ? filters.tagIds : undefined,
+    rating: filters.rating,
+    isFavorite: filters.isFavorite,
+    mediaType:
+      filters.mediaType === 'all'
+        ? undefined
+        : filters.mediaType === 'image'
+          ? AssetTypeEnum.Image
+          : AssetTypeEnum.Video,
+    takenAfter: context?.takenAfter,
+    takenBefore: context?.takenBefore,
+  };
 }

--- a/web/src/lib/utils/recently-added-filter-options.ts
+++ b/web/src/lib/utils/recently-added-filter-options.ts
@@ -47,6 +47,8 @@ export function buildRecentlyAddedSuggestionRequest(filters: FilterState) {
     tagIds: filters.tagIds.length > 0 ? filters.tagIds : undefined,
     rating: filters.rating,
     isFavorite: filters.isFavorite,
+    isNotInAlbum: filters.isNotInAlbum === true ? true : undefined,
+    isInAlbum: filters.isInAlbum === true ? true : undefined,
     mediaType:
       filters.mediaType === 'all'
         ? undefined

--- a/web/src/lib/utils/recently-added-filter-options.ts
+++ b/web/src/lib/utils/recently-added-filter-options.ts
@@ -1,0 +1,11 @@
+/**
+ * Whether the Recently Added header should display an item count.
+ *
+ * Hidden only when there is nothing to show *and* no filter is active: that state is either
+ * "buckets have not loaded yet" or "empty account", and both are better served by the
+ * EmptyPlaceholder than by a transient "0 items". With a filter active, "0 items" is
+ * informative — it says the filter matched nothing.
+ */
+export function shouldShowRecentlyAddedCount(count: number, hasActiveFilters: boolean): boolean {
+  return count > 0 || hasActiveFilters;
+}

--- a/web/src/lib/utils/searchable-page-search.ts
+++ b/web/src/lib/utils/searchable-page-search.ts
@@ -87,18 +87,6 @@ export function getSearchablePageBasePath(pathname: string): string | null {
   return null;
 }
 
-/**
- * Query (free-text) support is a separate capability from URL filter persistence.
- *
- * Recently Added persists its filters in the URL but cannot answer a `?q=` yet — its text
- * section and smart-search path arrive together in the text slice. Until then it must not
- * advertise itself as searchable, or the global search UI would offer a query that silently
- * does nothing. Remove this exclusion in the same change that adds the search path.
- */
-function isQueryCapablePage(basePath: string): boolean {
-  return basePath !== '/recently-added';
-}
-
 export function getSearchablePageState(url: URL): SearchablePageState {
   const basePath = getSearchablePageBasePath(url.pathname);
   if (!basePath) {
@@ -115,7 +103,7 @@ export function getSearchablePageState(url: URL): SearchablePageState {
   const rawSort = url.searchParams.get('sort');
   return {
     basePath,
-    isSearchable: isQueryCapablePage(basePath),
+    isSearchable: true,
     query,
     hasExplicitSort: rawSort === 'asc' || rawSort === 'desc',
     sortOrder: getSortOrder(query, rawSort),
@@ -134,13 +122,6 @@ export function buildSearchablePageUrl(
   }
 
   const trimmedQuery = query.trim();
-
-  // A page that persists filters in the URL is not necessarily able to answer a `?q=`.
-  // Returning null here keeps global-search-manager's buildSearchDestination falling back to
-  // /photos, instead of stranding a query on a route that would silently ignore it.
-  if (trimmedQuery && !isQueryCapablePage(basePath)) {
-    return null;
-  }
 
   const params = new URLSearchParams(url.searchParams);
 

--- a/web/src/lib/utils/searchable-page-search.ts
+++ b/web/src/lib/utils/searchable-page-search.ts
@@ -67,6 +67,10 @@ export function getSearchablePageBasePath(pathname: string): string | null {
     return '/photos';
   }
 
+  if (pathname.startsWith('/recently-added')) {
+    return '/recently-added';
+  }
+
   const parts = pathname.split('/').filter(Boolean);
   if (parts[0] !== 'spaces' || parts[1] === undefined) {
     return null;
@@ -81,6 +85,18 @@ export function getSearchablePageBasePath(pathname: string): string | null {
   }
 
   return null;
+}
+
+/**
+ * Query (free-text) support is a separate capability from URL filter persistence.
+ *
+ * Recently Added persists its filters in the URL but cannot answer a `?q=` yet — its text
+ * section and smart-search path arrive together in the text slice. Until then it must not
+ * advertise itself as searchable, or the global search UI would offer a query that silently
+ * does nothing. Remove this exclusion in the same change that adds the search path.
+ */
+function isQueryCapablePage(basePath: string): boolean {
+  return basePath !== '/recently-added';
 }
 
 export function getSearchablePageState(url: URL): SearchablePageState {
@@ -99,7 +115,7 @@ export function getSearchablePageState(url: URL): SearchablePageState {
   const rawSort = url.searchParams.get('sort');
   return {
     basePath,
-    isSearchable: true,
+    isSearchable: isQueryCapablePage(basePath),
     query,
     hasExplicitSort: rawSort === 'asc' || rawSort === 'desc',
     sortOrder: getSortOrder(query, rawSort),
@@ -118,6 +134,14 @@ export function buildSearchablePageUrl(
   }
 
   const trimmedQuery = query.trim();
+
+  // A page that persists filters in the URL is not necessarily able to answer a `?q=`.
+  // Returning null here keeps global-search-manager's buildSearchDestination falling back to
+  // /photos, instead of stranding a query on a route that would silently ignore it.
+  if (trimmedQuery && !isQueryCapablePage(basePath)) {
+    return null;
+  }
+
   const params = new URLSearchParams(url.searchParams);
 
   // `at` is a one-shot grid scroll target left over from closing the asset viewer. It must not

--- a/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -53,6 +53,7 @@
   import { handlePhotosRemoveFilter } from '$lib/utils/photos-filter-options';
   import { buildRecentlyAddedFilterConfig } from '$lib/utils/recently-added-filter-config';
   import {
+    buildRecentlyAddedPickerBucketOptions,
     buildRecentlyAddedTimelineOptions,
     shouldShowRecentlyAddedCount,
   } from '$lib/utils/recently-added-filter-options';
@@ -68,13 +69,9 @@
     buildSmartSearchFacetsParams,
     mapSmartSearchFacetsToFilterSuggestions,
   } from '$lib/utils/space-search';
-  import {
-    getTimelineBucketZoomTarget,
-    getTimelineManagerTimeBuckets,
-    type ActivatableTimelineBucket,
-  } from '$lib/utils/timeline-zoom-navigation';
+  import { getTimelineBucketZoomTarget, type ActivatableTimelineBucket } from '$lib/utils/timeline-zoom-navigation';
   import { consumeTypedSearchNamesInto } from '$lib/utils/typed-search/typed-search-name-cache';
-  import { searchSmartFacets, type SmartSearchFacetsResponseDto } from '@immich/sdk';
+  import { getTimeBuckets, searchSmartFacets, type SmartSearchFacetsResponseDto } from '@immich/sdk';
   import { ActionButton, CommandPaletteDefaultProvider } from '@immich/ui';
   import { mdiDotsVertical } from '@mdi/js';
   import { untrack } from 'svelte';
@@ -139,8 +136,37 @@
       }
     | undefined;
 
-  const timelineBuckets = $derived(getTimelineManagerTimeBuckets(timelineManager));
-  const smartFacetBuckets = $derived(showSearchResults ? (smartFacets?.timeBuckets ?? []) : timelineBuckets);
+  // The temporal picker's year/month grid must be built from *taken*-date buckets, because clicking
+  // a year emits takenAfter/takenBefore. `timelineManager` groups by *added* date (orderBy
+  // CreatedAt, the whole point of this view), so its buckets would list upload years that the
+  // resulting predicate then matches against nothing — see `buildRecentlyAddedPickerBucketOptions`.
+  // Browse mode fetches its own bucket set; query mode keeps the smart-search facets, which already
+  // bucket on takenAt.
+  let pickerBuckets = $state<Array<{ timeBucket: string; count: number }>>([]);
+  const pickerBucketOptions = $derived(buildRecentlyAddedPickerBucketOptions(filters));
+
+  $effect(() => {
+    // Read the derived options up front so every filter change is tracked as a dependency.
+    const options = pickerBucketOptions;
+    if (showSearchResults) {
+      return;
+    }
+
+    const controller = new AbortController();
+    void getTimeBuckets(options, { signal: controller.signal })
+      .then((buckets) => {
+        pickerBuckets = buckets.map(({ timeBucket, count }) => ({ timeBucket, count }));
+      })
+      .catch((error: unknown) => {
+        if (!controller.signal.aborted) {
+          console.error('Failed to fetch Recently Added filter buckets:', error);
+        }
+      });
+
+    return () => controller.abort();
+  });
+
+  const smartFacetBuckets = $derived(showSearchResults ? (smartFacets?.timeBuckets ?? []) : pickerBuckets);
   const smartFacetTotal = $derived(showSearchResults ? smartFacets?.total : undefined);
 
   const emptyFilterSuggestions = () => ({

--- a/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -10,8 +10,10 @@
     createFilterState,
     getActiveFilterCount,
     loadFilterCollapsed,
+    type FilterPanelConfig,
     type FilterState,
   } from '$lib/components/filter-panel/filter-panel';
+  import SmartSearchResults from '$lib/components/search/smart-search-results.svelte';
   import UserPageLayout from '$lib/components/layouts/UserPageLayout.svelte';
   import ButtonContextMenu from '$lib/components/shared-components/context-menu/ButtonContextMenu.svelte';
   import EmptyPlaceholder from '$lib/components/shared-components/EmptyPlaceholder.svelte';
@@ -39,6 +41,7 @@
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
   import type { TimelineGrouping, TimelineTemporalAnchor } from '$lib/managers/timeline-manager/types';
   import { getAssetBulkActions } from '$lib/services/asset.service';
+  import { lang } from '$lib/stores/preferences.store';
   import {
     updateStackedAssetInTimeline,
     updateUnstackedAssetInTimeline,
@@ -61,11 +64,17 @@
     type SearchablePageTransientTemporalState,
   } from '$lib/utils/searchable-page-search';
   import {
+    buildSmartSearchFacetKey,
+    buildSmartSearchFacetsParams,
+    mapSmartSearchFacetsToFilterSuggestions,
+  } from '$lib/utils/space-search';
+  import {
     getTimelineBucketZoomTarget,
     getTimelineManagerTimeBuckets,
     type ActivatableTimelineBucket,
   } from '$lib/utils/timeline-zoom-navigation';
   import { consumeTypedSearchNamesInto } from '$lib/utils/typed-search/typed-search-name-cache';
+  import { searchSmartFacets, type SmartSearchFacetsResponseDto } from '@immich/sdk';
   import { ActionButton, CommandPaletteDefaultProvider } from '@immich/ui';
   import { mdiDotsVertical } from '@mdi/js';
   import { untrack } from 'svelte';
@@ -104,10 +113,13 @@
   };
   let timelineGrouping = $state<TimelineGrouping>('day');
   let temporalAnchor = $state<TimelineTemporalAnchor | undefined>();
+  let committedQuery = $state(initialSearchState.query);
   let lastHandledSearchState = $state(`${initialSearchState.query}:${initialSearchState.sortOrder}:${page.url.search}`);
   let pendingFilterUrlSync = $state<
     { url: string; transientTemporal?: SearchablePageTransientTemporalState } | undefined
   >();
+  let isLoading = $state(false);
+  const showSearchResults = $derived(committedQuery.trim().length > 0);
   const options = $derived({ ...buildRecentlyAddedTimelineOptions(filters), grouping: timelineGrouping });
   $effect(() => {
     filtersBeforePanelChange = filters;
@@ -117,20 +129,121 @@
   consumeTypedSearchNamesInto(page.url.pathname + page.url.search, personNames, tagNames);
   $effect(() => globalSearchManager.registerSearchablePageFilters(() => filters));
 
+  let smartFacets = $state<SmartSearchFacetsResponseDto>();
+  let smartFacetKey = $state('');
+  let smartFacetInFlight:
+    | {
+        key: string;
+        controller: AbortController;
+        promise: Promise<SmartSearchFacetsResponseDto | undefined>;
+      }
+    | undefined;
+
   const timelineBuckets = $derived(getTimelineManagerTimeBuckets(timelineManager));
+  const smartFacetBuckets = $derived(showSearchResults ? (smartFacets?.timeBuckets ?? []) : timelineBuckets);
+  const smartFacetTotal = $derived(showSearchResults ? smartFacets?.total : undefined);
 
-  const filterConfig = withNameCapture(buildRecentlyAddedFilterConfig(), personNames, tagNames);
+  const emptyFilterSuggestions = () => ({
+    countries: [],
+    cities: [],
+    cameraMakes: [],
+    cameraModels: [],
+    tags: [],
+    people: [],
+    ratings: [],
+    mediaTypes: [],
+    hasUnnamedPeople: false,
+  });
 
-  const hasActiveFilters = $derived(getActiveFilterCount(filters) > 0);
+  // Own + partner scope only — `withSharedSpaces` is hardcoded `false` here (never derived from
+  // `filters`, unlike Photos), matching every other search-path call in this view.
+  async function loadRecentlyAddedSmartFacets(
+    nextFilters: FilterState,
+  ): Promise<SmartSearchFacetsResponseDto | undefined> {
+    const query = committedQuery.trim();
+    if (!query) {
+      return undefined;
+    }
+
+    const key = buildSmartSearchFacetKey({ query, filters: nextFilters, withSharedSpaces: false, language: $lang });
+    if (smartFacets && smartFacetKey === key) {
+      return smartFacets;
+    }
+    if (smartFacetInFlight?.key === key) {
+      return smartFacetInFlight.promise;
+    }
+
+    smartFacetInFlight?.controller.abort();
+    const controller = new AbortController();
+
+    const promise = searchSmartFacets(
+      {
+        smartSearchFacetsDto: buildSmartSearchFacetsParams({
+          query,
+          filters: nextFilters,
+          withSharedSpaces: false,
+          language: $lang,
+        }),
+      },
+      { signal: controller.signal },
+    )
+      .then((result) => {
+        if (smartFacetInFlight?.key === key && !controller.signal.aborted) {
+          smartFacets = result;
+          smartFacetKey = key;
+        }
+        return result;
+      })
+      .catch((error: unknown) => {
+        if (!controller.signal.aborted) {
+          console.error('Failed to fetch smart search facets:', error);
+        }
+        return smartFacets;
+      })
+      .finally(() => {
+        if (smartFacetInFlight?.key === key) {
+          smartFacetInFlight = undefined;
+        }
+      });
+
+    smartFacetInFlight = { key, controller, promise };
+    return promise;
+  }
+
+  // `getSearchContext` scopes the dependent providers (cities/cameraModels) by the *live* filters —
+  // see the module doc on `buildRecentlyAddedFilterConfig`. The base suggestionsProvider it returns
+  // is used as-is for browse mode; query mode overrides it below with a cached loader so a filter
+  // change that doesn't affect the facet key (e.g. sortOrder) doesn't refetch, and so the raw facets
+  // (total, timeBuckets) are available to the rest of the page, not just the mapped suggestions.
+  const baseFilterConfig = buildRecentlyAddedFilterConfig(() => ({ query: committedQuery, language: $lang, filters }));
+
+  const filterConfig: FilterPanelConfig = withNameCapture(
+    {
+      ...baseFilterConfig,
+      suggestionsProvider: async (nextFilters: FilterState) => {
+        if (!showSearchResults) {
+          return baseFilterConfig.suggestionsProvider!(nextFilters);
+        }
+
+        const facets = await loadRecentlyAddedSmartFacets(nextFilters);
+        if (!facets) {
+          return emptyFilterSuggestions();
+        }
+        return mapSmartSearchFacetsToFilterSuggestions(facets);
+      },
+    },
+    personNames,
+    tagNames,
+  );
+
+  const hasActiveFilters = $derived(getActiveFilterCount(filters) > 0 || showSearchResults);
 
   // Filter-panel collapse is driven here so a header filter button can reclaim the panel's space.
   let filterCollapsed = $state(loadFilterCollapsed());
 
-  const assetCount = $derived(timelineManager?.assetCount ?? 0);
+  const count = $derived(showSearchResults ? (smartFacetTotal ?? 0) : (timelineManager?.assetCount ?? 0));
   const countLabel = $derived(
-    shouldShowRecentlyAddedCount(assetCount, hasActiveFilters)
-      ? $t('items_count', { values: { count: assetCount } })
-      : undefined,
+    shouldShowRecentlyAddedCount(count, hasActiveFilters) ? $t('items_count', { values: { count } }) : undefined,
   );
 
   // Use the timeline's *loaded* result (for the current options) rather than a bare
@@ -175,17 +288,30 @@
     assetMultiSelectManager.clear();
   };
 
+  function clearSearch() {
+    isLoading = false;
+    const nextUrl = buildSearchablePageUrl(page.url, '', filters.sortOrder, filters);
+    if (!nextUrl) {
+      return;
+    }
+    void goto(nextUrl, { replaceState: true, keepFocus: true, noScroll: true });
+  }
+
   function syncFilterUrl(nextFilters: FilterState) {
     const currentSearchState = getSearchablePageState(page.url);
     // `buildSearchablePageUrl` writes an explicit `sort=` param whenever it is handed a literal
     // 'asc' | 'desc'; only 'relevance' clears it. `createFilterState()` defaults sortOrder to
     // 'desc', so passing it straight through would stamp `sort=desc` onto every filter URL the
     // user never asked for. Convert the *implicit* default to 'relevance' (= "no explicit sort")
-    // and pass through anything the user actually chose. Photos does the same thing; its extra
-    // free-text-query guard is query-mode-only and drops out here (this view has no query yet).
+    // and pass through anything the user actually chose. The extra `!committedQuery.trim()` guard
+    // matters once a query is active: `getSearchablePageState` initializes a query's sortOrder to
+    // 'relevance', so any 'desc' seen here while a query is committed is a real, deliberate user
+    // choice (not the implicit default) and must be passed through unconverted. Copied from Photos.
     const sortOrder =
-      nextFilters.sortOrder === 'desc' && !currentSearchState.hasExplicitSort ? 'relevance' : nextFilters.sortOrder;
-    const nextUrl = buildSearchablePageUrl(page.url, '', sortOrder, nextFilters);
+      !committedQuery.trim() && nextFilters.sortOrder === 'desc' && !currentSearchState.hasExplicitSort
+        ? 'relevance'
+        : nextFilters.sortOrder;
+    const nextUrl = buildSearchablePageUrl(page.url, committedQuery, sortOrder, nextFilters);
     if (!nextUrl || nextUrl === page.url.pathname + page.url.search) {
       return;
     }
@@ -246,7 +372,9 @@
     const nextFilters = clearFilters(filters);
     temporalAnchor = undefined;
     filters = nextFilters;
-    syncFilterUrl(nextFilters);
+    if (!committedQuery.trim()) {
+      syncFilterUrl(nextFilters);
+    }
   }
 
   $effect(() => {
@@ -258,10 +386,13 @@
       return;
     }
 
+    const queryChanged = nextSearchState.query !== committedQuery;
     untrack(() => {
       const filterState = getSearchablePageFilterState(page.url);
       const transientTemporal =
         pendingFilterUrlSync?.url === currentUrl ? pendingFilterUrlSync.transientTemporal : undefined;
+      committedQuery = nextSearchState.query;
+      isLoading = false;
       filters = {
         ...createFilterState(),
         ...preserveTransientTemporalFilters(filterState, transientTemporal),
@@ -271,6 +402,12 @@
         pendingFilterUrlSync = undefined;
       }
       consumeTypedSearchNamesInto(page.url.pathname + page.url.search, personNames, tagNames);
+      if (queryChanged) {
+        smartFacetInFlight?.controller.abort();
+        smartFacets = undefined;
+        smartFacetKey = '';
+        smartFacetInFlight = undefined;
+      }
       lastHandledSearchState = nextToken;
     });
   });
@@ -283,23 +420,27 @@
   scrollbar={false}
 >
   <div class="flex h-full">
-    <FilterPanel
-      bind:filters
-      bind:collapsed={filterCollapsed}
-      externalToggle
-      config={filterConfig}
-      timeBuckets={timelineBuckets}
-      storageKey="gallery-filter-visible-sections-recently-added"
-      hidden={isTimelineEmpty}
-      {personNames}
-      {tagNames}
-      onFiltersChange={handleFiltersChange}
-    />
+    {#key showSearchResults ? `recently-added-search-${committedQuery.trim()}:${$lang}` : 'recently-added-browse'}
+      <FilterPanel
+        bind:filters
+        bind:collapsed={filterCollapsed}
+        externalToggle
+        config={filterConfig}
+        timeBuckets={smartFacetBuckets}
+        storageKey="gallery-filter-visible-sections-recently-added"
+        hidden={isTimelineEmpty}
+        {personNames}
+        {tagNames}
+        onFiltersChange={handleFiltersChange}
+      />
+    {/key}
     <div class="flex flex-1 flex-col overflow-hidden pl-4">
       {#snippet recentlyAddedFiltersBar()}
         <ActiveFiltersBar
           embedded
           {filters}
+          searchQuery={committedQuery}
+          onClearSearch={clearSearch}
           {personNames}
           {tagNames}
           onRemoveFilter={handleRemoveActiveFilter}
@@ -310,35 +451,47 @@
         class="mb-2"
         grouping={timelineGrouping}
         onGroupingChange={handleTimelineGroupingChange}
-        showGrouping={!assetMultiSelectManager.selectionActive}
+        showGrouping={!showSearchResults && !assetMultiSelectManager.selectionActive}
         showFilters={hasActiveFilters}
         filters={recentlyAddedFiltersBar}
         showFilterButton={filterCollapsed && !isTimelineEmpty && !assetMultiSelectManager.selectionActive}
         filterActive={getActiveFilterCount(filters) > 0}
         onExpandFilters={() => (filterCollapsed = false)}
       />
-      <Timeline
-        enableRouting={true}
-        bind:timelineManager
-        {options}
-        assetInteraction={assetMultiSelectManager}
-        removeAction={AssetAction.ARCHIVE}
-        onEscape={handleEscape}
-        onTimelineBucketActivate={handleTimelineBucketActivate}
-        {temporalAnchor}
-        onTemporalAnchorResolved={() => (temporalAnchor = undefined)}
-        grouping={timelineGrouping}
-        onGroupingChange={handleTimelineGroupingChange}
-        withStacked
-      >
-        {#snippet empty()}
-          <EmptyPlaceholder
-            text={$t('no_assets_message')}
-            onClick={() => openFileUploadDialog()}
-            class="mx-auto mt-10"
-          />
-        {/snippet}
-      </Timeline>
+      {#if showSearchResults}
+        <SmartSearchResults
+          bind:isLoading
+          searchQuery={committedQuery}
+          {filters}
+          language={$lang}
+          isShared={false}
+          withSharedSpaces={false}
+          total={smartFacetTotal}
+        />
+      {:else}
+        <Timeline
+          enableRouting={true}
+          bind:timelineManager
+          {options}
+          assetInteraction={assetMultiSelectManager}
+          removeAction={AssetAction.ARCHIVE}
+          onEscape={handleEscape}
+          onTimelineBucketActivate={handleTimelineBucketActivate}
+          {temporalAnchor}
+          onTemporalAnchorResolved={() => (temporalAnchor = undefined)}
+          grouping={timelineGrouping}
+          onGroupingChange={handleTimelineGroupingChange}
+          withStacked
+        >
+          {#snippet empty()}
+            <EmptyPlaceholder
+              text={$t('no_assets_message')}
+              onClick={() => openFileUploadDialog()}
+              class="mx-auto mt-10"
+            />
+          {/snippet}
+        </Timeline>
+      {/if}
     </div>
   </div>
 </UserPageLayout>

--- a/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -1,5 +1,17 @@
 <script lang="ts">
+  import { goto } from '$app/navigation';
+  import { page } from '$app/state';
   import ActionMenuItem from '$lib/components/ActionMenuItem.svelte';
+  import ActiveFiltersBar from '$lib/components/filter-panel/active-filters-bar.svelte';
+  import FilterPanel from '$lib/components/filter-panel/filter-panel.svelte';
+  import FilterToolbar from '$lib/components/filter-panel/filter-toolbar.svelte';
+  import {
+    clearFilters,
+    createFilterState,
+    getActiveFilterCount,
+    loadFilterCollapsed,
+    type FilterState,
+  } from '$lib/components/filter-panel/filter-panel';
   import UserPageLayout from '$lib/components/layouts/UserPageLayout.svelte';
   import ButtonContextMenu from '$lib/components/shared-components/context-menu/ButtonContextMenu.svelte';
   import EmptyPlaceholder from '$lib/components/shared-components/EmptyPlaceholder.svelte';
@@ -22,7 +34,10 @@
   import { assetMultiSelectManager } from '$lib/managers/asset-multi-select-manager.svelte';
   import { assetViewerManager } from '$lib/managers/asset-viewer-manager.svelte';
   import { authManager } from '$lib/managers/auth-manager.svelte';
+  import { globalSearchManager } from '$lib/managers/global-search-manager.svelte';
+  import { getTimelineTopVisibleAnchor } from '$lib/managers/timeline-manager/timeline-anchor';
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+  import type { TimelineGrouping, TimelineTemporalAnchor } from '$lib/managers/timeline-manager/types';
   import { getAssetBulkActions } from '$lib/services/asset.service';
   import {
     updateStackedAssetInTimeline,
@@ -31,11 +46,31 @@
     type OnUnlink,
   } from '$lib/utils/actions';
   import { openFileUploadDialog } from '$lib/utils/file-uploader';
-  import { shouldShowRecentlyAddedCount } from '$lib/utils/recently-added-filter-options';
-  import { AssetVisibility, AssetOrderBy } from '@immich/sdk';
+  import { withNameCapture } from '$lib/utils/filter-name-capture';
+  import { handlePhotosRemoveFilter } from '$lib/utils/photos-filter-options';
+  import { buildRecentlyAddedFilterConfig } from '$lib/utils/recently-added-filter-config';
+  import {
+    buildRecentlyAddedTimelineOptions,
+    shouldShowRecentlyAddedCount,
+  } from '$lib/utils/recently-added-filter-options';
+  import {
+    buildSearchablePageUrl,
+    getSearchablePageFilterState,
+    getSearchablePageState,
+    preserveTransientTemporalFilters,
+    type SearchablePageTransientTemporalState,
+  } from '$lib/utils/searchable-page-search';
+  import {
+    getTimelineBucketZoomTarget,
+    getTimelineManagerTimeBuckets,
+    type ActivatableTimelineBucket,
+  } from '$lib/utils/timeline-zoom-navigation';
+  import { consumeTypedSearchNamesInto } from '$lib/utils/typed-search/typed-search-name-cache';
   import { ActionButton, CommandPaletteDefaultProvider } from '@immich/ui';
   import { mdiDotsVertical } from '@mdi/js';
+  import { untrack } from 'svelte';
   import { t } from 'svelte-i18n';
+  import { SvelteMap } from 'svelte/reactivity';
   import type { PageData } from './$types';
 
   type Props = {
@@ -45,19 +80,63 @@
   let { data }: Props = $props();
 
   let timelineManager = $state<TimelineManager>() as TimelineManager;
-  const options = {
-    visibility: AssetVisibility.Timeline,
-    withStacked: true,
-    withPartners: true,
-    orderBy: AssetOrderBy.CreatedAt,
+
+  // Filter state
+  const initialSearchState = getSearchablePageState(page.url);
+  const initialFilterState = getSearchablePageFilterState(page.url);
+  let filters = $state<FilterState>({
+    ...createFilterState(),
+    dateAfter: undefined,
+    dateBefore: undefined,
+    selectedYear: undefined,
+    selectedMonth: undefined,
+    ...initialFilterState,
+    sortOrder: initialSearchState.sortOrder,
+  });
+  let filtersBeforePanelChange: FilterState = {
+    ...createFilterState(),
+    dateAfter: undefined,
+    dateBefore: undefined,
+    selectedYear: undefined,
+    selectedMonth: undefined,
+    ...initialFilterState,
+    sortOrder: initialSearchState.sortOrder,
   };
+  let timelineGrouping = $state<TimelineGrouping>('day');
+  let temporalAnchor = $state<TimelineTemporalAnchor | undefined>();
+  let lastHandledSearchState = $state(`${initialSearchState.query}:${initialSearchState.sortOrder}:${page.url.search}`);
+  let pendingFilterUrlSync = $state<
+    { url: string; transientTemporal?: SearchablePageTransientTemporalState } | undefined
+  >();
+  const options = $derived({ ...buildRecentlyAddedTimelineOptions(filters), grouping: timelineGrouping });
+  $effect(() => {
+    filtersBeforePanelChange = filters;
+  });
+  let personNames = new SvelteMap<string, string>();
+  let tagNames = new SvelteMap<string, string>();
+  consumeTypedSearchNamesInto(page.url.pathname + page.url.search, personNames, tagNames);
+  $effect(() => globalSearchManager.registerSearchablePageFilters(() => filters));
+
+  const timelineBuckets = $derived(getTimelineManagerTimeBuckets(timelineManager));
+
+  const filterConfig = withNameCapture(buildRecentlyAddedFilterConfig(), personNames, tagNames);
+
+  const hasActiveFilters = $derived(getActiveFilterCount(filters) > 0);
+
+  // Filter-panel collapse is driven here so a header filter button can reclaim the panel's space.
+  let filterCollapsed = $state(loadFilterCollapsed());
 
   const assetCount = $derived(timelineManager?.assetCount ?? 0);
-  // Slice 1 has no filters yet, so `hasActiveFilters` is always false here; Slice 2 replaces
-  // the literal with `getActiveFilterCount(filters) > 0`.
   const countLabel = $derived(
-    shouldShowRecentlyAddedCount(assetCount, false) ? $t('items_count', { values: { count: assetCount } }) : undefined,
+    shouldShowRecentlyAddedCount(assetCount, hasActiveFilters)
+      ? $t('items_count', { values: { count: assetCount } })
+      : undefined,
   );
+
+  // Use the timeline's *loaded* result (for the current options) rather than a bare
+  // `assetCount === 0`: clearing a filter that had 0 results would otherwise flip this true
+  // for a tick (stale count, reload pending), unmounting the filter panel and dropping focus.
+  const isTimelineEmpty = $derived(!!timelineManager?.isEmptyForOptions(options) && !hasActiveFilters);
 
   let selectedAssets = $derived(assetMultiSelectManager.assets);
   let isAssetStackSelected = $derived(selectedAssets.length === 1 && !!selectedAssets[0].stack);
@@ -95,6 +174,106 @@
     timelineManager.removeAssets(assetIds);
     assetMultiSelectManager.clear();
   };
+
+  function syncFilterUrl(nextFilters: FilterState) {
+    const currentSearchState = getSearchablePageState(page.url);
+    // `buildSearchablePageUrl` writes an explicit `sort=` param whenever it is handed a literal
+    // 'asc' | 'desc'; only 'relevance' clears it. `createFilterState()` defaults sortOrder to
+    // 'desc', so passing it straight through would stamp `sort=desc` onto every filter URL the
+    // user never asked for. Convert the *implicit* default to 'relevance' (= "no explicit sort")
+    // and pass through anything the user actually chose. Photos does the same thing; its extra
+    // free-text-query guard is query-mode-only and drops out here (this view has no query yet).
+    const sortOrder =
+      nextFilters.sortOrder === 'desc' && !currentSearchState.hasExplicitSort ? 'relevance' : nextFilters.sortOrder;
+    const nextUrl = buildSearchablePageUrl(page.url, '', sortOrder, nextFilters);
+    if (!nextUrl || nextUrl === page.url.pathname + page.url.search) {
+      return;
+    }
+    pendingFilterUrlSync = {
+      url: nextUrl,
+      transientTemporal: {
+        selectedYear: nextFilters.selectedYear,
+        selectedMonth: nextFilters.selectedMonth,
+      },
+    };
+    void goto(nextUrl, { replaceState: true, keepFocus: true, noScroll: true });
+  }
+
+  function handleFiltersChange(nextFilters: FilterState) {
+    const temporalChanged =
+      nextFilters.dateAfter !== filtersBeforePanelChange.dateAfter ||
+      nextFilters.dateBefore !== filtersBeforePanelChange.dateBefore ||
+      nextFilters.selectedYear !== filtersBeforePanelChange.selectedYear ||
+      nextFilters.selectedMonth !== filtersBeforePanelChange.selectedMonth;
+
+    if (temporalChanged) {
+      temporalAnchor = undefined;
+    }
+
+    syncFilterUrl(nextFilters);
+  }
+
+  function handleTimelineBucketActivate(bucket: ActivatableTimelineBucket) {
+    if (assetMultiSelectManager.selectionActive) {
+      return;
+    }
+
+    const result = getTimelineBucketZoomTarget(bucket);
+    if (!result) {
+      return;
+    }
+
+    timelineGrouping = result.grouping;
+    temporalAnchor = result.anchor;
+  }
+
+  function handleTimelineGroupingChange(grouping: TimelineGrouping) {
+    const anchor = getTimelineTopVisibleAnchor(timelineManager);
+    timelineGrouping = grouping;
+    temporalAnchor = anchor;
+  }
+
+  function handleRemoveActiveFilter(type: string, id?: string) {
+    const nextFilters = handlePhotosRemoveFilter(filters, type, id);
+    if (type === 'timeline') {
+      temporalAnchor = undefined;
+    }
+    filters = nextFilters;
+    syncFilterUrl(nextFilters);
+  }
+
+  function handleClearAllFilters() {
+    const nextFilters = clearFilters(filters);
+    temporalAnchor = undefined;
+    filters = nextFilters;
+    syncFilterUrl(nextFilters);
+  }
+
+  $effect(() => {
+    const nextSearchState = getSearchablePageState(page.url);
+    const nextToken = `${nextSearchState.query}:${nextSearchState.sortOrder}:${page.url.search}`;
+    const currentUrl = page.url.pathname + page.url.search;
+
+    if (nextToken === lastHandledSearchState) {
+      return;
+    }
+
+    untrack(() => {
+      const filterState = getSearchablePageFilterState(page.url);
+      const transientTemporal =
+        pendingFilterUrlSync?.url === currentUrl ? pendingFilterUrlSync.transientTemporal : undefined;
+      filters = {
+        ...createFilterState(),
+        ...preserveTransientTemporalFilters(filterState, transientTemporal),
+        sortOrder: nextSearchState.sortOrder,
+      };
+      if (pendingFilterUrlSync?.url === currentUrl) {
+        pendingFilterUrlSync = undefined;
+      }
+      consumeTypedSearchNamesInto(page.url.pathname + page.url.search, personNames, tagNames);
+      lastHandledSearchState = nextToken;
+    });
+  });
 </script>
 
 <UserPageLayout
@@ -103,19 +282,65 @@
   description={countLabel}
   scrollbar={false}
 >
-  <Timeline
-    enableRouting={true}
-    bind:timelineManager
-    {options}
-    assetInteraction={assetMultiSelectManager}
-    removeAction={AssetAction.ARCHIVE}
-    onEscape={handleEscape}
-    withStacked
-  >
-    {#snippet empty()}
-      <EmptyPlaceholder text={$t('no_assets_message')} onClick={() => openFileUploadDialog()} class="mx-auto mt-10" />
-    {/snippet}
-  </Timeline>
+  <div class="flex h-full">
+    <FilterPanel
+      bind:filters
+      bind:collapsed={filterCollapsed}
+      externalToggle
+      config={filterConfig}
+      timeBuckets={timelineBuckets}
+      storageKey="gallery-filter-visible-sections-recently-added"
+      hidden={isTimelineEmpty}
+      {personNames}
+      {tagNames}
+      onFiltersChange={handleFiltersChange}
+    />
+    <div class="flex flex-1 flex-col overflow-hidden pl-4">
+      {#snippet recentlyAddedFiltersBar()}
+        <ActiveFiltersBar
+          embedded
+          {filters}
+          {personNames}
+          {tagNames}
+          onRemoveFilter={handleRemoveActiveFilter}
+          onClearAll={handleClearAllFilters}
+        />
+      {/snippet}
+      <FilterToolbar
+        class="mb-2"
+        grouping={timelineGrouping}
+        onGroupingChange={handleTimelineGroupingChange}
+        showGrouping={!assetMultiSelectManager.selectionActive}
+        showFilters={hasActiveFilters}
+        filters={recentlyAddedFiltersBar}
+        showFilterButton={filterCollapsed && !isTimelineEmpty && !assetMultiSelectManager.selectionActive}
+        filterActive={getActiveFilterCount(filters) > 0}
+        onExpandFilters={() => (filterCollapsed = false)}
+      />
+      <Timeline
+        enableRouting={true}
+        bind:timelineManager
+        {options}
+        assetInteraction={assetMultiSelectManager}
+        removeAction={AssetAction.ARCHIVE}
+        onEscape={handleEscape}
+        onTimelineBucketActivate={handleTimelineBucketActivate}
+        {temporalAnchor}
+        onTemporalAnchorResolved={() => (temporalAnchor = undefined)}
+        grouping={timelineGrouping}
+        onGroupingChange={handleTimelineGroupingChange}
+        withStacked
+      >
+        {#snippet empty()}
+          <EmptyPlaceholder
+            text={$t('no_assets_message')}
+            onClick={() => openFileUploadDialog()}
+            class="mx-auto mt-10"
+          />
+        {/snippet}
+      </Timeline>
+    </div>
+  </div>
 </UserPageLayout>
 
 {#if assetMultiSelectManager.selectionActive}

--- a/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -31,6 +31,7 @@
     type OnUnlink,
   } from '$lib/utils/actions';
   import { openFileUploadDialog } from '$lib/utils/file-uploader';
+  import { shouldShowRecentlyAddedCount } from '$lib/utils/recently-added-filter-options';
   import { AssetVisibility, AssetOrderBy } from '@immich/sdk';
   import { ActionButton, CommandPaletteDefaultProvider } from '@immich/ui';
   import { mdiDotsVertical } from '@mdi/js';
@@ -50,6 +51,13 @@
     withPartners: true,
     orderBy: AssetOrderBy.CreatedAt,
   };
+
+  const assetCount = $derived(timelineManager?.assetCount ?? 0);
+  // Slice 1 has no filters yet, so `hasActiveFilters` is always false here; Slice 2 replaces
+  // the literal with `getActiveFilterCount(filters) > 0`.
+  const countLabel = $derived(
+    shouldShowRecentlyAddedCount(assetCount, false) ? $t('items_count', { values: { count: assetCount } }) : undefined,
+  );
 
   let selectedAssets = $derived(assetMultiSelectManager.assets);
   let isAssetStackSelected = $derived(selectedAssets.length === 1 && !!selectedAssets[0].stack);
@@ -89,7 +97,12 @@
   };
 </script>
 
-<UserPageLayout hideNavbar={assetMultiSelectManager.selectionActive} title={data.meta.title} scrollbar={false}>
+<UserPageLayout
+  hideNavbar={assetMultiSelectManager.selectionActive}
+  title={data.meta.title}
+  description={countLabel}
+  scrollbar={false}
+>
   <Timeline
     enableRouting={true}
     bind:timelineManager

--- a/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts
+++ b/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts
@@ -206,6 +206,7 @@ describe('Recently Added page filters', () => {
       hasUnnamedPeople: false,
     });
     sdkMock.getSearchSuggestions.mockResolvedValue([]);
+    sdkMock.getTimeBuckets.mockResolvedValue([]);
   });
 
   it('derives timeline options from the filters — orderBy CreatedAt, no withSharedSpaces', async () => {
@@ -215,6 +216,33 @@ describe('Recently Added page filters', () => {
       expect(buildRecentlyAddedTimelineOptions).toHaveBeenCalled();
       expect(screen.getByTestId('timeline-options')).toHaveTextContent('"orderBy":"createdAt"');
       expect(screen.getByTestId('timeline-options')).not.toHaveTextContent('"withSharedSpaces"');
+    });
+  });
+
+  it('fetches the temporal picker buckets by taken date, not by added date', async () => {
+    // The timeline groups by added date (orderBy createdAt) — but the year/month grid must be
+    // built from taken-date buckets, because clicking a year filters on takenAfter/takenBefore.
+    // Sourcing the grid from the timeline's own buckets listed upload years that then matched
+    // nothing.
+    renderPage();
+
+    await waitFor(() => expect(sdkMock.getTimeBuckets).toHaveBeenCalled());
+    expect(sdkMock.getTimeBuckets.mock.calls[0][0]).toMatchObject({ orderBy: 'takenAt' });
+    expect(sdkMock.getTimeBuckets.mock.calls[0][0]).not.toHaveProperty('withSharedSpaces');
+  });
+
+  it('rescopes the picker buckets when another filter changes', async () => {
+    // Each year chip carries a count, so the grid has to describe the currently filtered set.
+    renderPage();
+
+    await waitFor(() => expect(sdkMock.getTimeBuckets).toHaveBeenCalled());
+    await fireEvent.click(await screen.findByTestId('filter-panel-set-country'));
+
+    await waitFor(() => {
+      expect(sdkMock.getTimeBuckets).toHaveBeenCalledWith(
+        expect.objectContaining({ country: 'Germany', orderBy: 'takenAt' }),
+        expect.anything(),
+      );
     });
   });
 
@@ -300,6 +328,7 @@ describe('Recently Added page query mode', () => {
       hasUnnamedPeople: false,
     });
     sdkMock.getSearchSuggestions.mockResolvedValue([]);
+    sdkMock.getTimeBuckets.mockResolvedValue([]);
     sdkMock.searchSmartFacets.mockResolvedValue({
       total: 12,
       timeBuckets: [{ timeBucket: '2024-01-01', count: 12 }],

--- a/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts
+++ b/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts
@@ -1,6 +1,8 @@
+import { AssetTypeEnum } from '@immich/sdk';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import type { Component } from 'svelte';
+import { init, register, waitLocale } from 'svelte-i18n';
 import { goto } from '$app/navigation';
 import { sdkMock } from '$lib/__mocks__/sdk.mock';
 import TestWrapper from '$lib/components/TestWrapper.svelte';
@@ -47,6 +49,11 @@ vi.mock('$lib/components/filter-panel/active-filters-bar.svelte', async () => {
 
 vi.mock('$lib/components/filter-panel/filter-panel.svelte', async () => {
   const { default: MockComponent } = await import('@test-data/mocks/bindable-filter-panel.stub.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/search/smart-search-results.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/smart-search-results.stub.svelte');
   return { default: MockComponent };
 });
 
@@ -262,5 +269,105 @@ describe('Recently Added page filters', () => {
       'data-sections',
       'timeline,people,location,camera,tags,rating,media,favorites,albums,text',
     );
+  });
+});
+
+describe('Recently Added page query mode', () => {
+  beforeAll(async () => {
+    // Global test setup (`src/test-data/setup.ts`) only inits the `dev` fallback locale, which
+    // returns raw i18n keys — fine for tests that never inspect translated text, but the header
+    // count's `$t('items_count', { values: { count } })` needs real ICU plural interpolation to
+    // tell "12 items" apart from "2 items". Load the real English bundle, mirroring
+    // `recent-row.spec.ts`'s precedent for the same `items_count` key.
+    register('en-US', () => import('$i18n/en.json'));
+    await init({ fallbackLocale: 'en-US' });
+    await waitLocale('en-US');
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockPage.url = new URL('https://gallery.test/recently-added?q=beach');
+    mockAssetMultiSelectManager.selectionActive = false;
+    mockAssetMultiSelectManager.assets = [];
+    mockRegisterSearchablePageFilters.mockReturnValue(vi.fn());
+    sdkMock.getFilterSuggestions.mockResolvedValue({
+      people: [],
+      countries: [],
+      cameraMakes: [],
+      tags: [],
+      ratings: [],
+      mediaTypes: [],
+      hasUnnamedPeople: false,
+    });
+    sdkMock.getSearchSuggestions.mockResolvedValue([]);
+    sdkMock.searchSmartFacets.mockResolvedValue({
+      total: 12,
+      timeBuckets: [{ timeBucket: '2024-01-01', count: 12 }],
+      countries: ['Germany'],
+      cities: ['Berlin'],
+      cameraMakes: ['Sony'],
+      cameraModels: ['A7'],
+      tags: [{ id: 'tag-1', value: 'Travel' }],
+      people: [{ id: 'person-1', name: 'Ada' }],
+      ratings: [4],
+      mediaTypes: [AssetTypeEnum.Image],
+      hasUnnamedPeople: false,
+    });
+  });
+
+  it('renders SmartSearchResults instead of the timeline when the URL carries ?q=', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'beach');
+    });
+    expect(screen.queryByTestId('timeline-options')).not.toBeInTheDocument();
+  });
+
+  it('does not send shared-space scope to SmartSearchResults', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-with-shared-spaces', 'false');
+    });
+  });
+
+  it('stays in browse mode for a blank/whitespace-only query', async () => {
+    mockPage.url = new URL('https://gallery.test/recently-added?q=%20%20');
+
+    renderPage();
+
+    expect(screen.queryByTestId('smart-search-results')).not.toBeInTheDocument();
+    expect(sdkMock.searchSmartFacets).not.toHaveBeenCalled();
+    await waitFor(() => expect(sdkMock.getFilterSuggestions).toHaveBeenCalled());
+  });
+
+  it('the header count uses the search total in query mode, not timelineManager.assetCount', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('user-page-layout')).toHaveAttribute('data-description', '12 items');
+    });
+  });
+
+  it('a failed facet fetch falls back to the previous facets (count survives)', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-total', '12'));
+
+    sdkMock.searchSmartFacets.mockRejectedValueOnce(new Error('facets failed'));
+    await fireEvent.click(screen.getByTestId('filter-panel-set-country'));
+
+    await waitFor(() => expect(sdkMock.searchSmartFacets).toHaveBeenCalledTimes(2));
+    expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-total', '12');
+  });
+
+  it('re-rendering with an unchanged query+filters does not refetch facets (key cache)', async () => {
+    renderPage();
+    await waitFor(() => expect(sdkMock.searchSmartFacets).toHaveBeenCalledTimes(1));
+
+    await fireEvent.click(screen.getByTestId('filter-panel-set-sort-asc'));
+
+    await waitFor(() => expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-sort-order', 'asc'));
+    expect(sdkMock.searchSmartFacets).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts
+++ b/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts
@@ -332,6 +332,13 @@ describe('Recently Added page query mode', () => {
     });
   });
 
+  it('omits withSharedSpaces from the real searchSmartFacets payload', async () => {
+    renderPage();
+
+    await waitFor(() => expect(sdkMock.searchSmartFacets).toHaveBeenCalled());
+    expect(sdkMock.searchSmartFacets.mock.calls[0][0].smartSearchFacetsDto).not.toHaveProperty('withSharedSpaces');
+  });
+
   it('stays in browse mode for a blank/whitespace-only query', async () => {
     mockPage.url = new URL('https://gallery.test/recently-added?q=%20%20');
 

--- a/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts
+++ b/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts
@@ -1,0 +1,267 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import type { Component } from 'svelte';
+import { goto } from '$app/navigation';
+import { sdkMock } from '$lib/__mocks__/sdk.mock';
+import TestWrapper from '$lib/components/TestWrapper.svelte';
+import { buildRecentlyAddedTimelineOptions } from '$lib/utils/recently-added-filter-options';
+import RecentlyAddedPage from './+page.svelte';
+
+const { mockPage, mockAssetMultiSelectManager, mockAuthManager, mockRegisterSearchablePageFilters } = vi.hoisted(
+  () => ({
+    mockPage: {
+      url: new URL('https://gallery.test/recently-added'),
+      route: { id: '/(user)/recently-added/[[photos=photos]]/[[assetId=id]]' },
+      params: {},
+    },
+    mockAssetMultiSelectManager: {
+      selectionActive: false,
+      assets: [],
+      clear: vi.fn(),
+      isAllUserOwned: true,
+    },
+    mockAuthManager: {
+      preferences: { tags: { enabled: false } },
+    },
+    mockRegisterSearchablePageFilters: vi.fn(() => vi.fn()),
+  }),
+);
+
+vi.mock('$app/navigation', () => ({ goto: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('$app/state', () => ({ page: mockPage }));
+
+vi.mock('$lib/components/layouts/UserPageLayout.svelte', async () => {
+  const { default: MockComponent } = await import('$lib/components/spaces/mock-user-page-layout.test-wrapper.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/ActionMenuItem.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/filter-panel/active-filters-bar.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/active-filters-bar-actions.stub.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/filter-panel/filter-panel.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/bindable-filter-panel.stub.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/shared-components/context-menu/ButtonContextMenu.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/shared-components/EmptyPlaceholder.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/timeline/Timeline.svelte', async () => {
+  const { default: MockComponent } =
+    await import('../../../albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/mock-timeline.test-wrapper.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/timeline/AssetSelectControlBar.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/timeline/actions/ArchiveAction.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/timeline/actions/ChangeDateAction.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/timeline/actions/ChangeDescriptionAction.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/timeline/actions/ChangeLocationAction.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/timeline/actions/CreateSharedLinkAction.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/timeline/actions/DeleteAssetsAction.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/timeline/actions/DownloadAction.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/timeline/actions/FavoriteAction.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/timeline/actions/LinkLivePhotoAction.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/timeline/actions/SelectAllAction.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/timeline/actions/SetVisibilityAction.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/timeline/actions/StackAction.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/components/timeline/actions/TagAction.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  return { default: MockComponent };
+});
+
+vi.mock('$lib/managers/asset-multi-select-manager.svelte', () => ({
+  assetMultiSelectManager: mockAssetMultiSelectManager,
+}));
+
+vi.mock('$lib/managers/asset-viewer-manager.svelte', () => ({
+  assetViewerManager: { isViewing: false },
+}));
+
+vi.mock('$lib/managers/auth-manager.svelte', () => ({
+  authManager: mockAuthManager,
+}));
+
+vi.mock('$lib/managers/global-search-manager.svelte', () => ({
+  globalSearchManager: {
+    registerSearchablePageFilters: mockRegisterSearchablePageFilters,
+  },
+}));
+
+vi.mock('$lib/services/asset.service', () => ({
+  getAssetBulkActions: vi.fn(() => ({})),
+}));
+
+vi.mock('$lib/utils/file-uploader', () => ({
+  openFileUploadDialog: vi.fn(),
+}));
+
+vi.mock('$lib/utils/recently-added-filter-options', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/utils/recently-added-filter-options')>();
+  return {
+    ...actual,
+    buildRecentlyAddedTimelineOptions: vi.fn(actual.buildRecentlyAddedTimelineOptions),
+  };
+});
+
+type RecentlyAddedPageProps = { data: { meta: { title: string } } };
+
+function renderPage() {
+  return render(
+    TestWrapper as Component<{ component: typeof RecentlyAddedPage; componentProps: RecentlyAddedPageProps }>,
+    {
+      component: RecentlyAddedPage,
+      componentProps: { data: { meta: { title: 'Recently added' } } },
+    },
+  );
+}
+
+describe('Recently Added page filters', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockPage.url = new URL('https://gallery.test/recently-added');
+    mockAssetMultiSelectManager.selectionActive = false;
+    mockAssetMultiSelectManager.assets = [];
+    mockRegisterSearchablePageFilters.mockReturnValue(vi.fn());
+    sdkMock.getFilterSuggestions.mockResolvedValue({
+      people: [],
+      countries: [],
+      cameraMakes: [],
+      tags: [],
+      ratings: [],
+      mediaTypes: [],
+      hasUnnamedPeople: false,
+    });
+    sdkMock.getSearchSuggestions.mockResolvedValue([]);
+  });
+
+  it('derives timeline options from the filters — orderBy CreatedAt, no withSharedSpaces', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(buildRecentlyAddedTimelineOptions).toHaveBeenCalled();
+      expect(screen.getByTestId('timeline-options')).toHaveTextContent('"orderBy":"createdAt"');
+      expect(screen.getByTestId('timeline-options')).not.toHaveTextContent('"withSharedSpaces"');
+    });
+  });
+
+  it('seeds filter state from the URL on load (deep link, e.g. ?rating=5)', async () => {
+    mockPage.url = new URL('https://gallery.test/recently-added?rating=5');
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(buildRecentlyAddedTimelineOptions).toHaveBeenCalledWith(expect.objectContaining({ rating: 5 }));
+      expect(screen.getByTestId('timeline-options')).toHaveTextContent('"rating":5');
+    });
+  });
+
+  it('writes filter changes to the URL via goto', async () => {
+    renderPage();
+
+    await fireEvent.click(await screen.findByTestId('filter-panel-set-country'));
+
+    expect(goto).toHaveBeenCalledWith('/recently-added?country=Germany', {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true,
+    });
+  });
+
+  it('clearing all filters removes the filter params from the URL', async () => {
+    mockPage.url = new URL('https://gallery.test/recently-added?people=person-1&city=Berlin');
+
+    renderPage();
+    await fireEvent.click(await screen.findByTestId('active-filters-clear-all'));
+
+    expect(goto).toHaveBeenLastCalledWith('/recently-added', {
+      replaceState: true,
+      keepFocus: true,
+      noScroll: true,
+    });
+  });
+
+  it('registers its filters with globalSearchManager (registerSearchablePageFilters called)', async () => {
+    renderPage();
+
+    await waitFor(() => expect(mockRegisterSearchablePageFilters).toHaveBeenCalledOnce());
+  });
+
+  it("passes the nine sections to the filter panel, and no 'text' section", async () => {
+    renderPage();
+
+    const panel = await screen.findByTestId('filter-panel-stub');
+
+    expect(panel).toHaveAttribute(
+      'data-sections',
+      'timeline,people,location,camera,tags,rating,media,favorites,albums',
+    );
+    expect(panel.dataset.sections).not.toContain('text');
+  });
+});

--- a/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts
+++ b/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts
@@ -253,15 +253,14 @@ describe('Recently Added page filters', () => {
     await waitFor(() => expect(mockRegisterSearchablePageFilters).toHaveBeenCalledOnce());
   });
 
-  it("passes the nine sections to the filter panel, and no 'text' section", async () => {
+  it('passes all ten sections to the filter panel', async () => {
     renderPage();
 
     const panel = await screen.findByTestId('filter-panel-stub');
 
     expect(panel).toHaveAttribute(
       'data-sections',
-      'timeline,people,location,camera,tags,rating,media,favorites,albums',
+      'timeline,people,location,camera,tags,rating,media,favorites,albums,text',
     );
-    expect(panel.dataset.sections).not.toContain('text');
   });
 });


### PR DESCRIPTION
Gives the web **Recently Added** view the two things #805 asks for: a visible item count, and the same 10-section filter panel Photos uses — while preserving what makes the view "recently added".

Closes #805.

## What's here

| Slice | Delivers |
|---|---|
| **1** | "N items" in the header, live-updating; hidden while empty/loading so there's no "0 items" flash |
| **2** | The 9 metadata filter sections (Timeline, People, Location, Camera, Tags, Rating, Media type, Favorites, Albums) with chips, URL persistence and deep links; the count reflects the filtered set |
| **3** | The 10th `text` section plus smart-search query mode, completing parity with Photos |

## The two invariants

Recently Added differs from Photos in exactly two ways, and both are enforced and tested on every path:

- **Ordered/day-grouped by _added_ date** — `orderBy: CreatedAt` holds under every filter combination. Set last after the spread, so nothing upstream can override it.
- **Own + partner scope, never shared spaces** — `withSharedSpaces` cannot be truthy anywhere: stripped from timeline options, absent from suggestion requests, structurally impossible via `FilterContext` in the dependent providers, and hardcoded `false` on all three smart-search paths.

The date filter still filters _taken_ date while day-groups reflect _added_ date. That's intentional (e.g. old photos just imported) — there is no created-at range predicate, and adding one is backend work.

## Notable design points

- **`/recently-added` had to become a URL-persisting page.** It wasn't registered in `getSearchablePageBasePath()`, so filter→URL sync would have silently no-opped — filters applying to the grid but never reaching the URL. Registering it also flips `isSearchable`, which would have let global search strand a `?q=` on a route that couldn't answer it. Slice 2 therefore split the two capabilities (enforced both where the flag is read *and* where the query is written, keeping `buildSearchDestination`'s `/photos` fallback intact); Slice 3 removes the split now that the search path exists. Photos and Spaces behaviour is provably unchanged — their existing tests pass untouched.
- **`ActiveFiltersBar` deliberately gets no `resultCount` / `onAddAllToCollection`**, so the header carries the single count rather than duplicating it.
- **Favorites excludes partner assets** (own-only), matching Photos — a favorite is a personal flag.

## Testing

- 3712 web unit tests (exhaustive coverage of the pure builders and the config)
- 12 route-level component cases (`recently-added-page.spec.ts`)
- 13 Playwright acceptance scenarios (`recently-added-filters.e2e-spec.ts`)

Every slice was built red→green: tests were written and observed failing before the implementation, including the e2e specs.

Two tests worth calling out, because absence-based assertions are easy to write and worthless:

- The **ordering** scenario seeds videos whose taken-date order runs _opposite_ to their upload order, so it can actually distinguish `CreatedAt` from `TakenAt` — the same test with naive seeding would pass either way.
- The **scope** scenario asserts the smart-search **request payload** (no `withSharedSpaces` on `/recently-added`) with a **positive control** on `/photos` asserting `withSharedSpaces: true`. This was necessary because the e2e stack has no ML service, so every query returns empty and a result-based scope test would pass vacuously.

## Notes for the reviewer

- **Merge atomically.** Between two Slice-3 commits a `?q=` is briefly ignored on this route; the slice is only coherent as a whole.
- Design spec and per-slice plans are in `docs/superpowers/`.
- Unrelated: `photos-search.e2e-spec.ts` has 3 pre-existing failures (the Ctrl+K dialog never opens). This branch touches no search-dialog, global-search, or navigation source — worth a separate look.
- Also unrelated: `make e2e-web-dev` points web Playwright at `:2283`, which on a dev stack serves 0-byte page bodies, so web specs fail for reasons unrelated to the code. The dev web app is on `:3000`.
