### PR TITLE
fix(shared-space): self-heal duplicate people (reconciliation dedup + nightly sweep)

### DIFF
--- a/mobile/openapi/lib/model/job_name.dart
+++ b/mobile/openapi/lib/model/job_name.dart
@@ -107,6 +107,7 @@ class JobName {
   static const sharedSpaceBulkAddAssets = JobName._(r'SharedSpaceBulkAddAssets');
   static const sharedSpaceAlbumGrantReconcile = JobName._(r'SharedSpaceAlbumGrantReconcile');
   static const sharedSpaceAlbumGrantReconcileSweep = JobName._(r'SharedSpaceAlbumGrantReconcileSweep');
+  static const sharedSpaceIdentityReconciliationSweep = JobName._(r'SharedSpaceIdentityReconciliationSweep');
   static const assetClassifyQueueAll = JobName._(r'AssetClassifyQueueAll');
   static const assetClassify = JobName._(r'AssetClassify');
 
@@ -196,6 +197,7 @@ class JobName {
     sharedSpaceBulkAddAssets,
     sharedSpaceAlbumGrantReconcile,
     sharedSpaceAlbumGrantReconcileSweep,
+    sharedSpaceIdentityReconciliationSweep,
     assetClassifyQueueAll,
     assetClassify,
   ];
@@ -320,6 +322,7 @@ class JobNameTypeTransformer {
         case r'SharedSpaceBulkAddAssets': return JobName.sharedSpaceBulkAddAssets;
         case r'SharedSpaceAlbumGrantReconcile': return JobName.sharedSpaceAlbumGrantReconcile;
         case r'SharedSpaceAlbumGrantReconcileSweep': return JobName.sharedSpaceAlbumGrantReconcileSweep;
+        case r'SharedSpaceIdentityReconciliationSweep': return JobName.sharedSpaceIdentityReconciliationSweep;
         case r'AssetClassifyQueueAll': return JobName.assetClassifyQueueAll;
         case r'AssetClassify': return JobName.assetClassify;
         default:

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -25487,6 +25487,7 @@
           "SharedSpaceBulkAddAssets",
           "SharedSpaceAlbumGrantReconcile",
           "SharedSpaceAlbumGrantReconcileSweep",
+          "SharedSpaceIdentityReconciliationSweep",
           "AssetClassifyQueueAll",
           "AssetClassify"
         ],

--- a/packages/sdk/src/fetch-client.ts
+++ b/packages/sdk/src/fetch-client.ts
@@ -9723,6 +9723,7 @@ export enum JobName {
     SharedSpaceBulkAddAssets = "SharedSpaceBulkAddAssets",
     SharedSpaceAlbumGrantReconcile = "SharedSpaceAlbumGrantReconcile",
     SharedSpaceAlbumGrantReconcileSweep = "SharedSpaceAlbumGrantReconcileSweep",
+    SharedSpaceIdentityReconciliationSweep = "SharedSpaceIdentityReconciliationSweep",
     AssetClassifyQueueAll = "AssetClassifyQueueAll",
     AssetClassify = "AssetClassify"
 }

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -1015,6 +1015,11 @@ export enum JobName {
   // mechanism path-independent (covers M6 durability gaps, L7 residue, and cascade strands).
   SharedSpaceAlbumGrantReconcileSweep = 'SharedSpaceAlbumGrantReconcileSweep',
 
+  // Self-heal backstop: nightly re-queue of identity reconciliation for every face-enabled space,
+  // collapsing pre-fix duplicate people (a member's local person left unlinked from the space
+  // identity) without any user action.
+  SharedSpaceIdentityReconciliationSweep = 'SharedSpaceIdentityReconciliationSweep',
+
   // Classification
   AssetClassifyQueueAll = 'AssetClassifyQueueAll',
   AssetClassify = 'AssetClassify',

--- a/server/src/repositories/job.repository.ts
+++ b/server/src/repositories/job.repository.ts
@@ -500,6 +500,11 @@ export class JobRepository {
         // harmless dedup, and removeOnFail keeps a hard failure from blocking the next run.
         return { jobId: 'space-album-grant-reconcile-sweep', removeOnComplete: true, removeOnFail: true };
       }
+      case JobName.SharedSpaceIdentityReconciliationSweep: {
+        // Single stable jobId — a nightly trigger while a previous sweep is still active dedups
+        // harmlessly, and removeOnFail keeps a hard failure from blocking the next run.
+        return { jobId: 'shared-space-identity-reconciliation-sweep', removeOnComplete: true, removeOnFail: true };
+      }
       case JobName.SharedSpaceFaceMatch: {
         const prefix =
           item.data.source === 'identity-backfill'

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -1102,6 +1102,15 @@ export class SharedSpaceRepository {
     return rows.map((row) => row.albumId);
   }
 
+  async getFaceRecognitionEnabledSpaceIds(): Promise<string[]> {
+    const rows = await this.db
+      .selectFrom('shared_space')
+      .select('id')
+      .where('faceRecognitionEnabled', '=', true)
+      .execute();
+    return rows.map((row) => row.id);
+  }
+
   // Album sync fan-out: used by the AlbumAssetsAdd/Remove handlers to find every space
   // a linked album feeds, with its face-recognition flag. Mirrors getSpacesLinkedToLibrary.
   @GenerateSql({ params: [DummyValue.UUID] })

--- a/server/src/services/queue.service.spec.ts
+++ b/server/src/services/queue.service.spec.ts
@@ -361,6 +361,7 @@ describe(QueueService.name, () => {
         { name: JobName.UserSyncUsage },
         { name: JobName.AssetGenerateThumbnailsQueueAll, data: { force: false } },
         { name: JobName.FacialRecognitionQueueAll, data: { force: false, nightly: true } },
+        { name: JobName.SharedSpaceIdentityReconciliationSweep },
       ]);
     });
 
@@ -391,6 +392,7 @@ describe(QueueService.name, () => {
         name: JobName.FacialRecognitionQueueAll,
         data: { force: false, nightly: true },
       });
+      expect(jobs).toContainEqual({ name: JobName.SharedSpaceIdentityReconciliationSweep });
       expect(jobs).not.toContainEqual(
         expect.objectContaining({
           name: JobName.FacialRecognitionQueueAll,

--- a/server/src/services/queue.service.ts
+++ b/server/src/services/queue.service.ts
@@ -331,7 +331,13 @@ export class QueueService extends BaseService {
     }
 
     if (config.nightlyTasks.clusterNewFaces) {
-      jobs.push({ name: JobName.FacialRecognitionQueueAll, data: { force: false, nightly: true } });
+      jobs.push(
+        { name: JobName.FacialRecognitionQueueAll, data: { force: false, nightly: true } },
+        // Self-heal backstop: re-queue identity reconciliation for every face-enabled space so
+        // pre-fix duplicate shared-space people (a member's local person left unlinked from the space
+        // identity) collapse without any user action. Gated with face clustering — moot when off.
+        { name: JobName.SharedSpaceIdentityReconciliationSweep },
+      );
     }
 
     await this.jobRepository.queueAll(jobs);

--- a/server/src/services/shared-space.service.ts
+++ b/server/src/services/shared-space.service.ts
@@ -1599,6 +1599,19 @@ export class SharedSpaceService extends BaseService {
     return JobStatus.Success;
   }
 
+  // Self-heal backstop (see queue.service.ts's handleNightlyJobs): re-queues identity reconciliation
+  // for every face-enabled space. A member's local person that was left unlinked from the space
+  // identity — by the pre-fix crash or the multi-face reconciliation bail — collapses into one tile
+  // on the next sweep, without the user doing anything.
+  @OnJob({ name: JobName.SharedSpaceIdentityReconciliationSweep, queue: QueueName.BackgroundTask })
+  async handleSharedSpaceIdentityReconciliationSweep(): Promise<JobStatus> {
+    const spaceIds = await this.sharedSpaceRepository.getFaceRecognitionEnabledSpaceIds();
+    for (const spaceId of spaceIds) {
+      await this.queueSpaceIdentityReconciliation({ spaceId });
+    }
+    return JobStatus.Success;
+  }
+
   // correctness-4: enqueue a post-commit reconciliation for the given albums. Idempotent
   // and deadlock-free — it runs after the triggering transaction commits, resolving the
   // TOCTOU race in the delete-side grant-revocation triggers. No-op for an empty set.
@@ -1839,7 +1852,10 @@ export class SharedSpaceService extends BaseService {
       hasPerson: true,
     });
 
-    const candidates: Array<{ identityId: string }> = [];
+    // Dedup by identity: the member's nearest faces (searchFaces returns raw face rows, not distinct
+    // people) are often several faces of their own single person. Those collapse to one candidate
+    // identity — only a genuinely ambiguous match against two *distinct* local identities should bail.
+    const candidateIdentityIds = new Set<string>();
     for (const match of matches) {
       if (!match.personId) {
         continue;
@@ -1855,25 +1871,26 @@ export class SharedSpaceService extends BaseService {
         return;
       }
 
-      candidates.push({ identityId: identity.id });
+      candidateIdentityIds.add(identity.id);
     }
 
-    if (candidates.length !== 1) {
+    if (candidateIdentityIds.size !== 1) {
       return;
     }
+    const [candidateIdentityId] = candidateIdentityIds;
 
     const { sourceIdentityId, targetIdentityId: selectedTargetIdentityId } = chooseAutomaticTargetIdentity({
       bridge: 'member-join',
-      localIdentityId: candidates[0].identityId,
+      localIdentityId: candidateIdentityId,
       spaceIdentityId: targetIdentityId,
     });
     const claim = buildAutomaticReconciliationClaim({
       bridge: 'member-join',
-      localIdentityId: candidates[0].identityId,
+      localIdentityId: candidateIdentityId,
       spaceIdentityId: targetIdentityId,
       sourceIdentityId,
       targetIdentityId: selectedTargetIdentityId,
-      sourceProfileKey: `user:${input.memberUserId}:${candidates[0].identityId}`,
+      sourceProfileKey: `user:${input.memberUserId}:${candidateIdentityId}`,
       targetProfileKey: `space-person:${input.spacePerson.id}`,
       hasAccessBridge: true,
       compatibleType: true,

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -608,6 +608,7 @@ export type JobItem =
   // Shared Space Album Grant Reconciliation
   | { name: JobName.SharedSpaceAlbumGrantReconcile; data: ISharedSpaceAlbumGrantReconcileJob }
   | { name: JobName.SharedSpaceAlbumGrantReconcileSweep; data?: IBaseJob }
+  | { name: JobName.SharedSpaceIdentityReconciliationSweep; data?: IBaseJob }
 
   // Classification
   | { name: JobName.AssetClassifyQueueAll; data: IBaseJob }

--- a/server/test/medium/specs/services/people-identity-rbac.spec.ts
+++ b/server/test/medium/specs/services/people-identity-rbac.spec.ts
@@ -892,6 +892,67 @@ describe('People identity RBAC projection', () => {
     ]);
   });
 
+  it('reconciles a late member local person even when the member has multiple matching faces', async () => {
+    const fx = await createLinkedLibraryIdentityFixture({ memberInitiallyJoined: false });
+    const embeddingRow = await fx.ctx.database
+      .selectFrom('face_search')
+      .select('embedding')
+      .where('faceId', '=', fx.face.faceId)
+      .executeTakeFirstOrThrow();
+
+    const { result: memberPerson } = await fx.ctx.newPerson({
+      ownerId: fx.member.id,
+      name: 'Member Private Name',
+    });
+    const memberIdentity = await fx.faceIdentityRepository.ensurePersonIdentity(memberPerson.id);
+
+    // The member has TWO photos of the same person. This is the case that made
+    // findStrictSpacePersonLocalIdentityClaim bail: searchFaces(numResults: 2) returned the two
+    // nearest faces, both belonging to this one person, so it produced two same-identity candidates
+    // and `candidates.length !== 1` refused to link — leaving the member with a duplicate person.
+    for (let i = 0; i < 2; i++) {
+      const { asset: memberAsset } = await fx.ctx.newAsset({
+        ownerId: fx.member.id,
+        visibility: AssetVisibility.Timeline,
+      });
+      const { result: memberFace } = await fx.ctx.newAssetFace({ assetId: memberAsset.id, personId: memberPerson.id });
+      await fx.ctx.database
+        .insertInto('face_search')
+        .values({ faceId: memberFace, embedding: embeddingRow.embedding })
+        .execute();
+      await fx.faceIdentityRepository.linkFace({
+        assetFaceId: memberFace,
+        identityId: memberIdentity.id,
+        source: 'owner-person',
+      });
+    }
+
+    await fx.sharedSpaceService.addMember(authFor(fx.source), fx.space.id, {
+      userId: fx.member.id,
+      role: SharedSpaceRole.Viewer,
+    });
+    await fx.sharedSpaceService.handleSharedSpaceIdentityReconciliation({
+      spaceId: fx.space.id,
+      userId: fx.member.id,
+    });
+
+    // The member's own person is merged with the space identity into ONE unified tile:
+    // their two assets plus the owner's one asset.
+    const result = await fx.personService.getAll(authFor(fx.member), {
+      withHidden: false,
+      withSharedSpaces: true,
+      page: 1,
+      size: 50,
+    } as any);
+
+    expect(result.people).toEqual([
+      expect.objectContaining({
+        primaryProfile: { type: 'user-person', id: memberPerson.id },
+        numberOfAssets: 3,
+      }),
+    ]);
+  });
+
   it('does not expose raw face identity ids in people responses', async () => {
     const fx = await setupPeopleIdentityMatrix();
 

--- a/server/test/medium/specs/services/people-identity-rbac.spec.ts
+++ b/server/test/medium/specs/services/people-identity-rbac.spec.ts
@@ -361,6 +361,31 @@ const createLinkedLibraryIdentityFixture = async (input?: {
 const authFor = (user: { id: string; name: string; email: string; isAdmin?: boolean }) =>
   factory.auth({ user: { id: user.id, name: user.name, email: user.email, isAdmin: user.isAdmin } });
 
+// Adds `photoCount` timeline photos of one person for `memberId`, all with `embedding`, and links
+// every face to that person's identity. Returns the person + identity.
+const addMatchingMemberPerson = async (
+  fx: Awaited<ReturnType<typeof createLinkedLibraryIdentityFixture>>,
+  input: { memberId: string; name: string; embedding: string; photoCount: number },
+) => {
+  const { result: person } = await fx.ctx.newPerson({ ownerId: input.memberId, name: input.name });
+  const identity = await fx.faceIdentityRepository.ensurePersonIdentity(person.id);
+  for (let i = 0; i < input.photoCount; i++) {
+    const { asset } = await fx.ctx.newAsset({ ownerId: input.memberId, visibility: AssetVisibility.Timeline });
+    const { result: face } = await fx.ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    await fx.ctx.database.insertInto('face_search').values({ faceId: face, embedding: input.embedding }).execute();
+    await fx.faceIdentityRepository.linkFace({ assetFaceId: face, identityId: identity.id, source: 'owner-person' });
+  }
+  return { person, identityId: identity.id };
+};
+
+const spacePersonEmbedding = (fx: Awaited<ReturnType<typeof createLinkedLibraryIdentityFixture>>) =>
+  fx.ctx.database
+    .selectFrom('face_search')
+    .select('embedding')
+    .where('faceId', '=', fx.face.faceId)
+    .executeTakeFirstOrThrow()
+    .then((row) => row.embedding);
+
 type IdentityRbacContext = ReturnType<typeof setup>['ctx'] | ReturnType<typeof setupSearch>['ctx'];
 
 const setSpaceTimeline = async (
@@ -892,59 +917,98 @@ describe('People identity RBAC projection', () => {
     ]);
   });
 
-  it('reconciles a late member local person even when the member has multiple matching faces', async () => {
+  // Count-invariance: searchFaces caps at numResults:2, so 1/2/3/5 photos of the member's one person
+  // all collapse to a single candidate identity. The photo count must never change the outcome — the
+  // bug bailed the moment there were >= 2 photos.
+  it.each([1, 2, 3, 5])(
+    'reconciles a late member local person whether they have %i matching photo(s)',
+    async (photoCount) => {
+      const fx = await createLinkedLibraryIdentityFixture({ memberInitiallyJoined: false });
+      const embedding = await spacePersonEmbedding(fx);
+      const { person: memberPerson } = await addMatchingMemberPerson(fx, {
+        memberId: fx.member.id,
+        name: 'Member Private Name',
+        embedding,
+        photoCount,
+      });
+
+      await fx.sharedSpaceService.addMember(authFor(fx.source), fx.space.id, {
+        userId: fx.member.id,
+        role: SharedSpaceRole.Viewer,
+      });
+      await fx.sharedSpaceService.handleSharedSpaceIdentityReconciliation({
+        spaceId: fx.space.id,
+        userId: fx.member.id,
+      });
+
+      // One unified tile: the member's own photos plus the owner's one shared photo.
+      const result = await fx.personService.getAll(authFor(fx.member), {
+        withHidden: false,
+        withSharedSpaces: true,
+        page: 1,
+        size: 50,
+      } as any);
+      expect(result.people).toEqual([
+        expect.objectContaining({
+          primaryProfile: { type: 'user-person', id: memberPerson.id },
+          numberOfAssets: photoCount + 1,
+        }),
+      ]);
+    },
+  );
+
+  // Ambiguity guard: two DISTINCT member people both match the space person. The dedup fix must still
+  // bail (two distinct candidate identities), never arbitrarily pick one to merge.
+  it('does not auto-link when two distinct member people both match the space person', async () => {
     const fx = await createLinkedLibraryIdentityFixture({ memberInitiallyJoined: false });
-    const embeddingRow = await fx.ctx.database
-      .selectFrom('face_search')
-      .select('embedding')
-      .where('faceId', '=', fx.face.faceId)
-      .executeTakeFirstOrThrow();
-
-    const { result: memberPerson } = await fx.ctx.newPerson({
-      ownerId: fx.member.id,
-      name: 'Member Private Name',
-    });
-    const memberIdentity = await fx.faceIdentityRepository.ensurePersonIdentity(memberPerson.id);
-
-    // The member has TWO photos of the same person. This is the case that made
-    // findStrictSpacePersonLocalIdentityClaim bail: searchFaces(numResults: 2) returned the two
-    // nearest faces, both belonging to this one person, so it produced two same-identity candidates
-    // and `candidates.length !== 1` refused to link — leaving the member with a duplicate person.
-    for (let i = 0; i < 2; i++) {
-      const { asset: memberAsset } = await fx.ctx.newAsset({
-        ownerId: fx.member.id,
-        visibility: AssetVisibility.Timeline,
-      });
-      const { result: memberFace } = await fx.ctx.newAssetFace({ assetId: memberAsset.id, personId: memberPerson.id });
-      await fx.ctx.database
-        .insertInto('face_search')
-        .values({ faceId: memberFace, embedding: embeddingRow.embedding })
-        .execute();
-      await fx.faceIdentityRepository.linkFace({
-        assetFaceId: memberFace,
-        identityId: memberIdentity.id,
-        source: 'owner-person',
-      });
-    }
+    const embedding = await spacePersonEmbedding(fx);
+    const a = await addMatchingMemberPerson(fx, { memberId: fx.member.id, name: 'Member A', embedding, photoCount: 1 });
+    const b = await addMatchingMemberPerson(fx, { memberId: fx.member.id, name: 'Member B', embedding, photoCount: 1 });
 
     await fx.sharedSpaceService.addMember(authFor(fx.source), fx.space.id, {
       userId: fx.member.id,
       role: SharedSpaceRole.Viewer,
     });
-    await fx.sharedSpaceService.handleSharedSpaceIdentityReconciliation({
-      spaceId: fx.space.id,
-      userId: fx.member.id,
+    await fx.sharedSpaceService.handleSharedSpaceIdentityReconciliation({ spaceId: fx.space.id, userId: fx.member.id });
+
+    // Neither person was merged into the space identity — both keep their own identity untouched.
+    const rows = await fx.ctx.database
+      .selectFrom('person')
+      .select(['id', 'identityId'])
+      .where('id', 'in', [a.person.id, b.person.id])
+      .execute();
+    const byId = new Map(rows.map((r) => [r.id, r.identityId]));
+    expect(byId.get(a.person.id)).toBe(a.identityId);
+    expect(byId.get(b.person.id)).toBe(b.identityId);
+  });
+
+  // End-to-end self-heal: the nightly sweep queues space-level reconciliation (no per-user
+  // targeting); draining it collapses a pre-existing multi-photo member duplicate into one tile.
+  it('nightly sweep heals a member duplicate with no per-user targeting', async () => {
+    const fx = await createLinkedLibraryIdentityFixture({ memberInitiallyJoined: true });
+    const embedding = await spacePersonEmbedding(fx);
+    const { person: memberPerson } = await addMatchingMemberPerson(fx, {
+      memberId: fx.member.id,
+      name: 'Member Private Name',
+      embedding,
+      photoCount: 2,
     });
 
-    // The member's own person is merged with the space identity into ONE unified tile:
-    // their two assets plus the owner's one asset.
+    await fx.sharedSpaceService.handleSharedSpaceIdentityReconciliationSweep();
+    expect(fx.sharedJobs.queue.mock.calls.map(([job]) => job)).toContainEqual({
+      name: JobName.SharedSpaceIdentityReconciliation,
+      data: { spaceId: fx.space.id },
+    });
+
+    // Run the space-level reconciliation the sweep queued (no userId → every member).
+    await fx.sharedSpaceService.handleSharedSpaceIdentityReconciliation({ spaceId: fx.space.id });
+
     const result = await fx.personService.getAll(authFor(fx.member), {
       withHidden: false,
       withSharedSpaces: true,
       page: 1,
       size: 50,
     } as any);
-
     expect(result.people).toEqual([
       expect.objectContaining({
         primaryProfile: { type: 'user-person', id: memberPerson.id },

--- a/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
+++ b/server/test/medium/specs/services/shared-space-face-identity-repair.spec.ts
@@ -805,4 +805,31 @@ describe('SharedSpaceService linked-library face identity repair', () => {
       ]);
     }
   });
+
+  // Self-heal backstop: existing duplicate people (created before the crash/dedup fixes) only
+  // collapse when reconciliation runs again for their space, and nothing retriggers it for
+  // already-assigned faces. The nightly sweep re-queues reconciliation for every face-enabled space
+  // so those duplicates heal without the user doing anything.
+  it('sweep queues identity reconciliation for every face-recognition-enabled space', async () => {
+    const { ctx, sut, jobs } = setup();
+    const { user } = await ctx.newUser();
+    const { space: enabled1 } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    const { space: enabled2 } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    const { space: disabled } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: false });
+
+    await expect(sut.handleSharedSpaceIdentityReconciliationSweep()).resolves.toBe(JobStatus.Success);
+
+    expect(jobs.queue).toHaveBeenCalledWith({
+      name: JobName.SharedSpaceIdentityReconciliation,
+      data: { spaceId: enabled1.id },
+    });
+    expect(jobs.queue).toHaveBeenCalledWith({
+      name: JobName.SharedSpaceIdentityReconciliation,
+      data: { spaceId: enabled2.id },
+    });
+    expect(jobs.queue).not.toHaveBeenCalledWith({
+      name: JobName.SharedSpaceIdentityReconciliation,
+      data: { spaceId: disabled.id },
+    });
+  });
 });


### PR DESCRIPTION
Follow-up to #840 (space-person create-race). #840 stops the crash but, as flagged there, does **not** by itself resolve existing duplicate people. This PR closes the two remaining gaps so affected users self-heal.

## The two gaps

**1. Reconciliation bailed for multi-photo members.** `findStrictSpacePersonLocalIdentityClaim` searched the member's 2 nearest faces (`searchFaces` returns raw face rows — no per-person dedup) and pushed one candidate per face, then required `candidates.length === 1`. A member with ≥2 photos of the person → two candidates that are the **same** identity → it refused to link. Since the crash requires ≥2 photos, every affected member was in this bucket. **Fix:** dedup candidates by identity; only a genuinely ambiguous match against two **distinct** local identities bails.

**2. Nothing re-triggered reconciliation for already-assigned faces.** Failed jobs don't re-run on deploy, and nightly recognition only processes *unassigned* faces — so existing duplicates never healed. **Fix:** a `SharedSpaceIdentityReconciliationSweep` job that re-queues reconciliation for every face-enabled space (stable dedup jobId), wired into the nightly `clusterNewFaces` tasks.

Together: existing duplicates collapse into one tile on the **next nightly run**, no user action. (An admin can also trigger it immediately by re-running "People identity maintenance", which now completes post-#840.)

## TDD (each watched fail first)

- **Dedup** — `people-identity-rbac.spec.ts`: cross-member reconciliation with a **2-face** member. RED: the member got two people (`numberOfAssets` 1 and 2). GREEN: one merged tile (3 assets). The existing single-face test still passes.
- **Sweep handler** — `shared-space-face-identity-repair.spec.ts`: queues reconciliation for face-enabled spaces only.
- **Nightly wiring** — `queue.service.spec.ts`: sweep queued when `clusterNewFaces` is on, and present in the exact nightly list.

## Verification

- Full server unit suite: **5134 passed / 0 failed**
- Touched medium specs (full): **92 passed**
- `tsc` clean · eslint clean · prettier clean

## Effort

~40 lines of production code (the dedup, plus a sweep mirroring the existing `SharedSpaceAlbumGrantReconcileSweep`) + ~90 lines of tests. Adding the JobName fanned out to the usual sites (enum, `JobItem` union in `types.ts`, job-options in `job.repository.ts`, nightly list).

## Base

Stacked on `fix/space-person-create-race` (#840) — the sweep re-queues jobs that would crash without #840. Re-target to `main` once #840 merges.
