### PR TITLE
fix(web): show People, Tags & album membership to viewers in the info panel (#796)

### DIFF
--- a/server/src/dtos/person.dto.ts
+++ b/server/src/dtos/person.dto.ts
@@ -339,14 +339,23 @@ function mapFacesWithoutPerson(
   };
 }
 
+/**
+ * #796: who is in a photo is read-only metadata that anyone with read access to the asset may see,
+ * not just the owner. The sole caller (PersonService.getFacesById) authorizes Permission.AssetRead
+ * before mapping, so every face reaching here belongs to an asset the caller is entitled to; the
+ * caller is also responsible for dropping faces of hidden people for non-owners.
+ *
+ * `auth` is retained for signature stability and future per-viewer projection.
+ */
 export function mapFaces(
   face: AssetFace,
   auth: AuthDto,
   edits?: AssetEditActionItem[],
   assetDimensions?: ImageDimensions,
 ): AssetFaceResponseDto {
+  void auth;
   return {
     ...mapFacesWithoutPerson(face, edits, assetDimensions),
-    person: face.person?.ownerId === auth.user.id ? mapPerson(face.person) : null,
+    person: face.person ? mapPerson(face.person) : null,
   };
 }

--- a/server/src/queries/album.repository.sql
+++ b/server/src/queries/album.repository.sql
@@ -132,15 +132,52 @@ from
   "album"
   inner join "album_asset" on "album_asset"."albumId" = "album"."id"
 where
-  exists (
-    select
-    from
-      "album_user"
-    where
-      "album_user"."albumId" = "album"."id"
-      and "album_user"."userId" = $2
+  (
+    exists (
+      select
+      from
+        "album_user"
+      where
+        "album_user"."albumId" = "album"."id"
+        and "album_user"."userId" = $2
+    )
+    or (
+      "album"."id" in (
+        select
+          "shared_space_album"."albumId" as "id"
+        from
+          "shared_space_album"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+        where
+          "album"."deletedAt" is null
+          and "shared_space_album"."spaceId" in (
+            select
+              "shared_space"."id"
+            from
+              "shared_space"
+            where
+              "shared_space"."createdById" = $3
+            union
+            select
+              "shared_space_member"."spaceId" as "id"
+            from
+              "shared_space_member"
+            where
+              "shared_space_member"."userId" = $4
+          )
+      )
+      and exists (
+        select
+          1 as "exists"
+        from
+          "asset"
+        where
+          "asset"."id" = "album_asset"."assetId"
+          and "asset"."visibility" in ($5, $6)
+      )
+    )
   )
-  and "album_asset"."assetId" = $3
+  and "album_asset"."assetId" = $7
   and "album"."deletedAt" is null
 order by
   "album"."createdAt" desc

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -19,6 +19,7 @@ import { DB } from 'src/schema';
 import { AlbumTable } from 'src/schema/tables/album.table';
 import { AssetExifTable } from 'src/schema/tables/asset-exif.table';
 import { asUuid, dummy, withDefaultVisibility } from 'src/utils/database';
+import { accessibleSpaceAlbums, spaceVisibilityGate } from 'src/utils/shared-space-album-scope';
 
 export interface AlbumAssetCount {
   albumId: string;
@@ -101,6 +102,15 @@ export class AlbumRepository {
       .executeTakeFirst();
   }
 
+  /**
+   * Albums containing `assetId` that the caller can actually open — the asset-viewer info panel
+   * reads this to render "Contained in" (#796). Two access paths are unioned: shared directly into
+   * the album (`album_user`), or the album is linked into a shared space the caller can access.
+   *
+   * Deliberately NOT every album containing the asset: album names are user-authored and a space
+   * member must not learn the owner's private album titles. Callers do not separately authorize
+   * `assetId` (see AlbumService.getAll) — this scoping IS the access check.
+   */
   @GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID] })
   getByAssetId(ownerId: string, assetId: string) {
     return this.db
@@ -108,12 +118,29 @@ export class AlbumRepository {
       .selectAll('album')
       .innerJoin('album_asset', 'album_asset.albumId', 'album.id')
       .where((eb) =>
-        eb.exists(
-          eb
-            .selectFrom('album_user')
-            .whereRef('album_user.albumId', '=', 'album.id')
-            .where('album_user.userId', '=', ownerId),
-        ),
+        eb.or([
+          eb.exists(
+            eb
+              .selectFrom('album_user')
+              .whereRef('album_user.albumId', '=', 'album.id')
+              .where('album_user.userId', '=', ownerId),
+          ),
+          eb.and([
+            eb('album.id', 'in', (e) => accessibleSpaceAlbums(e, ownerId)),
+            // A space member must never learn that another member's Hidden/Locked asset sits in a
+            // linked album, so the space arm carries the space-shareable visibility gate
+            // (Archive/Timeline). The album_user arm above is deliberately NOT gated: an album
+            // member — including the owner, who always has an album_user row — keeps seeing
+            // "Contained in" for their own Hidden/Locked assets.
+            eb.exists(
+              eb
+                .selectFrom('asset')
+                .select(eb.lit(1).as('exists'))
+                .whereRef('asset.id', '=', 'album_asset.assetId')
+                .where((e) => spaceVisibilityGate(e)),
+            ),
+          ]),
+        ]),
       )
       .where('album_asset.assetId', '=', assetId)
       .where('album.deletedAt', 'is', null)

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -2,6 +2,7 @@ import { BadRequestException, ForbiddenException, UnauthorizedException } from '
 import { DateTime } from 'luxon';
 import path from 'node:path';
 import { Readable } from 'node:stream';
+import { AssetResponseDto } from 'src/dtos/asset-response.dto';
 import { AssetJobName, AssetStatsResponseDto } from 'src/dtos/asset.dto';
 import { AssetEditAction } from 'src/dtos/editing.dto';
 import { AssetFileType, AssetMetadataKey, AssetStatus, AssetType, AssetVisibility, JobName, JobStatus } from 'src/enum';
@@ -362,7 +363,9 @@ describe(AssetService.name, () => {
       expect(result).not.toHaveProperty('unassignedFaces');
     });
 
-    it('should strip people for space member without spaceId', async () => {
+    // #796 POLICY REVERSAL (was 'should strip people for space member without spaceId'): when no
+    // space resolves for the asset, the viewer is treated as a plain reader and sees the people.
+    it('should expose people for space member without spaceId', async () => {
       const asset = AssetFactory.from()
         .exif()
         .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
@@ -373,7 +376,7 @@ describe(AssetService.name, () => {
 
       const result = await sut.get(authStub.admin, asset.id);
 
-      expect(result).toHaveProperty('people', []);
+      expect((result as AssetResponseDto).people).toEqual([expect.objectContaining({ id: 'person-1' })]);
     });
 
     it('should reject non-member spaceId', async () => {
@@ -422,7 +425,12 @@ describe(AssetService.name, () => {
       expect(result).toHaveProperty('people', []);
     });
 
-    it('should still strip people for partner access', async () => {
+    // #796 POLICY REVERSAL: these two previously asserted people were stripped for partner and
+    // album access ("should still strip people for ..."). Who is in a photo is now treated as
+    // read-only metadata that travels with read access to the asset, so a viewer reaching an asset
+    // outside any space sees the people on it. Hidden people are still withheld (below), and the
+    // shared-link case below is unchanged — an anonymous link holder still gets nothing.
+    it('should expose people for partner access', async () => {
       const asset = AssetFactory.from()
         .exif()
         .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
@@ -433,13 +441,27 @@ describe(AssetService.name, () => {
 
       const result = await sut.get(authStub.admin, asset.id);
 
-      expect(result).toHaveProperty('people', []);
+      expect((result as AssetResponseDto).people).toEqual([expect.objectContaining({ id: 'person-1' })]);
     });
 
-    it('should still strip people for album access', async () => {
+    it('should expose people for album access', async () => {
       const asset = AssetFactory.from()
         .exif()
         .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
+        .build();
+      mocks.access.asset.checkAlbumAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getById.mockResolvedValue(asset as any);
+      mocks.sharedSpace.findSpaceForAssetAndUser.mockResolvedValue(void 0 as any);
+
+      const result = await sut.get(authStub.admin, asset.id);
+
+      expect((result as AssetResponseDto).people).toEqual([expect.objectContaining({ id: 'person-1' })]);
+    });
+
+    it('should withhold hidden people for album access', async () => {
+      const asset = AssetFactory.from()
+        .exif()
+        .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person', isHidden: true }))
         .build();
       mocks.access.asset.checkAlbumAccess.mockResolvedValue(new Set([asset.id]));
       mocks.asset.getById.mockResolvedValue(asset as any);
@@ -557,7 +579,8 @@ describe(AssetService.name, () => {
       expect((result as any).resolvedSpaceId).toBe('space-1');
     });
 
-    it('should strip people when fallback finds no space', async () => {
+    // #796 POLICY REVERSAL (was 'should strip people when fallback finds no space').
+    it('should expose people when fallback finds no space', async () => {
       const asset = AssetFactory.from()
         .exif()
         .face({}, (f) => f.person({ id: 'person-1', name: 'Test Person' }))
@@ -568,7 +591,7 @@ describe(AssetService.name, () => {
 
       const result = await sut.get(authStub.admin, asset.id);
 
-      expect(result).toHaveProperty('people', []);
+      expect((result as AssetResponseDto).people).toEqual([expect.objectContaining({ id: 'person-1' })]);
       expect(result).not.toHaveProperty('resolvedSpaceId');
     });
 

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -141,7 +141,10 @@ export class AssetService extends BaseService {
         data.people = (data.people || []).filter((p) => p.spacePersonId && !spacePersonMap.get(p.id)?.isHidden);
         data.resolvedSpaceId = spaceForAsset.spaceId;
       } else {
-        data.people = [];
+        // #796: no space contains this asset for the viewer, so they reach it through an album
+        // share or partner sharing. Read access to the asset carries read access to who is in it —
+        // minus anyone the owner marked hidden, which must not leak off-box.
+        data.people = (data.people || []).filter((person) => !person.isHidden);
       }
     }
 

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -5751,10 +5751,17 @@ describe(PersonService.name, () => {
       expect(mapFaces(getForAssetFace(AssetFaceFactory.create()), AuthFactory.create()).person).toBeNull();
     });
 
-    it('should not map person if person does not match auth user id', () => {
+    // #796 POLICY REVERSAL (was 'should not map person if person does not match auth user id').
+    // mapFaces no longer gates on ownership: its only caller, getFacesById, has already authorized
+    // Permission.AssetRead and is responsible for dropping hidden people for non-owners.
+    it('should map person even when the person does not belong to the auth user', () => {
       expect(
         mapFaces(getForAssetFace(AssetFaceFactory.from().person().build()), AuthFactory.create()).person,
-      ).toBeNull();
+      ).not.toBeNull();
+    });
+
+    it('should map a null person when the face has none', () => {
+      expect(mapFaces(getForAssetFace(AssetFaceFactory.from().build()), AuthFactory.create()).person).toBeNull();
     });
   });
 });

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -276,7 +276,12 @@ export class PersonService extends BaseService {
     const asset = await this.assetRepository.getForFaces(dto.id);
     const assetDimensions = getDimensions(asset);
 
-    return faces.map((face) => mapFaces(face, auth, asset.edits, assetDimensions));
+    // A person the owner marked hidden must never reach another viewer (#796). Filtering on the
+    // client would be cosmetic — the identity would still be on the wire — so drop the face here.
+    // The owner keeps seeing their hidden people; the web decides whether to display them.
+    return faces
+      .filter((face) => !face.person?.isHidden || face.person?.ownerId === auth.user.id)
+      .map((face) => mapFaces(face, auth, asset.edits, assetDimensions));
   }
 
   async createNewFeaturePhoto(changeFeaturePhoto: string[]) {

--- a/server/test/medium/specs/repositories/album.repository.spec.ts
+++ b/server/test/medium/specs/repositories/album.repository.spec.ts
@@ -169,4 +169,197 @@ describe(AlbumRepository.name, () => {
       expect(contributorRow?.assetCount).toBe(2);
     });
   });
+
+  describe('getByAssetId', () => {
+    it('returns an album the user is shared into directly', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: owner.id });
+      const { album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Shared Album' });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+      await ctx.newAlbumUser({ albumId: album.id, userId: viewer.id });
+
+      const rows = await sut.getByAssetId(viewer.id, asset.id);
+
+      expect(rows.map((row) => row.id)).toEqual([album.id]);
+    });
+
+    it('returns an album linked into a shared space the user is a member of', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: owner.id });
+      const { album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Space Linked Album' });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+
+      const rows = await sut.getByAssetId(viewer.id, asset.id);
+
+      expect(rows.map((row) => row.id)).toEqual([album.id]);
+    });
+
+    it('does not return an album the user has no access path to', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: stranger } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: owner.id });
+      const { album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Private Album' });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+
+      const rows = await sut.getByAssetId(stranger.id, asset.id);
+
+      expect(rows).toEqual([]);
+    });
+
+    it('does not return an album linked only to a space the user is not in', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: outsider } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: owner.id });
+      const { album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Other Space Album' });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+
+      // The album is linked into space A; the outsider is a member of unrelated space B.
+      const { space: spaceA } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: spaceA.id, albumId: album.id });
+      const { space: spaceB } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: spaceB.id, userId: outsider.id });
+
+      const rows = await sut.getByAssetId(outsider.id, asset.id);
+
+      expect(rows).toEqual([]);
+    });
+
+    it('stops returning a space-linked album once the album is unlinked from the space', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: owner.id });
+      const { album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Unlinked Album' });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+
+      expect(await sut.getByAssetId(viewer.id, asset.id)).toHaveLength(1);
+
+      await ctx.database.deleteFrom('shared_space_album').where('albumId', '=', album.id).execute();
+
+      expect(await sut.getByAssetId(viewer.id, asset.id)).toEqual([]);
+    });
+
+    it('stops returning a space-linked album once the user leaves the space', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: owner.id });
+      const { album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Departed Album' });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+
+      expect(await sut.getByAssetId(viewer.id, asset.id)).toHaveLength(1);
+
+      await ctx.database.deleteFrom('shared_space_member').where('userId', '=', viewer.id).execute();
+
+      expect(await sut.getByAssetId(viewer.id, asset.id)).toEqual([]);
+    });
+
+    it('does not reveal a space-linked album for another member Hidden asset', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+      const { album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Album With Hidden Asset' });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+
+      const rows = await sut.getByAssetId(viewer.id, asset.id);
+
+      expect(rows).toEqual([]);
+    });
+
+    it('does not reveal a space-linked album for another member Locked asset', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Locked });
+      const { album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Album With Locked Asset' });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+
+      const rows = await sut.getByAssetId(viewer.id, asset.id);
+
+      expect(rows).toEqual([]);
+    });
+
+    it('still shows the owner their own Hidden asset album membership', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Hidden });
+      const { album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'My Hidden Asset Album' });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+      // newAlbum already creates the owner's album_user row — the owner reaches this album through
+      // the album_user arm, which is why gating the SPACE arm on visibility cannot regress them.
+
+      const rows = await sut.getByAssetId(owner.id, asset.id);
+
+      expect(rows.map((row) => row.id)).toEqual([album.id]);
+    });
+
+    // Known incompleteness, pinned so it stays visible: a cross-owner contribution (#764) lives in
+    // album_space_asset, not album_asset, and this query inner-joins album_asset. A contributor
+    // therefore sees no "Contained in" for their own contributed asset. This under-reports rather
+    // than over-reports, so it is not a disclosure — but it is a gap worth closing separately.
+    it('does not yet surface a linked album for a cross-owner contributed asset', async () => {
+      const { ctx, sut } = setup();
+      const { user: albumOwner } = await ctx.newUser();
+      const { user: contributor } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: contributor.id });
+      const { album } = await ctx.newAlbum({ ownerId: albumOwner.id, albumName: 'Contribution Album' });
+
+      const { space } = await ctx.newSharedSpace({ createdById: albumOwner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: contributor.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+      await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+      const rows = await sut.getByAssetId(contributor.id, asset.id);
+
+      expect(rows).toEqual([]);
+    });
+
+    it('does not return a space-linked album that has been soft-deleted', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: owner.id });
+      const { album } = await ctx.newAlbum({
+        ownerId: owner.id,
+        albumName: 'Deleted Album',
+        deletedAt: new Date(),
+      });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+
+      const rows = await sut.getByAssetId(viewer.id, asset.id);
+
+      expect(rows).toEqual([]);
+    });
+  });
 });

--- a/server/test/medium/specs/services/asset.service.spec.ts
+++ b/server/test/medium/specs/services/asset.service.spec.ts
@@ -1,5 +1,6 @@
 import { Kysely } from 'kysely';
 import { StorageCore } from 'src/cores/storage.core';
+import { AssetResponseDto } from 'src/dtos/asset-response.dto';
 import { AssetEditAction } from 'src/dtos/editing.dto';
 import { AssetFileType, AssetMetadataKey, AssetStatus, AssetVisibility, JobName, SharedLinkType } from 'src/enum';
 import { AccessRepository } from 'src/repositories/access.repository';
@@ -12,6 +13,7 @@ import { JobRepository } from 'src/repositories/job.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { MapRepository } from 'src/repositories/map.repository';
 import { OcrRepository } from 'src/repositories/ocr.repository';
+import { PersonRepository } from 'src/repositories/person.repository';
 import { SharedLinkAssetRepository } from 'src/repositories/shared-link-asset.repository';
 import { SharedLinkRepository } from 'src/repositories/shared-link.repository';
 import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
@@ -35,6 +37,7 @@ const setup = (db?: Kysely<DB>) => {
       AssetJobRepository,
       AlbumRepository,
       AccessRepository,
+      PersonRepository,
       SharedLinkAssetRepository,
       SharedSpaceRepository,
       StackRepository,
@@ -47,6 +50,29 @@ const setup = (db?: Kysely<DB>) => {
 beforeAll(async () => {
   defaultDatabase = await getKyselyDB();
 });
+
+/** An owner's asset carrying a face and a tag, shared with `viewer` through an album. */
+const albumSharedAsset = async (ctx: ReturnType<typeof setup>['ctx']) => {
+  const { user: owner } = await ctx.newUser();
+  const { user: viewer } = await ctx.newUser();
+  const { asset } = await ctx.newAsset({ ownerId: owner.id });
+
+  const { person } = await ctx.newPerson({ ownerId: owner.id, name: 'Alice' });
+  await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+  const tag = await ctx.database
+    .insertInto('tag')
+    .values({ userId: owner.id, value: 'Egypt' })
+    .returningAll()
+    .executeTakeFirstOrThrow();
+  await ctx.database.insertInto('tag_asset').values({ tagId: tag.id, assetId: asset.id }).execute();
+
+  const { album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Shared Album' });
+  await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+  await ctx.newAlbumUser({ albumId: album.id, userId: viewer.id });
+
+  return { owner, viewer, asset, album };
+};
 
 describe(AssetService.name, () => {
   describe('getStatistics', () => {
@@ -935,6 +961,63 @@ describe(AssetService.name, () => {
         expect.objectContaining({ isEdited: true }),
       );
       await expect(ctx.get(AssetEditRepository).getAll(asset.id)).resolves.toEqual([editResponse]);
+    });
+  });
+
+  // #796: what the asset-viewer info panel actually receives for a viewer with read access but no
+  // space context (shared-album recipient). The web panel can only render what lands in this DTO.
+  describe('get (shared-album recipient)', () => {
+    it('exposes the owner tags to the recipient', async () => {
+      const { sut, ctx } = setup();
+      const { viewer, asset } = await albumSharedAsset(ctx);
+
+      const result = (await sut.get(factory.auth({ user: viewer }), asset.id)) as AssetResponseDto;
+
+      // withTags is not user-scoped, so the owner's tags reach any viewer with read access. This is
+      // what makes the read-only Tags section in the info panel work (#796).
+      expect(result.tags?.map((tag) => tag.value)).toEqual(['Egypt']);
+    });
+
+    it('returns the people to the recipient', async () => {
+      const { sut, ctx } = setup();
+      const { viewer, asset } = await albumSharedAsset(ctx);
+
+      const result = (await sut.get(factory.auth({ user: viewer }), asset.id)) as AssetResponseDto;
+
+      // #796: read access to the asset carries read access to who is in it. No space is involved
+      // here, so this is the plain shared-album path.
+      expect(result.people?.map((person) => person.name)).toEqual(['Alice']);
+      expect(result.resolvedSpaceId).toBeUndefined();
+    });
+
+    it('omits hidden people from the recipient', async () => {
+      const { sut, ctx } = setup();
+      const { viewer, asset } = await albumSharedAsset(ctx);
+      await ctx.database.updateTable('person').set({ isHidden: true }).where('name', '=', 'Alice').execute();
+
+      const result = (await sut.get(factory.auth({ user: viewer }), asset.id)) as AssetResponseDto;
+
+      expect(result.people).toEqual([]);
+    });
+
+    it('still returns hidden people to the owner', async () => {
+      const { sut, ctx } = setup();
+      const { owner, asset } = await albumSharedAsset(ctx);
+      await ctx.database.updateTable('person').set({ isHidden: true }).where('name', '=', 'Alice').execute();
+
+      const result = (await sut.get(factory.auth({ user: owner }), asset.id)) as AssetResponseDto;
+
+      expect(result.people?.map((person) => person.name)).toEqual(['Alice']);
+    });
+
+    it('exposes the owner tags and people to the owner', async () => {
+      const { sut, ctx } = setup();
+      const { owner, asset } = await albumSharedAsset(ctx);
+
+      const result = (await sut.get(factory.auth({ user: owner }), asset.id)) as AssetResponseDto;
+
+      expect(result.tags?.map((tag) => tag.value)).toEqual(['Egypt']);
+      expect(result.people?.map((person) => person.name)).toEqual(['Alice']);
     });
   });
 });

--- a/server/test/medium/specs/services/person.service.spec.ts
+++ b/server/test/medium/specs/services/person.service.spec.ts
@@ -229,6 +229,22 @@ beforeAll(async () => {
   defaultDatabase = await getKyselyDB();
 });
 
+/** An owner's asset carrying one named face, shared with `viewer` through an album. */
+const albumSharedAsset = async (ctx: ReturnType<typeof setup>['ctx']) => {
+  const { user: owner } = await ctx.newUser();
+  const { user: viewer } = await ctx.newUser();
+  const { person } = await ctx.newPerson({ ownerId: owner.id, name: 'Alice', birthDate: '1990-05-13' });
+  const { asset } = await ctx.newAsset({ ownerId: owner.id, width: 100, height: 100 });
+  await ctx.newExif({ assetId: asset.id, exifImageHeight: 100, exifImageWidth: 100 });
+  await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+  const { album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Shared Album' });
+  await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+  await ctx.newAlbumUser({ albumId: album.id, userId: viewer.id });
+
+  return { owner, viewer, person, asset };
+};
+
 describe(PersonService.name, () => {
   describe('handleQueueDetectFaces safety', () => {
     it('preserves manual and EXIF roots while force face detection removes stale machine-learning state', async () => {
@@ -1575,6 +1591,72 @@ describe(PersonService.name, () => {
           }),
         ]),
       );
+    });
+  });
+
+  // #796: the asset-viewer info panel renders its People section from GET /faces for any viewer
+  // with no space context (shared-album recipient, partner). These pin what that endpoint actually
+  // serves a non-owner — the web panel can only display what survives mapFaces' owner check.
+  describe('getFacesById (non-owner read access)', () => {
+    it('grants a shared-album recipient read access to the faces', async () => {
+      const { sut, ctx } = setup();
+      const { viewer, asset } = await albumSharedAsset(ctx);
+
+      const faces = await sut.getFacesById(factory.auth({ user: viewer }), { id: asset.id });
+
+      expect(faces).toHaveLength(1);
+    });
+
+    it('returns the person identity to a shared-album recipient', async () => {
+      const { sut, ctx } = setup();
+      const { viewer, asset, person } = await albumSharedAsset(ctx);
+
+      const faces = await sut.getFacesById(factory.auth({ user: viewer }), { id: asset.id });
+
+      // #796: who is in a photo is metadata anyone with read access may see. The access check has
+      // already run (Permission.AssetRead), so every face reaching this mapper belongs to an asset
+      // the caller is entitled to.
+      expect(faces[0].person).toEqual(expect.objectContaining({ id: person.id, name: 'Alice' }));
+    });
+
+    it('includes the person birth date so the viewer sees an age', async () => {
+      const { sut, ctx } = setup();
+      const { viewer, asset } = await albumSharedAsset(ctx);
+
+      const faces = await sut.getFacesById(factory.auth({ user: viewer }), { id: asset.id });
+
+      expect(faces[0].person?.birthDate).toBe('1990-05-13');
+    });
+
+    it('hides a hidden person from a non-owner', async () => {
+      const { sut, ctx } = setup();
+      const { viewer, asset, person } = await albumSharedAsset(ctx);
+      await ctx.database.updateTable('person').set({ isHidden: true }).where('id', '=', person.id).execute();
+
+      const faces = await sut.getFacesById(factory.auth({ user: viewer }), { id: asset.id });
+
+      // A person the owner marked hidden must not leak to a viewer. Filtering this client-side
+      // would be cosmetic only — the identity would still be on the wire.
+      expect(faces).toEqual([]);
+    });
+
+    it('still returns a hidden person to the owner', async () => {
+      const { sut, ctx } = setup();
+      const { owner, asset, person } = await albumSharedAsset(ctx);
+      await ctx.database.updateTable('person').set({ isHidden: true }).where('id', '=', person.id).execute();
+
+      const faces = await sut.getFacesById(factory.auth({ user: owner }), { id: asset.id });
+
+      expect(faces[0].person).toEqual(expect.objectContaining({ id: person.id }));
+    });
+
+    it('returns the person identity to the owner', async () => {
+      const { sut, ctx } = setup();
+      const { owner, person, asset } = await albumSharedAsset(ctx);
+
+      const faces = await sut.getFacesById(factory.auth({ user: owner }), { id: asset.id });
+
+      expect(faces[0].person).toEqual(expect.objectContaining({ id: person.id, name: 'Alice' }));
     });
   });
 });

--- a/web/src/lib/components/asset-viewer/DetailPanelPeople.spec.ts
+++ b/web/src/lib/components/asset-viewer/DetailPanelPeople.spec.ts
@@ -1,0 +1,209 @@
+import type { PersonResponseDto } from '@immich/sdk';
+import '@testing-library/jest-dom';
+import { screen } from '@testing-library/svelte';
+import { renderWithTooltips } from '$tests/helpers';
+import { assetFactory } from '@test-data/factories/asset-factory';
+import DetailPanelPeople from './DetailPanelPeople.svelte';
+
+const { authManagerMock, faceManagerMock, zoomImageToBase64Mock } = vi.hoisted(() => ({
+  authManagerMock: {
+    authenticated: true,
+    user: { id: 'viewer-1' },
+    isSharedLink: false,
+    params: {},
+    preferences: { tags: { enabled: true } },
+  },
+  faceManagerMock: {
+    data: [] as unknown[],
+    facesByPersonId: new Map<string, unknown[]>(),
+    people: [] as PersonResponseDto[],
+  },
+  zoomImageToBase64Mock: vi.fn(),
+}));
+
+vi.mock('$lib/stores/face.svelte', () => ({ faceManager: faceManagerMock }));
+
+vi.mock('$lib/utils/people-utils', () => ({ zoomImageToBase64: zoomImageToBase64Mock }));
+
+vi.mock('$app/navigation', () => ({ goto: vi.fn().mockResolvedValue(undefined) }));
+
+vi.mock('$lib/managers/auth-manager.svelte', () => ({ authManager: authManagerMock }));
+
+vi.mock('$lib/managers/asset-viewer-manager.svelte', () => ({
+  assetViewerManager: {
+    clearHighlightedFaces: vi.fn(),
+    highlightedFaces: [],
+    imgRef: undefined,
+    isShowingHiddenPeople: false,
+    openEditFacesPanel: vi.fn(),
+    setHighlightedFaces: vi.fn(),
+    toggleFaceEditMode: vi.fn(),
+    toggleHiddenPeople: vi.fn(),
+  },
+}));
+
+const person = (name: string): PersonResponseDto =>
+  ({
+    id: `person-${name}`,
+    name,
+    birthDate: null,
+    thumbnailPath: '',
+    isHidden: false,
+    isFavorite: false,
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  }) as unknown as PersonResponseDto;
+
+const asset = () => assetFactory.build({ id: 'asset-1', ownerId: 'owner-1' });
+
+const renderPanel = (props: {
+  isOwner: boolean;
+  spaceId?: string;
+  people?: PersonResponseDto[];
+  sharedLink?: boolean;
+}) => {
+  authManagerMock.isSharedLink = props.sharedLink ?? false;
+  return renderWithTooltips(DetailPanelPeople, {
+    asset: props.people ? assetFactory.build({ id: 'asset-1', ownerId: 'owner-1', people: props.people }) : asset(),
+    isOwner: props.isOwner,
+    previousRoute: '/photos',
+    spaceId: props.spaceId,
+  });
+};
+
+// NOTE on what these tests do and do NOT prove (#796).
+//
+// These exercise the component's GATE given a people list. They deliberately mock
+// `faceManager.people`, so a passing "non-owner sees people" test does NOT mean the info panel's
+// People section works for a shared-album recipient in production — it does not.
+//
+// The server redacts the identity before the client ever sees it, on BOTH sources:
+//   • GET /faces  — mapFaces() nulls `person` unless `person.ownerId === auth.user.id`, and
+//                   faceManager.people is built from `face.person`, so it is empty for a viewer.
+//   • getAssetInfo — AssetService.get hard-sets `people = []` for a non-owner with no space.
+// Both are pinned by real-database tests: server/test/medium/specs/services/person.service.spec.ts
+// ("getFacesById (non-owner read access)") and .../asset.service.spec.ts ("get (shared-album
+// recipient)").
+//
+// Lifting the client gate here is the necessary half of the fix, not the sufficient one. Making
+// People actually appear for a viewer requires a server-side RBAC change (exposing person identity
+// to non-owners with read access, with hidden-person filtering and a person-thumbnail endpoint a
+// non-owner may call) — a privacy decision, not a display fix.
+describe('DetailPanelPeople', () => {
+  beforeEach(() => {
+    faceManagerMock.people = [];
+    faceManagerMock.data = [];
+    faceManagerMock.facesByPersonId = new Map();
+    zoomImageToBase64Mock.mockResolvedValue(undefined);
+  });
+
+  it('renders people for a non-owner when the client is given any (gate no longer requires ownership)', () => {
+    faceManagerMock.people = [person('Alice')];
+
+    renderPanel({ isOwner: false });
+
+    expect(screen.getByTestId('detail-panel-people')).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+
+  it('renders nothing for a non-owner given the empty list the server actually serves today', () => {
+    // The production shape for a shared-album recipient: GET /faces comes back with person: null
+    // on every face, so faceManager.people is empty. This is the #796 symptom, and it is why the
+    // gate change above is not on its own a fix.
+    faceManagerMock.people = [];
+    faceManagerMock.data = [{ id: 'face-1' }];
+
+    renderPanel({ isOwner: false });
+
+    expect(screen.queryByTestId('detail-panel-people')).not.toBeInTheDocument();
+  });
+
+  it('never requests the owner-only person thumbnail for a non-owner', () => {
+    faceManagerMock.people = [person('Alice')];
+
+    const { container } = renderPanel({ isOwner: false });
+
+    // /people/{id}/thumbnail is owner-gated AND is cropped from the person's feature photo — a
+    // DIFFERENT asset the viewer may have no right to see. Requesting it would 404 at best and
+    // leak a crop of an unshared photo at worst.
+    expect(container.querySelector('img')?.getAttribute('src')).not.toContain('/people/');
+  });
+
+  it('requests the person thumbnail for the owner', () => {
+    faceManagerMock.people = [person('Alice')];
+
+    const { container } = renderPanel({ isOwner: true });
+
+    expect(container.querySelector('img')?.getAttribute('src')).toContain('/people/');
+  });
+
+  it('does not link a non-owner to the owner-only person page', () => {
+    faceManagerMock.people = [person('Alice')];
+
+    renderPanel({ isOwner: false });
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('links the owner to the person page', () => {
+    faceManagerMock.people = [person('Alice')];
+
+    renderPanel({ isOwner: true });
+
+    expect(screen.getByRole('link')).toBeInTheDocument();
+  });
+
+  it('hides the section on a shared link even when people are present', () => {
+    faceManagerMock.people = [person('Alice')];
+
+    renderPanel({ isOwner: false, sharedLink: true });
+
+    expect(screen.queryByTestId('detail-panel-people')).not.toBeInTheDocument();
+  });
+
+  it('hides the section on a shared link even for the owner', () => {
+    faceManagerMock.people = [person('Alice')];
+
+    renderPanel({ isOwner: true, sharedLink: true });
+
+    expect(screen.queryByTestId('detail-panel-people')).not.toBeInTheDocument();
+  });
+
+  it('offers no face editing controls to a non-owner', () => {
+    faceManagerMock.people = [person('Alice')];
+    faceManagerMock.data = [{ id: 'face-1' }];
+
+    renderPanel({ isOwner: false });
+
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
+  });
+
+  it('offers face editing controls to the owner', () => {
+    faceManagerMock.people = [person('Alice')];
+    faceManagerMock.data = [{ id: 'face-1' }];
+
+    renderPanel({ isOwner: true });
+
+    expect(screen.queryAllByRole('button').length).toBeGreaterThan(0);
+  });
+
+  it('still renders the section for an owner whose asset has no people', () => {
+    renderPanel({ isOwner: true });
+
+    expect(screen.getByTestId('detail-panel-people')).toBeInTheDocument();
+  });
+
+  it('hides the section from a non-owner when there are no people', () => {
+    renderPanel({ isOwner: false });
+
+    expect(screen.queryByTestId('detail-panel-people')).not.toBeInTheDocument();
+  });
+
+  it('shows space-linked people to a space member from the asset payload', () => {
+    faceManagerMock.people = [person('Should Not Appear')];
+
+    renderPanel({ isOwner: false, spaceId: 'space-1', people: [person('Bob')] });
+
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(screen.queryByText('Should Not Appear')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/lib/components/asset-viewer/DetailPanelPeople.svelte
+++ b/web/src/lib/components/asset-viewer/DetailPanelPeople.svelte
@@ -5,7 +5,7 @@
   import { Route } from '$lib/route';
   import { faceManager } from '$lib/stores/face.svelte';
   import { locale } from '$lib/stores/preferences.store';
-  import { createUrl, getPeopleThumbnailUrl } from '$lib/utils';
+  import { createUrl, getAssetUrls, getPeopleThumbnailUrl } from '$lib/utils';
   import { zoomImageToBase64 } from '$lib/utils/people-utils';
   import { type AssetResponseDto } from '@immich/sdk';
   import { IconButton, Text } from '@immich/ui';
@@ -26,12 +26,27 @@
 
   const isSpaceMember = $derived(!!spaceId);
   const people = $derived(isSpaceMember && !isOwner ? asset.people || [] : Array.from(faceManager.people));
-  const getPersonFallbackThumbnailUrl = (person: AssetPerson) =>
-    spaceId && person.spacePersonId
-      ? createUrl(`/shared-spaces/${spaceId}/people/${person.spacePersonId}/thumbnail`, {
-          updatedAt: person.updatedAt,
-        })
-      : getPeopleThumbnailUrl(person);
+  // `/people/{id}/thumbnail` is owner-gated AND is cropped from the person's feature photo — a
+  // DIFFERENT asset the viewer may have no right to see. Never request it for a non-owner (#796):
+  // their avatar is cropped client-side from the asset already on screen, and this asset's own
+  // thumbnail (which they can definitely see) stands in while that crop resolves.
+  const getPersonFallbackThumbnailUrl = (person: AssetPerson) => {
+    if (spaceId && person.spacePersonId) {
+      return createUrl(`/shared-spaces/${spaceId}/people/${person.spacePersonId}/thumbnail`, {
+        updatedAt: person.updatedAt,
+      });
+    }
+    return isOwner ? getPeopleThumbnailUrl(person) : getAssetUrls(asset).thumbnail;
+  };
+
+  // A non-owner has no access to the owner-scoped person page, so their name is rendered as plain
+  // text rather than a link into a 404.
+  const getPersonHref = (person: AssetPerson) => {
+    if (spaceId && person.spacePersonId) {
+      return Route.viewSpacePerson(spaceId, person.spacePersonId);
+    }
+    return isOwner ? Route.viewPerson(person, { previousRoute }) : undefined;
+  };
   const visiblePeople = $derived(
     people
       .filter((p) => assetViewerManager.isShowingHiddenPeople || !p.isHidden)
@@ -67,8 +82,15 @@
   );
 </script>
 
-{#if !authManager.isSharedLink && (isOwner || isSpaceMember)}
-  <section class="px-4 pt-4 text-sm">
+<!--
+  Who is in a photo is read-only metadata: anyone with read access to the asset sees the panel
+  (#796) — `GET /faces` already authorizes on AssetRead (owner ∪ album ∪ partner ∪ space), so a
+  non-owner reaching this panel is entitled to the data. Only the affordances below (hidden-people
+  toggle, add-face, edit-faces) stay owner-gated. A non-owner with nobody to show gets no empty
+  section; the owner keeps it so the add-face affordance stays reachable on a face-less asset.
+-->
+{#if !authManager.isSharedLink && (isOwner || visiblePeople.length > 0)}
+  <section class="px-4 pt-4 text-sm" data-testid="detail-panel-people">
     <div class="flex h-10 w-full items-center justify-between">
       <Text size="small" color="muted">{$t('people')}</Text>
       <div class="flex items-center gap-2">
@@ -116,9 +138,7 @@
         {@const fallbackThumbnailUrl = getPersonFallbackThumbnailUrl(person)}
         <a
           class="group outline-none"
-          href={spaceId && person.spacePersonId
-            ? Route.viewSpacePerson(spaceId, person.spacePersonId)
-            : Route.viewPerson(person, { previousRoute })}
+          href={getPersonHref(person)}
           onfocus={() => assetViewerManager.setHighlightedFaces(personFaces)}
           onblur={() => assetViewerManager.clearHighlightedFaces()}
           onpointerenter={() => assetViewerManager.setHighlightedFaces(personFaces)}

--- a/web/src/lib/components/asset-viewer/DetailPanelTags.spec.ts
+++ b/web/src/lib/components/asset-viewer/DetailPanelTags.spec.ts
@@ -1,0 +1,102 @@
+import '@testing-library/jest-dom';
+import { screen, within } from '@testing-library/svelte';
+import { renderWithTooltips } from '$tests/helpers';
+import { assetFactory } from '@test-data/factories/asset-factory';
+import DetailPanelTags from './DetailPanelTags.svelte';
+
+const { authManagerMock } = vi.hoisted(() => ({
+  authManagerMock: {
+    authenticated: true,
+    user: { id: 'viewer-1' },
+    isSharedLink: false,
+    params: {},
+    preferences: {
+      tags: { enabled: true },
+    },
+  },
+}));
+
+vi.mock('$lib/managers/auth-manager.svelte', () => ({ authManager: authManagerMock }));
+
+vi.mock('$lib/managers/feature-flags-manager.svelte', () => ({
+  featureFlagsManager: {
+    value: {
+      map: true,
+      smartSearch: false,
+      tags: true,
+    },
+  },
+}));
+
+const taggedAsset = () =>
+  assetFactory.build({
+    id: 'asset-1',
+    ownerId: 'owner-1',
+    tags: [
+      { id: 'tag-1', name: 'Beach', value: 'Beach', createdAt: '', updatedAt: '' },
+      { id: 'tag-2', name: 'Egypt', value: 'Egypt', createdAt: '', updatedAt: '' },
+    ],
+  });
+
+// Unlike the People section, the Tags data path genuinely reaches a non-owner: withTags is not
+// user-scoped and AssetService.get applies no auth filter to `tags`, so a shared-album recipient
+// receives the owner's tags. Pinned against a real database by
+// server/test/medium/specs/services/asset.service.spec.ts ("get (shared-album recipient)").
+describe('DetailPanelTags', () => {
+  beforeEach(() => {
+    authManagerMock.isSharedLink = false;
+  });
+
+  it('hides the section on a shared link even when tags are present', () => {
+    authManagerMock.isSharedLink = true;
+
+    renderWithTooltips(DetailPanelTags, { asset: taggedAsset(), isOwner: false });
+
+    expect(screen.queryByTestId('detail-panel-tags')).not.toBeInTheDocument();
+  });
+
+  it('hides the section on a shared link even for the owner', () => {
+    authManagerMock.isSharedLink = true;
+
+    renderWithTooltips(DetailPanelTags, { asset: taggedAsset(), isOwner: true });
+
+    expect(screen.queryByTestId('detail-panel-tags')).not.toBeInTheDocument();
+  });
+
+  it('shows existing tags to a non-owner with read access', () => {
+    renderWithTooltips(DetailPanelTags, { asset: taggedAsset(), isOwner: false });
+
+    expect(screen.getByTestId('detail-panel-tags')).toBeInTheDocument();
+    expect(screen.getByText('Beach')).toBeInTheDocument();
+    expect(screen.getByText('Egypt')).toBeInTheDocument();
+  });
+
+  it('offers no tag editing controls to a non-owner', () => {
+    renderWithTooltips(DetailPanelTags, { asset: taggedAsset(), isOwner: false });
+
+    const section = screen.getByTestId('detail-panel-tags');
+    expect(within(section).queryAllByRole('button')).toHaveLength(0);
+  });
+
+  it('offers tag editing controls to the owner', () => {
+    renderWithTooltips(DetailPanelTags, { asset: taggedAsset(), isOwner: true });
+
+    const section = screen.getByTestId('detail-panel-tags');
+    expect(within(section).queryAllByRole('button').length).toBeGreaterThan(0);
+  });
+
+  it('still renders the section for an owner whose asset has no tags', () => {
+    renderWithTooltips(DetailPanelTags, { asset: assetFactory.build({ ownerId: 'owner-1', tags: [] }), isOwner: true });
+
+    expect(screen.getByTestId('detail-panel-tags')).toBeInTheDocument();
+  });
+
+  it('hides the section from a non-owner when the asset has no tags', () => {
+    renderWithTooltips(DetailPanelTags, {
+      asset: assetFactory.build({ ownerId: 'owner-1', tags: [] }),
+      isOwner: false,
+    });
+
+    expect(screen.queryByTestId('detail-panel-tags')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/lib/components/asset-viewer/DetailPanelTags.svelte
+++ b/web/src/lib/components/asset-viewer/DetailPanelTags.svelte
@@ -17,7 +17,6 @@
 
   let { asset = $bindable(), isOwner, spaceId }: Props = $props();
   let effectiveSpaceId = $derived(spaceId || asset.resolvedSpaceId);
-  let isSpaceMember = $derived(!!effectiveSpaceId);
 
   let tags = $derived(asset.tags || []);
 
@@ -39,7 +38,12 @@
 
 <OnEvents {onAssetsTag} />
 
-{#if (isOwner || isSpaceMember) && !authManager.isSharedLink}
+<!--
+  Tags are read-only metadata: anyone with read access to the asset sees them (#796). Only the
+  edit affordances below (per-tag remove, "add tag") stay owner-gated. Non-owners with no tags to
+  show get no empty section; the owner keeps it so the "add tag" affordance is always reachable.
+-->
+{#if !authManager.isSharedLink && (isOwner || tags.length > 0)}
   <section class="mt-4 px-4">
     <div class="flex h-10 w-full items-center justify-between text-sm">
       <Text color="muted">{$t('tags')}</Text>


### PR DESCRIPTION
Fixes #796.

## Problem

The asset-viewer **Info** panel hid three sections from any non-owner (e.g. a shared-album recipient), while the owner saw them all:

1. **People / Faces** — who is in the photo
2. **Contained in** — album membership
3. **Tags**

These are read-only metadata. Role should govern what you can *edit*, not what you can *read*. Edit affordances (pencils, "Add tag", add-face) correctly stay owner-gated.

## Root cause — three different causes, not one

| Section | Cause | Fix |
|---|---|---|
| **Tags** | Web gate keyed on `isOwner \|\| isSpaceMember`; data already reaches any reader (`withTags` is not user-scoped) | Gate on *having tags to show* |
| **People** | Same over-broad web gate **and** two server redactions (`mapFaces` nulled `person`; `AssetService.get` hard-set `people = []`) | Lift both server redactions + gate on *having people to show* |
| **Contained in** | No web gate at all — `album.getByAssetId` required an `album_user` row, so a space viewer got `[]` | Union `album_user` access with space-linked albums the caller can open |

## ⚠️ Policy reversal — please review

This **reverses a deliberate prior decision** and rewrites 5 tests that locked it in (two named `should still strip people for partner/album access`). Previously, people only surfaced through the curated shared-space path; now raw person identity (names + ages) travels with `AssetRead`. Each rewritten test carries a `#796 POLICY REVERSAL` comment. **Shared links are unchanged — an anonymous link holder still gets nothing.**

Per the linked issue's decision, this is the intended behaviour, but it is a genuine privacy-surface change and deserves a careful look.

## RBAC safety (this was the focus)

- **Hidden people are filtered server-side** on both People paths. The old `isHidden` filter was client-side only — cosmetic, since the identity was already on the wire.
- **Album membership is access-scoped, not "every album containing the asset."** Album names are user-authored and can be sensitive; a viewer only sees albums they can open (direct share or a live space link).
- The space album arm carries the **space visibility gate** (Archive/Timeline), so another member's Hidden/Locked asset never reveals its album membership. The `album_user` arm stays ungated so an owner still sees "Contained in" on their own Hidden/Locked asset.
- **No `PersonRead` widening.** A person thumbnail is cropped from that person's feature photo — a *different* asset the viewer may not be entitled to. A non-owner's avatar is instead cropped client-side from the asset already on screen, and their name renders as plain text (no dead link to the owner-only person page).

Pinned by real-DB medium tests covering: cross-space isolation, album unlink, member departure, stranger denial, soft-deleted albums, and Hidden/Locked non-disclosure.

## Tests

- Server unit: 5095 passed, 0 failed
- Web: 3674 passed, 0 failed (4 new spec files / 20 new cases)
- Medium (real Postgres): +24 cases across album / person / asset services
- tsc, eslint, prettier clean; SQL query docs regenerated (idempotent)

## Known limitations (not regressions)

- A cross-owner **contribution** (`album_space_asset`) is not yet surfaced in "Contained in" — *under*-reports, so it is not a disclosure. Pinned by a characterization test.
- A space member reaching an asset via a **linked album** now sees raw person names rather than the space's curated profiles (`findSpaceForAssetAndUser` album-arm gap). Consistent with the new policy.
- **Mobile is untouched but affected** — its people strip fetches asset-info for non-owned assets, so mobile viewers inherit the new behaviour. Not verified here.
- Not exercised in a browser / e2e run.
