### PR TITLE
fix(release): exclude prereleases when resolving the previous release tag

### DIFF
--- a/.github/workflows/gallery-release-server-only.yml
+++ b/.github/workflows/gallery-release-server-only.yml
@@ -511,9 +511,23 @@ jobs:
 
           upstream_version=$(jq -r '.upstream.version' branding/config.json)
 
-          # Find the most recent previous release for the APK link. We just
-          # pushed $VERSION, so skip it in the sorted list.
-          prev_tag=$(git tag --list 'v*.*.*' --sort=-version:refname | grep -Fvx "$VERSION" | head -n1)
+          # Find the most recent previous release to diff against. We just pushed
+          # $VERSION, so skip it in the sorted list.
+          #
+          # Prereleases MUST be excluded. Two reasons, and both bite:
+          #   1. `--sort=version:refname` has no idea `-rc.0` means "earlier"
+          #      unless `versionsort.suffix` is configured, so it sorts
+          #      `v5.2.0-rc.0` ABOVE `v5.2.0` and the RC wins `head -n1`.
+          #   2. Even sorted correctly, an RC is not a shipped release — the
+          #      `shipped` subtraction below would treat everything already in
+          #      the RC as "announced in the previous release" and silently drop
+          #      it from these notes.
+          # v5.2.0 shipped with 6 of its 18 commits listed because of this.
+          prev_tag=$(git tag --list 'v*.*.*' --sort=-version:refname \
+            | grep -Ev -- '-(rc|alpha|beta)' \
+            | grep -Fvx "$VERSION" \
+            | head -n1)
+          echo "Previous release: ${prev_tag:-<none>}"
 
           notes="Based on [Immich v${upstream_version}](https://github.com/immich-app/immich/releases/tag/v${upstream_version})"
 
@@ -561,6 +575,30 @@ jobs:
 
             highlights=$(echo "$gallery_all" | grep -E '^(feat|fix|perf)' | sed 's/^/- /' || true)
             other=$(echo "$gallery_all" | grep -vE '^(feat|fix|perf)' | sed 's/^/- /' || true)
+
+            # Guardrail. The counts legitimately differ from the raw range (an
+            # upstream rebase makes `shipped` drop commits that already shipped;
+            # reverts cancel out), so this can't assert equality — but listing
+            # NOTHING for a non-empty range is always a bug, and that is exactly
+            # how the v5.2.0 notes failed. Make the arithmetic visible in the run
+            # summary so a partial drop is noticeable, and hard-fail on a total
+            # drop rather than publishing empty notes.
+            raw_count=$(git rev-list --count --no-merges "${prev_tag}..${SHA}")
+            listed_count=$(echo "$gallery_all" | grep -c . || true)
+            {
+              echo "### Release notes"
+              echo ""
+              echo "| | |"
+              echo "|---|---|"
+              echo "| Previous release | \`${prev_tag}\` |"
+              echo "| Commits in \`${prev_tag}..${VERSION}\` | ${raw_count} |"
+              echo "| Gallery entries listed | ${listed_count} |"
+            } >> "$GITHUB_STEP_SUMMARY"
+
+            if [[ "$raw_count" -gt 0 && "$listed_count" -eq 0 ]]; then
+              echo "::error::Release notes would list 0 Gallery changes for ${raw_count} commits in ${prev_tag}..${SHA}. Refusing to publish empty notes." >&2
+              exit 1
+            fi
 
             # Gallery's own changes lead; upstream's go in a collapsed section.
             if [[ -n "$highlights" ]]; then


### PR DESCRIPTION
## The bug

v5.2.0 published with **6 of its 18 commits** listed in the release notes. The shared-space albums feature (#752) was among the missing 12 — I've patched that release's notes by hand, but the generator would drop commits again on the next release preceded by an RC.

## Root cause

`gallery-release-server-only.yml` resolved the previous release with:

```bash
prev_tag=$(git tag --list 'v*.*.*' --sort=-version:refname | grep -Fvx "$VERSION" | head -n1)
```

Two problems compound:

1. `v*.*.*` matches prerelease tags — `v5.2.0-rc.0` glob-matches fine.
2. `--sort=version:refname` sorts `v5.2.0-rc.0` **above** `v5.2.0`. Without `versionsort.suffix` configured, git has no idea `-rc.0` means "earlier". Reproducible on this repo today:

```console
$ git tag --list 'v*.*.*' --sort=-version:refname | head -3
v5.2.0-rc.0
v5.2.0
v5.1.1
```

So after `grep -Fvx v5.2.0` removes the release itself, `prev_tag` = `v5.2.0-rc.0`. The `shipped` subtraction then treats everything already in the RC as "announced in the previous release" and drops it. `v5.2.0-rc.0` points at `dcd2924` — the albums commit — so it became the range's base and was excluded outright.

## The fix

Filter prereleases out, so the diff is always against the last **stable** release. An RC is not a shipped release; its contents still need announcing.

Verified against the real tag list:

| `$VERSION` | old `prev_tag` | new `prev_tag` |
|---|---|---|
| `v5.2.0` | `v5.2.0-rc.0` ❌ | `v5.1.1` ✅ |
| `v5.3.0` | `v5.2.0` | `v5.2.0` |
| `v5.3.0-rc.0` | `v5.2.0` | `v5.2.0` |

Re-running the generator over v5.2.0 with the fix produces all 18 commits (15 feat/fix/perf + 3 CI), matching `git rev-list --count --no-merges v5.1.1..v5.2.0` = 18.

## Guardrail

The listed count *can't* be asserted equal to the raw range — an upstream rebase legitimately drops already-shipped commits via `shipped`, and reverts cancel out. But listing **zero** entries for a non-empty range is always a bug, which is the failure mode here in its extreme form.

So: print the arithmetic (`prev_tag`, raw count, listed count) to the job summary so a *partial* drop is noticeable, and hard-fail rather than publish empty notes.

This is the second time notes have silently lost fork commits — the earlier one was the upstream/fork `if/elif` split — hence making the counts visible rather than only guarding the total-loss case.

## Testing

- Workflow YAML parses (all 10 jobs intact).
- `prev_tag` resolution verified against the live tag list (table above).
- Guardrail arithmetic reproduces 18/18 on the v5.2.0 range.
- Empty-input path returns `0` without tripping `set -euo pipefail`.

Not exercised end-to-end in CI, since the `tag` job only runs during a real release.
