### PR TITLE
fix(shared-space): make space-person creation idempotent to stop duplicate-key crashes

### DIFF
--- a/mobile/openapi/lib/model/job_name.dart
+++ b/mobile/openapi/lib/model/job_name.dart
@@ -107,6 +107,7 @@ class JobName {
   static const sharedSpaceBulkAddAssets = JobName._(r'SharedSpaceBulkAddAssets');
   static const sharedSpaceAlbumGrantReconcile = JobName._(r'SharedSpaceAlbumGrantReconcile');
   static const sharedSpaceAlbumGrantReconcileSweep = JobName._(r'SharedSpaceAlbumGrantReconcileSweep');
+  static const sharedSpaceIdentityReconciliationSweep = JobName._(r'SharedSpaceIdentityReconciliationSweep');
   static const assetClassifyQueueAll = JobName._(r'AssetClassifyQueueAll');
   static const assetClassify = JobName._(r'AssetClassify');
 
@@ -196,6 +197,7 @@ class JobName {
     sharedSpaceBulkAddAssets,
     sharedSpaceAlbumGrantReconcile,
     sharedSpaceAlbumGrantReconcileSweep,
+    sharedSpaceIdentityReconciliationSweep,
     assetClassifyQueueAll,
     assetClassify,
   ];
@@ -320,6 +322,7 @@ class JobNameTypeTransformer {
         case r'SharedSpaceBulkAddAssets': return JobName.sharedSpaceBulkAddAssets;
         case r'SharedSpaceAlbumGrantReconcile': return JobName.sharedSpaceAlbumGrantReconcile;
         case r'SharedSpaceAlbumGrantReconcileSweep': return JobName.sharedSpaceAlbumGrantReconcileSweep;
+        case r'SharedSpaceIdentityReconciliationSweep': return JobName.sharedSpaceIdentityReconciliationSweep;
         case r'AssetClassifyQueueAll': return JobName.assetClassifyQueueAll;
         case r'AssetClassify': return JobName.assetClassify;
         default:

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -25487,6 +25487,7 @@
           "SharedSpaceBulkAddAssets",
           "SharedSpaceAlbumGrantReconcile",
           "SharedSpaceAlbumGrantReconcileSweep",
+          "SharedSpaceIdentityReconciliationSweep",
           "AssetClassifyQueueAll",
           "AssetClassify"
         ],

--- a/packages/sdk/src/fetch-client.ts
+++ b/packages/sdk/src/fetch-client.ts
@@ -9723,6 +9723,7 @@ export enum JobName {
     SharedSpaceBulkAddAssets = "SharedSpaceBulkAddAssets",
     SharedSpaceAlbumGrantReconcile = "SharedSpaceAlbumGrantReconcile",
     SharedSpaceAlbumGrantReconcileSweep = "SharedSpaceAlbumGrantReconcileSweep",
+    SharedSpaceIdentityReconciliationSweep = "SharedSpaceIdentityReconciliationSweep",
     AssetClassifyQueueAll = "AssetClassifyQueueAll",
     AssetClassify = "AssetClassify"
 }

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -1015,6 +1015,11 @@ export enum JobName {
   // mechanism path-independent (covers M6 durability gaps, L7 residue, and cascade strands).
   SharedSpaceAlbumGrantReconcileSweep = 'SharedSpaceAlbumGrantReconcileSweep',
 
+  // Self-heal backstop: nightly re-queue of identity reconciliation for every face-enabled space,
+  // collapsing pre-fix duplicate people (a member's local person left unlinked from the space
+  // identity) without any user action.
+  SharedSpaceIdentityReconciliationSweep = 'SharedSpaceIdentityReconciliationSweep',
+
   // Classification
   AssetClassifyQueueAll = 'AssetClassifyQueueAll',
   AssetClassify = 'AssetClassify',

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -406,6 +406,7 @@ export enum SystemMetadataKey {
   License = 'license',
   IntegrityChecksumCheckpoint = 'integrity-checksum-checkpoint',
   ClassificationConfigState = 'classification-config-state',
+  SharedSpaceFaceJobCleanupState = 'shared-space-face-job-cleanup-state',
 }
 
 export enum UserMetadataKey {

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -2654,7 +2654,11 @@ export class FaceIdentityRepository {
           targetPersonId = existingPerson.id;
           didMutateSpacePerson = true;
         } else if (currentIdentityId) {
-          const createdPerson = await this.db
+          // Race-safe: a concurrent backfill/face-match pass may create this identity's space person
+          // between the getSpacePersonByIdentity lookup above and here. ON CONFLICT DO NOTHING lets
+          // the loser reuse the winner's row instead of crashing on the (spaceId, identityId) unique
+          // index.
+          const inserted = await this.db
             .insertInto('shared_space_person')
             .values({
               spaceId: person.spaceId,
@@ -2662,8 +2666,17 @@ export class FaceIdentityRepository {
               representativeFaceId: group.representativeFaceId,
               type: group.type,
             })
+            .onConflict((oc) => oc.columns(['spaceId', 'identityId']).where('identityId', 'is not', null).doNothing())
             .returning(['id'])
-            .executeTakeFirstOrThrow();
+            .executeTakeFirst();
+          const createdPerson =
+            inserted ??
+            (await this.db
+              .selectFrom('shared_space_person')
+              .select(['id'])
+              .where('spaceId', '=', person.spaceId)
+              .where('identityId', '=', group.identityId)
+              .executeTakeFirstOrThrow());
           targetPersonId = createdPerson.id;
           didMutateSpacePerson = true;
         } else {

--- a/server/src/repositories/job.repository.spec.ts
+++ b/server/src/repositories/job.repository.spec.ts
@@ -68,6 +68,8 @@ const setHandlers = (sut: JobRepository, jobs: JobName[]) => {
   ) as Record<JobName, { queueName: QueueName }>;
 };
 
+const failedJob = (id: string) => ({ id, remove: vi.fn().mockResolvedValue(void 0) });
+
 describe(JobRepository.name, () => {
   beforeEach(() => {
     setTimeoutMock.mockClear();
@@ -156,6 +158,44 @@ describe(JobRepository.name, () => {
 
       expect(removed).toEqual([]);
       expect(client.lrem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeFailedJobsByJobIdPrefix', () => {
+    it('removes only the failed jobs whose id matches a prefix and reports the count', async () => {
+      const { sut, queue } = setup();
+      const blocked = failedJob('shared-space-face-match/from-backfill/space-1/asset-1');
+      const reconcile = failedJob('space-identity-reconcile-space-1-all-members-all-people');
+      const unrelated = failedJob('face-identity-backfill/root');
+      const anonymous = { remove: vi.fn().mockResolvedValue(void 0) };
+      queue.getJobs.mockResolvedValueOnce([blocked, unrelated, reconcile, anonymous] as any);
+
+      const removed = await sut.removeFailedJobsByJobIdPrefix(QueueName.PeopleBackfill, [
+        'shared-space-face-match',
+        'space-identity-reconcile-',
+      ]);
+
+      expect(removed).toBe(2);
+      expect(queue.getJobs).toHaveBeenCalledWith(['failed'], 0, 999);
+      expect(blocked.remove).toHaveBeenCalled();
+      expect(reconcile.remove).toHaveBeenCalled();
+      expect(unrelated.remove).not.toHaveBeenCalled();
+    });
+
+    it('walks every page of the failed set before removing so shifting ranks cannot skip jobs', async () => {
+      const { sut, queue } = setup();
+      const firstPageMatch = failedJob('shared-space-face-match/space-1/asset-1');
+      const firstPage = [firstPageMatch, ...Array.from({ length: 999 }, (_, i) => failedJob(`unrelated-${i}`))];
+      const secondPageMatch = failedJob('shared-space-face-match/space-1/asset-2');
+      queue.getJobs.mockResolvedValueOnce(firstPage as any).mockResolvedValueOnce([secondPageMatch] as any);
+
+      const removed = await sut.removeFailedJobsByJobIdPrefix(QueueName.FacialRecognition, ['shared-space-face-match']);
+
+      expect(removed).toBe(2);
+      expect(queue.getJobs).toHaveBeenCalledWith(['failed'], 0, 999);
+      expect(queue.getJobs).toHaveBeenCalledWith(['failed'], 1000, 1999);
+      expect(firstPageMatch.remove).toHaveBeenCalled();
+      expect(secondPageMatch.remove).toHaveBeenCalled();
     });
   });
 

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -500,6 +500,11 @@ export class JobRepository {
         // harmless dedup, and removeOnFail keeps a hard failure from blocking the next run.
         return { jobId: 'space-album-grant-reconcile-sweep', removeOnComplete: true, removeOnFail: true };
       }
+      case JobName.SharedSpaceIdentityReconciliationSweep: {
+        // Single stable jobId — a nightly trigger while a previous sweep is still active dedups
+        // harmlessly, and removeOnFail keeps a hard failure from blocking the next run.
+        return { jobId: 'shared-space-identity-reconciliation-sweep', removeOnComplete: true, removeOnFail: true };
+      }
       case JobName.SharedSpaceFaceMatch: {
         const prefix =
           item.data.source === 'identity-backfill'

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -255,6 +255,31 @@ export class JobRepository {
     return removed;
   }
 
+  /**
+   * Removes failed jobs whose jobId starts with one of the given prefixes. Stable-jobId jobs that
+   * failed while `removeOnFail` was unset permanently occupy their dedup jobIds — BullMQ silently
+   * ignores any later add() with the same id, blocking every re-queue of that work. Collects all
+   * matches before removing anything: removal shifts the failed set's ranks, so a
+   * remove-while-paging walk would skip entries.
+   */
+  async removeFailedJobsByJobIdPrefix(name: QueueName, prefixes: string[]): Promise<number> {
+    const queue = this.getQueue(name);
+    const pageSize = 1000;
+    const matches = [];
+    for (let start = 0; ; start += pageSize) {
+      const jobs = await queue.getJobs(['failed'], start, start + pageSize - 1);
+      matches.push(...jobs.filter((job) => job?.id && prefixes.some((prefix) => job.id!.startsWith(prefix))));
+      if (jobs.length < pageSize) {
+        break;
+      }
+    }
+
+    for (const job of matches) {
+      await job.remove();
+    }
+    return matches.length;
+  }
+
   getJobCounts(name: QueueName): Promise<JobCounts> {
     return this.getQueue(name).getJobCounts(
       'active',

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -1102,6 +1102,15 @@ export class SharedSpaceRepository {
     return rows.map((row) => row.albumId);
   }
 
+  async getFaceRecognitionEnabledSpaceIds(): Promise<string[]> {
+    const rows = await this.db
+      .selectFrom('shared_space')
+      .select('id')
+      .where('faceRecognitionEnabled', '=', true)
+      .execute();
+    return rows.map((row) => row.id);
+  }
+
   // Album sync fan-out: used by the AlbumAssetsAdd/Remove handlers to find every space
   // a linked album feeds, with its face-recognition flag. Mirrors getSpacesLinkedToLibrary.
   @GenerateSql({ params: [DummyValue.UUID] })

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -2225,6 +2225,32 @@ export class SharedSpaceRepository {
     return this.db.insertInto('shared_space_person').values(values).returningAll().executeTakeFirstOrThrow();
   }
 
+  // Race-safe insert-or-get for the `(spaceId, identityId)` unique index. Concurrent
+  // SharedSpaceFaceMatch* jobs carrying faces of the same identity all miss the not-yet-committed
+  // space person and then race to INSERT; the losers previously crashed the handler with a
+  // duplicate-key error. ON CONFLICT DO NOTHING lets the loser fall through to re-read the winner's
+  // committed row instead of throwing.
+  async createOrGetPersonForIdentity(
+    values: Insertable<SharedSpacePersonTable> & { spaceId: string; identityId: string },
+  ) {
+    const inserted = await this.db
+      .insertInto('shared_space_person')
+      .values(values)
+      .onConflict((oc) => oc.columns(['spaceId', 'identityId']).where('identityId', 'is not', null).doNothing())
+      .returningAll()
+      .executeTakeFirst();
+    if (inserted) {
+      return inserted;
+    }
+
+    return this.db
+      .selectFrom('shared_space_person')
+      .selectAll()
+      .where('spaceId', '=', values.spaceId)
+      .where('identityId', '=', values.identityId)
+      .executeTakeFirstOrThrow();
+  }
+
   @GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID] })
   getSpacePersonByIdentity(spaceId: string, identityId: string) {
     return this.db

--- a/server/src/services/queue.service.spec.ts
+++ b/server/src/services/queue.service.spec.ts
@@ -361,6 +361,7 @@ describe(QueueService.name, () => {
         { name: JobName.UserSyncUsage },
         { name: JobName.AssetGenerateThumbnailsQueueAll, data: { force: false } },
         { name: JobName.FacialRecognitionQueueAll, data: { force: false, nightly: true } },
+        { name: JobName.SharedSpaceIdentityReconciliationSweep },
       ]);
     });
 
@@ -391,6 +392,7 @@ describe(QueueService.name, () => {
         name: JobName.FacialRecognitionQueueAll,
         data: { force: false, nightly: true },
       });
+      expect(jobs).toContainEqual({ name: JobName.SharedSpaceIdentityReconciliationSweep });
       expect(jobs).not.toContainEqual(
         expect.objectContaining({
           name: JobName.FacialRecognitionQueueAll,

--- a/server/src/services/queue.service.ts
+++ b/server/src/services/queue.service.ts
@@ -331,7 +331,13 @@ export class QueueService extends BaseService {
     }
 
     if (config.nightlyTasks.clusterNewFaces) {
-      jobs.push({ name: JobName.FacialRecognitionQueueAll, data: { force: false, nightly: true } });
+      jobs.push(
+        { name: JobName.FacialRecognitionQueueAll, data: { force: false, nightly: true } },
+        // Self-heal backstop: re-queue identity reconciliation for every face-enabled space so
+        // pre-fix duplicate shared-space people (a member's local person left unlinked from the space
+        // identity) collapse without any user action. Gated with face clustering — moot when off.
+        { name: JobName.SharedSpaceIdentityReconciliationSweep },
+      );
     }
 
     await this.jobRepository.queueAll(jobs);

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -3960,7 +3960,7 @@ describe(SharedSpaceService.name, () => {
       mocks.sharedSpace.isPersonFaceAssigned.mockResolvedValue(false);
       mocks.sharedSpace.getSpacePersonByIdentity.mockResolvedValue(void 0 as any);
       mocks.sharedSpace.findClosestSpacePerson.mockResolvedValue([]);
-      mocks.sharedSpace.createPerson.mockResolvedValue(
+      mocks.sharedSpace.createOrGetPersonForIdentity.mockResolvedValue(
         factory.sharedSpacePerson({ id: spacePersonId, spaceId, identityId }),
       );
       mocks.sharedSpace.addPersonFaces.mockResolvedValue([]);
@@ -3969,7 +3969,7 @@ describe(SharedSpaceService.name, () => {
       const result = await sut.handleSharedSpaceFaceMatch({ spaceId, assetId });
 
       expect(result).toBe(JobStatus.Success);
-      expect(mocks.sharedSpace.createPerson).toHaveBeenCalledWith({
+      expect(mocks.sharedSpace.createOrGetPersonForIdentity).toHaveBeenCalledWith({
         spaceId,
         identityId,
         name: '',
@@ -4004,7 +4004,7 @@ describe(SharedSpaceService.name, () => {
       mocks.sharedSpace.findClosestSpacePerson.mockResolvedValue([
         { personId: nearbySpacePersonId, name: '', distance: 0.1, identityId: nearbyIdentityId, type: 'person' },
       ]);
-      mocks.sharedSpace.createPerson.mockResolvedValue(
+      mocks.sharedSpace.createOrGetPersonForIdentity.mockResolvedValue(
         factory.sharedSpacePerson({ id: createdSpacePersonId, spaceId, identityId: sourceIdentityId }),
       );
       mocks.sharedSpace.addPersonFaces.mockResolvedValue([]);
@@ -4013,7 +4013,7 @@ describe(SharedSpaceService.name, () => {
       const result = await sut.handleSharedSpaceFaceMatch({ spaceId, assetId });
 
       expect(result).toBe(JobStatus.Success);
-      expect(mocks.sharedSpace.createPerson).toHaveBeenCalledWith({
+      expect(mocks.sharedSpace.createOrGetPersonForIdentity).toHaveBeenCalledWith({
         spaceId,
         identityId: sourceIdentityId,
         name: '',
@@ -4054,7 +4054,7 @@ describe(SharedSpaceService.name, () => {
         }),
       );
       mocks.sharedSpace.isFaceInSpace.mockResolvedValue(true);
-      mocks.sharedSpace.createPerson.mockResolvedValue(
+      mocks.sharedSpace.createOrGetPersonForIdentity.mockResolvedValue(
         factory.sharedSpacePerson({
           id: spacePersonId,
           spaceId,
@@ -4070,7 +4070,7 @@ describe(SharedSpaceService.name, () => {
       expect(result).toBe(JobStatus.Success);
       expect(mocks.person.getById).toHaveBeenCalledWith(personalPersonId);
       expect(mocks.sharedSpace.isFaceInSpace).toHaveBeenCalledWith(spaceId, personalRepresentativeFaceId);
-      expect(mocks.sharedSpace.createPerson).toHaveBeenCalledWith({
+      expect(mocks.sharedSpace.createOrGetPersonForIdentity).toHaveBeenCalledWith({
         spaceId,
         identityId,
         name: '',

--- a/server/src/services/shared-space.service.spec.ts
+++ b/server/src/services/shared-space.service.spec.ts
@@ -21,6 +21,7 @@ import {
   QueueName,
   SharedSpaceActivityType,
   SharedSpaceRole,
+  SystemMetadataKey,
   UserAvatarColor,
 } from 'src/enum';
 import { SHARED_SPACE_DEDUP_MAX_PASSES, SharedSpaceService } from 'src/services/shared-space.service';
@@ -5180,6 +5181,50 @@ describe(SharedSpaceService.name, () => {
 
       expect(result).toBe(JobStatus.Success);
       expect(mocks.sharedSpace.reconcileAlbumGrants).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe('onBootstrap', () => {
+    it('clears blocked failed face jobs from both pipeline queues and kicks identity maintenance', async () => {
+      mocks.systemMetadata.get.mockResolvedValue(null);
+      mocks.job.removeFailedJobsByJobIdPrefix.mockResolvedValueOnce(1).mockResolvedValueOnce(2);
+
+      await sut.onBootstrap();
+
+      expect(mocks.job.removeFailedJobsByJobIdPrefix).toHaveBeenCalledWith(QueueName.PeopleBackfill, [
+        'shared-space-face-match',
+        'space-identity-reconcile-',
+      ]);
+      expect(mocks.job.removeFailedJobsByJobIdPrefix).toHaveBeenCalledWith(QueueName.FacialRecognition, [
+        'shared-space-face-match',
+        'space-identity-reconcile-',
+      ]);
+      expect(mocks.job.queue).toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
+      expect(mocks.systemMetadata.set).toHaveBeenCalledWith(SystemMetadataKey.SharedSpaceFaceJobCleanupState, {
+        cleanedAt: expect.any(String),
+      });
+    });
+
+    it('does not kick identity maintenance when no blocked jobs were removed', async () => {
+      mocks.systemMetadata.get.mockResolvedValue(null);
+      mocks.job.removeFailedJobsByJobIdPrefix.mockResolvedValue(0);
+
+      await sut.onBootstrap();
+
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expect(mocks.systemMetadata.set).toHaveBeenCalledWith(SystemMetadataKey.SharedSpaceFaceJobCleanupState, {
+        cleanedAt: expect.any(String),
+      });
+    });
+
+    it('skips the cleanup entirely once it has already run', async () => {
+      mocks.systemMetadata.get.mockResolvedValue({ cleanedAt: '2026-07-25T00:00:00.000Z' });
+
+      await sut.onBootstrap();
+
+      expect(mocks.job.removeFailedJobsByJobIdPrefix).not.toHaveBeenCalled();
+      expect(mocks.job.queue).not.toHaveBeenCalled();
+      expect(mocks.systemMetadata.set).not.toHaveBeenCalled();
     });
   });
 

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -44,6 +44,7 @@ import {
   AssetType,
   AssetVisibility,
   CacheControl,
+  ImmichWorker,
   JobName,
   JobStatus,
   NotificationLevel,
@@ -52,6 +53,7 @@ import {
   QueueName,
   SharedSpaceActivityType,
   SharedSpaceRole,
+  SystemMetadataKey,
   UserAvatarColor,
 } from 'src/enum';
 import { AlbumAssetCount } from 'src/repositories/album.repository';
@@ -1597,6 +1599,38 @@ export class SharedSpaceService extends BaseService {
     const albumIds = await this.sharedSpaceRepository.getAllGrantedAlbumIds();
     await this.sharedSpaceRepository.reconcileAlbumGrants(albumIds);
     return JobStatus.Success;
+  }
+
+  // One-time recovery for the pre-idempotency-fix crashes: the duplicate-key failures left
+  // SharedSpaceFaceMatch*/reconciliation jobs in the failed set with `removeOnFail` unset, where
+  // they permanently occupy their stable dedup jobIds — BullMQ silently ignores any later add()
+  // with the same id, so identity maintenance could never re-queue exactly the crashed work.
+  // Deliberately NOT `removeOnFail: true` on the job options: jobs that fail *after* this cleanup
+  // should park visibly in the failed set instead of being retried on every trigger forever.
+  // The flag is written after the sweep so a crash mid-cleanup retries on the next boot
+  // (removals are idempotent), and only a non-zero cleanup kicks identity maintenance.
+  @OnEvent({ name: 'AppBootstrap', workers: [ImmichWorker.Microservices] })
+  async onBootstrap(): Promise<void> {
+    const state = await this.systemMetadataRepository.get(SystemMetadataKey.SharedSpaceFaceJobCleanupState);
+    if (state?.cleanedAt) {
+      return;
+    }
+
+    const prefixes = ['shared-space-face-match', 'space-identity-reconcile-'];
+    const removed =
+      (await this.jobRepository.removeFailedJobsByJobIdPrefix(QueueName.PeopleBackfill, prefixes)) +
+      (await this.jobRepository.removeFailedJobsByJobIdPrefix(QueueName.FacialRecognition, prefixes));
+
+    if (removed > 0) {
+      this.logger.log(
+        `Removed ${removed} failed shared-space face job(s) that were blocking their dedup jobIds; queueing face identity maintenance`,
+      );
+      await this.jobRepository.queue({ name: JobName.FaceIdentityBackfill, data: {} });
+    }
+
+    await this.systemMetadataRepository.set(SystemMetadataKey.SharedSpaceFaceJobCleanupState, {
+      cleanedAt: new Date().toISOString(),
+    });
   }
 
   // Self-heal backstop (see queue.service.ts's handleNightlyJobs): re-queues identity reconciliation

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -1599,6 +1599,19 @@ export class SharedSpaceService extends BaseService {
     return JobStatus.Success;
   }
 
+  // Self-heal backstop (see queue.service.ts's handleNightlyJobs): re-queues identity reconciliation
+  // for every face-enabled space. A member's local person that was left unlinked from the space
+  // identity — by the pre-fix crash or the multi-face reconciliation bail — collapses into one tile
+  // on the next sweep, without the user doing anything.
+  @OnJob({ name: JobName.SharedSpaceIdentityReconciliationSweep, queue: QueueName.BackgroundTask })
+  async handleSharedSpaceIdentityReconciliationSweep(): Promise<JobStatus> {
+    const spaceIds = await this.sharedSpaceRepository.getFaceRecognitionEnabledSpaceIds();
+    for (const spaceId of spaceIds) {
+      await this.queueSpaceIdentityReconciliation({ spaceId });
+    }
+    return JobStatus.Success;
+  }
+
   // correctness-4: enqueue a post-commit reconciliation for the given albums. Idempotent
   // and deadlock-free — it runs after the triggering transaction commits, resolving the
   // TOCTOU race in the delete-side grant-revocation triggers. No-op for an empty set.
@@ -1839,7 +1852,10 @@ export class SharedSpaceService extends BaseService {
       hasPerson: true,
     });
 
-    const candidates: Array<{ identityId: string }> = [];
+    // Dedup by identity: the member's nearest faces (searchFaces returns raw face rows, not distinct
+    // people) are often several faces of their own single person. Those collapse to one candidate
+    // identity — only a genuinely ambiguous match against two *distinct* local identities should bail.
+    const candidateIdentityIds = new Set<string>();
     for (const match of matches) {
       if (!match.personId) {
         continue;
@@ -1855,25 +1871,26 @@ export class SharedSpaceService extends BaseService {
         return;
       }
 
-      candidates.push({ identityId: identity.id });
+      candidateIdentityIds.add(identity.id);
     }
 
-    if (candidates.length !== 1) {
+    if (candidateIdentityIds.size !== 1) {
       return;
     }
+    const [candidateIdentityId] = candidateIdentityIds;
 
     const { sourceIdentityId, targetIdentityId: selectedTargetIdentityId } = chooseAutomaticTargetIdentity({
       bridge: 'member-join',
-      localIdentityId: candidates[0].identityId,
+      localIdentityId: candidateIdentityId,
       spaceIdentityId: targetIdentityId,
     });
     const claim = buildAutomaticReconciliationClaim({
       bridge: 'member-join',
-      localIdentityId: candidates[0].identityId,
+      localIdentityId: candidateIdentityId,
       spaceIdentityId: targetIdentityId,
       sourceIdentityId,
       targetIdentityId: selectedTargetIdentityId,
-      sourceProfileKey: `user:${input.memberUserId}:${candidates[0].identityId}`,
+      sourceProfileKey: `user:${input.memberUserId}:${candidateIdentityId}`,
       targetProfileKey: `space-person:${input.spacePerson.id}`,
       hasAccessBridge: true,
       compatibleType: true,

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -2769,13 +2769,22 @@ export class SharedSpaceService extends BaseService {
       personalPersonId: input.personId,
     });
 
-    return this.sharedSpaceRepository.createPerson({
+    // Race-safe create: concurrent SharedSpaceFaceMatch* jobs carrying faces of this same identity
+    // may have created the space person between our getSpacePersonByIdentity check above and here.
+    // createOrGetPersonForIdentity returns the winner's row instead of crashing on the
+    // (spaceId, identityId) unique index; re-apply the type-compat check since the raced-in row may
+    // belong to a different type.
+    const spacePerson = await this.sharedSpaceRepository.createOrGetPersonForIdentity({
       spaceId: input.spaceId,
       identityId: input.identityId,
       name: '',
       representativeFaceId,
       type: input.type,
     });
+    if (spacePerson.type && spacePerson.type !== input.type) {
+      return undefined;
+    }
+    return spacePerson;
   }
 
   private isExactSelectedSpaceAssignment(

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -723,6 +723,7 @@ export interface SystemMetadata extends Record<SystemMetadataKey, Record<string,
   [SystemMetadataKey.MaintenanceMode]: MaintenanceModeState;
   [SystemMetadataKey.MediaLocation]: MediaLocation;
   [SystemMetadataKey.ReverseGeocodingState]: { lastUpdate?: string; lastImportFileName?: string };
+  [SystemMetadataKey.SharedSpaceFaceJobCleanupState]: { cleanedAt?: string };
   [SystemMetadataKey.SystemConfig]: DeepPartial<SystemConfig>;
   [SystemMetadataKey.SystemFlags]: DeepPartial<SystemFlags>;
   [SystemMetadataKey.VersionCheckState]: VersionCheckMetadata;

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -608,6 +608,7 @@ export type JobItem =
   // Shared Space Album Grant Reconciliation
   | { name: JobName.SharedSpaceAlbumGrantReconcile; data: ISharedSpaceAlbumGrantReconcileJob }
   | { name: JobName.SharedSpaceAlbumGrantReconcileSweep; data?: IBaseJob }
+  | { name: JobName.SharedSpaceIdentityReconciliationSweep; data?: IBaseJob }
 
   // Classification
   | { name: JobName.AssetClassifyQueueAll; data: IBaseJob }

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -962,6 +962,56 @@ describe(FaceIdentityRepository.name, () => {
     }
   });
 
+  // Regression for the same duplicate-key crash class on the repair path. A space person stamped
+  // with identity A but whose face actually belongs to identity C must be split — repair INSERTs a
+  // new space person for C. Two concurrent backfill passes both miss the not-yet-committed C row and
+  // race to INSERT it, tripping `shared_space_person_spaceId_identityId_key`; the loser crashed the
+  // FaceIdentityBackfill job.
+  it('does not crash when concurrent backfill passes create the space person for a split-out identity', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    try {
+      const { space } = await ctx.newSharedSpace({ createdById: user.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+
+      const { person: personA } = await ctx.newPerson({ ownerId: user.id });
+      const identityA = await sut.ensurePersonIdentity(personA.id);
+
+      const { person: personC } = await ctx.newPerson({ ownerId: user.id });
+      const identityC = await sut.ensurePersonIdentity(personC.id);
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: personC.id });
+      await sut.linkFace({ assetFaceId: assetFace.id, identityId: identityC.id, source: 'backfill' });
+
+      // Space person carries identity A, but its only face belongs to identity C → repair splits it out.
+      const spacePerson = await ctx.database
+        .insertInto('shared_space_person')
+        .values({ spaceId: space.id, identityId: identityA.id, representativeFaceId: assetFace.id, type: 'person' })
+        .returningAll()
+        .executeTakeFirstOrThrow();
+      await linkSpaceFace(ctx, spacePerson.id, assetFace.id);
+
+      // Two backfill passes at once both race to INSERT the C space person.
+      await expect(
+        Promise.all([
+          sut.backfillSpacePersonIdentities({ limit: 100 }),
+          sut.backfillSpacePersonIdentities({ limit: 100 }),
+        ]),
+      ).resolves.toBeDefined();
+
+      // Exactly one space person exists for the split-out identity.
+      const cPeople = await ctx.database
+        .selectFrom('shared_space_person')
+        .select('id')
+        .where('spaceId', '=', space.id)
+        .where('identityId', '=', identityC.id)
+        .execute();
+      expect(cPeople).toHaveLength(1);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+    }
+  });
+
   it('does not rewrite already-consistent space people on repeated identity backfill passes', async () => {
     const { ctx, sut } = setup(await getKyselyDB());
     const { user } = await ctx.newUser();

--- a/server/test/medium/specs/repositories/shared-space-face-matching.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space-face-matching.spec.ts
@@ -1417,4 +1417,54 @@ describe('SharedSpaceRepository - face matching pipeline', () => {
       expect(assetIds).toContain(asset.id);
     });
   });
+
+  // Regression for the duplicate-key crash the shared-space face-match backfill hit when a person
+  // has multiple photos: FaceIdentityBackfill fans out one SharedSpaceFaceMatchFromBackfill job per
+  // affected asset, and those parallel jobs — all carrying faces of the SAME identity — each read
+  // "no space person yet" and then race to INSERT, tripping the `shared_space_person_spaceId_identityId_key`
+  // unique index. All but the winner threw `duplicate key value ...`, crashing the handler and
+  // aborting the face-match/link chain, which left the member's person unlinked as a duplicate tile.
+  describe('concurrent space-person creation for the same identity', () => {
+    it('returns the existing space person instead of throwing on a duplicate (spaceId, identityId)', async () => {
+      const { ctx, sut, faceIdentityRepository } = setup();
+      const { user } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: user.id });
+      const { result: person } = await ctx.newPerson({ ownerId: user.id, name: 'Brad' });
+      const identity = await faceIdentityRepository.ensurePersonIdentity(person.id);
+
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+      const faceId = await createFaceWithEmbedding(ctx, { assetId: asset.id, personId: person.id });
+
+      // A concurrent job already created the space person for this identity.
+      const existing = await sut.createPerson({
+        spaceId: space.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: faceId,
+        type: 'person',
+      });
+
+      // The racing job must get the existing row back — not crash on the unique index.
+      const result = await sut.createOrGetPersonForIdentity({
+        spaceId: space.id,
+        identityId: identity.id,
+        name: '',
+        representativeFaceId: faceId,
+        type: 'person',
+      });
+
+      expect(result.id).toBe(existing.id);
+
+      // No duplicate row was inserted for the identity — the loser reused the winner's row.
+      const rows = await ctx.database
+        .selectFrom('shared_space_person')
+        .select('id')
+        .where('spaceId', '=', space.id)
+        .where('identityId', '=', identity.id)
+        .execute();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].id).toBe(existing.id);
+    });
+  });
 });

--- a/server/test/medium/specs/services/people-identity-rbac.spec.ts
+++ b/server/test/medium/specs/services/people-identity-rbac.spec.ts
@@ -361,6 +361,31 @@ const createLinkedLibraryIdentityFixture = async (input?: {
 const authFor = (user: { id: string; name: string; email: string; isAdmin?: boolean }) =>
   factory.auth({ user: { id: user.id, name: user.name, email: user.email, isAdmin: user.isAdmin } });
 
+// Adds `photoCount` timeline photos of one person for `memberId`, all with `embedding`, and links
+// every face to that person's identity. Returns the person + identity.
+const addMatchingMemberPerson = async (
+  fx: Awaited<ReturnType<typeof createLinkedLibraryIdentityFixture>>,
+  input: { memberId: string; name: string; embedding: string; photoCount: number },
+) => {
+  const { result: person } = await fx.ctx.newPerson({ ownerId: input.memberId, name: input.name });
+  const identity = await fx.faceIdentityRepository.ensurePersonIdentity(person.id);
+  for (let i = 0; i < input.photoCount; i++) {
+    const { asset } = await fx.ctx.newAsset({ ownerId: input.memberId, visibility: AssetVisibility.Timeline });
+    const { result: face } = await fx.ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    await fx.ctx.database.insertInto('face_search').values({ faceId: face, embedding: input.embedding }).execute();
+    await fx.faceIdentityRepository.linkFace({ assetFaceId: face, identityId: identity.id, source: 'owner-person' });
+  }
+  return { person, identityId: identity.id };
+};
+
+const spacePersonEmbedding = (fx: Awaited<ReturnType<typeof createLinkedLibraryIdentityFixture>>) =>
+  fx.ctx.database
+    .selectFrom('face_search')
+    .select('embedding')
+    .where('faceId', '=', fx.face.faceId)
+    .executeTakeFirstOrThrow()
+    .then((row) => row.embedding);
+
 type IdentityRbacContext = ReturnType<typeof setup>['ctx'] | ReturnType<typeof setupSearch>['ctx'];
 
 const setSpaceTimeline = async (
@@ -888,6 +913,106 @@ describe('People identity RBAC projection', () => {
       expect.objectContaining({
         primaryProfile: { type: 'user-person', id: memberPerson.id },
         numberOfAssets: 2,
+      }),
+    ]);
+  });
+
+  // Count-invariance: searchFaces caps at numResults:2, so 1/2/3/5 photos of the member's one person
+  // all collapse to a single candidate identity. The photo count must never change the outcome — the
+  // bug bailed the moment there were >= 2 photos.
+  it.each([1, 2, 3, 5])(
+    'reconciles a late member local person whether they have %i matching photo(s)',
+    async (photoCount) => {
+      const fx = await createLinkedLibraryIdentityFixture({ memberInitiallyJoined: false });
+      const embedding = await spacePersonEmbedding(fx);
+      const { person: memberPerson } = await addMatchingMemberPerson(fx, {
+        memberId: fx.member.id,
+        name: 'Member Private Name',
+        embedding,
+        photoCount,
+      });
+
+      await fx.sharedSpaceService.addMember(authFor(fx.source), fx.space.id, {
+        userId: fx.member.id,
+        role: SharedSpaceRole.Viewer,
+      });
+      await fx.sharedSpaceService.handleSharedSpaceIdentityReconciliation({
+        spaceId: fx.space.id,
+        userId: fx.member.id,
+      });
+
+      // One unified tile: the member's own photos plus the owner's one shared photo.
+      const result = await fx.personService.getAll(authFor(fx.member), {
+        withHidden: false,
+        withSharedSpaces: true,
+        page: 1,
+        size: 50,
+      } as any);
+      expect(result.people).toEqual([
+        expect.objectContaining({
+          primaryProfile: { type: 'user-person', id: memberPerson.id },
+          numberOfAssets: photoCount + 1,
+        }),
+      ]);
+    },
+  );
+
+  // Ambiguity guard: two DISTINCT member people both match the space person. The dedup fix must still
+  // bail (two distinct candidate identities), never arbitrarily pick one to merge.
+  it('does not auto-link when two distinct member people both match the space person', async () => {
+    const fx = await createLinkedLibraryIdentityFixture({ memberInitiallyJoined: false });
+    const embedding = await spacePersonEmbedding(fx);
+    const a = await addMatchingMemberPerson(fx, { memberId: fx.member.id, name: 'Member A', embedding, photoCount: 1 });
+    const b = await addMatchingMemberPerson(fx, { memberId: fx.member.id, name: 'Member B', embedding, photoCount: 1 });
+
+    await fx.sharedSpaceService.addMember(authFor(fx.source), fx.space.id, {
+      userId: fx.member.id,
+      role: SharedSpaceRole.Viewer,
+    });
+    await fx.sharedSpaceService.handleSharedSpaceIdentityReconciliation({ spaceId: fx.space.id, userId: fx.member.id });
+
+    // Neither person was merged into the space identity — both keep their own identity untouched.
+    const rows = await fx.ctx.database
+      .selectFrom('person')
+      .select(['id', 'identityId'])
+      .where('id', 'in', [a.person.id, b.person.id])
+      .execute();
+    const byId = new Map(rows.map((r) => [r.id, r.identityId]));
+    expect(byId.get(a.person.id)).toBe(a.identityId);
+    expect(byId.get(b.person.id)).toBe(b.identityId);
+  });
+
+  // End-to-end self-heal: the nightly sweep queues space-level reconciliation (no per-user
+  // targeting); draining it collapses a pre-existing multi-photo member duplicate into one tile.
+  it('nightly sweep heals a member duplicate with no per-user targeting', async () => {
+    const fx = await createLinkedLibraryIdentityFixture({ memberInitiallyJoined: true });
+    const embedding = await spacePersonEmbedding(fx);
+    const { person: memberPerson } = await addMatchingMemberPerson(fx, {
+      memberId: fx.member.id,
+      name: 'Member Private Name',
+      embedding,
+      photoCount: 2,
+    });
+
+    await fx.sharedSpaceService.handleSharedSpaceIdentityReconciliationSweep();
+    expect(fx.sharedJobs.queue.mock.calls.map(([job]) => job)).toContainEqual({
+      name: JobName.SharedSpaceIdentityReconciliation,
+      data: { spaceId: fx.space.id },
+    });
+
+    // Run the space-level reconciliation the sweep queued (no userId → every member).
+    await fx.sharedSpaceService.handleSharedSpaceIdentityReconciliation({ spaceId: fx.space.id });
+
+    const result = await fx.personService.getAll(authFor(fx.member), {
+      withHidden: false,
+      withSharedSpaces: true,
+      page: 1,
+      size: 50,
+    } as any);
+    expect(result.people).toEqual([
+      expect.objectContaining({
+        primaryProfile: { type: 'user-person', id: memberPerson.id },
+        numberOfAssets: 3,
       }),
     ]);
   });

--- a/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
+++ b/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
@@ -805,4 +805,31 @@ describe('SharedSpaceService linked-library face identity repair', () => {
       ]);
     }
   });
+
+  // Self-heal backstop: existing duplicate people (created before the crash/dedup fixes) only
+  // collapse when reconciliation runs again for their space, and nothing retriggers it for
+  // already-assigned faces. The nightly sweep re-queues reconciliation for every face-enabled space
+  // so those duplicates heal without the user doing anything.
+  it('sweep queues identity reconciliation for every face-recognition-enabled space', async () => {
+    const { ctx, sut, jobs } = setup();
+    const { user } = await ctx.newUser();
+    const { space: enabled1 } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    const { space: enabled2 } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    const { space: disabled } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: false });
+
+    await expect(sut.handleSharedSpaceIdentityReconciliationSweep()).resolves.toBe(JobStatus.Success);
+
+    expect(jobs.queue).toHaveBeenCalledWith({
+      name: JobName.SharedSpaceIdentityReconciliation,
+      data: { spaceId: enabled1.id },
+    });
+    expect(jobs.queue).toHaveBeenCalledWith({
+      name: JobName.SharedSpaceIdentityReconciliation,
+      data: { spaceId: enabled2.id },
+    });
+    expect(jobs.queue).not.toHaveBeenCalledWith({
+      name: JobName.SharedSpaceIdentityReconciliation,
+      data: { spaceId: disabled.id },
+    });
+  });
 });

--- a/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
+++ b/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
@@ -800,9 +800,9 @@ describe('SharedSpaceService linked-library face identity repair', () => {
     expect(people).toHaveLength(1);
 
     for (const f of faces) {
-      await expect(
-        sharedSpaceRepository.getPersonFaceAssignmentsForSpace(f.assetFace.id, space.id),
-      ).resolves.toEqual([{ personId: people[0].id, identityId: first.identity.id, type: 'person' }]);
+      await expect(sharedSpaceRepository.getPersonFaceAssignmentsForSpace(f.assetFace.id, space.id)).resolves.toEqual([
+        { personId: people[0].id, identityId: first.identity.id, type: 'person' },
+      ]);
     }
   });
 });

--- a/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
+++ b/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
@@ -752,4 +752,57 @@ describe('SharedSpaceService linked-library face identity repair', () => {
       unassignedFaceCount: 1,
     });
   });
+
+  // Regression for the user-reported crash: a person with multiple photos makes FaceIdentityBackfill
+  // fan out one SharedSpaceFaceMatchFromBackfill job per asset, all carrying the SAME identity. Run
+  // in parallel they each miss the not-yet-committed space person and race to INSERT it, tripping the
+  // `shared_space_person_spaceId_identityId_key` unique index — the losers crashed the handler and
+  // left the face-match/link chain half-done (the duplicate-person symptom).
+  it('links all faces to one space person when parallel backfill jobs race to create it', async () => {
+    const { ctx, sut, faceIdentityRepository, sharedSpaceRepository } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: user.id, role: SharedSpaceRole.Owner });
+    const { library } = await ctx.newLibrary({ ownerId: user.id });
+    await ctx.newSharedSpaceLibrary({ spaceId: space.id, libraryId: library.id, addedById: user.id });
+
+    // Four assets, all faces of the SAME identity — the reporter's four-photo case.
+    const first = await createIdentityFace(ctx, faceIdentityRepository, {
+      ownerId: user.id,
+      libraryId: library.id,
+      name: 'Brad',
+    });
+    const rest = await Promise.all(
+      [0, 1, 2].map(() =>
+        createIdentityFace(ctx, faceIdentityRepository, {
+          ownerId: user.id,
+          libraryId: library.id,
+          personId: first.person.id,
+          identityId: first.identity.id,
+        }),
+      ),
+    );
+    const faces = [first, ...rest];
+
+    // Fire every backfill job at once, exactly as the queue would.
+    const results = await Promise.all(
+      faces.map((f) => sut.handleSharedSpaceFaceMatchFromBackfill({ spaceId: space.id, assetId: f.asset.id })),
+    );
+    expect(results).toEqual(faces.map(() => JobStatus.Success));
+
+    // Exactly one space person for the identity, with every face assigned to it.
+    const people = await ctx.database
+      .selectFrom('shared_space_person')
+      .selectAll()
+      .where('spaceId', '=', space.id)
+      .where('identityId', '=', first.identity.id)
+      .execute();
+    expect(people).toHaveLength(1);
+
+    for (const f of faces) {
+      await expect(
+        sharedSpaceRepository.getPersonFaceAssignmentsForSpace(f.assetFace.id, space.id),
+      ).resolves.toEqual([{ personId: people[0].id, identityId: first.identity.id, type: 'person' }]);
+    }
+  });
 });

--- a/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
+++ b/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
@@ -832,4 +832,27 @@ describe('SharedSpaceService linked-library face identity repair', () => {
       data: { spaceId: disabled.id },
     });
   });
+
+  // One-time recovery for the pre-idempotency-fix crashes: those failed jobs occupy their stable
+  // dedup jobIds forever (removeOnFail unset), silently blocking the post-fix re-queue of exactly
+  // the crashed work. The bootstrap sweep must run once per install — the flag persists in
+  // system_metadata, so a second bootstrap (each instance here simulates a fresh process after a
+  // restart) must not sweep or kick identity maintenance again, even if new jobs failed since.
+  it('sweeps blocked failed face jobs on the first bootstrap only', async () => {
+    const firstBoot = setup();
+    firstBoot.jobs.removeFailedJobsByJobIdPrefix.mockResolvedValue(3);
+
+    await firstBoot.sut.onBootstrap();
+
+    expect(firstBoot.jobs.removeFailedJobsByJobIdPrefix).toHaveBeenCalledTimes(2);
+    expect(firstBoot.jobs.queue).toHaveBeenCalledWith({ name: JobName.FaceIdentityBackfill, data: {} });
+
+    const secondBoot = setup();
+    secondBoot.jobs.removeFailedJobsByJobIdPrefix.mockResolvedValue(3);
+
+    await secondBoot.sut.onBootstrap();
+
+    expect(secondBoot.jobs.removeFailedJobsByJobIdPrefix).not.toHaveBeenCalled();
+    expect(secondBoot.jobs.queue).not.toHaveBeenCalled();
+  });
 });

--- a/server/test/repositories/job.repository.mock.ts
+++ b/server/test/repositories/job.repository.mock.ts
@@ -25,6 +25,7 @@ export const newJobRepositoryMock = (): Mocked<RepositoryInterface<JobRepository
     clear: vitest.fn(),
     reconcileOrphanedActiveJobs: vitest.fn().mockImplementation(() => Promise.resolve()),
     removeOrphanedActiveJobs: vitest.fn().mockImplementation(() => Promise.resolve([])),
+    removeFailedJobsByJobIdPrefix: vitest.fn().mockResolvedValue(0),
     waitForQueueCompletion: vitest.fn(),
     removeJob: vitest.fn(),
   };


### PR DESCRIPTION
## Problem

A user reported that when User A puts photos of a person into a Space and User B uploads the **same** photos, the person shows up as **two separate, unlinked people** on the People page. The server logs showed the real cause:

```
Unable to run job handler (SharedSpaceFaceMatchFromBackfill):
PostgresError: duplicate key value violates unique constraint
"shared_space_person_spaceId_identityId_key"
```

### Root cause

Creating a `shared_space_person` is a **non-atomic find-then-INSERT**: `getSpacePersonByIdentity` checks for an existing row, and if none is found the code `INSERT`s. When a person has **multiple photos**, `FaceIdentityBackfill` fans out **one `SharedSpaceFaceMatchFromBackfill` job per asset**, all carrying faces of the *same* identity. Run in parallel, they each miss the not-yet-committed row and then race to `INSERT` — the losers throw `duplicate key … shared_space_person_spaceId_identityId_key`, crashing the job handler and aborting the face-match/link chain. The member's person never gets linked to the shared identity, so it renders as a duplicate tile.

This is why the user's "People identity maintenance" re-run changed nothing: that job (`FaceIdentityBackfill`) is exactly what queues the crashing `SharedSpaceFaceMatchFromBackfill` jobs.

## Fix

Guard **both** `shared_space_person` insert sites that write a non-null `identityId` with `ON CONFLICT (spaceId, identityId) WHERE identityId IS NOT NULL DO NOTHING` + re-read, so the loser reuses the winner's row instead of crashing:

- **`SharedSpaceRepository.createOrGetPersonForIdentity`** (new) — used by the identity match path in `findOrCreateCompatibleSpacePersonForIdentity`; the service re-applies the type-compat check on the returned row.
- **`FaceIdentityRepository.repairSpacePersonIdentityAssignments`** — the split-out insert reachable from the same `FaceIdentityBackfill` flow.

The two remaining bare `createPerson` callers (pet, legacy) pass a **null** `identityId` and therefore cannot hit the partial unique index.

## Tests (TDD — each watched fail for the right reason first)

- **Repo idempotency** (`shared-space-face-matching.spec.ts`) — reproduced the crash byte-for-byte (same `23505`, same INSERT SQL), green after the guard.
- **Service integration** (`shared-space-face-identity-repair.spec.ts`) — 4 parallel `handleSharedSpaceFaceMatchFromBackfill` jobs for one identity (the reporter's exact scenario): reliably crashed pre-fix → green, one space person, all faces linked.
- **Sibling / backfill** (`face-identity.repository.spec.ts`) — two concurrent `backfillSpacePersonIdentities` passes splitting a mixed space person: reliably crashed across 3 runs → green across 3 runs.

## Verification

- Full server unit suite: **5134 passed / 0 failed**
- Touched medium specs (full): **161 passed**
- `tsc --noEmit` clean · eslint (changed files) clean

## Scope / audited but intentionally out

Audited every `shared_space_person` / `person` / `face_identity` create + identity-write site. The reported crash surface (`shared_space_person (spaceId, identityId)`) is now fully closed. The `person (ownerId, identityId)` index is **not** exposed — creation never sets `identityId`, and the merge paths that write existing identities are advisory-lock-serialized with a `23505`→`409` retriable translation.

Two lower-severity, separate follow-ups (not this crash) left for their own PRs:
1. Pet/legacy null-identity `createPerson` isn't idempotent under concurrency (no crash — can create duplicate rows, cleaned up by `SharedSpacePersonDedup`; would need a different mechanism than `ON CONFLICT`).
2. Background `mergeIdentities` callers rely on a point-in-time per-owner guard rather than a lock; a narrow concurrent-merge race could throw `23505` on the *person* index (self-heals via job retry).

## For the affected user

No data corruption — failed inserts roll back cleanly. Once this ships, re-running **People identity maintenance** completes and collapses the two tiles into one; the interim stopgap is merging the two people in the UI.
