### PR TITLE
fix(schema): realign declarative schema with shipped migrations (kills schema drift)

### DIFF
--- a/scripts/revert-to-immich.sql
+++ b/scripts/revert-to-immich.sql
@@ -385,6 +385,7 @@ DELETE FROM "kysely_migrations"
    '1783100000000-AddAlbumSpaceAssetSyncAndAudit',
    '1783628194057-DisablePostgresJit',
    '1783700000000-FixSharedSpaceMemberJoinGrantCreateId',
+   '1784800000000-RepairSharedSpaceAlbumGrantDrift',
 
    -- Build-time compatibility alias (server/bin/sync-gallery-migrations.mjs).
    -- Gallery's postbuild records ChangeDurationToInteger under BOTH its current

--- a/server/src/schema/functions.ts
+++ b/server/src/schema/functions.ts
@@ -684,6 +684,13 @@ export const shared_space_album_after_insert_user = registerFunction({
 // When a user joins a space (shared_space_member INSERT), grant
 // shared_space_album_user for every album already linked to that space and
 // bump album.updateId so AlbumSync re-delivers those album metadata rows.
+//
+// Refresh createId on conflict (#752 launch review F-A, migration 1783700000000): a re-added
+// member whose grant SURVIVED removal (album_user access or a second co-linking space) kept the
+// original createId, so the grant-keyed per-album backfill never re-fired and contributions made
+// during the absence were permanently undeliverable to that member's devices. Mirror of
+// shared_space_album_after_insert_user above. Keep byte-identical to that migration's DDL —
+// migration-override-parity.spec.ts pins it.
 export const shared_space_member_after_insert_album = registerFunction({
   name: 'shared_space_member_after_insert_album',
   returnType: 'TRIGGER',
@@ -694,7 +701,8 @@ export const shared_space_member_after_insert_album = registerFunction({
       SELECT DISTINCT ir."userId", ssa."albumId"
       FROM inserted_rows ir
       INNER JOIN shared_space_album ssa ON ssa."spaceId" = ir."spaceId"
-      ON CONFLICT DO NOTHING;
+      ON CONFLICT ("userId", "albumId")
+      DO UPDATE SET "createId" = immich_uuid_v7(), "createdAt" = now();
 
       UPDATE album
       SET "updatedAt" = clock_timestamp(), "updateId" = immich_uuid_v7(clock_timestamp())
@@ -789,6 +797,28 @@ export const album_soft_delete_shared_space_album = registerFunction({
         WHERE o."deletedAt" IS NOT NULL AND n."deletedAt" IS NULL
       );
 
+      RETURN NULL;
+    END`,
+});
+
+// --- gallery-fork: album_space_asset delete-audit (#764) ---
+//
+// Tombstones every deleted cross-owner contribution — explicit removal
+// (AlbumService.removeAssets) AND every FK cascade (asset/album/space delete) — driving
+// SharedSpaceAlbumToAssetSync's delete stream. Statement-level AFTER DELETE so cascades are
+// captured too; see AlbumSpaceAssetAuditTable.
+//
+// Created by migration 1783100000000; registered here so `migrations:generate` / schema-check
+// see a declarative counterpart. Keep byte-identical to that migration's DDL —
+// migration-override-parity.spec.ts pins it.
+export const album_space_asset_delete_audit = registerFunction({
+  name: 'album_space_asset_delete_audit',
+  returnType: 'TRIGGER',
+  language: 'PLPGSQL',
+  body: `
+    BEGIN
+      INSERT INTO album_space_asset_audit ("albumId", "assetId")
+      SELECT "albumId", "assetId" FROM "old";
       RETURN NULL;
     END`,
 });

--- a/server/src/schema/migration-override-parity.spec.ts
+++ b/server/src/schema/migration-override-parity.spec.ts
@@ -28,14 +28,20 @@ vi.mock('kysely', async () => {
   return { ...actual, sql: fakeSql };
 });
 
-import { album_soft_delete_shared_space_album } from 'src/schema/functions';
+import {
+  album_soft_delete_shared_space_album,
+  album_space_asset_delete_audit,
+  shared_space_member_after_insert_album,
+} from 'src/schema/functions';
 // Static import (not dynamic `import()`): tsc's node16/nodenext resolution can't resolve a
 // `src/`-aliased specifier inside a dynamic import expression (TS2307), unlike a static
 // import. vitest hoists `vi.mock('kysely', ...)` above every import in this file regardless
 // of source position (same pattern as composite-migration-provider.spec.ts), so the mock is
 // already installed by the time this migration module's top-level `import { sql } from
 // 'kysely'` resolves.
-import { up } from 'src/schema/migrations-gallery/1782050000000-AddAlbumSoftDeleteSharedSpaceAlbumTrigger';
+import { up as upAlbumSoftDelete } from 'src/schema/migrations-gallery/1782050000000-AddAlbumSoftDeleteSharedSpaceAlbumTrigger';
+import { up as upAlbumSpaceAssetSyncAndAudit } from 'src/schema/migrations-gallery/1783100000000-AddAlbumSpaceAssetSyncAndAudit';
+import { up as upMemberJoinGrantCreateId } from 'src/schema/migrations-gallery/1783700000000-FixSharedSpaceMemberJoinGrantCreateId';
 
 describe('1782050000000-AddAlbumSoftDeleteSharedSpaceAlbumTrigger override parity', () => {
   beforeEach(() => {
@@ -43,7 +49,7 @@ describe('1782050000000-AddAlbumSoftDeleteSharedSpaceAlbumTrigger override parit
   });
 
   it('executes and overrides the function with DDL byte-identical to functions.ts', async () => {
-    await up({} as any);
+    await upAlbumSoftDelete({} as any);
 
     const [executedFunctionDdl, , functionOverrideInsert] = capturedSql;
 
@@ -56,5 +62,62 @@ describe('1782050000000-AddAlbumSoftDeleteSharedSpaceAlbumTrigger override parit
       functionOverrideInsert.match(/VALUES \('function_album_soft_delete_shared_space_album', '(.+)'::jsonb\)/s)![1],
     ) as { type: string; name: string; sql: string };
     expect(overrideValue.sql).toBe(album_soft_delete_shared_space_album.expression);
+  });
+});
+
+// This migration REPLACED the body registered in functions.ts (ON CONFLICT DO NOTHING ->
+// DO UPDATE SET createId/createdAt, fixing #752 review F-A: a re-added member whose grant
+// survived removal kept its original createId, so the grant-keyed backfill never re-fired and
+// contributions made during the absence stayed undeliverable). Its sibling 1782100000000 updated
+// functions.ts to match; this one did not, so every DB that ran it reports FunctionCreate +
+// OverrideUpdate forever — and `migrations:generate` would emit a migration REVERTING the fix.
+describe('1783700000000-FixSharedSpaceMemberJoinGrantCreateId override parity', () => {
+  beforeEach(() => {
+    capturedSql.length = 0;
+  });
+
+  it('executes and overrides the function with DDL byte-identical to functions.ts', async () => {
+    await upMemberJoinGrantCreateId({} as any);
+
+    const [executedFunctionDdl, functionOverrideUpdate] = capturedSql;
+
+    expect(executedFunctionDdl).toBe(shared_space_member_after_insert_album.expression);
+
+    const overrideValue = JSON.parse(functionOverrideUpdate.match(/SET "value" = '(.+)'::jsonb/s)![1]) as {
+      type: string;
+      name: string;
+      sql: string;
+    };
+    expect(overrideValue.sql).toBe(shared_space_member_after_insert_album.expression);
+  });
+});
+
+// This migration created album_space_asset_delete_audit (function + statement AFTER DELETE
+// trigger) but nothing was ever registered in functions.ts / on AlbumSpaceAssetTable, so
+// schema-check reported FunctionDrop + two OverrideDrops on every DB that ran it. The generated
+// `DROP FUNCTION` can't even execute (the trigger depends on it, and no DROP TRIGGER is emitted);
+// forcing it with CASCADE would silently break #764's sync delete stream.
+describe('1783100000000-AddAlbumSpaceAssetSyncAndAudit override parity', () => {
+  beforeEach(() => {
+    capturedSql.length = 0;
+  });
+
+  it('executes and overrides the delete-audit function with DDL byte-identical to functions.ts', async () => {
+    await upAlbumSpaceAssetSyncAndAudit({} as any);
+
+    // Located by content rather than index — this migration also emits the sync columns, the
+    // audit table and four indexes, and that ordering is not what this test is pinning.
+    const executedFunctionDdl = capturedSql.find((s) =>
+      s.startsWith('CREATE OR REPLACE FUNCTION album_space_asset_delete_audit()'),
+    );
+    expect(executedFunctionDdl).toBe(album_space_asset_delete_audit.expression);
+
+    const functionOverrideInsert = capturedSql.find((s) =>
+      s.includes(`VALUES ('function_album_space_asset_delete_audit'`),
+    )!;
+    const overrideValue = JSON.parse(
+      functionOverrideInsert.match(/VALUES \('function_album_space_asset_delete_audit', '(.+)'::jsonb\)/s)![1],
+    ) as { type: string; name: string; sql: string };
+    expect(overrideValue.sql).toBe(album_space_asset_delete_audit.expression);
   });
 });

--- a/server/src/schema/migration-override-parity.spec.ts
+++ b/server/src/schema/migration-override-parity.spec.ts
@@ -42,6 +42,7 @@ import {
 import { up as upAlbumSoftDelete } from 'src/schema/migrations-gallery/1782050000000-AddAlbumSoftDeleteSharedSpaceAlbumTrigger';
 import { up as upAlbumSpaceAssetSyncAndAudit } from 'src/schema/migrations-gallery/1783100000000-AddAlbumSpaceAssetSyncAndAudit';
 import { up as upMemberJoinGrantCreateId } from 'src/schema/migrations-gallery/1783700000000-FixSharedSpaceMemberJoinGrantCreateId';
+import { up as upRepairDrift } from 'src/schema/migrations-gallery/1784800000000-RepairSharedSpaceAlbumGrantDrift';
 
 describe('1782050000000-AddAlbumSoftDeleteSharedSpaceAlbumTrigger override parity', () => {
   beforeEach(() => {
@@ -154,5 +155,71 @@ describe('1783100000000-AddAlbumSpaceAssetSyncAndAudit override parity', () => {
     expect(executedTriggerDdl).toContain('REFERENCING OLD TABLE AS "old"');
     expect(executedTriggerDdl).toContain('FOR EACH STATEMENT');
     expect(executedTriggerDdl).not.toContain('WHEN (');
+  });
+});
+
+// The repair migration re-asserts all three objects for v5.2.0-rc.0 installs whose admin acted on
+// the (wrong-way) drift advice. Because it writes migration_overrides rows, its DDL must match
+// functions.ts byte-for-byte too — otherwise the repair would itself introduce fresh drift.
+describe('1784800000000-RepairSharedSpaceAlbumGrantDrift override parity', () => {
+  beforeEach(() => {
+    capturedSql.length = 0;
+  });
+
+  it('re-asserts every object with DDL byte-identical to functions.ts', async () => {
+    await upRepairDrift({} as any);
+
+    const memberFn = findSql('the member-join CREATE FUNCTION', (s) =>
+      s.startsWith('CREATE OR REPLACE FUNCTION shared_space_member_after_insert_album()'),
+    );
+    expect(memberFn).toBe(shared_space_member_after_insert_album.expression);
+    expect(
+      parseOverrideValue(
+        findSql('the member-join override upsert', (s) =>
+          s.includes(`VALUES ('function_shared_space_member_after_insert_album'`),
+        ),
+      ).sql,
+    ).toBe(shared_space_member_after_insert_album.expression);
+
+    const auditFn = findSql('the delete-audit CREATE FUNCTION', (s) =>
+      s.startsWith('CREATE OR REPLACE FUNCTION album_space_asset_delete_audit()'),
+    );
+    expect(auditFn).toBe(album_space_asset_delete_audit.expression);
+    expect(
+      parseOverrideValue(
+        findSql('the delete-audit function override upsert', (s) =>
+          s.includes(`VALUES ('function_album_space_asset_delete_audit'`),
+        ),
+      ).sql,
+    ).toBe(album_space_asset_delete_audit.expression);
+
+    // The trigger is recreated too (a CASCADE drop takes it with the function).
+    const auditTrigger = findSql('the delete-audit CREATE TRIGGER', (s) =>
+      s.startsWith('CREATE OR REPLACE TRIGGER "album_space_asset_delete_audit"'),
+    );
+    expect(
+      parseOverrideValue(
+        findSql('the delete-audit trigger override upsert', (s) =>
+          s.includes(`VALUES ('trigger_album_space_asset_delete_audit'`),
+        ),
+      ).sql,
+    ).toBe(auditTrigger);
+  });
+
+  // Every statement must be safe to run against a database that is already correct.
+  it('is idempotent — only CREATE OR REPLACE and override upserts, never a DROP', async () => {
+    await upRepairDrift({} as any);
+
+    expect(capturedSql.length).toBeGreaterThan(0);
+    for (const statement of capturedSql) {
+      expect(statement).not.toMatch(/\bDROP\b/);
+      expect(statement).toMatch(/^(CREATE OR REPLACE|INSERT INTO "migration_overrides")/);
+    }
+    // Override writes must upsert, not blind-insert: a healthy DB already has these rows.
+    const overrideWrites = capturedSql.filter((s) => s.startsWith('INSERT INTO "migration_overrides"'));
+    expect(overrideWrites).toHaveLength(3);
+    for (const write of overrideWrites) {
+      expect(write).toContain('ON CONFLICT ("name") DO UPDATE SET "value" = EXCLUDED."value"');
+    }
   });
 });

--- a/server/src/schema/migration-override-parity.spec.ts
+++ b/server/src/schema/migration-override-parity.spec.ts
@@ -92,11 +92,28 @@ describe('1783700000000-FixSharedSpaceMemberJoinGrantCreateId override parity', 
   });
 });
 
+// Locate a statement by content rather than index — these migrations also emit columns, tables
+// and indexes whose ordering is not what these tests pin. Throws with the searched-for label
+// instead of letting a miss surface as `expect(undefined).toBe(<300 chars of DDL>)`.
+const findSql = (label: string, predicate: (statement: string) => boolean): string => {
+  const found = capturedSql.find((element) => predicate(element));
+  if (found === undefined) {
+    throw new Error(`no captured statement matched ${label} (captured ${capturedSql.length} statements)`);
+  }
+  return found;
+};
+
+const parseOverrideValue = (statement: string): { type: string; name: string; sql: string } =>
+  JSON.parse(statement.match(/'(\{.+\})'::jsonb/s)![1]) as { type: string; name: string; sql: string };
+
 // This migration created album_space_asset_delete_audit (function + statement AFTER DELETE
-// trigger) but nothing was ever registered in functions.ts / on AlbumSpaceAssetTable, so
-// schema-check reported FunctionDrop + two OverrideDrops on every DB that ran it. The generated
-// `DROP FUNCTION` can't even execute (the trigger depends on it, and no DROP TRIGGER is emitted);
-// forcing it with CASCADE would silently break #764's sync delete stream.
+// trigger) but nothing was ever registered in functions.ts / on AlbumSpaceAssetTable, so every DB
+// that ran it reported FunctionDrop + two OverrideDrops. The two tools differ in how dangerous
+// their suggested remediation is: `schema-check` (and the boot warning) pass
+// `triggers: { ignoreExtra: true }`, so they emit no DROP TRIGGER and the bare `DROP FUNCTION`
+// fails outright on the trigger dependency; `migrations:generate` passes no such option, emits
+// DROP TRIGGER *before* DROP FUNCTION, and would therefore execute cleanly — silently removing
+// #764's sync delete stream.
 describe('1783100000000-AddAlbumSpaceAssetSyncAndAudit override parity', () => {
   beforeEach(() => {
     capturedSql.length = 0;
@@ -105,19 +122,37 @@ describe('1783100000000-AddAlbumSpaceAssetSyncAndAudit override parity', () => {
   it('executes and overrides the delete-audit function with DDL byte-identical to functions.ts', async () => {
     await upAlbumSpaceAssetSyncAndAudit({} as any);
 
-    // Located by content rather than index — this migration also emits the sync columns, the
-    // audit table and four indexes, and that ordering is not what this test is pinning.
-    const executedFunctionDdl = capturedSql.find((s) =>
+    const executedFunctionDdl = findSql('the delete-audit CREATE FUNCTION', (s) =>
       s.startsWith('CREATE OR REPLACE FUNCTION album_space_asset_delete_audit()'),
     );
     expect(executedFunctionDdl).toBe(album_space_asset_delete_audit.expression);
 
-    const functionOverrideInsert = capturedSql.find((s) =>
+    const functionOverrideInsert = findSql('the delete-audit function override row', (s) =>
       s.includes(`VALUES ('function_album_space_asset_delete_audit'`),
-    )!;
-    const overrideValue = JSON.parse(
-      functionOverrideInsert.match(/VALUES \('function_album_space_asset_delete_audit', '(.+)'::jsonb\)/s)![1],
-    ) as { type: string; name: string; sql: string };
-    expect(overrideValue.sql).toBe(album_space_asset_delete_audit.expression);
+    );
+    expect(parseOverrideValue(functionOverrideInsert).sql).toBe(album_space_asset_delete_audit.expression);
+  });
+
+  // The trigger half. functions.ts has no counterpart to compare against (a trigger is declared by
+  // the @AfterDeleteTrigger decorator on AlbumSpaceAssetTable, and importing src/schema under this
+  // file's `kysely` mock blows up), so this pins the migration's two strings to each other and
+  // trigger-override-parity.spec.ts pins the decorator's generated DDL to the same text. Together
+  // they close the loop: decorator === executed DDL === override row.
+  it('stores a trigger override row byte-identical to the trigger it executes', async () => {
+    await upAlbumSpaceAssetSyncAndAudit({} as any);
+
+    const executedTriggerDdl = findSql('the delete-audit CREATE TRIGGER', (s) =>
+      s.startsWith('CREATE OR REPLACE TRIGGER "album_space_asset_delete_audit"'),
+    );
+    const triggerOverrideInsert = findSql('the delete-audit trigger override row', (s) =>
+      s.includes(`VALUES ('trigger_album_space_asset_delete_audit'`),
+    );
+
+    expect(parseOverrideValue(triggerOverrideInsert).sql).toBe(executedTriggerDdl);
+    // Guards the shape the decorator has to reproduce: statement scope, an OLD transition table,
+    // and NO `WHEN` guard (FK cascades run at trigger depth > 1 and must still be tombstoned).
+    expect(executedTriggerDdl).toContain('REFERENCING OLD TABLE AS "old"');
+    expect(executedTriggerDdl).toContain('FOR EACH STATEMENT');
+    expect(executedTriggerDdl).not.toContain('WHEN (');
   });
 });

--- a/server/src/schema/migrations-gallery/1784800000000-RepairSharedSpaceAlbumGrantDrift.ts
+++ b/server/src/schema/migrations-gallery/1784800000000-RepairSharedSpaceAlbumGrantDrift.ts
@@ -1,0 +1,83 @@
+import { Kysely, sql } from 'kysely';
+
+// Repairs databases damaged by acting on the schema-drift warning that v5.2.0-rc.0 emitted.
+//
+// rc.0 shipped migrations 1783100000000 + 1783700000000 without the matching declarations in
+// src/schema/functions.ts, so every rc.0 install booted with `Detected schema drift` and
+// `immich-admin schema-check` printed remediation SQL that pointed the WRONG way — it reverted
+// the #752 F-A fix and tried to drop #764's delete-audit. An admin who pasted that into psql
+// (which continues past errors by default) ends up with:
+//   - shared_space_member_after_insert_album back on `ON CONFLICT DO NOTHING` -> F-A returns:
+//     a re-added member whose grant survived removal keeps its original createId, the
+//     grant-keyed backfill never re-fires, and contributions made during their absence stay
+//     permanently undeliverable to that member's devices.
+//   - both album_space_asset_delete_audit override rows deleted (the DROP FUNCTION itself fails
+//     on the trigger dependency, so the function usually survives — but not if they used CASCADE).
+//
+// Fixing functions.ts alone cannot heal that: those migrations are already recorded as applied,
+// so nothing re-runs. Worse, the reverted function is INVISIBLE to drift detection, because
+// sql-tools compares migration_overrides rows rather than live function bodies — so if the paste
+// updated the function but not its override row, schema-check reports nothing at all.
+//
+// Every statement below is idempotent and asserts the state a healthy database already has, so
+// this is a no-op rewrite for anyone who never touched their schema. All DDL is byte-identical to
+// src/schema/functions.ts and the originating migrations — migration-override-parity.spec.ts and
+// trigger-override-parity.spec.ts pin it.
+export async function up(db: Kysely<any>): Promise<void> {
+  // --- #752 F-A: member-join album grant must refresh createId on conflict ---
+  await sql`CREATE OR REPLACE FUNCTION shared_space_member_after_insert_album()
+  RETURNS TRIGGER
+  LANGUAGE PLPGSQL
+  AS $$
+    BEGIN
+      INSERT INTO shared_space_album_user ("userId", "albumId")
+      SELECT DISTINCT ir."userId", ssa."albumId"
+      FROM inserted_rows ir
+      INNER JOIN shared_space_album ssa ON ssa."spaceId" = ir."spaceId"
+      ON CONFLICT ("userId", "albumId")
+      DO UPDATE SET "createId" = immich_uuid_v7(), "createdAt" = now();
+
+      UPDATE album
+      SET "updatedAt" = clock_timestamp(), "updateId" = immich_uuid_v7(clock_timestamp())
+      WHERE "id" IN (
+        SELECT DISTINCT ssa."albumId"
+        FROM inserted_rows ir
+        INNER JOIN shared_space_album ssa ON ssa."spaceId" = ir."spaceId"
+      );
+      RETURN NULL;
+    END
+  $$;`.execute(db);
+
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('function_shared_space_member_after_insert_album', '{"type":"function","name":"shared_space_member_after_insert_album","sql":"CREATE OR REPLACE FUNCTION shared_space_member_after_insert_album()\\n  RETURNS TRIGGER\\n  LANGUAGE PLPGSQL\\n  AS $$\\n    BEGIN\\n      INSERT INTO shared_space_album_user (\\"userId\\", \\"albumId\\")\\n      SELECT DISTINCT ir.\\"userId\\", ssa.\\"albumId\\"\\n      FROM inserted_rows ir\\n      INNER JOIN shared_space_album ssa ON ssa.\\"spaceId\\" = ir.\\"spaceId\\"\\n      ON CONFLICT (\\"userId\\", \\"albumId\\")\\n      DO UPDATE SET \\"createId\\" = immich_uuid_v7(), \\"createdAt\\" = now();\\n\\n      UPDATE album\\n      SET \\"updatedAt\\" = clock_timestamp(), \\"updateId\\" = immich_uuid_v7(clock_timestamp())\\n      WHERE \\"id\\" IN (\\n        SELECT DISTINCT ssa.\\"albumId\\"\\n        FROM inserted_rows ir\\n        INNER JOIN shared_space_album ssa ON ssa.\\"spaceId\\" = ir.\\"spaceId\\"\\n      );\\n      RETURN NULL;\\n    END\\n  $$;"}'::jsonb)
+  ON CONFLICT ("name") DO UPDATE SET "value" = EXCLUDED."value";`.execute(db);
+
+  // --- #764: cross-owner contribution delete-audit (function + statement AFTER DELETE trigger) ---
+  await sql`CREATE OR REPLACE FUNCTION album_space_asset_delete_audit()
+  RETURNS TRIGGER
+  LANGUAGE PLPGSQL
+  AS $$
+    BEGIN
+      INSERT INTO album_space_asset_audit ("albumId", "assetId")
+      SELECT "albumId", "assetId" FROM "old";
+      RETURN NULL;
+    END
+  $$;`.execute(db);
+
+  await sql`CREATE OR REPLACE TRIGGER "album_space_asset_delete_audit"
+  AFTER DELETE ON "album_space_asset"
+  REFERENCING OLD TABLE AS "old"
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION album_space_asset_delete_audit();`.execute(db);
+
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('function_album_space_asset_delete_audit', '{"type":"function","name":"album_space_asset_delete_audit","sql":"CREATE OR REPLACE FUNCTION album_space_asset_delete_audit()\\n  RETURNS TRIGGER\\n  LANGUAGE PLPGSQL\\n  AS $$\\n    BEGIN\\n      INSERT INTO album_space_asset_audit (\\"albumId\\", \\"assetId\\")\\n      SELECT \\"albumId\\", \\"assetId\\" FROM \\"old\\";\\n      RETURN NULL;\\n    END\\n  $$;"}'::jsonb)
+  ON CONFLICT ("name") DO UPDATE SET "value" = EXCLUDED."value";`.execute(db);
+
+  await sql`INSERT INTO "migration_overrides" ("name", "value") VALUES ('trigger_album_space_asset_delete_audit', '{"type":"trigger","name":"album_space_asset_delete_audit","sql":"CREATE OR REPLACE TRIGGER \\"album_space_asset_delete_audit\\"\\n  AFTER DELETE ON \\"album_space_asset\\"\\n  REFERENCING OLD TABLE AS \\"old\\"\\n  FOR EACH STATEMENT\\n  EXECUTE FUNCTION album_space_asset_delete_audit();"}'::jsonb)
+  ON CONFLICT ("name") DO UPDATE SET "value" = EXCLUDED."value";`.execute(db);
+}
+
+// Intentionally a no-op. This migration only re-asserts the state every other migration already
+// established; "undoing" it would mean deliberately restoring the reverted, broken definitions.
+export async function down(): Promise<void> {
+  // no-op
+}

--- a/server/src/schema/tables/album-space-asset.table.ts
+++ b/server/src/schema/tables/album-space-asset.table.ts
@@ -1,4 +1,5 @@
 import {
+  AfterDeleteTrigger,
   CreateDateColumn,
   ForeignKeyColumn,
   Generated,
@@ -8,6 +9,7 @@ import {
   UpdateDateColumn,
 } from '@immich/sql-tools';
 import { CreateIdColumn, UpdatedAtTrigger, UpdateIdColumn } from 'src/decorators';
+import { album_space_asset_delete_audit } from 'src/schema/functions';
 import { AlbumTable } from 'src/schema/tables/album.table';
 import { AssetTable } from 'src/schema/tables/asset.table';
 import { SharedSpaceTable } from 'src/schema/tables/shared-space.table';
@@ -26,6 +28,14 @@ import { UserTable } from 'src/schema/tables/user.table';
 // so a contribution re-appears on devices that purged it when its asset was un-hidden.
 @Table({ name: 'album_space_asset' })
 @UpdatedAtTrigger('album_space_asset_updatedAt')
+// No `when` guard (unlike album_asset's audit trigger): FK cascades from asset/album/space deletes
+// arrive at trigger depth > 1 and MUST still be tombstoned, or those contributions linger on
+// members' devices. Matches migration 1783100000000's DDL exactly.
+@AfterDeleteTrigger({
+  scope: 'statement',
+  function: album_space_asset_delete_audit,
+  referencingOldTableAs: 'old',
+})
 @Index({ name: 'album_space_asset_spaceId_idx', columns: ['spaceId'] })
 export class AlbumSpaceAssetTable {
   // index: false — albumId is the leading column of the composite PK, so a separate FK index is redundant.

--- a/server/src/schema/trigger-override-parity.spec.ts
+++ b/server/src/schema/trigger-override-parity.spec.ts
@@ -1,0 +1,59 @@
+import { schemaFromCode } from '@immich/sql-tools';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import 'src/schema';
+
+// Companion to migration-override-parity.spec.ts, which pins FUNCTION DDL. A trigger has no
+// `registerFunction(...).expression` to compare against — it is generated from a decorator
+// (`@AfterDeleteTrigger` on AlbumSpaceAssetTable) by sql-tools' asTriggerCreate. sql-tools compares
+// `migration_overrides` rows by exact string equality, so if the decorator's options ever stop
+// reproducing the DDL its migration executed (scope, transition table, a stray `when`), every
+// deployed DB drifts again — and nothing else in the suite would notice.
+//
+// This lives in its own file because migration-override-parity.spec.ts mocks `kysely`'s `sql` tag,
+// under which importing `src/schema` throws.
+//
+// Same options as DatabaseRepository.getSchemaDrift so the generated text matches what actually
+// runs against a database.
+const overrides = schemaFromCode({ overrides: true, namingStrategy: 'default' }).overrides;
+
+const overrideSql = (name: string): string => {
+  const override = overrides.find((element) => element.name === name);
+  if (!override) {
+    throw new Error(`no override named ${name} was generated from the declarative schema`);
+  }
+  return (override.value as { sql: string }).sql;
+};
+
+const migrationSource = (filename: string): string =>
+  readFileSync(join(process.cwd(), 'src/schema/migrations-gallery', filename), 'utf8');
+
+describe('album_space_asset_delete_audit trigger parity (#764, migration 1783100000000)', () => {
+  it('generates trigger DDL byte-identical to the statement the migration executed', () => {
+    // Verbatim from 1783100000000-AddAlbumSpaceAssetSyncAndAudit.ts. Asserted against the migration
+    // source below too, so this literal cannot silently rot away from it.
+    const expected = `CREATE OR REPLACE TRIGGER "album_space_asset_delete_audit"
+  AFTER DELETE ON "album_space_asset"
+  REFERENCING OLD TABLE AS "old"
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION album_space_asset_delete_audit();`;
+
+    expect(overrideSql('trigger_album_space_asset_delete_audit')).toBe(expected);
+
+    // The migration executes this as a plain (unescaped) template literal, so the source contains
+    // the text verbatim — no template-literal unescaping to hand-simulate.
+    expect(migrationSource('1783100000000-AddAlbumSpaceAssetSyncAndAudit.ts')).toContain(expected);
+  });
+
+  // The pre-existing updatedAt trigger on the same table, as a control: proves the assertion above
+  // is exercising real generation rather than an accident of how this one trigger is declared.
+  it('keeps the sibling updatedAt trigger on the same table in parity', () => {
+    const expected = `CREATE OR REPLACE TRIGGER "album_space_asset_updatedAt"
+  BEFORE UPDATE ON "album_space_asset"
+  FOR EACH ROW
+  EXECUTE FUNCTION updated_at();`;
+
+    expect(overrideSql('trigger_album_space_asset_updatedAt')).toBe(expected);
+    expect(migrationSource('1783100000000-AddAlbumSpaceAssetSyncAndAudit.ts')).toContain(expected);
+  });
+});


### PR DESCRIPTION
## The problem

Every Gallery instance on v5.2.0-rc.0 logs `Detected schema drift` on boot. `immich-admin schema-check` says **"Migrations are up to date"** and then reports five differences:

```
- FunctionCreate: "shared_space_member_after_insert_album" is missing and needs to be created
- FunctionDrop:   "album_space_asset_delete_audit" exists but should be removed
- OverrideUpdate: "function_shared_space_member_after_insert_album" needs to be updated
- OverrideDrop:   "function_album_space_asset_delete_audit" is no longer needed
- OverrideDrop:   "trigger_album_space_asset_delete_audit" is no longer needed
```

**The databases are right on all five. `src/schema/` is what's stale.** Instances build their schema by running migrations; the declarative schema is only ever *read* — by `migrations:generate` and `schema-check` — so it can rot silently.

Confirmed live on **demo** and on the **personal** instance (both on `v5.2.0-rc.0`). Instances on `v5.1.1` and earlier are unaffected — they predate the two migrations involved. `release` and `v5` still point at v5.1.1, so only RC opt-ins are affected today; it would reach everyone the moment v5.2.0 ships.

## Two independent causes

**1. `shared_space_member_after_insert_album` — body never back-ported**

`1783700000000-FixSharedSpaceMemberJoinGrantCreateId` changed `ON CONFLICT DO NOTHING` to `DO UPDATE SET "createId" = immich_uuid_v7(), "createdAt" = now()`. That is the #752 launch-review **F-A** fix: a re-added member whose `shared_space_album_user` grant *survived* removal kept its original `createId`, so the grant-keyed per-album backfill never re-fired and contributions made during their absence were permanently undeliverable to their devices.

That migration calls itself the "mirror of 1782100000000". The mirror **did** update `functions.ts`; this one didn't. That asymmetry is why only one of the pair drifts.

**2. `album_space_asset_delete_audit` — never declared at all**

`1783100000000-AddAlbumSpaceAssetSyncAndAudit` (#764) created the function, the statement-level `AFTER DELETE` trigger and both `migration_overrides` rows, but nothing was added to `functions.ts` and no trigger was declared on `AlbumSpaceAssetTable`.

## Why this needs a repair migration, not just a source fix

The remediation the tooling prints points the **wrong way** — it reverts the F-A fix and drops #764's delete-audit. Since rc.0 is published, an admin may already have acted on it. Pasting `schema-check`'s SQL into `psql` (which continues past errors by default) leaves:

- `shared_space_member_after_insert_album` reverted → **F-A silently returns**
- both audit override rows deleted (the `DROP FUNCTION` fails on the trigger dependency — unless they used `CASCADE`, which takes the trigger too)

Realigning `functions.ts` **cannot heal that**: `1783700000000` is already recorded as applied, so nothing re-runs. Worse, the reverted function is **invisible to drift detection** — sql-tools compares `migration_overrides` rows, not live function bodies, so a paste that updated the function but not its override row reports nothing at all.

(For the record: `schema-check` and the boot warning pass `triggers: { ignoreExtra: true }` so their `DROP FUNCTION` fails outright; `migrations:generate` emits `DROP TRIGGER` first and would execute cleanly. The latter is the dangerous one.)

## The fix

**Source** — stop the declarative schema disagreeing with shipped migrations:
- `functions.ts`: `shared_space_member_after_insert_album` body now matches migration `1783700000000`.
- `functions.ts`: register `album_space_asset_delete_audit`.
- `album-space-asset.table.ts`: declare the `@AfterDeleteTrigger` (statement scope, `REFERENCING OLD TABLE AS "old"`, **no** `when` guard — FK cascades run at trigger depth > 1 and must still be tombstoned, which `sync.repository.ts` explicitly relies on).

**Repair migration** `1784800000000-RepairSharedSpaceAlbumGrantDrift` — idempotently re-asserts all three objects (`CREATE OR REPLACE` for both functions and the trigger, override upserts via `ON CONFLICT DO UPDATE`). **No `DROP` anywhere**, so it is a no-op rewrite for anyone who never touched their schema.

## Verification

**Damage/repair matrix** — throwaway Postgres seeded by `migrations:run`, every state ending `No changes detected`:

| Database state | Before repair | After repair |
|---|---|---|
| Partially damaged (realistic paste) | createId **reverted**, 2 override rows gone | restored, trigger intact |
| CASCADE-damaged (function *and* trigger gone) | both gone | both recreated |
| Fresh install | — | no-op, correct state |
| Already healthy | — | no-op |

Also confirmed the source fix **alone** leaves a damaged DB unhealed — which is what motivated the migration.

**Upgrade paths** — every state a real user can be in, all **0 drift**: fresh install; from before `1783100000000`; between the two migrations; already on latest; migrating in from upstream Immich. Control on stock `main`: **5 drift items**, and `migrations:generate` writes a destructive migration.

**Live** — deployed to staging as `schema-drift-rc1`. Staging was on `v5.1.1`, which predates both migrations, so the deploy ran them for the first time on a real populated database — the genuine "user upgrading" path. Result: `No schema drift detected` on both Api and Microservices workers, `schema-check` clean, DB verified to hold the createId fix and the audit function + trigger.

**Nothing is ever applied from the declarative schema.** Every `schemaFromCode()` consumer was traced and is read-only; the only declarative→DDL path is `migrations:generate`, which writes a *file*.

**Byte-identity**, driven through the real generators: function `expression` === executed DDL === override row, for every object including the trigger and the repair migration. A whole-schema replay of all migrations folded into a `migration_overrides` map gives **142 rows on both sides, 0 differences** — these were the only drifting objects.

**Tests.** `migration-override-parity.spec.ts` now covers all four relevant migrations (it previously covered one, which is how these slipped through); `trigger-override-parity.spec.ts` pins the DDL the decorator generates; and the repair migration has an idempotence test asserting it only ever emits `CREATE OR REPLACE` / upserts and never a `DROP`. Every new case was confirmed to fail without its fix — the trigger case was mutation-tested (adding a `WHEN` guard, `FOR EACH ROW`, or dropping `REFERENCING OLD TABLE` each fail it).

Server unit suite: 5105 passed, 0 failed. `tsc`, eslint `--max-warnings 0`, prettier clean.

## Notes for the reviewer

- The parity specs are the real guard; the source edits are mechanical once they're in place.
- `revert-to-immich.sql` gained the new migration in its step-8 delete block — `revert-to-immich.spec.ts` guards this and caught the omission.
- **Follow-up worth considering:** the parity spec is a hand-maintained per-migration allowlist — 4 of 25 fork migrations that write override rows are covered. A generic version is DB-free and was proven to work during review: replay every migration's `up()` with a mocked `sql` tag, fold the `migration_overrides` statements into a map, and assert it equals `schemaFromCode({ overrides: true, namingStrategy: 'default' }).overrides`. One test that can never go stale. (Caveats: both migration folders must be replayed — 21 upstream migrations also write override rows — and three upstream migrations need a `.as()` on the mock plus a statement cap.)