### PR TITLE
fix(web): stop "the" hijacking search via the Theme top-result promotion

### DIFF
--- a/web/src/lib/components/global-search/__tests__/global-search.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search.spec.ts
@@ -327,7 +327,11 @@ describe('global-search root', () => {
     const m = new GlobalSearchManager();
     m.open();
     render(GlobalSearch, { props: { manager: m } });
-    await user.type(screen.getByRole('combobox'), 'delete selected');
+    // Single word on purpose: svelte-i18n is uninitialised here so labels render
+    // as their raw keys (`cmdk_cmd_selection_delete_label`), which contain
+    // "delete" but not "selected". Selection is the only context set, so
+    // "delete" resolves unambiguously to the selection-delete command.
+    await user.type(screen.getByRole('combobox'), 'delete');
 
     await vi.waitFor(() => expect(m.topCommandMatch?.id).toBe('cmd:selection_delete'));
     await user.keyboard('{Enter}');
@@ -1078,7 +1082,13 @@ describe('global-search root', () => {
     const m = new GlobalSearchManager();
     m.open();
     render(GlobalSearch, { props: { manager: m } });
-    await user.type(screen.getByRole('combobox'), 'people');
+    // Pasted rather than typed: the nav section wrapper has an `out:fade`, and
+    // Svelte outros never complete under happy-dom. Typing character by
+    // character renders People in the section before the promotion gate opens,
+    // leaving a permanently fading ghost row that no amount of waiting clears.
+    // A single input event goes straight to the promoted state.
+    await user.click(screen.getByRole('combobox'));
+    await user.paste('people');
     await vi.waitFor(() => expect(document.querySelector('[data-cmdk-top-result-navigation]')).not.toBeNull());
     // There should be exactly one row carrying the People nav id.
     const rows = document.querySelectorAll('[data-command-item][data-value="nav:userPages:people"]');

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -188,7 +188,17 @@
       previousActiveItemId = manager.activeItemId;
       return;
     }
-    if (previousActiveItemId === topResultId && manager.activeItemId !== topResultId) {
+    // Only a *user* moving off the top row counts as a dismissal, and a user can
+    // only do that while the token is unchanged. When the query grows by another
+    // character the token changes and the promoted row is re-created, which
+    // transiently clears the cmdk selection — reading that as a dismissal would
+    // strand the palette with no active row (Enter then does nothing) for any
+    // query whose promotion turns on one keystroke before the last, e.g. "theme".
+    if (
+      previousActiveItemId === topResultId &&
+      manager.activeItemId !== topResultId &&
+      lastAutoSelectedTopResultToken === topResultToken
+    ) {
       lastDismissedTopResultToken = topResultToken;
     }
     if (lastAutoSelectedTopResultToken !== topResultToken && lastDismissedTopResultToken !== topResultToken) {

--- a/web/src/lib/managers/cmdk-match.spec.ts
+++ b/web/src/lib/managers/cmdk-match.spec.ts
@@ -12,4 +12,51 @@ describe('isAlmostExactWordMatch', () => {
   it('case-insensitive + non-alnum split', () => {
     expect(isAlmostExactWordMatch('UPLOAD', 'upload-files', MIN)).toBe(true);
   });
+
+  describe('close-prefix gate', () => {
+    it('promotes a word the query spells out in full', () => {
+      expect(isAlmostExactWordMatch('theme', 'Theme', MIN)).toBe(true);
+    });
+
+    it('tolerates a prefix one character short of the label word', () => {
+      expect(isAlmostExactWordMatch('them', 'Theme', MIN)).toBe(true);
+      expect(isAlmostExactWordMatch('album', 'Albums', MIN)).toBe(true);
+      expect(isAlmostExactWordMatch('tag', 'Tags', MIN)).toBe(true);
+    });
+
+    it('rejects a prefix that leaves more than one character unspoken', () => {
+      // The bug: "the" must not be treated as an attempt to type "Theme",
+      // otherwise every smart search containing the word "the" is hijacked.
+      expect(isAlmostExactWordMatch('the', 'Theme', MIN)).toBe(false);
+      expect(isAlmostExactWordMatch('arch', 'Archive', MIN)).toBe(false);
+      expect(isAlmostExactWordMatch('classif', 'Classification Settings', MIN)).toBe(false);
+    });
+  });
+
+  describe('every-word gate', () => {
+    it('rejects a sentence in which only one word incidentally matches', () => {
+      expect(isAlmostExactWordMatch('theme park in paris', 'Theme', MIN)).toBe(false);
+    });
+
+    it('rejects a sentence colliding with a common word in a long label', () => {
+      expect(isAlmostExactWordMatch('photos of the beach', 'Add photos to this space', MIN)).toBe(false);
+    });
+
+    it('promotes a multi-word query that spells out the whole label', () => {
+      expect(isAlmostExactWordMatch('run face detection', 'Run face detection', MIN)).toBe(true);
+    });
+
+    it('ignores query words below the length floor when requiring every word to match', () => {
+      expect(isAlmostExactWordMatch('add a member', 'Add a member to this space', MIN)).toBe(true);
+    });
+
+    it('promotes a compound word when any of its sub-tokens matches', () => {
+      expect(isAlmostExactWordMatch('auto-classification', 'Classification Settings', MIN)).toBe(true);
+    });
+
+    it('returns false when the query has no word at or above the floor', () => {
+      expect(isAlmostExactWordMatch('a b', 'Albums', MIN)).toBe(false);
+      expect(isAlmostExactWordMatch('', 'Albums', MIN)).toBe(false);
+    });
+  });
 });

--- a/web/src/lib/managers/cmdk-match.ts
+++ b/web/src/lib/managers/cmdk-match.ts
@@ -1,28 +1,60 @@
 const NON_ALNUM = /[^a-z0-9]+/;
+const WHITESPACE = /\s+/;
 
 /**
- * Shared "almost exact" word-prefix match used by both the navigation and
- * commands providers for top-result promotion under the `'all'` scope.
+ * How many characters of a label word the user is allowed to leave untyped and
+ * still have it count as "that word". One character covers the common
+ * singular/plural slip (`album` → `Albums`, `tag` → `Tags`) without letting a
+ * short English word stand in for a longer one (`the` → `Theme`).
+ */
+const MAX_UNTYPED_CHARS = 1;
+
+function isClosePrefix(token: string, labelWord: string): boolean {
+  return labelWord.startsWith(token) && labelWord.length - token.length <= MAX_UNTYPED_CHARS;
+}
+
+/**
+ * Shared "almost exact" word match used by both the navigation and commands
+ * providers for top-result promotion under the `'all'` scope.
  *
- * Rule: after case-folding and splitting both sides on non-alphanumerics, at
- * least one query word ≥ minLength chars must be a prefix of some label word.
+ * Promotion steals the top slot *and* suppresses the free-text "search for …"
+ * row, so a false positive makes a query unsearchable. The gate is therefore
+ * deliberately narrow — two rules, both of which must hold:
+ *
+ * 1. **Close prefix.** A query token only counts as a label word when it spells
+ *    that word out to within {@link MAX_UNTYPED_CHARS} characters. Plain prefix
+ *    matching let `the` claim `Theme`, which hijacked every smart search
+ *    containing the word "the".
+ * 2. **Every word matches.** Each whitespace-separated query word (that carries
+ *    at least one token ≥ `minLength`) must match some label word. A sentence
+ *    like `photos of the beach` therefore cannot be promoted by the incidental
+ *    `photos` collision with "Add photos to this space", while a query that
+ *    spells a label out in full — `run face detection` — still is.
+ *
+ * Words are split on whitespace but matched on their alphanumeric sub-tokens,
+ * so a compound query like `auto-classification` counts as one word and still
+ * promotes `Classification Settings` via its second token.
+ *
+ * Only the label is inspected, not the description — the description is richer
+ * and would promote items the user did not visually intend to pick.
  */
 export function isAlmostExactWordMatch(query: string, label: string, minLength: number): boolean {
   const q = query.trim().toLowerCase();
   if (q.length < minLength) {
     return false;
   }
-  const qWords = q.split(NON_ALNUM).filter((w) => w.length >= minLength);
-  if (qWords.length === 0) {
-    return false;
-  }
   const labelWords = label.toLowerCase().split(NON_ALNUM).filter(Boolean);
-  for (const qw of qWords) {
-    for (const lw of labelWords) {
-      if (lw.startsWith(qw)) {
-        return true;
-      }
+  let significantWords = 0;
+  for (const word of q.split(WHITESPACE)) {
+    const tokens = word.split(NON_ALNUM).filter((token) => token.length >= minLength);
+    if (tokens.length === 0) {
+      // Filler too short to be meaningful ("of", "a") — never disqualifies.
+      continue;
+    }
+    significantWords++;
+    if (!tokens.some((token) => labelWords.some((labelWord) => isClosePrefix(token, labelWord)))) {
+      return false;
     }
   }
-  return false;
+  return significantWords > 0;
 }

--- a/web/src/lib/managers/command-items.spec.ts
+++ b/web/src/lib/managers/command-items.spec.ts
@@ -404,9 +404,15 @@ describe('isAlmostExactCommandMatch', () => {
   it('returns false for queries shorter than 3 chars', () => {
     expect(isAlmostExactCommandMatch('up', 'Upload files')).toBe(false);
   });
-  it('matches when a query word is a prefix of a label word', () => {
+  it('matches when a query word all but spells out a label word', () => {
     expect(isAlmostExactCommandMatch('upload', 'Upload files')).toBe(true);
-    expect(isAlmostExactCommandMatch('upl', 'Upload files')).toBe(true);
+    expect(isAlmostExactCommandMatch('uploa', 'Upload files')).toBe(true);
+  });
+  it('rejects a partial prefix that leaves more than one character untyped', () => {
+    expect(isAlmostExactCommandMatch('upl', 'Upload files')).toBe(false);
+  });
+  it('rejects a sentence that only incidentally contains a label word', () => {
+    expect(isAlmostExactCommandMatch('upload files to the beach album', 'Upload files')).toBe(false);
   });
   it('is case-insensitive', () => {
     expect(isAlmostExactCommandMatch('UPLOAD', 'Upload files')).toBe(true);

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -2833,6 +2833,34 @@ describe('topNavigationMatch', () => {
     m.setQuery('zzzzzz');
     expect(m.topNavigationMatch).toBeNull();
   });
+
+  it('leaves a smart search containing the word "the" searchable', () => {
+    // Regression: "the" prefix-matched "Theme", so the Theme command/settings
+    // took the top slot and — because promotion suppresses `topSearchMatch` —
+    // Enter toggled the theme instead of running the search.
+    const m = new GlobalSearchManager();
+    m.open();
+    m.setQuery('the beach at sunset');
+
+    expect(m.topNavigationMatch).toBeNull();
+    expect(m.topCommandMatch).toBeNull();
+    expect(m.topSearchMatch).toEqual({
+      id: 'top-search',
+      query: 'the beach at sunset',
+      rawQuery: 'the beach at sunset',
+    });
+  });
+
+  it('still promotes Theme settings when the user actually types "theme"', () => {
+    const m = new GlobalSearchManager();
+    m.open();
+    m.setQuery('theme');
+
+    // The command wins the slot over the settings page (command-wins tie-break),
+    // which is the intended behaviour for a high-intent verb.
+    expect(m.topCommandMatch?.id).toBe('cmd:theme');
+    expect(m.topSearchMatch).toBeNull();
+  });
 });
 
 describe('topSearchMatch', () => {

--- a/web/src/lib/managers/navigation-items.spec.ts
+++ b/web/src/lib/managers/navigation-items.spec.ts
@@ -214,20 +214,23 @@ describe('NAVIGATION_ITEMS schema', () => {
 
 describe('isAlmostExactNavMatch', () => {
   // Promotes a navigation item to the palette's "Top result" band when the
-  // user's query unambiguously points at the item. Word-level prefix match is
-  // the sweet spot: strict enough to avoid promoting weak matches, loose
-  // enough to handle compound queries ("auto-classification") and prefixes
-  // ("album" → "Albums"). Rejects queries shorter than 3 chars and words
-  // shorter than 3 chars to avoid promoting on a single keystroke.
+  // user's query unambiguously points at the item. The gate is deliberately
+  // narrow, because promotion also suppresses the free-text "search for …" row:
+  // a query word must all but spell out a label word (one untyped character of
+  // slack, so "album" → "Albums" still lands), and every query word must match,
+  // so a sentence can never be promoted by one incidental collision.
 
   it('returns true on an exact case-insensitive match', () => {
     expect(isAlmostExactNavMatch('people', 'People')).toBe(true);
     expect(isAlmostExactNavMatch('PHOTOS', 'photos')).toBe(true);
   });
 
-  it('returns true when the label starts with the query (prefix match)', () => {
+  it('returns true when the query is one character short of the label word', () => {
     expect(isAlmostExactNavMatch('album', 'Albums')).toBe(true);
-    expect(isAlmostExactNavMatch('classif', 'Classification Settings')).toBe(true);
+  });
+
+  it('rejects a partial prefix that leaves more than one character untyped', () => {
+    expect(isAlmostExactNavMatch('classif', 'Classification Settings')).toBe(false);
   });
 
   it('returns true when a whole word in the label starts with the query', () => {

--- a/web/src/lib/managers/navigation-items.ts
+++ b/web/src/lib/managers/navigation-items.ts
@@ -256,15 +256,10 @@ const MIN_MATCH_LENGTH = 3;
  * "Top result" band above photos/places/etc. when the query unambiguously
  * points at its label.
  *
- * Rule: after case-folding and splitting both sides on non-alphanumerics, at
- * least one query word ≥ 3 chars must be a prefix of some label word. The
- * length floor keeps single-letter queries from promoting the first match in
- * the catalog, and working at word granularity lets compound queries like
- * `auto-classification` still promote `Classification Settings` by matching
- * on the second query word.
- *
- * Only the label is inspected, not the description — the description is
- * richer and would promote items the user did not visually intend to pick.
+ * See {@link isAlmostExactWordMatch} for the rule. The 3-char floor keeps
+ * single keystrokes from promoting the first match in the catalog, while
+ * working at word granularity lets compound queries like `auto-classification`
+ * still promote `Classification Settings` on their second token.
  */
 export function isAlmostExactNavMatch(query: string, label: string): boolean {
   return isAlmostExactWordMatch(query, label, MIN_MATCH_LENGTH);


### PR DESCRIPTION
## Problem

Searching for anything containing the word **"the"** auto-promoted the Theme command / Theme Settings to the palette's "Top result" slot.

The almost-exact gate in `cmdk-match.ts` accepted a plain word prefix, so `'theme'.startsWith('the')` matched. Promotion also **suppresses the synthetic free-text row** (`global-search-manager.svelte.ts:2108`), so Enter toggled the theme instead of running the search — making it impossible to smart-search for anything containing "the".

It was broader than Theme: command labels carry other common words (`this`, `photos`), so `photos of the beach at sunset` also promoted *"Add photos to this space"*.

## Fix

Two gates, both of which must hold:

1. **Close prefix** — a token must spell a label word out to within one untyped character. `them` → Theme ✓, `the` → Theme ✗. Singular/plural typing still works (`album` → Albums, `tag` → Tags).
2. **Every word matches** — each whitespace-separated query word carrying a token ≥ the length floor must match some label word. A sentence can never be promoted by one incidental collision, while `run face detection` still is.

Query words split on whitespace but match on their alphanumeric sub-tokens, so `auto-classification` stays one word and still promotes `Classification Settings` via its second token.

| Query | Before | After |
|---|---|---|
| `theme` | ✓ Theme | ✓ Theme |
| `them` | ✓ Theme | ✓ Theme |
| `the` | ✓ Theme | ✗ searches |
| `the beach at sunset` | ✓ Theme | ✗ searches |
| `photos of the beach` | ✓ Add photos to this space | ✗ searches |
| `run face detection` | ✓ | ✓ |
| `auto-classification` | ✓ Classification Settings | ✓ Classification Settings |

## Second bug fixed

The stricter gate exposed a latent top-slot bug. When the query grows by one more character, the promoted row is re-created and cmdk transiently clears its selection — which the auto-select effect misread as a **user dismissal** and then permanently refused to re-arm.

It was masked before because promotion turned on early enough that the stray dismissal landed on a non-final keystroke and self-healed. With the stricter gate, typing `theme` ended with **no active row and Enter did nothing**. A genuine dismissal cannot change the token, so it's only treated as one when the token is unchanged. The existing "does not steal selection back from a real row" test still passes unmodified.

## Notes for review

- **Two existing assertions were flipped**: `'upl'` → Upload files and `'classif'` → Classification Settings encoded the old loose-prefix behaviour and now assert rejection. This is the deliberate consequence of the one-untyped-character rule.
- **Two component tests adjusted for test-env artifacts, not product behaviour**: `svelte-i18n` is uninitialised in that spec so labels render as raw i18n keys (`cmdk_cmd_selection_delete_label` contains "delete" but not "selected"); and the nav section wrapper's `out:fade` outro never completes under happy-dom, leaving a ghost row when typing character by character.

## Testing

Built with TDD — every test was watched fail first (including reverting `cmdk-match.ts` via stash to confirm the manager-level regression test went red against the old code).

- Full web unit suite: **286 files passed, 3763 tests passed, 0 failures** (baseline 3749 — 14 new tests)
- `tsc --noEmit` exit 0 · `eslint` exit 0 (only pre-existing Tailwind warnings) · `prettier --check` clean
- `svelte-check`: 40 pre-existing errors repo-wide, none in touched files
- E2E specs use `theme` and `auto-classification`, both still exact matches