### PR TITLE
[docs] Update of the manual "Switching Back to Immich"

### DIFF
--- a/docs/docs/guides/switch-back-to-immich.md
+++ b/docs/docs/guides/switch-back-to-immich.md
@@ -73,15 +73,28 @@ Notes:
 
 Edit your `docker-compose.yml` and replace every reference to the Gallery image with the upstream `immich-server` image. Pin a version close to the Immich release Gallery was last rebased from — you can find it in [`branding/config.json`](https://github.com/open-noodle/gallery/blob/main/branding/config.json) in the Gallery repository, under `upstream.version`.
 
-```yaml
+```yaml title="docker-compose.yml"
 services:
   immich-server:
-    image: ghcr.io/immich-app/immich-server:v2.7.5 # replace with the version matching your Gallery install
+    # image: ghcr.io/open-noodle/gallery-server:${IMMICH_VERSION:-release}
+    // highlight-next-line
+    image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
+...
+  immich-machine-learning:
+    #image: ghcr.io/open-noodle/gallery-ml:${IMMICH_VERSION:-release}
+    // highlight-next-line
+    image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}
 ```
 
 Upstream Immich uses the same [postgres image](https://github.com/immich-app/base-images) as Gallery, so no database image change is needed.
 
 If you set any Gallery-only environment variables, remove them from your `.env` file — upstream Immich will log warnings about unknown settings otherwise.
+
+```yaml title=".env"
+#IMMICH_VERSION=v5
+// highlight-next-line
+IMMICH_VERSION=v3
+```
 
 ## 6. Start the stack
 
@@ -96,7 +109,7 @@ Watch the server log. A successful boot ends with the usual Immich startup banne
 
 For transparency, here is what the cleanup script changes:
 
-- **Drops Gallery-only tables**: `shared_space*`, `library_user`, `library_audit`, `library_asset_audit`, `shared_space_library*`, `user_group`, `user_group_member`, `classification_category`, `classification_prompt_embedding`, `storage_migration_log`, `asset_duplicate_checksum`.
+- **Drops Gallery-only tables**: `shared_space*`, `album_space_asset*`, `library_user`, `library_audit`, `library_asset_audit`, `shared_space_library*`, `face_identity*`, `user_group`, `user_group_member`, `classification_category`, `classification_prompt_embedding`, `storage_migration_log`, `asset_duplicate_checksum`.
 - **Drops Gallery-added columns**: `person.type`, `person.species`, `asset_job_status.petsDetectedAt`, `asset_job_status.classifiedAt`, `library.createId`.
 - **Drops Gallery-only functions and triggers** that reference the dropped tables.
 - **Strips the `classification` key** out of the `system-config` row in `system_metadata`.


### PR DESCRIPTION
Now the guide is similar to "Migrating from upstream Immich":
- added mention of two images
- added version change in the ".env" file
- added two tables that are deleted upon return: `album_space_asset*` and `face_identity*`