### PR TITLE
fix(web): unify the multi-select toolbar across Shared Space surfaces (#839)

### DIFF
--- a/docs/superpowers/specs/2026-07-24-selection-toolbar-consistency-design.md
+++ b/docs/superpowers/specs/2026-07-24-selection-toolbar-consistency-design.md
@@ -87,6 +87,11 @@ actions). Those are personal-library operations that do not belong inside a shar
   conflicts for no user-visible gain. They stay untouched. (A parity guard test — Slice 2 — protects
   against silent drift if upstream restructures the album toolbar.)
 - **New actions** beyond the album model (no Stack / Link-live-photo / library jobs in spaces).
+- **Exposing space-editor edits of non-owned _direct_ space assets.** The server permits an Editor to
+  favorite/edit assets in the space's direct pool even when they don't own them (Slice 1). We do NOT
+  surface this: the merged space timeline has no per-asset direct-vs-album-path origin signal, so
+  editor-edit on a mixed selection would partially 400. Owner-gating (`isAllUserOwned`) matches the
+  current behaviour and the album model. Revisiting this needs a per-asset origin signal — future work.
 - **Changing the ⌘K command palette itself.** We reuse its context; we do not alter its items.
 - **Trashed-asset actions (restore/permanent-delete).** Space timelines do not surface trash;
   `isAllTrashed` selections are not a reachable state here.
@@ -390,20 +395,28 @@ Using `buildSpaceContext()` (gives `spaceOwner`/`spaceEditor`/`spaceViewer`/`spa
 actor). The expected statuses below are the **resolved** server behaviour (evidence file:line noted);
 the e2e spec codifies them and is the regression tripwire:
 
-- **Download** of `spaceAssetId`: owner/editor/viewer → 200; non-member → 4xx.
-- **Create-shared-link** referencing a **non-owned** `spaceAssetId`: editor/viewer → **4xx** (owner →
-  200). `Permission.AssetShare` = owner∪partner only (`access.ts:127-131`). → `canShare =
-isAllUserOwned`.
-- **Add-to-album** of a **non-owned** `spaceAssetId` into the actor's own (non-space) album:
-  editor/viewer → **4xx** (owner → 200). Same `AssetShare` gate via `asset.util.ts` (`album.service.ts:253-262`).
-  → `canAddToAlbum = isAllUserOwned`.
-- **Favorite / metadata update / delete** of `spaceAssetId`: only the asset **owner** → 200; other
-  members → 4xx (owner-scoped `Permission.AssetUpdate`/`AssetDelete`, `access.ts:155-163`). **Q5
-  confirmed:** `AssetUpdate` runs `checkOwnerAccess` first and only applies `checkSpaceEditAccess` to
-  the leftover non-owned ids — it never _subtracts_ an owner's grant, so an owner is never 400'd for
-  their own asset just because it is album-path in a space. Owner-gated actions are therefore safe in
-  the space album (Slice 6).
-- **Remove-from-space** (`shared_space_asset`): editor/owner → 200; viewer/non-member → 4xx.
+- **Download** of `spaceAssetId`: owner/editor/viewer → 200; non-member → 400.
+- **Create-shared-link** referencing a **non-owned** `spaceAssetId`: owner → 201; editor/viewer/
+  non-member → **400**. `Permission.AssetShare` = owner∪partner only (`access.ts:127-131`). →
+  `canShare = isAllUserOwned`.
+- **Add-to-album** of a **non-owned** `spaceAssetId` into the actor's own (non-space) album: the
+  request is **HTTP 200 for everyone** (they own the target album), but the non-owned asset is denied
+  **per-item in the body** (`success:false, error:no_permission`) via the non-throwing `AssetShare`
+  check — only the owner's item is `success:true`. So the honest client gate is `canAddToAlbum =
+isAllUserOwned` (a non-owned add would silently no-op).
+- **Favorite / metadata update** of a **direct** `spaceAssetId`: owner **AND space editor** → 204;
+  viewer/non-member → 400. `Permission.AssetUpdate` = `isOwner ∪ checkSpaceEditAccess`
+  (`access.ts:155-159`); `checkSpaceEditAccess` grants an Editor/Owner write over the space's **direct**
+  pool (`shared_space_asset`) regardless of asset owner (visibility/livePhoto are the one owner-only
+  exception — rbac-3). **Delete** is owner-only (`AssetDelete` has no space arm, `access.ts:161-163`).
+  **Client note:** despite the server allowing an editor to edit a non-owned _direct_ asset, the rule
+  engine still gates `canFavorite`/`canEditMetadata`/`canTag` by `isAllUserOwned`. The merged space
+  timeline carries no per-asset direct-vs-album-path origin signal (rbac-5/albums-8), so exposing
+  editor-edit would produce partial 400/`success:false` on any mixed selection — matching the current
+  space-timeline behaviour and the album model. Owner-path edits are always safe (Q5), which is what
+  the toolbar surfaces.
+- **Remove-from-space** (`shared_space_asset`, `requireRole(Editor)`): editor/owner → 200;
+  viewer/non-member → **403** (role guard, not an access check).
 - **Remove-from-space-album:** manager (space/album editor) removing any asset → 200; **non-manager
   removing their own asset → 4xx** (decision C: `AlbumAssetDelete` is role-gated, `access.ts:247-257` +
   `access.repository.ts:144-161`). → `canRemoveFromAlbum` (space album) `= canManage`, **no** own-asset

--- a/docs/superpowers/specs/2026-07-24-selection-toolbar-consistency-design.md
+++ b/docs/superpowers/specs/2026-07-24-selection-toolbar-consistency-design.md
@@ -417,10 +417,17 @@ isAllUserOwned` (a non-owned add would silently no-op).
   the toolbar surfaces.
 - **Remove-from-space** (`shared_space_asset`, `requireRole(Editor)`): editor/owner → 200;
   viewer/non-member → **403** (role guard, not an access check).
-- **Remove-from-space-album:** manager (space/album editor) removing any asset → 200; **non-manager
-  removing their own asset → 4xx** (decision C: `AlbumAssetDelete` is role-gated, `access.ts:247-257` +
-  `access.repository.ts:144-161`). → `canRemoveFromAlbum` (space album) `= canManage`, **no** own-asset
-  arm.
+- **Remove-from-space-album (decision C — two-layer gate):** removal has an album-level gate AND a
+  per-asset gate. (1) Album-level `AlbumAssetDelete` (`access.ts:247-257` + `access.repository.ts:144-161`)
+  is role-gated: a **non-manager** (plain space/album Viewer) is refused outright → **400**, so a
+  non-manager can't remove even their **own** asset. (2) For a caller who passes the album gate, the
+  shared `removeAssets` util applies removal **per asset**: it bypasses per-asset ownership only for a
+  caller holding `Permission.AlbumDelete` (the **album owner**); otherwise each asset is re-checked
+  against `AssetShare` (owner ∪ partner). So a **space Editor** who owns neither the album nor the
+  asset passes the gate (**200**) but the item is denied in the body (`success:false`); only the
+  **album owner** (or the asset's owner, if they also clear the album gate) actually removes it. →
+  `canRemoveFromAlbum` (space album) `= canManage`, **no** own-asset arm — this is a UI-affordance gate
+  (matching the pre-existing space-album page); the server remains the per-asset authority.
 
 ### Infra notes (folded in from prior e2e pain)
 

--- a/docs/superpowers/specs/2026-07-24-selection-toolbar-consistency-design.md
+++ b/docs/superpowers/specs/2026-07-24-selection-toolbar-consistency-design.md
@@ -70,7 +70,7 @@ From `albums/[albumId]/…/+page.svelte:734-780` (the untouched reference):
 
 ¹ The album renders these buttons unconditionally; whether the **server** honours a
 create-shared-link / add-to-album call for a _non-owned_ asset is pinned by the API RBAC matrix
-(Slice 6). Whatever the album's real behaviour is, spaces mirror it — see the Share/Add-to-album note
+(Slice 1). Whatever the album's real behaviour is, spaces mirror it — see the Share/Add-to-album note
 under Capability rules.
 
 We deliberately mirror the **album's** metadata set (Rotate + date/description/location + Archive +
@@ -83,7 +83,7 @@ actions). Those are personal-library operations that do not belong inside a shar
   codebase (Flutter/Riverpod) and a separate spec that will reuse these capability rules conceptually.
 - **Refactoring the upstream `photos` and `albums` pages onto the shared toolbar.** They are the
   reference and already correct; patching two of Immich's hottest files buys recurring rebase
-  conflicts for no user-visible gain. They stay untouched. (A parity guard test — Slice 1 — protects
+  conflicts for no user-visible gain. They stay untouched. (A parity guard test — Slice 2 — protects
   against silent drift if upstream restructures the album toolbar.)
 - **New actions** beyond the album model (no Stack / Link-live-photo / library jobs in spaces).
 - **Changing the ⌘K command palette itself.** We reuse its context; we do not alter its items.
@@ -135,7 +135,7 @@ Predicates (the single rule set):
 
 ```
 canSelectAll       = sel !== null
-canDownload        = true
+canDownload        = true            // mirror album; download-disable is a shared-link-only flag (out of scope)
 canShare           = true            // mirror album (see Share/Add-to-album note)
 canAddToAlbum      = true            // mirror album
 canFavorite        = sel.isAllUserOwned
@@ -146,12 +146,28 @@ isEditorOfContext  = isRegularAlbum ? (ctx.album.isOwner || ctx.album.isEditor)
                    : isDirectSpace  ? ctx.space.canWrite
                    : isSpaceAlbum   ? (ctx.space.canWrite || ctx.album.isEditor)   // == canManage
                    : /* personal */   false
-canSetCover        = isEditorOfContext && sel.selectedAssetIds.length === 1 && !isPersonal
+canSetCover        = isEditorOfContext && sel.selectedAssetIds.length === 1   // ROLE gate only; see cover note
 canRemoveFromAlbum = isRegularAlbum ? (ctx.album.isOwner || sel.isAllUserOwned)
-                   : isSpaceAlbum   ? (ctx.space.canWrite || ctx.album.isEditor)
+                   : isSpaceAlbum   ? (ctx.space.canWrite || ctx.album.isEditor || sel.isAllUserOwned)  // canManage OR own asset — see C
                    : false
 canRemoveFromSpace = isDirectSpace && ctx.space.canWrite
 ```
+
+**Cover note (fixes a space-person over-grant):** `canSetCover` is only the _role+single_ gate — it is
+surface-agnostic. Not every surface has a cover: the **space-timeline** sets the space cover, a
+**space-album** sets the album cover, but the **space-person** page has **no cover action**
+(verified: no `set_as_space_cover`, context menu at `people/[personId]/…:716-741`). So the component
+renders Set-cover only when `caps.canSetCover && onSetCover != null`; the space-person page passes no
+`onSetCover`, so cover never appears there even for an editor. `canSetCover` never returns true on the
+personal timeline because `isEditorOfContext` is false there.
+
+**Space-album Remove-from-album (decision C):** the regular album lets a member remove **their own**
+asset (`ctx.album.isOwner || sel.isAllUserOwned`). A space-album manager adds assets that may be owned
+by various members, so a non-manager member CAN have an own asset in the album — and under
+"mimic album" they should be able to remove it. Hence the `|| sel.isAllUserOwned` arm above. This is
+**pending server confirmation** (Slice 1 API row: can a non-manager remove their own asset from a
+space album?). If the server refuses, drop the arm to `canManage`-only and record that as an
+intentional space-album deviation; the parity guard (Slice 2) encodes whichever we land on.
 
 **Orthogonality invariant (critical):** _space role_ (Owner/Editor/Viewer, from
 `ctx.space.canWrite`/`isOwner`) and _asset ownership_ (`sel.isAllUserOwned`, i.e.
@@ -178,6 +194,10 @@ New fork component (proposed:
   the album-page layout — top row (Share, Select-all, Add-to-album, Favorite) + overflow
   `ButtonContextMenu` (Download, metadata edits, Set-cover, Tag, Remove-from-album/space, Delete) —
   each action wrapped in `{#if caps.canX}`.
+- Two render gates depend on props as well as caps: **Set-cover** renders only when
+  `caps.canSetCover && onSetCover != null` (so the space-person page, which passes no `onSetCover`,
+  never shows it); **Remove** renders `RemoveFromSpaceAction` when `spaceId` is set and
+  `caps.canRemoveFromSpace`, else `RemoveFromAlbum` when `album` is set and `caps.canRemoveFromAlbum`.
 
 **Separation of concerns:** capabilities decide _what to show_; the page passes a typed props bundle
 for _what to do_. Proposed props:
@@ -203,14 +223,24 @@ correspond to a disabled capability are simply never reached.
 ### 3. Space page integration
 
 Each of the three fork space routes replaces its bespoke control-bar block with a single
-`<SelectionToolbar {...} />` and flips its `registerSelectionContext({ canAddToAlbum: () => false })`
-to `true` (so the ⌘K palette stays consistent with the toolbar). Net result per surface:
+`<SelectionToolbar {...} />`. Note two **separate** mechanisms (verified — do not conflate them):
 
-| Surface        | Before                                                           | After                                                                                        |
-| -------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| Space album    | Download + Remove-from-album only                                | Full album-equivalent toolbar; Remove-from-album gated `canManage`; **no** Remove-from-space |
-| Space timeline | Select-all, Remove-from-space, Favorite, Download + partial menu | Full album-equivalent; adds Share, Add-to-album, Rotate, Set-visibility, Delete, Set-cover   |
-| Space person   | same as space timeline                                           | same as space timeline                                                                       |
+- **Toolbar Add-to-album** works because `<SelectionToolbar>` owns the `CommandPaletteDefaultProvider`
+  - `getAssetBulkActions($t)` block. This is self-contained and works on all three space surfaces
+    regardless of any selection-context registration.
+- **⌘K palette parity** is a different surface. Only the **space-timeline** page registers a
+  `registerSelectionContext` (`canAddToAlbum: () => false` at line 522); the space-person and
+  space-album pages register **none**. Flipping the space-timeline flag to `true` is a 1-line
+  palette-consistency nicety included here; _adding_ a selection context to the other two pages is a
+  separate palette-parity concern and is **out of scope** (it does not affect the toolbar fix).
+
+Net result per surface:
+
+| Surface        | Before                                                           | After                                                                                                           |
+| -------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Space album    | Download + Remove-from-album only                                | Full album-equivalent toolbar; Remove-from-album gated `canManage \|\| own asset` (C); **no** Remove-from-space |
+| Space timeline | Select-all, Remove-from-space, Favorite, Download + partial menu | Full album-equivalent; adds Share, Add-to-album, Rotate, Set-visibility, Delete, Set-cover (space cover)        |
+| Space person   | same as space timeline                                           | same as space timeline **except no Set-cover** (page has no cover action)                                       |
 
 ## RBAC safety invariants & verifications
 
@@ -231,15 +261,16 @@ Two things are **verified by tests, not assumed**:
 
 - **V1 — `TimelineAsset.ownerId` is correct on space-projected assets.** The entire owner-gate rests
   on it. If ownerId were wrong/absent on the merged space timeline or space album, owner-gated
-  actions could appear on non-owned assets. Asserted by the web e2e owner/other cases (Slice 5) and,
+  actions could appear on non-owned assets. Asserted by the web e2e owner/other cases (Slice 6) and,
   if needed, a focused unit check.
 - **V2 — owner-scoped Share / Add-to-album / edit / delete endpoints accept space-accessed asset
-  IDs and enforce ownership/role.** Proven by the server/API RBAC matrix (Slice 6).
+  IDs and enforce ownership/role.** Proven by the server/API RBAC matrix (Slice 1).
 
 ### Share / Add-to-album note
 
-The capability defaults to unconditional (mirror the album). Slice 6 pins the **actual** server
-behaviour for a non-owned asset:
+The capability defaults to unconditional (mirror the album). **Slice 1 (the API matrix) runs first**
+precisely so this is decided before the rule engine and web e2e depend on it. It pins the **actual**
+server behaviour for a non-owned asset:
 
 - If the server **owner-scopes** create-shared-link and/or add-to-album (rejects non-owned), then to
   keep the toolbar honest we gate those two capabilities by `sel.isAllUserOwned` — which on the
@@ -249,13 +280,28 @@ behaviour for a non-owned asset:
 - If the server permits it (as the album UI implies), they stay unconditional.
 
 Either way the toolbar never offers a button the server would 400 — that equivalence is the property
-Slice 6 guarantees.
+Slice 1 guarantees.
 
 ## Testing strategy (TDD + BDD)
 
 TDD throughout: for every slice, write the failing test(s) first, watch them fail for the right
-reason, then implement to green. Tests are written as BDD scenarios (Given/When/Then). RBAC coverage
-is exhaustive on the pure rule engine (cheap) and representative on e2e (expensive).
+reason, then implement to green. RBAC coverage is exhaustive on the pure rule engine (cheap) and
+representative on e2e (expensive).
+
+**BDD convention (applies to unit, component, and e2e):** every scenario is named and structured
+Given/When/Then — the `describe`/`it` (or Playwright `test`) titles read as behaviour, and each edge
+in the catalogue below maps to exactly one scenario. Example for E4:
+
+```
+describe('getSelectionCapabilities — space timeline')
+  it('Given a space OWNER who does not own the selected asset, When capabilities resolve, Then role
+      actions (remove-from-space, set-cover) are allowed but owner-gated actions (favorite/edit/
+      delete) are denied')
+```
+
+The "Given" fixes the context (surface + role + ownership + asset state), the "When" is the single
+`getSelectionCapabilities(ctx)` call (or the toolbar render / UI selection), and the "Then" asserts
+the exact allowed/denied set. No scenario asserts more than one behaviour.
 
 ### Layers
 
@@ -265,8 +311,9 @@ is exhaustive on the pure rule engine (cheap) and representative on e2e (expensi
   all-archived, tags on/off). Includes the **parity assertion**: for equivalent role+ownership, the
   space capability set equals the album capability set with one substitution — on **direct-space**
   surfaces (space timeline/person) `canRemoveFromAlbum` is replaced by `canRemoveFromSpace`; on a
-  **space album** the set matches the album exactly (`canRemoveFromAlbum` via `canManage`). This is
-  what fails CI if upstream restructures the album toolbar.
+  **space album** the set matches the album under the role mapping (`canRemoveFromAlbum` via
+  `canManage || own asset`, mirroring the album's `owns-container || own asset`). This is what fails
+  CI if upstream restructures the album toolbar. The parity test encodes the resolved decision C.
 - **b. Component — `<SelectionToolbar>`:** given a capability set, renders exactly the permitted
   buttons and no others (reuse the `register-selection-context-harness.svelte` pattern). Asserts
   the ⌘K provider is present so Add-to-album registers.
@@ -299,6 +346,8 @@ is exhaustive on the pure rule engine (cheap) and representative on e2e (expensi
 | E13 | Space **non-member** hits a space URL                                        | cannot reach the page (existing visibility specs); toolbar N/A — cross-referenced, not re-tested                        |
 | E14 | Regression: personal timeline unchanged                                      | full personal set unchanged (function returns personal answer; pages untouched)                                         |
 | E15 | Regression: regular album unchanged                                          | full album set unchanged                                                                                                |
+| E16 | Space **viewer** (non-manager) selects their **own** asset in a space album  | Remove-from-album ✓ via the own-asset arm (decision C); owner-gated ✓; Set-cover ✗ (not a manager)                      |
+| E17 | **Admin** (not the asset owner, not a space/album role) selects an asset     | no special power — owner/role gates apply exactly as for any user (`isAdmin` is never consulted by the rule engine)     |
 
 ### Web e2e matrix (subset of the catalogue that is reachable through the UI)
 
@@ -313,24 +362,31 @@ is exhaustive on the pure rule engine (cheap) and representative on e2e (expensi
 | 7   | Space album    | member             | **own** asset in album      | owner-gated (Favorite/edit/Delete)                          | —                                                    | E2        |
 | 8   | Space person   | Viewer             | person's asset (not theirs) | Select-all, Download, Share, Add-to-album                   | owner-gated, Remove-from-space                       | smoke     |
 
-Cases 1 and 5 are the reporter's exact regressions. A _viewer's own asset in a space_ is not a
-reachable fixture (viewers cannot contribute), so viewer×ownership variation lives in the unit matrix
-(E1 vs a synthetic all-owned viewer ctx), not e2e.
+Cases 1 and 5 are the reporter's exact regressions. **E16 and E17 are covered by the unit matrix
+(decision-parameterised) and the API matrix, not e2e:** whether a non-manager viewer can end up
+owning an asset that a manager added to a space/space-album is a contribution-model question that
+Slice 1 pins directly at the API level, so the fragile UI fixture is not worth building — the unit
+matrix asserts the capability logic for that `ctx` regardless of reachability, and the API matrix
+asserts the server truth.
 
-### Server/API RBAC matrix (Slice 6)
+### Server/API RBAC matrix (Slice 1 — runs first, decides the gates)
 
 Using `buildSpaceContext()` (gives `spaceOwner`/`spaceEditor`/`spaceViewer`/`spaceNonMember` +
 `spaceAssetId` owned by owner) and `forEachActor()` (asserts a status per actor, names the failing
 actor):
 
 - **Download** of `spaceAssetId`: owner/editor/viewer → 200; non-member → 4xx.
-- **Create-shared-link** referencing `spaceAssetId`: pin the real status per actor (decides the
-  `canShare` gate — see Share note).
-- **Add-to-album** of `spaceAssetId` into the actor's own album: pin per actor (decides `canAddToAlbum`
-  gate).
+- **Create-shared-link** referencing `spaceAssetId`: pin the real status per actor → **decides the
+  `canShare` gate** (unconditional vs `isAllUserOwned`; see Share note).
+- **Add-to-album** of `spaceAssetId` into the actor's own album: pin per actor → **decides the
+  `canAddToAlbum` gate**.
 - **Favorite / metadata update / delete** of `spaceAssetId`: only the asset **owner** → 200; other
   members → 4xx (proves owner-gate is real server-side, backs V1/V2).
 - **Remove-from-space**: editor/owner → 200; viewer/non-member → 4xx.
+- **Remove-from-space-album, own asset:** a non-manager member removing **their own** asset from a
+  space album → **decides decision C** (if 4xx, drop the `isAllUserOwned` arm from
+  `canRemoveFromAlbum`). Also assert: manager removing another member's asset → 200; non-manager
+  removing another member's asset → 4xx.
 
 ### Infra notes (folded in from prior e2e pain)
 
@@ -348,77 +404,94 @@ Each slice is a vertical, independently green increment. TDD order inside every 
 → fail → implement → green → refactor**. A slice is "done" only when its acceptance criteria hold and
 the full web gate (`check:typescript` + `check:svelte` + `pnpm lint`) is clean.
 
-### Slice 1 — `getSelectionCapabilities` rule engine + unit matrix + parity guard
+**Ordering rationale:** the server/API matrix runs **first** because it resolves the two open gate
+decisions (Share/Add-to-album owner-scoping, and decision C) that the rule engine and every web e2e
+assertion depend on. Then rules → component → page wirings (each with its own web e2e) → cleanup.
+Slices 4–6 each mutate one fork page and are independent of each other (any order), but all follow
+Slices 1–3.
 
-- **Tests first:** `selection-capabilities.spec.ts` implementing the full RBAC edge catalogue E1–E15
-  as BDD scenarios over synthetic `CommandContext` fixtures, plus the album↔space parity assertion.
+### Slice 1 — Server/API RBAC matrix (decides the gates; runs first)
+
+- **Tests first + implement (test-only slice):** `spaces-selection-actions.e2e-spec.ts` under
+  `e2e/src/specs/server/api/` using `buildSpaceContext()` + `forEachActor()`, covering every row of
+  the "Server/API RBAC matrix" above (download, create-shared-link, add-to-album, favorite, metadata
+  update, delete, remove-from-space, and **own-asset remove-from-space-album**) against
+  space-accessed asset IDs.
+- **Decision gates recorded in this slice:** (i) `canShare`/`canAddToAlbum` — unconditional vs
+  `isAllUserOwned`, from the pinned create-shared-link / add-to-album statuses; (ii) **decision C** —
+  keep or drop the `isAllUserOwned` arm on `canRemoveFromAlbum` from the own-asset remove status.
+- **Acceptance:** matrix green; both gate decisions written down (they become constants the rule
+  engine encodes in Slice 2); V2 satisfied.
+- **Files:** `e2e/src/specs/server/api/spaces-selection-actions.e2e-spec.ts` (new).
+
+### Slice 2 — `getSelectionCapabilities` rule engine + unit matrix + parity guard
+
+- **Tests first:** `selection-capabilities.spec.ts` — the full RBAC edge catalogue **E1–E17** as
+  Given/When/Then scenarios over synthetic `CommandContext` fixtures, plus the album↔space parity
+  assertion. Encodes the Slice-1 gate decisions.
 - **Implement:** `selection-capabilities.ts` (pure function + `SelectionCapabilities` type). Extend
   `AlbumContext` with `isEditor` and compute it in `registerAlbumContext` (fork file). Reuse existing
   handlers (`canFavoriteSelected`, `canDeleteSelected`, `canAddSelectedToAlbum`) where they align.
-- **Acceptance:** every E1–E15 scenario passes; parity assertion passes; no UI touched yet.
+- **Acceptance:** every E1–E17 scenario passes; parity assertion passes; no UI touched yet.
 - **Files:** `web/src/lib/managers/selection-capabilities.ts` (new),
   `…/selection-capabilities.spec.ts` (new), `…/command-context-manager.svelte.ts` (extend
   `AlbumContext`), `…/command-context-manager.spec.ts` (extend for `isEditor`).
 
-### Slice 2 — `<SelectionToolbar>` component + component tests
+### Slice 3 — `<SelectionToolbar>` component + component tests
 
 - **Tests first:** `SelectionToolbar.spec.ts` — Given a capability set (drive via a stubbed
-  context/harness), Then exactly the permitted buttons render (E8–E12 rendering aspects), and the
-  ⌘K default provider is present.
+  context/harness), Then exactly the permitted buttons render; assert the two prop-dependent render
+  gates (Set-cover hidden when `onSetCover` absent — the space-person case; Remove picks
+  space-vs-album by which of `spaceId`/`album` is set) and that the ⌘K default provider is present so
+  Add-to-album registers.
 - **Implement:** `SelectionToolbar.svelte` wrapping `AssetSelectControlBar`, owning
   `CommandPaletteDefaultProvider`, rendering album-layout actions gated by
   `getSelectionCapabilities`, taking the props bundle.
-- **Acceptance:** component renders correct buttons per caps; no page wired yet; existing suites green.
+- **Acceptance:** component renders correct buttons per caps + props; no page wired yet; existing
+  suites green.
 - **Files:** `web/src/lib/components/timeline/SelectionToolbar.svelte` (new), spec (new).
 
-### Slice 3 — Wire space timeline page + web e2e cases 1–4
+### Slice 4 — Wire space timeline page + web e2e cases 1–4
 
-- **Tests first:** new Playwright spec `spaces-selection-toolbar.e2e-spec.ts` cases 1–4 (fail: Share/
-  Add-to-album/Delete/Set-cover absent today).
+- **Tests first:** new Playwright spec `spaces-selection-toolbar.e2e-spec.ts` cases 1–4 (fail today:
+  Share/Add-to-album/Delete/Set-cover absent).
 - **Implement:** replace the control-bar block (`spaces/[spaceId]/…/+page.svelte:877-911`) with
-  `<SelectionToolbar>`; flip `canAddToAlbum` to `true`; pass space wiring (spaceId, onRemove=
-  `handleRemoveAssets`, onSetCover=`handleSetAsCover`, onFavorite/onArchive).
-- **Acceptance:** cases 1–4 green; the page's old inline action imports removed; web gate clean.
+  `<SelectionToolbar>`; pass space wiring (`spaceId`, `onRemove=handleRemoveAssets`,
+  `onSetCover=handleSetAsCover`, `onFavorite`, `onArchive`). Toolbar Add-to-album comes from the
+  component's own provider. Separately, flip this page's `registerSelectionContext` `canAddToAlbum`
+  (line 522) `false → true` for ⌘K-palette parity (1 line; the only page that has a selection context
+  to flip).
+- **Acceptance:** cases 1–4 green; old inline action imports removed; web gate clean.
 - **Files:** `spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`, e2e spec (new).
 
-### Slice 4 — Wire space person page + smoke e2e case 8
+### Slice 5 — Wire space person page + smoke e2e case 8
 
-- **Tests first:** e2e case 8 (space-person viewer sees always-set, not owner-gated/Remove-from-space).
-- **Implement:** same swap in
-  `spaces/[spaceId]/people/[personId]/…/+page.svelte:714-742`.
-- **Acceptance:** case 8 green; space-person toolbar identical to space timeline; web gate clean.
+- **Tests first:** e2e case 8 (space-person viewer sees the always-set, not owner-gated /
+  Remove-from-space; **no Set-cover** even for an editor).
+- **Implement:** same swap at `spaces/[spaceId]/people/[personId]/…/+page.svelte:715-742`; pass
+  `spaceId` + handlers but **no `onSetCover`** (this page has no cover). This page registers no
+  selection context — do not add one (out of scope).
+- **Acceptance:** case 8 green; toolbar matches space timeline minus Set-cover; web gate clean.
 - **Files:** the space-person page, e2e spec (append).
 
-### Slice 5 — Wire space album page (the reversal) + web e2e cases 5–7 + V1
+### Slice 6 — Wire space album page (the reversal) + web e2e cases 5–7 + V1
 
-- **Tests first:** e2e cases 5–7 (fail: Select-all/menu/Share absent in space album today). Case 7
-  specifically proves V1 (owner-gated actions appear on the member's **own** album asset and only
-  then).
+- **Tests first:** e2e cases 5–7 (fail today: Select-all/menu/Share absent in space album). Case 7
+  proves V1 (owner-gated actions appear on the member's **own** album asset and only then).
 - **Implement:** replace the Download+Remove-only bar
   (`spaces/[spaceId]/albums/[albumId]/…/+page.svelte:412-419`) with `<SelectionToolbar>`; album wiring
-  (album DTO, onRemove=`handleRemoveAssets`, onSetCover=album cover); `canRemoveFromAlbum` via
-  `canManage`; **no** Remove-from-space. Update/replace the `rbac-5/albums-8` comment to document the
-  new invariant (owner-gated via `isAllUserOwned`; space-editor cross-owner edit still never offered).
-- **Acceptance:** cases 5–7 green; verify no owner-gated button shows on a non-owned album asset
-  (V1); web gate clean.
+  (`album` DTO, `onRemove=handleRemoveAssets`, `onSetCover=`album cover); `canRemoveFromAlbum` per the
+  resolved decision C; **no** `spaceId`/Remove-from-space. Replace the `rbac-5/albums-8` comment to
+  document the new invariant (mutations gated via `isAllUserOwned`; space-editor cross-owner edit
+  still never offered). This page registers no selection context — do not add one.
+- **Acceptance:** cases 5–7 green; verify no owner-gated button shows on a non-owned album asset (V1);
+  web gate clean.
 - **Files:** the space-album page, e2e spec (append).
-
-### Slice 6 — Server/API RBAC matrix + Share/Add-to-album decision (V2)
-
-- **Tests first + implement (test-only slice):** `spaces-selection-actions.e2e-spec.ts` under
-  `e2e/src/specs/server/api/` using `buildSpaceContext()` + `forEachActor()` covering download,
-  create-shared-link, add-to-album, favorite, metadata update, delete, remove-from-space against
-  space-accessed asset IDs.
-- **Decision gate:** from the pinned create-shared-link / add-to-album statuses, either leave
-  `canShare`/`canAddToAlbum` unconditional or gate them by `isAllUserOwned` (update Slice 1's
-  function + matrix accordingly, keeping album/personal unaffected).
-- **Acceptance:** matrix green; capability gate matches proven server behaviour; V2 satisfied.
-- **Files:** e2e API spec (new); possibly `selection-capabilities.ts` + its spec (adjust gate).
 
 ### Slice 7 — Cleanup, i18n, parity guard confirmation, full verify
 
 - **Implement:** remove now-dead action imports from all three space pages; add any new i18n keys
-  (en.json only — web+mobile share `i18n/`); confirm the parity guard from Slice 1 is explicit and
+  (en.json only — web+mobile share `i18n/`); confirm the parity guard from Slice 2 is explicit and
   named.
 - **Acceptance:** `make check-web` + `make lint-web` clean; unit + component + web e2e + API e2e all
   green; a final skim confirms the three space surfaces match the album reference per the catalogue.
@@ -426,13 +499,16 @@ the full web gate (`check:typescript` + `check:svelte` + `pnpm lint`) is clean.
 
 ## Risks & open questions
 
-- **R1 — Share/Add-to-album server behaviour (resolved by Slice 6).** If either is owner-scoped
+- **R1 — Share/Add-to-album server behaviour (resolved by Slice 1).** If either is owner-scoped
   server-side, the capability is gated by `isAllUserOwned`; no user-visible regression on album/
   personal. Tracked, not blocking.
 - **R2 — `ownerId` fidelity on space-projected assets (V1).** If the merged space timeline supplies a
-  wrong/absent `ownerId`, owner-gated actions could mis-render. Slice 5 e2e (owner vs other) is the
+  wrong/absent `ownerId`, owner-gated actions could mis-render. Slice 6 e2e (owner vs other) is the
   tripwire; a focused unit check is the fallback.
-- **R3 — Drift from the untouched upstream album.** Mitigated by the Slice 1 parity guard: if upstream
+- **R3 — Drift from the untouched upstream album.** Mitigated by the Slice 2 parity guard: if upstream
   restructures the album toolbar, the assertion fails in CI rather than shipping silent divergence.
-- **R4 — `check:svelte` local blindness.** It has been observed to scan 0 files locally; rely on the
+- **R4 — Decision C (own-asset remove from a space album).** Resolved empirically in Slice 1; either
+  outcome is consistent (mimic-album if the server allows it, or a recorded space-album deviation if
+  not). Not blocking.
+- **R5 — `check:svelte` local blindness.** It has been observed to scan 0 files locally; rely on the
   push-time CI gate for the svelte check, and don't treat a local 0-file run as proof.

--- a/docs/superpowers/specs/2026-07-24-selection-toolbar-consistency-design.md
+++ b/docs/superpowers/specs/2026-07-24-selection-toolbar-consistency-design.md
@@ -68,10 +68,11 @@ From `albums/[albumId]/…/+page.svelte:734-780` (the untouched reference):
 | Remove-from-album                                                                                | Album owner (`isOwned`) **or** own assets                                 |
 | Delete                                                                                           | Own assets only                                                           |
 
-¹ The album renders these buttons unconditionally; whether the **server** honours a
-create-shared-link / add-to-album call for a _non-owned_ asset is pinned by the API RBAC matrix
-(Slice 1). Whatever the album's real behaviour is, spaces mirror it — see the Share/Add-to-album note
-under Capability rules.
+¹ The album _page_ renders these buttons unconditionally, but Slice 1 proved the **server** honours
+create-shared-link / add-to-album only for **owned (∪ partner)** assets (`Permission.AssetShare`,
+`access.ts:127-131`). So our space toolbar owner-gates them (`isAllUserOwned`) to stay honest rather
+than reproduce the album page's unconditional-but-sometimes-400 buttons — see the Share/Add-to-album
+note under Capability rules.
 
 We deliberately mirror the **album's** metadata set (Rotate + date/description/location + Archive +
 Set-visibility), **not** the personal timeline's richer set (Stack, Link-live-photo, and library job
@@ -135,9 +136,9 @@ Predicates (the single rule set):
 
 ```
 canSelectAll       = sel !== null
-canDownload        = true            // mirror album; download-disable is a shared-link-only flag (out of scope)
-canShare           = true            // mirror album (see Share/Add-to-album note)
-canAddToAlbum      = true            // mirror album
+canDownload        = true            // download-disable is a shared-link-only flag (out of scope); auth toolbar downloads unconditionally
+canShare           = sel.isAllUserOwned   // RESOLVED Slice 1 Q1: server AssetShare = owner∪partner only (no space/album arm)
+canAddToAlbum      = sel.isAllUserOwned   // RESOLVED Slice 1 Q2: same owner∪partner gate (the #764 space-editor contribution is a separate flow, out of scope)
 canFavorite        = sel.isAllUserOwned
 canEditMetadata    = sel.isAllUserOwned
 canTag             = sel.isAllUserOwned && tagsEnabled
@@ -148,10 +149,22 @@ isEditorOfContext  = isRegularAlbum ? (ctx.album.isOwner || ctx.album.isEditor)
                    : /* personal */   false
 canSetCover        = isEditorOfContext && sel.selectedAssetIds.length === 1   // ROLE gate only; see cover note
 canRemoveFromAlbum = isRegularAlbum ? (ctx.album.isOwner || sel.isAllUserOwned)
-                   : isSpaceAlbum   ? (ctx.space.canWrite || ctx.album.isEditor || sel.isAllUserOwned)  // canManage OR own asset — see C
+                   : isSpaceAlbum   ? (ctx.space.canWrite || ctx.album.isEditor)   // RESOLVED Slice 1 Q3 (decision C): canManage ONLY — server AlbumAssetDelete is role-gated, ownership grants nothing
                    : false
 canRemoveFromSpace = isDirectSpace && ctx.space.canWrite
 ```
+
+**On owner-gating Share and Add-to-album (resolved Slice 1, Q1/Q2):** the server's `Permission.AssetShare`
+(used by both create-shared-link and the ordinary add-assets-to-album path) is **owner ∪ partner
+only** — it has no album or space arm (`server/src/utils/access.ts:127-131`, deliberate per the
+`shared-space.service.ts:669-671` comment). So a shared link or album-add referencing a non-owned
+space asset is refused server-side. Gating `canShare`/`canAddToAlbum` by `isAllUserOwned` keeps the
+toolbar **honest** (it never offers a button the server would 400). On the personal timeline and
+regular album this is always true, so those reference surfaces are unaffected; in a space the buttons
+appear only for your own selected assets. This is stricter than the album _page_'s unconditional
+buttons (a latent album quirk we deliberately do not reproduce), but it is exactly "show whatever the
+user is **able** to do." (Partner-shared assets are a rare extra the server also allows; the toolbar's
+`isAllUserOwned` signal conservatively omits them — acceptable, never offers a 400.)
 
 **Cover note (fixes a space-person over-grant):** `canSetCover` is only the _role+single_ gate — it is
 surface-agnostic. Not every surface has a cover: the **space-timeline** sets the space cover, a
@@ -161,13 +174,15 @@ renders Set-cover only when `caps.canSetCover && onSetCover != null`; the space-
 `onSetCover`, so cover never appears there even for an editor. `canSetCover` never returns true on the
 personal timeline because `isEditorOfContext` is false there.
 
-**Space-album Remove-from-album (decision C):** the regular album lets a member remove **their own**
-asset (`ctx.album.isOwner || sel.isAllUserOwned`). A space-album manager adds assets that may be owned
-by various members, so a non-manager member CAN have an own asset in the album — and under
-"mimic album" they should be able to remove it. Hence the `|| sel.isAllUserOwned` arm above. This is
-**pending server confirmation** (Slice 1 API row: can a non-manager remove their own asset from a
-space album?). If the server refuses, drop the arm to `canManage`-only and record that as an
-intentional space-album deviation; the parity guard (Slice 2) encodes whichever we land on.
+**Space-album Remove-from-album (decision C — RESOLVED Slice 1, Q3):** removing an asset from a space
+album goes through `Permission.AlbumAssetDelete`, whose server check is **strictly role-gated** —
+album owner/editor **or** space owner/editor of the linked space (`server/src/utils/access.ts:247-257`
+
+- `access.repository.ts:144-161`, which excludes a space Viewer's membership row). Asset **ownership
+  grants nothing**: a plain viewer/member is refused (403) before any per-asset logic runs, even for
+  their own asset. So `canRemoveFromAlbum` in a space album is `canManage` **only** — no `isAllUserOwned`
+  arm. This is a **server-enforced deviation** from the regular album (which does allow own-asset
+  removal); the parity guard (Slice 2) encodes this space-album exception explicitly.
 
 **Orthogonality invariant (critical):** _space role_ (Owner/Editor/Viewer, from
 `ctx.space.canWrite`/`isOwner`) and _asset ownership_ (`sel.isAllUserOwned`, i.e.
@@ -236,11 +251,11 @@ Each of the three fork space routes replaces its bespoke control-bar block with 
 
 Net result per surface:
 
-| Surface        | Before                                                           | After                                                                                                           |
-| -------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| Space album    | Download + Remove-from-album only                                | Full album-equivalent toolbar; Remove-from-album gated `canManage \|\| own asset` (C); **no** Remove-from-space |
-| Space timeline | Select-all, Remove-from-space, Favorite, Download + partial menu | Full album-equivalent; adds Share, Add-to-album, Rotate, Set-visibility, Delete, Set-cover (space cover)        |
-| Space person   | same as space timeline                                           | same as space timeline **except no Set-cover** (page has no cover action)                                       |
+| Surface        | Before                                                           | After                                                                                                                                                              |
+| -------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Space album    | Download + Remove-from-album only                                | Full album-equivalent toolbar; Select-all + Download always; owner-gated actions on own assets; Remove-from-album gated `canManage` (Q3); **no** Remove-from-space |
+| Space timeline | Select-all, Remove-from-space, Favorite, Download + partial menu | Full album-equivalent; adds Share/Add-to-album (own assets only), Rotate, Set-visibility, Delete, Set-cover (space cover)                                          |
+| Space person   | same as space timeline                                           | same as space timeline **except no Set-cover** (page has no cover action)                                                                                          |
 
 ## RBAC safety invariants & verifications
 
@@ -255,32 +270,31 @@ Reversing the deliberate space-album strip (`rbac-5/albums-8` comment at
    (`shared-space-album-scope.guard.spec.ts`) remain valid and untouched.
 2. **Editor/owner-role actions** (Set-cover, Remove-from-album/space) are gated by container role and
    independently enforced server-side.
-3. **Share / Add-to-album** mirror the album (see note below); the server is the enforcement point.
+3. **Share / Add-to-album** are owner-gated (`isAllUserOwned`) to match the server's owner∪partner
+   `AssetShare` rule (Q1/Q2), so they too never fire on a non-owned asset.
 
-Two things are **verified by tests, not assumed**:
+Both verifications are now **resolved by Slice 1's server-code investigation** (evidence in the API
+matrix section) and re-asserted by tests:
 
-- **V1 — `TimelineAsset.ownerId` is correct on space-projected assets.** The entire owner-gate rests
-  on it. If ownerId were wrong/absent on the merged space timeline or space album, owner-gated
-  actions could appear on non-owned assets. Asserted by the web e2e owner/other cases (Slice 6) and,
-  if needed, a focused unit check.
-- **V2 — owner-scoped Share / Add-to-album / edit / delete endpoints accept space-accessed asset
-  IDs and enforce ownership/role.** Proven by the server/API RBAC matrix (Slice 1).
+- **V1 — `TimelineAsset.ownerId` is correct on space-projected assets.** RESOLVED (Q4): traced
+  end-to-end (`asset.repository.ts:1439/1502`, no mask/override), so the owner-gate is reliable. The
+  web e2e owner/other cases (Slice 6) re-assert it as a tripwire.
+- **V2 — owner-scoped Share / Add-to-album / edit / delete / remove endpoints enforce ownership/role
+  for space-accessed asset IDs.** RESOLVED (Q1–Q3): create-shared-link and add-to-album are
+  owner∪partner-only; metadata/favorite/delete are owner-only; remove-from-space-album is role-gated.
+  Codified by the server/API RBAC matrix (Slice 1).
 
-### Share / Add-to-album note
+### Share / Add-to-album note (RESOLVED — Slice 1, Q1/Q2)
 
-The capability defaults to unconditional (mirror the album). **Slice 1 (the API matrix) runs first**
-precisely so this is decided before the rule engine and web e2e depend on it. It pins the **actual**
-server behaviour for a non-owned asset:
-
-- If the server **owner-scopes** create-shared-link and/or add-to-album (rejects non-owned), then to
-  keep the toolbar honest we gate those two capabilities by `sel.isAllUserOwned` — which on the
-  personal timeline and regular album is always true, so those reference surfaces are unaffected,
-  and in a space the button appears only for your own selected assets. This is still "mimic album":
-  identical rule, made explicit.
-- If the server permits it (as the album UI implies), they stay unconditional.
-
-Either way the toolbar never offers a button the server would 400 — that equivalence is the property
-Slice 1 guarantees.
+The server's `Permission.AssetShare` (used by both create-shared-link and add-assets-to-album) is
+**owner ∪ partner only** — no album/space arm (`server/src/utils/access.ts:127-131`, deliberate per
+`shared-space.service.ts:669-671`). So we gate `canShare`/`canAddToAlbum` by `sel.isAllUserOwned`:
+always true on personal/regular-album (reference surfaces unaffected), and in a space the buttons
+appear only for your own selected assets. The toolbar therefore never offers a button the server would
+400 — stricter than the album _page_'s unconditional buttons (a latent quirk we intentionally do not
+reproduce), and exactly "show whatever the user is **able** to do." The fork's #764 cross-owner
+contribution (space Owner/Editor adding others' assets to a space-linked album) is a **separate
+existing flow**, not this generic toolbar button, and stays out of scope.
 
 ## Testing strategy (TDD + BDD)
 
@@ -309,11 +323,12 @@ the exact allowed/denied set. No scenario asserts more than one behaviour.
   cross-product `{personal, regular-album, space-timeline, space-album} × {owner, editor, viewer} ×
 {all-owned, mixed, none-owned} × {single, multi}`, plus asset-state axes (all-favorite,
   all-archived, tags on/off). Includes the **parity assertion**: for equivalent role+ownership, the
-  space capability set equals the album capability set with one substitution — on **direct-space**
-  surfaces (space timeline/person) `canRemoveFromAlbum` is replaced by `canRemoveFromSpace`; on a
-  **space album** the set matches the album under the role mapping (`canRemoveFromAlbum` via
-  `canManage || own asset`, mirroring the album's `owns-container || own asset`). This is what fails
-  CI if upstream restructures the album toolbar. The parity test encodes the resolved decision C.
+  space capability set equals the album capability set except for two documented, server-enforced
+  deviations — (i) on **direct-space** surfaces (space timeline/person) `canRemoveFromAlbum` is
+  replaced by `canRemoveFromSpace`; (ii) on a **space album** `canRemoveFromAlbum` is `canManage`
+  ONLY (no own-asset arm — Q3), unlike the regular album's `owns-container || own asset`. Share and
+  Add-to-album are `isAllUserOwned` on every surface (so album-context and space-context agree). This
+  is what fails CI if upstream restructures the album toolbar.
 - **b. Component — `<SelectionToolbar>`:** given a capability set, renders exactly the permitted
   buttons and no others (reuse the `register-selection-context-harness.svelte` pattern). Asserts
   the ⌘K provider is present so Add-to-album registers.
@@ -329,64 +344,70 @@ the exact allowed/denied set. No scenario asserts more than one behaviour.
 
 ### RBAC edge-case catalogue (must all be covered — unit at minimum)
 
-| #   | Scenario                                                                     | Expected                                                                                                                |
-| --- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| E1  | Space **viewer** selects an owner's (not their) asset — space timeline       | Select-all, Download, Share, Add-to-album ✓; Favorite/edit/Tag/Delete ✗; Remove-from-space ✗; Set-cover ✗               |
-| E2  | Space **editor** selects their **own** asset — space timeline                | all of E1 ✓ + Favorite/edit/Tag/Delete ✓ + Remove-from-space ✓ + Set-cover ✓ (if single)                                |
-| E3  | Space **editor** selects an owner's (not their) asset                        | E1 ✓ + Remove-from-space ✓ + Set-cover ✓; Favorite/edit/Tag/Delete ✗                                                    |
-| E4  | Space **owner** selects **another member's** asset                           | Remove-from-space ✓, Set-cover ✓ (role); Favorite/edit/Delete ✗ (**not** the asset owner) — the orthogonality invariant |
-| E5  | Space **viewer** who is the space album's **album-editor**, in a space album | Remove-from-album ✓ (canManage via `isAlbumEditor`) even though space viewer                                            |
-| E6  | Space **editor**, not an album member, in a space album                      | Remove-from-album ✓ (canManage via `isSpaceEditor`)                                                                     |
-| E7  | **Mixed** selection (some owned, some not)                                   | owner-gated all ✗ (`isAllUserOwned` false); always-set ✓                                                                |
-| E8  | **Multi** selection                                                          | Set-cover ✗ (single only); everything else per role/ownership                                                           |
-| E9  | All-favorite selection                                                       | Favorite renders as "remove from favorites"; else "favorite"                                                            |
-| E10 | All-archived selection                                                       | Archive renders as "unarchive"; else "archive"                                                                          |
-| E11 | Tags preference disabled                                                     | Tag ✗ even when `isAllUserOwned`                                                                                        |
-| E12 | Empty selection                                                              | toolbar not rendered (`sel === null`)                                                                                   |
-| E13 | Space **non-member** hits a space URL                                        | cannot reach the page (existing visibility specs); toolbar N/A — cross-referenced, not re-tested                        |
-| E14 | Regression: personal timeline unchanged                                      | full personal set unchanged (function returns personal answer; pages untouched)                                         |
-| E15 | Regression: regular album unchanged                                          | full album set unchanged                                                                                                |
-| E16 | Space **viewer** (non-manager) selects their **own** asset in a space album  | Remove-from-album ✓ via the own-asset arm (decision C); owner-gated ✓; Set-cover ✗ (not a manager)                      |
-| E17 | **Admin** (not the asset owner, not a space/album role) selects an asset     | no special power — owner/role gates apply exactly as for any user (`isAdmin` is never consulted by the rule engine)     |
+| #   | Scenario                                                                     | Expected                                                                                                                            |
+| --- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| E1  | Space **viewer** selects an owner's (not their) asset — space timeline       | Select-all, Download ✓; Share/Add-to-album ✗ (not owner — Q1/Q2); Favorite/edit/Tag/Delete ✗; Remove-from-space ✗; Set-cover ✗      |
+| E2  | Space **editor** selects their **own** asset — space timeline                | Select-all, Download ✓ + Share, Add-to-album, Favorite, edit, Tag, Delete ✓ + Remove-from-space ✓ + Set-cover ✓ (if single)         |
+| E3  | Space **editor** selects an owner's (not their) asset                        | Select-all, Download ✓ + Remove-from-space ✓ + Set-cover ✓; Share/Add-to-album, Favorite/edit/Tag/Delete ✗ (not owner)              |
+| E4  | Space **owner** selects **another member's** asset                           | Remove-from-space ✓, Set-cover ✓ (role); Share/Add-to-album, Favorite/edit/Delete ✗ (**not** the asset owner) — orthogonality       |
+| E5  | Space **viewer** who is the space album's **album-editor**, in a space album | Remove-from-album ✓ (canManage via `isAlbumEditor`) even though space viewer                                                        |
+| E6  | Space **editor**, not an album member, in a space album                      | Remove-from-album ✓ (canManage via `isSpaceEditor`)                                                                                 |
+| E7  | **Mixed** selection (some owned, some not)                                   | owner-gated + Share/Add-to-album all ✗ (`isAllUserOwned` false); Select-all + Download ✓ (the only truly-always actions)            |
+| E8  | **Multi** selection                                                          | Set-cover ✗ (single only); everything else per role/ownership                                                                       |
+| E9  | All-favorite selection                                                       | Favorite renders as "remove from favorites"; else "favorite"                                                                        |
+| E10 | All-archived selection                                                       | Archive renders as "unarchive"; else "archive"                                                                                      |
+| E11 | Tags preference disabled                                                     | Tag ✗ even when `isAllUserOwned`                                                                                                    |
+| E12 | Empty selection                                                              | toolbar not rendered (`sel === null`)                                                                                               |
+| E13 | Space **non-member** hits a space URL                                        | cannot reach the page (existing visibility specs); toolbar N/A — cross-referenced, not re-tested                                    |
+| E14 | Regression: personal timeline unchanged                                      | full personal set unchanged (function returns personal answer; pages untouched)                                                     |
+| E15 | Regression: regular album unchanged                                          | full album set unchanged                                                                                                            |
+| E16 | Space **viewer** (non-manager) selects their **own** asset in a space album  | Remove-from-album ✗ (Q3: role-gated, viewer is not a manager); owner-gated (Favorite/edit/Delete/Share/Add-to-album) ✓; Set-cover ✗ |
+| E17 | **Admin** (not the asset owner, not a space/album role) selects an asset     | no special power — owner/role gates apply exactly as for any user (`isAdmin` is never consulted by the rule engine)                 |
 
 ### Web e2e matrix (subset of the catalogue that is reachable through the UI)
 
-| #   | Surface        | Actor              | Selection                   | Assert SHOW                                                 | Assert HIDE                                          | Catalogue |
-| --- | -------------- | ------------------ | --------------------------- | ----------------------------------------------------------- | ---------------------------------------------------- | --------- |
-| 1   | Space timeline | Viewer             | owner's asset               | Select-all, Download, Share, Add-to-album                   | Favorite, edit, Delete, Remove-from-space, Set-cover | E1        |
-| 2   | Space timeline | Editor             | own asset (editor adds it)  | + Favorite, edit, Tag, Delete, Remove-from-space, Set-cover | —                                                    | E2        |
-| 3   | Space timeline | Editor             | owner's asset               | Remove-from-space, Set-cover                                | Favorite, edit, Delete                               | E3        |
-| 4   | Space timeline | Owner              | own asset                   | everything                                                  | —                                                    | E2/E4     |
-| 5   | Space album    | Viewer/member      | album asset (not theirs)    | Select-all, Download, Share, Add-to-album                   | Remove-from-album, owner-gated                       | E1/E7     |
-| 6   | Space album    | Editor (canManage) | album asset                 | + Remove-from-album, Set-cover                              | —                                                    | E6        |
-| 7   | Space album    | member             | **own** asset in album      | owner-gated (Favorite/edit/Delete)                          | —                                                    | E2        |
-| 8   | Space person   | Viewer             | person's asset (not theirs) | Select-all, Download, Share, Add-to-album                   | owner-gated, Remove-from-space                       | smoke     |
+| #   | Surface        | Actor                | Selection                   | Assert SHOW                                                                                          | Assert HIDE                                                               | Catalogue |
+| --- | -------------- | -------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | --------- |
+| 1   | Space timeline | Viewer               | owner's asset               | Select-all, Download                                                                                 | Share, Add-to-album, Favorite, edit, Delete, Remove-from-space, Set-cover | E1        |
+| 2   | Space timeline | Editor               | own asset (editor adds it)  | Select-all, Download, Share, Add-to-album, Favorite, edit, Tag, Delete, Remove-from-space, Set-cover | —                                                                         | E2        |
+| 3   | Space timeline | Editor               | owner's asset               | Select-all, Download, Remove-from-space, Set-cover                                                   | Share, Add-to-album, Favorite, edit, Delete                               | E3        |
+| 4   | Space timeline | Owner                | own asset                   | everything                                                                                           | —                                                                         | E2/E4     |
+| 5   | Space album    | Viewer/member        | album asset (not theirs)    | Select-all, Download                                                                                 | Share, Add-to-album, Remove-from-album, owner-gated                       | E1/E7     |
+| 6   | Space album    | Editor (canManage)   | album asset (not theirs)    | Select-all, Download, Remove-from-album, Set-cover                                                   | Share, Add-to-album, Favorite, edit, Delete                               | E6        |
+| 7   | Space album    | member (non-manager) | **own** asset in album      | Select-all, Download, Share, Add-to-album, Favorite, edit, Tag, Delete                               | Remove-from-album, Set-cover                                              | E16       |
+| 8   | Space person   | Viewer               | person's asset (not theirs) | Select-all, Download                                                                                 | Share, Add-to-album, owner-gated, Remove-from-space                       | smoke     |
 
-Cases 1 and 5 are the reporter's exact regressions. **E16 and E17 are covered by the unit matrix
-(decision-parameterised) and the API matrix, not e2e:** whether a non-manager viewer can end up
-owning an asset that a manager added to a space/space-album is a contribution-model question that
-Slice 1 pins directly at the API level, so the fragile UI fixture is not worth building — the unit
-matrix asserts the capability logic for that `ctx` regardless of reachability, and the API matrix
-asserts the server truth.
+Cases 1 and 5 are the reporter's exact regressions (Select-all + Download were missing there). Case 7
+covers E16 and is reachable because a space Owner/Editor can add another member's asset to a
+space-linked album (fork #764 contribution). **E17** (admin has no special power) lives in the unit
+matrix only — there is no UI surface where admin-ness would change the toolbar, so an e2e fixture adds
+no signal.
 
-### Server/API RBAC matrix (Slice 1 — runs first, decides the gates)
+### Server/API RBAC matrix (Slice 1 — runs first, gates now RESOLVED)
 
 Using `buildSpaceContext()` (gives `spaceOwner`/`spaceEditor`/`spaceViewer`/`spaceNonMember` +
 `spaceAssetId` owned by owner) and `forEachActor()` (asserts a status per actor, names the failing
-actor):
+actor). The expected statuses below are the **resolved** server behaviour (evidence file:line noted);
+the e2e spec codifies them and is the regression tripwire:
 
 - **Download** of `spaceAssetId`: owner/editor/viewer → 200; non-member → 4xx.
-- **Create-shared-link** referencing `spaceAssetId`: pin the real status per actor → **decides the
-  `canShare` gate** (unconditional vs `isAllUserOwned`; see Share note).
-- **Add-to-album** of `spaceAssetId` into the actor's own album: pin per actor → **decides the
-  `canAddToAlbum` gate**.
+- **Create-shared-link** referencing a **non-owned** `spaceAssetId`: editor/viewer → **4xx** (owner →
+  200). `Permission.AssetShare` = owner∪partner only (`access.ts:127-131`). → `canShare =
+isAllUserOwned`.
+- **Add-to-album** of a **non-owned** `spaceAssetId` into the actor's own (non-space) album:
+  editor/viewer → **4xx** (owner → 200). Same `AssetShare` gate via `asset.util.ts` (`album.service.ts:253-262`).
+  → `canAddToAlbum = isAllUserOwned`.
 - **Favorite / metadata update / delete** of `spaceAssetId`: only the asset **owner** → 200; other
-  members → 4xx (proves owner-gate is real server-side, backs V1/V2).
-- **Remove-from-space**: editor/owner → 200; viewer/non-member → 4xx.
-- **Remove-from-space-album, own asset:** a non-manager member removing **their own** asset from a
-  space album → **decides decision C** (if 4xx, drop the `isAllUserOwned` arm from
-  `canRemoveFromAlbum`). Also assert: manager removing another member's asset → 200; non-manager
-  removing another member's asset → 4xx.
+  members → 4xx (owner-scoped `Permission.AssetUpdate`/`AssetDelete`, `access.ts:155-163`). **Q5
+  confirmed:** `AssetUpdate` runs `checkOwnerAccess` first and only applies `checkSpaceEditAccess` to
+  the leftover non-owned ids — it never _subtracts_ an owner's grant, so an owner is never 400'd for
+  their own asset just because it is album-path in a space. Owner-gated actions are therefore safe in
+  the space album (Slice 6).
+- **Remove-from-space** (`shared_space_asset`): editor/owner → 200; viewer/non-member → 4xx.
+- **Remove-from-space-album:** manager (space/album editor) removing any asset → 200; **non-manager
+  removing their own asset → 4xx** (decision C: `AlbumAssetDelete` is role-gated, `access.ts:247-257` +
+  `access.repository.ts:144-161`). → `canRemoveFromAlbum` (space album) `= canManage`, **no** own-asset
+  arm.
 
 ### Infra notes (folded in from prior e2e pain)
 
@@ -417,12 +438,18 @@ Slices 1–3.
   the "Server/API RBAC matrix" above (download, create-shared-link, add-to-album, favorite, metadata
   update, delete, remove-from-space, and **own-asset remove-from-space-album**) against
   space-accessed asset IDs.
-- **Decision gates recorded in this slice:** (i) `canShare`/`canAddToAlbum` — unconditional vs
-  `isAllUserOwned`, from the pinned create-shared-link / add-to-album statuses; (ii) **decision C** —
-  keep or drop the `isAllUserOwned` arm on `canRemoveFromAlbum` from the own-asset remove status.
-- **Acceptance:** matrix green; both gate decisions written down (they become constants the rule
-  engine encodes in Slice 2); V2 satisfied.
+- **Gate decisions (already resolved by server-code investigation; this slice codifies them as
+  executable assertions):** (i) `canShare = canAddToAlbum = isAllUserOwned` (`AssetShare` is
+  owner∪partner-only, Q1/Q2); (ii) **decision C** — `canRemoveFromAlbum` in a space album is
+  `canManage` ONLY, no own-asset arm (`AlbumAssetDelete` role-gated, Q3); (iii) owner mutations are
+  never album-path-blocked (Q5). If any assertion turns out red against a running server, the fix is
+  to correct the rule engine (Slice 2) — the e2e is the source of truth.
+- **Acceptance:** matrix green; the three findings stand as executable tests; V2 satisfied.
 - **Files:** `e2e/src/specs/server/api/spaces-selection-actions.e2e-spec.ts` (new).
+- **Note on local execution:** this suite needs the e2e API stack (testcontainers/Docker). The shared
+  e2e stack is a machine-wide singleton; if it is not safely available locally, push and let CI run it
+  — the gate decisions are already resolved from server code, so Slices 2–6 are not blocked on a local
+  red/green here.
 
 ### Slice 2 — `getSelectionCapabilities` rule engine + unit matrix + parity guard
 
@@ -453,8 +480,10 @@ Slices 1–3.
 
 ### Slice 4 — Wire space timeline page + web e2e cases 1–4
 
-- **Tests first:** new Playwright spec `spaces-selection-toolbar.e2e-spec.ts` cases 1–4 (fail today:
-  Share/Add-to-album/Delete/Set-cover absent).
+- **Tests first:** new Playwright spec `spaces-selection-toolbar.e2e-spec.ts` cases 1–4. The
+  own-asset cases (2, 4) fail today (Share/Add-to-album/Delete absent for owners); the others'-asset
+  cases (1, 3) assert the viewer/editor behaviour that must be preserved (mostly already correct — they
+  guard against regressions in the rewrite).
 - **Implement:** replace the control-bar block (`spaces/[spaceId]/…/+page.svelte:877-911`) with
   `<SelectionToolbar>`; pass space wiring (`spaceId`, `onRemove=handleRemoveAssets`,
   `onSetCover=handleSetAsCover`, `onFavorite`, `onArchive`). Toolbar Add-to-album comes from the
@@ -476,16 +505,19 @@ Slices 1–3.
 
 ### Slice 6 — Wire space album page (the reversal) + web e2e cases 5–7 + V1
 
-- **Tests first:** e2e cases 5–7 (fail today: Select-all/menu/Share absent in space album). Case 7
-  proves V1 (owner-gated actions appear on the member's **own** album asset and only then).
+- **Tests first:** e2e cases 5–7 (all fail today — space album shows only Download (+Remove for
+  managers); Select-all, the context menu, Share/Add, Favorite are all absent). Cases 5 (others'
+  asset → owner-gated hidden) vs 7 (own asset → owner-gated shown) together are the **V1 tripwire**;
+  case 7 also confirms decision C (Remove-from-album stays hidden for the non-manager owner).
 - **Implement:** replace the Download+Remove-only bar
   (`spaces/[spaceId]/albums/[albumId]/…/+page.svelte:412-419`) with `<SelectionToolbar>`; album wiring
-  (`album` DTO, `onRemove=handleRemoveAssets`, `onSetCover=`album cover); `canRemoveFromAlbum` per the
-  resolved decision C; **no** `spaceId`/Remove-from-space. Replace the `rbac-5/albums-8` comment to
-  document the new invariant (mutations gated via `isAllUserOwned`; space-editor cross-owner edit
-  still never offered). This page registers no selection context — do not add one.
-- **Acceptance:** cases 5–7 green; verify no owner-gated button shows on a non-owned album asset (V1);
-  web gate clean.
+  (`album` DTO, `onRemove=handleRemoveAssets`, `onSetCover=`album cover); `canRemoveFromAlbum` =
+  `canManage` only (resolved decision C — **no** own-asset arm); **no** `spaceId`/Remove-from-space.
+  Replace the `rbac-5/albums-8` comment to document the new invariant (owner-gated mutations are safe
+  via the owner path — Q5; space-editor cross-owner edit still never offered; remove stays role-gated
+  — Q3). This page registers no selection context — do not add one.
+- **Acceptance:** cases 5–7 green; verify no owner-gated button shows on a non-owned album asset and
+  no Remove-from-album shows for a non-manager (V1 + decision C); web gate clean.
 - **Files:** the space-album page, e2e spec (append).
 
 ### Slice 7 — Cleanup, i18n, parity guard confirmation, full verify
@@ -499,16 +531,23 @@ Slices 1–3.
 
 ## Risks & open questions
 
-- **R1 — Share/Add-to-album server behaviour (resolved by Slice 1).** If either is owner-scoped
-  server-side, the capability is gated by `isAllUserOwned`; no user-visible regression on album/
-  personal. Tracked, not blocking.
-- **R2 — `ownerId` fidelity on space-projected assets (V1).** If the merged space timeline supplies a
-  wrong/absent `ownerId`, owner-gated actions could mis-render. Slice 6 e2e (owner vs other) is the
-  tripwire; a focused unit check is the fallback.
+- **R1 — Share/Add-to-album server behaviour.** RESOLVED (Q1/Q2): `AssetShare` is owner∪partner-only,
+  so `canShare = canAddToAlbum = isAllUserOwned`. No user-visible regression on album/personal
+  (always all-owned there). Closed.
+- **R2 — `ownerId` fidelity on space-projected assets (V1).** RESOLVED (Q4): `ownerId` is the genuine
+  owner, never masked. Slice 6 e2e (owner vs other) re-asserts it as a tripwire. Closed.
 - **R3 — Drift from the untouched upstream album.** Mitigated by the Slice 2 parity guard: if upstream
   restructures the album toolbar, the assertion fails in CI rather than shipping silent divergence.
-- **R4 — Decision C (own-asset remove from a space album).** Resolved empirically in Slice 1; either
-  outcome is consistent (mimic-album if the server allows it, or a recorded space-album deviation if
-  not). Not blocking.
-- **R5 — `check:svelte` local blindness.** It has been observed to scan 0 files locally; rely on the
+  (Two deviations are encoded intentionally: Share/Add owner-gating, and the space-album `canManage`-only
+  remove.)
+- **R4 — Decision C (own-asset remove from a space album).** RESOLVED (Q3): `AlbumAssetDelete` is
+  role-gated, ownership grants nothing → `canManage`-only, no own-asset arm. Closed.
+- **R5 — Owner mutations on album-path assets.** RESOLVED (Q5): the owner path (`checkOwnerAccess`) is
+  never subtracted by `checkSpaceEditAccess`, so owner-gated actions are safe in the space album.
+  Closed.
+- **R6 — `check:svelte` local blindness.** It has been observed to scan 0 files locally; rely on the
   push-time CI gate for the svelte check, and don't treat a local 0-file run as proof.
+- **R7 — e2e stack is a shared machine-wide singleton.** The Slice 1 API suite and Slices 4–6
+  Playwright suites need the Docker e2e stack. To avoid clobbering other sessions, the loop validates
+  unit/component/typecheck/lint/svelte-check locally and relies on **CI (babysit)** to run the e2e
+  suites, rather than spinning the shared stack up locally.

--- a/docs/superpowers/specs/2026-07-24-selection-toolbar-consistency-design.md
+++ b/docs/superpowers/specs/2026-07-24-selection-toolbar-consistency-design.md
@@ -1,0 +1,438 @@
+# Selection-toolbar consistency for Shared Spaces (web)
+
+- **Discussion:** [open-noodle/gallery#839](https://github.com/open-noodle/gallery/discussions/839)
+  — "Inconsistent selection toolbar across timelines (missing in Shared Space timeline/albums)"
+- **Date:** 2026-07-24
+- **Scope:** web only (`web/`). Mobile is a deliberate follow-up (see Out of scope).
+- **Status:** design approved; implementation sliced for `impl-loop`.
+
+## Problem
+
+When a user multi-selects assets, the action toolbar that appears differs by surface:
+
+- **Personal timeline & regular albums** — full toolbar (Share, Select-all, Add-to-album,
+  Favorite, Download, and a context menu of edits/tags/delete).
+- **Shared Space timeline & space person** — reduced: Select-all, Remove-from-space (editor),
+  Favorite (own), Download + a partial context menu. No Share, no Add-to-album.
+- **Shared Space albums** — gutted: only Download and (for managers) Remove-from-album. No
+  Select-all, no Favorite, no context menu at all.
+
+A space member therefore "loses access to basic actions simply because they're browsing through a
+Shared Space." A viewer inside a space album bottoms out at a single Download icon.
+
+### Root cause
+
+`web/src/lib/components/timeline/AssetSelectControlBar.svelte` is a thin wrapper that renders
+whatever `children` a page passes into its `trailing` snippet. There is **no shared source of truth**
+for "which actions apply." Each of the five selection surfaces hand-wires its own list of action
+components, so they drifted apart:
+
+| Surface                                                           | Renders                         | Provenance |
+| ----------------------------------------------------------------- | ------------------------------- | ---------- |
+| `routes/(user)/photos/…/+page.svelte`                             | full list                       | upstream   |
+| `routes/(user)/albums/[albumId]/…/+page.svelte`                   | full list (+ Remove-from-album) | upstream   |
+| `routes/(user)/spaces/[spaceId]/…/+page.svelte`                   | reduced list                    | **fork**   |
+| `routes/(user)/spaces/[spaceId]/people/[personId]/…/+page.svelte` | reduced list                    | **fork**   |
+| `routes/(user)/spaces/[spaceId]/albums/[albumId]/…/+page.svelte`  | Download + Remove only          | **fork**   |
+
+The fork already has a **unified capability model** for the ⌘K command palette
+(`command-context-manager.svelte.ts` → `CommandContext` with album/space/selection sub-contexts and
+per-item `isAvailable(ctx)` predicates in `command-items.ts`). The bulk toolbar is the one selection
+surface that ignores it.
+
+## Goal / guiding principle
+
+**The regular shared album is the reference model.** Give every user, on every space surface,
+exactly the actions they would have on the same assets in a regular shared album — same per-action
+gates — mapping **space role → album role** (Owner/Editor/Viewer), with **Remove-from-space**
+substituted for **Remove-from-album** on the direct-space surfaces (space timeline / space person).
+
+"Consistent by rule": an action appears whenever the same conditions hold (surface + role +
+ownership + asset state). Differences survive **only** where a real permission constraint forces them.
+No surface hides an action it is allowed to show.
+
+## Reference model — what a shared album grants today
+
+From `albums/[albumId]/…/+page.svelte:734-780` (the untouched reference):
+
+| Action                                                                                           | Gate in a shared album                                                    |
+| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| Download                                                                                         | **Unconditional** — you can download a photo another user shared with you |
+| Select-all                                                                                       | Unconditional                                                             |
+| Create-shared-link (Share)                                                                       | Unconditional¹                                                            |
+| Add-to-album                                                                                     | Unconditional¹                                                            |
+| Favorite                                                                                         | Own assets only (`isAllUserOwned`)                                        |
+| Edit metadata: Rotate, Change date, Change description, Change location, Archive, Set-visibility | Own assets only                                                           |
+| Tag                                                                                              | Own assets only, and tags preference enabled                              |
+| Set-as-cover                                                                                     | Album editor (owner/editor role), single selection                        |
+| Remove-from-album                                                                                | Album owner (`isOwned`) **or** own assets                                 |
+| Delete                                                                                           | Own assets only                                                           |
+
+¹ The album renders these buttons unconditionally; whether the **server** honours a
+create-shared-link / add-to-album call for a _non-owned_ asset is pinned by the API RBAC matrix
+(Slice 6). Whatever the album's real behaviour is, spaces mirror it — see the Share/Add-to-album note
+under Capability rules.
+
+We deliberately mirror the **album's** metadata set (Rotate + date/description/location + Archive +
+Set-visibility), **not** the personal timeline's richer set (Stack, Link-live-photo, and library job
+actions). Those are personal-library operations that do not belong inside a shared space.
+
+## Non-goals / Out of scope (YAGNI)
+
+- **Mobile (iOS/Android).** The discussion notes the mobile app diverges too. It is a separate
+  codebase (Flutter/Riverpod) and a separate spec that will reuse these capability rules conceptually.
+- **Refactoring the upstream `photos` and `albums` pages onto the shared toolbar.** They are the
+  reference and already correct; patching two of Immich's hottest files buys recurring rebase
+  conflicts for no user-visible gain. They stay untouched. (A parity guard test — Slice 1 — protects
+  against silent drift if upstream restructures the album toolbar.)
+- **New actions** beyond the album model (no Stack / Link-live-photo / library jobs in spaces).
+- **Changing the ⌘K command palette itself.** We reuse its context; we do not alter its items.
+- **Trashed-asset actions (restore/permanent-delete).** Space timelines do not surface trash;
+  `isAllTrashed` selections are not a reachable state here.
+
+## Architecture
+
+Two new fork files, one rule set, **zero upstream edits**. The toolbar's upstream action components
+(`DownloadAction`, `FavoriteAction`, `AssetSelectControlBar`, …) are imported and rendered, never
+modified — rebase-safe.
+
+### 1. `getSelectionCapabilities(ctx: CommandContext): SelectionCapabilities` — the rule engine
+
+New pure fork module (proposed: `web/src/lib/managers/selection-capabilities.ts`). Consumes the
+`CommandContext` the fork already assembles (`commandContextManager.getContext()`), returns one
+struct of booleans. It encodes the album model **once**; because it reads `ctx.album` / `ctx.space`,
+it yields the album answer in album context and the mirrored answer in space context.
+
+```ts
+export interface SelectionCapabilities {
+  canSelectAll: boolean;
+  canDownload: boolean;
+  canShare: boolean; // CreateSharedLink
+  canAddToAlbum: boolean;
+  canFavorite: boolean;
+  canEditMetadata: boolean; // Rotate, ChangeDate/Description/Location, Archive, SetVisibility
+  canTag: boolean;
+  canDelete: boolean;
+  canSetCover: boolean;
+  canRemoveFromAlbum: boolean;
+  canRemoveFromSpace: boolean;
+}
+```
+
+Surface discriminators derived from `ctx` (no new signal needed):
+
+```
+sel            = ctx.selection            // null ⇒ no toolbar rendered at all
+inAlbum        = ctx.album !== null
+inSpace        = ctx.space !== null
+isRegularAlbum = inAlbum && !inSpace
+isDirectSpace  = inSpace && !inAlbum      // space timeline & space person
+isSpaceAlbum   = inAlbum && inSpace
+isPersonal     = !inAlbum && !inSpace
+```
+
+Predicates (the single rule set):
+
+```
+canSelectAll       = sel !== null
+canDownload        = true
+canShare           = true            // mirror album (see Share/Add-to-album note)
+canAddToAlbum      = true            // mirror album
+canFavorite        = sel.isAllUserOwned
+canEditMetadata    = sel.isAllUserOwned
+canTag             = sel.isAllUserOwned && tagsEnabled
+canDelete          = sel.isAllUserOwned
+isEditorOfContext  = isRegularAlbum ? (ctx.album.isOwner || ctx.album.isEditor)
+                   : isDirectSpace  ? ctx.space.canWrite
+                   : isSpaceAlbum   ? (ctx.space.canWrite || ctx.album.isEditor)   // == canManage
+                   : /* personal */   false
+canSetCover        = isEditorOfContext && sel.selectedAssetIds.length === 1 && !isPersonal
+canRemoveFromAlbum = isRegularAlbum ? (ctx.album.isOwner || sel.isAllUserOwned)
+                   : isSpaceAlbum   ? (ctx.space.canWrite || ctx.album.isEditor)
+                   : false
+canRemoveFromSpace = isDirectSpace && ctx.space.canWrite
+```
+
+**Orthogonality invariant (critical):** _space role_ (Owner/Editor/Viewer, from
+`ctx.space.canWrite`/`isOwner`) and _asset ownership_ (`sel.isAllUserOwned`, i.e.
+`asset.ownerId === userId`) are independent axes. A space **Owner** viewing **another member's**
+asset must NOT get owner-gated actions (they don't own the asset); a space **Viewer** who happens to
+own the selected asset DOES get them. Every owner-gated capability keys off `isAllUserOwned`, never
+off space role, and vice-versa.
+
+**Context extension (fork files only):** `AlbumContext` currently exposes `isOwner` but not
+`isEditor`. Add `isEditor` to `AlbumContext` and compute it in `registerAlbumContext` from
+`album.albumUsers` (mirrors the existing `isAlbumEditor` derivation in the space-album page). This is
+a fork file (`command-context-manager.svelte.ts`), so it is rebase-safe. `SpaceContext.canWrite`
+(owner||editor) already exists.
+
+### 2. `<SelectionToolbar>` component
+
+New fork component (proposed:
+`web/src/lib/components/timeline/SelectionToolbar.svelte`). Responsibilities:
+
+- Wrap the upstream `<AssetSelectControlBar>`.
+- Own the `<CommandPaletteDefaultProvider>` + `getAssetBulkActions($t)` block (today only
+  personal/album pages render it; spaces must too, so Add-to-album registers).
+- Compute `caps = getSelectionCapabilities(commandContextManager.getContext())` reactively and render
+  the album-page layout — top row (Share, Select-all, Add-to-album, Favorite) + overflow
+  `ButtonContextMenu` (Download, metadata edits, Set-cover, Tag, Remove-from-album/space, Delete) —
+  each action wrapped in `{#if caps.canX}`.
+
+**Separation of concerns:** capabilities decide _what to show_; the page passes a typed props bundle
+for _what to do_. Proposed props:
+
+```ts
+interface SelectionToolbarProps {
+  timelineManager: TimelineManager;
+  assetInteraction: AssetInteraction; // the assetMultiSelectManager singleton
+  album?: AlbumResponseDto; // present on album surfaces (for Remove-from-album, download filename)
+  spaceId?: string; // present on direct-space surfaces (for Remove-from-space)
+  downloadFilename?: string;
+  onRemove?: (ids: string[]) => void; // remove-from-album / remove-from-space result handler
+  onSetCover?: () => void; // per-surface cover setter (album cover vs space cover)
+  onFavorite?: OnFavorite; // defaults to timelineManager.update
+  onArchive?: OnArchive;
+  onDelete?: OnDelete;
+}
+```
+
+The component never decides permissions from props — only `getSelectionCapabilities` does. Props that
+correspond to a disabled capability are simply never reached.
+
+### 3. Space page integration
+
+Each of the three fork space routes replaces its bespoke control-bar block with a single
+`<SelectionToolbar {...} />` and flips its `registerSelectionContext({ canAddToAlbum: () => false })`
+to `true` (so the ⌘K palette stays consistent with the toolbar). Net result per surface:
+
+| Surface        | Before                                                           | After                                                                                        |
+| -------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Space album    | Download + Remove-from-album only                                | Full album-equivalent toolbar; Remove-from-album gated `canManage`; **no** Remove-from-space |
+| Space timeline | Select-all, Remove-from-space, Favorite, Download + partial menu | Full album-equivalent; adds Share, Add-to-album, Rotate, Set-visibility, Delete, Set-cover   |
+| Space person   | same as space timeline                                           | same as space timeline                                                                       |
+
+## RBAC safety invariants & verifications
+
+Reversing the deliberate space-album strip (`rbac-5/albums-8` comment at
+`spaces/[spaceId]/albums/…/+page.svelte:405-411`) is safe because:
+
+1. **Every cross-owner mutation stays behind `isAllUserOwned`.** Favorite/metadata/Tag/Delete fire
+   only when the whole selection is the current user's own assets → owner-path → the server always
+   permits it, regardless of album-path. The concern the review closed — a space _editor_ editing
+   _another member's_ album-path asset — is a capability the album model never offers, so mimicking
+   the album never re-opens it. `checkSpaceEditAccess`'s album-arm omission and its guard
+   (`shared-space-album-scope.guard.spec.ts`) remain valid and untouched.
+2. **Editor/owner-role actions** (Set-cover, Remove-from-album/space) are gated by container role and
+   independently enforced server-side.
+3. **Share / Add-to-album** mirror the album (see note below); the server is the enforcement point.
+
+Two things are **verified by tests, not assumed**:
+
+- **V1 — `TimelineAsset.ownerId` is correct on space-projected assets.** The entire owner-gate rests
+  on it. If ownerId were wrong/absent on the merged space timeline or space album, owner-gated
+  actions could appear on non-owned assets. Asserted by the web e2e owner/other cases (Slice 5) and,
+  if needed, a focused unit check.
+- **V2 — owner-scoped Share / Add-to-album / edit / delete endpoints accept space-accessed asset
+  IDs and enforce ownership/role.** Proven by the server/API RBAC matrix (Slice 6).
+
+### Share / Add-to-album note
+
+The capability defaults to unconditional (mirror the album). Slice 6 pins the **actual** server
+behaviour for a non-owned asset:
+
+- If the server **owner-scopes** create-shared-link and/or add-to-album (rejects non-owned), then to
+  keep the toolbar honest we gate those two capabilities by `sel.isAllUserOwned` — which on the
+  personal timeline and regular album is always true, so those reference surfaces are unaffected,
+  and in a space the button appears only for your own selected assets. This is still "mimic album":
+  identical rule, made explicit.
+- If the server permits it (as the album UI implies), they stay unconditional.
+
+Either way the toolbar never offers a button the server would 400 — that equivalence is the property
+Slice 6 guarantees.
+
+## Testing strategy (TDD + BDD)
+
+TDD throughout: for every slice, write the failing test(s) first, watch them fail for the right
+reason, then implement to green. Tests are written as BDD scenarios (Given/When/Then). RBAC coverage
+is exhaustive on the pure rule engine (cheap) and representative on e2e (expensive).
+
+### Layers
+
+- **a. Unit — capability matrix (core + parity guard):** `getSelectionCapabilities` over the full
+  cross-product `{personal, regular-album, space-timeline, space-album} × {owner, editor, viewer} ×
+{all-owned, mixed, none-owned} × {single, multi}`, plus asset-state axes (all-favorite,
+  all-archived, tags on/off). Includes the **parity assertion**: for equivalent role+ownership, the
+  space capability set equals the album capability set with one substitution — on **direct-space**
+  surfaces (space timeline/person) `canRemoveFromAlbum` is replaced by `canRemoveFromSpace`; on a
+  **space album** the set matches the album exactly (`canRemoveFromAlbum` via `canManage`). This is
+  what fails CI if upstream restructures the album toolbar.
+- **b. Component — `<SelectionToolbar>`:** given a capability set, renders exactly the permitted
+  buttons and no others (reuse the `register-selection-context-harness.svelte` pattern). Asserts
+  the ⌘K provider is present so Add-to-album registers.
+- **c. Web e2e RBAC matrix (Playwright):** new spec mirroring `spaces-albums-timeline.e2e-spec.ts`,
+  driving the real UI and asserting toolbar visibility via `page.locator('#control-bar')` +
+  `getByLabel` / `data-testid`.
+- **d. Server/API RBAC matrix (supertest):** `buildSpaceContext()` + `forEachActor()` proving the
+  underlying endpoints enforce owner/role rules for space-accessed asset IDs (backs V2, and pins the
+  Share/Add-to-album behaviour that decides the capability gate).
+- **e. Keep green:** `command-items.spec.ts`, `selection-command-handlers.spec.ts`,
+  `shared-space-album-scope.guard.spec.ts`, `selection-command-page-boundaries.spec.ts`,
+  `archive-page.spec.ts`.
+
+### RBAC edge-case catalogue (must all be covered — unit at minimum)
+
+| #   | Scenario                                                                     | Expected                                                                                                                |
+| --- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| E1  | Space **viewer** selects an owner's (not their) asset — space timeline       | Select-all, Download, Share, Add-to-album ✓; Favorite/edit/Tag/Delete ✗; Remove-from-space ✗; Set-cover ✗               |
+| E2  | Space **editor** selects their **own** asset — space timeline                | all of E1 ✓ + Favorite/edit/Tag/Delete ✓ + Remove-from-space ✓ + Set-cover ✓ (if single)                                |
+| E3  | Space **editor** selects an owner's (not their) asset                        | E1 ✓ + Remove-from-space ✓ + Set-cover ✓; Favorite/edit/Tag/Delete ✗                                                    |
+| E4  | Space **owner** selects **another member's** asset                           | Remove-from-space ✓, Set-cover ✓ (role); Favorite/edit/Delete ✗ (**not** the asset owner) — the orthogonality invariant |
+| E5  | Space **viewer** who is the space album's **album-editor**, in a space album | Remove-from-album ✓ (canManage via `isAlbumEditor`) even though space viewer                                            |
+| E6  | Space **editor**, not an album member, in a space album                      | Remove-from-album ✓ (canManage via `isSpaceEditor`)                                                                     |
+| E7  | **Mixed** selection (some owned, some not)                                   | owner-gated all ✗ (`isAllUserOwned` false); always-set ✓                                                                |
+| E8  | **Multi** selection                                                          | Set-cover ✗ (single only); everything else per role/ownership                                                           |
+| E9  | All-favorite selection                                                       | Favorite renders as "remove from favorites"; else "favorite"                                                            |
+| E10 | All-archived selection                                                       | Archive renders as "unarchive"; else "archive"                                                                          |
+| E11 | Tags preference disabled                                                     | Tag ✗ even when `isAllUserOwned`                                                                                        |
+| E12 | Empty selection                                                              | toolbar not rendered (`sel === null`)                                                                                   |
+| E13 | Space **non-member** hits a space URL                                        | cannot reach the page (existing visibility specs); toolbar N/A — cross-referenced, not re-tested                        |
+| E14 | Regression: personal timeline unchanged                                      | full personal set unchanged (function returns personal answer; pages untouched)                                         |
+| E15 | Regression: regular album unchanged                                          | full album set unchanged                                                                                                |
+
+### Web e2e matrix (subset of the catalogue that is reachable through the UI)
+
+| #   | Surface        | Actor              | Selection                   | Assert SHOW                                                 | Assert HIDE                                          | Catalogue |
+| --- | -------------- | ------------------ | --------------------------- | ----------------------------------------------------------- | ---------------------------------------------------- | --------- |
+| 1   | Space timeline | Viewer             | owner's asset               | Select-all, Download, Share, Add-to-album                   | Favorite, edit, Delete, Remove-from-space, Set-cover | E1        |
+| 2   | Space timeline | Editor             | own asset (editor adds it)  | + Favorite, edit, Tag, Delete, Remove-from-space, Set-cover | —                                                    | E2        |
+| 3   | Space timeline | Editor             | owner's asset               | Remove-from-space, Set-cover                                | Favorite, edit, Delete                               | E3        |
+| 4   | Space timeline | Owner              | own asset                   | everything                                                  | —                                                    | E2/E4     |
+| 5   | Space album    | Viewer/member      | album asset (not theirs)    | Select-all, Download, Share, Add-to-album                   | Remove-from-album, owner-gated                       | E1/E7     |
+| 6   | Space album    | Editor (canManage) | album asset                 | + Remove-from-album, Set-cover                              | —                                                    | E6        |
+| 7   | Space album    | member             | **own** asset in album      | owner-gated (Favorite/edit/Delete)                          | —                                                    | E2        |
+| 8   | Space person   | Viewer             | person's asset (not theirs) | Select-all, Download, Share, Add-to-album                   | owner-gated, Remove-from-space                       | smoke     |
+
+Cases 1 and 5 are the reporter's exact regressions. A _viewer's own asset in a space_ is not a
+reachable fixture (viewers cannot contribute), so viewer×ownership variation lives in the unit matrix
+(E1 vs a synthetic all-owned viewer ctx), not e2e.
+
+### Server/API RBAC matrix (Slice 6)
+
+Using `buildSpaceContext()` (gives `spaceOwner`/`spaceEditor`/`spaceViewer`/`spaceNonMember` +
+`spaceAssetId` owned by owner) and `forEachActor()` (asserts a status per actor, names the failing
+actor):
+
+- **Download** of `spaceAssetId`: owner/editor/viewer → 200; non-member → 4xx.
+- **Create-shared-link** referencing `spaceAssetId`: pin the real status per actor (decides the
+  `canShare` gate — see Share note).
+- **Add-to-album** of `spaceAssetId` into the actor's own album: pin per actor (decides `canAddToAlbum`
+  gate).
+- **Favorite / metadata update / delete** of `spaceAssetId`: only the asset **owner** → 200; other
+  members → 4xx (proves owner-gate is real server-side, backs V1/V2).
+- **Remove-from-space**: editor/owner → 200; viewer/non-member → 4xx.
+
+### Infra notes (folded in from prior e2e pain)
+
+- Run the web suite on the `:2285` e2e stack (`--project=web`); the `:2283` dev stack serves empty
+  bodies and yields bogus "element not found".
+- Space role text is a raw lowercase enum under CSS `capitalize` → match with `{ ignoreCase: true }`.
+- Assert absence with `toHaveCount(0)` / `.not.toBeVisible()`, not a bare negation.
+- Do not trust `waitForQueueFinish`'s false-"done"; settle uploads via the established websocket/event
+  helpers.
+- Fresh worktree needs SDK build + test-assets + `playwright install` before the web suite runs.
+
+## Implementation slices (impl-loop)
+
+Each slice is a vertical, independently green increment. TDD order inside every slice: **tests first
+→ fail → implement → green → refactor**. A slice is "done" only when its acceptance criteria hold and
+the full web gate (`check:typescript` + `check:svelte` + `pnpm lint`) is clean.
+
+### Slice 1 — `getSelectionCapabilities` rule engine + unit matrix + parity guard
+
+- **Tests first:** `selection-capabilities.spec.ts` implementing the full RBAC edge catalogue E1–E15
+  as BDD scenarios over synthetic `CommandContext` fixtures, plus the album↔space parity assertion.
+- **Implement:** `selection-capabilities.ts` (pure function + `SelectionCapabilities` type). Extend
+  `AlbumContext` with `isEditor` and compute it in `registerAlbumContext` (fork file). Reuse existing
+  handlers (`canFavoriteSelected`, `canDeleteSelected`, `canAddSelectedToAlbum`) where they align.
+- **Acceptance:** every E1–E15 scenario passes; parity assertion passes; no UI touched yet.
+- **Files:** `web/src/lib/managers/selection-capabilities.ts` (new),
+  `…/selection-capabilities.spec.ts` (new), `…/command-context-manager.svelte.ts` (extend
+  `AlbumContext`), `…/command-context-manager.spec.ts` (extend for `isEditor`).
+
+### Slice 2 — `<SelectionToolbar>` component + component tests
+
+- **Tests first:** `SelectionToolbar.spec.ts` — Given a capability set (drive via a stubbed
+  context/harness), Then exactly the permitted buttons render (E8–E12 rendering aspects), and the
+  ⌘K default provider is present.
+- **Implement:** `SelectionToolbar.svelte` wrapping `AssetSelectControlBar`, owning
+  `CommandPaletteDefaultProvider`, rendering album-layout actions gated by
+  `getSelectionCapabilities`, taking the props bundle.
+- **Acceptance:** component renders correct buttons per caps; no page wired yet; existing suites green.
+- **Files:** `web/src/lib/components/timeline/SelectionToolbar.svelte` (new), spec (new).
+
+### Slice 3 — Wire space timeline page + web e2e cases 1–4
+
+- **Tests first:** new Playwright spec `spaces-selection-toolbar.e2e-spec.ts` cases 1–4 (fail: Share/
+  Add-to-album/Delete/Set-cover absent today).
+- **Implement:** replace the control-bar block (`spaces/[spaceId]/…/+page.svelte:877-911`) with
+  `<SelectionToolbar>`; flip `canAddToAlbum` to `true`; pass space wiring (spaceId, onRemove=
+  `handleRemoveAssets`, onSetCover=`handleSetAsCover`, onFavorite/onArchive).
+- **Acceptance:** cases 1–4 green; the page's old inline action imports removed; web gate clean.
+- **Files:** `spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte`, e2e spec (new).
+
+### Slice 4 — Wire space person page + smoke e2e case 8
+
+- **Tests first:** e2e case 8 (space-person viewer sees always-set, not owner-gated/Remove-from-space).
+- **Implement:** same swap in
+  `spaces/[spaceId]/people/[personId]/…/+page.svelte:714-742`.
+- **Acceptance:** case 8 green; space-person toolbar identical to space timeline; web gate clean.
+- **Files:** the space-person page, e2e spec (append).
+
+### Slice 5 — Wire space album page (the reversal) + web e2e cases 5–7 + V1
+
+- **Tests first:** e2e cases 5–7 (fail: Select-all/menu/Share absent in space album today). Case 7
+  specifically proves V1 (owner-gated actions appear on the member's **own** album asset and only
+  then).
+- **Implement:** replace the Download+Remove-only bar
+  (`spaces/[spaceId]/albums/[albumId]/…/+page.svelte:412-419`) with `<SelectionToolbar>`; album wiring
+  (album DTO, onRemove=`handleRemoveAssets`, onSetCover=album cover); `canRemoveFromAlbum` via
+  `canManage`; **no** Remove-from-space. Update/replace the `rbac-5/albums-8` comment to document the
+  new invariant (owner-gated via `isAllUserOwned`; space-editor cross-owner edit still never offered).
+- **Acceptance:** cases 5–7 green; verify no owner-gated button shows on a non-owned album asset
+  (V1); web gate clean.
+- **Files:** the space-album page, e2e spec (append).
+
+### Slice 6 — Server/API RBAC matrix + Share/Add-to-album decision (V2)
+
+- **Tests first + implement (test-only slice):** `spaces-selection-actions.e2e-spec.ts` under
+  `e2e/src/specs/server/api/` using `buildSpaceContext()` + `forEachActor()` covering download,
+  create-shared-link, add-to-album, favorite, metadata update, delete, remove-from-space against
+  space-accessed asset IDs.
+- **Decision gate:** from the pinned create-shared-link / add-to-album statuses, either leave
+  `canShare`/`canAddToAlbum` unconditional or gate them by `isAllUserOwned` (update Slice 1's
+  function + matrix accordingly, keeping album/personal unaffected).
+- **Acceptance:** matrix green; capability gate matches proven server behaviour; V2 satisfied.
+- **Files:** e2e API spec (new); possibly `selection-capabilities.ts` + its spec (adjust gate).
+
+### Slice 7 — Cleanup, i18n, parity guard confirmation, full verify
+
+- **Implement:** remove now-dead action imports from all three space pages; add any new i18n keys
+  (en.json only — web+mobile share `i18n/`); confirm the parity guard from Slice 1 is explicit and
+  named.
+- **Acceptance:** `make check-web` + `make lint-web` clean; unit + component + web e2e + API e2e all
+  green; a final skim confirms the three space surfaces match the album reference per the catalogue.
+- **Files:** the three space pages, `i18n/en.json` (if needed).
+
+## Risks & open questions
+
+- **R1 — Share/Add-to-album server behaviour (resolved by Slice 6).** If either is owner-scoped
+  server-side, the capability is gated by `isAllUserOwned`; no user-visible regression on album/
+  personal. Tracked, not blocking.
+- **R2 — `ownerId` fidelity on space-projected assets (V1).** If the merged space timeline supplies a
+  wrong/absent `ownerId`, owner-gated actions could mis-render. Slice 5 e2e (owner vs other) is the
+  tripwire; a focused unit check is the fallback.
+- **R3 — Drift from the untouched upstream album.** Mitigated by the Slice 1 parity guard: if upstream
+  restructures the album toolbar, the assertion fails in CI rather than shipping silent divergence.
+- **R4 — `check:svelte` local blindness.** It has been observed to scan 0 files locally; rely on the
+  push-time CI gate for the svelte check, and don't treat a local 0-file run as proof.

--- a/e2e/src/specs/server/api/spaces-selection-actions.e2e-spec.ts
+++ b/e2e/src/specs/server/api/spaces-selection-actions.e2e-spec.ts
@@ -255,8 +255,8 @@ describe('Server/API RBAC matrix — selection-toolbar consistency (Slice 1)', (
   //      an asset inside a space-linked album — exactly the decision-C precondition.
   // ─────────────────────────────────────────────────────────────────────────
 
-  describe('Decision C — Remove-from-space-album (own-asset arm is DENIED; role/manager arm is GRANTED)', () => {
-    it('Given a space-linked album containing an asset owned by a downgraded (non-manager) member, When that member tries to remove their own asset, Then it is rejected (400); when a space Editor with no album role removes it, Then it succeeds (200)', async () => {
+  describe('Decision C — Remove-from-space-album is role-gated at the album level AND ownership-gated per asset', () => {
+    it('Given a space-linked album containing an asset owned by a downgraded (non-manager) member: the non-manager is refused at the album gate (400); a space Editor passes the album gate (200) but the per-asset removal of a not-owned asset is denied in the body (success:false); only the album owner actually removes it (success:true)', async () => {
       const album = await utils.createAlbum(ctx.spaceOwner.token!, { albumName: 'slice1-decision-c-album' });
 
       // Step 1: temporarily elevate spaceViewer to album Editor so they can add their own asset.
@@ -302,14 +302,35 @@ describe('Server/API RBAC matrix — selection-toolbar consistency (Slice 1)', (
         .send({ ids: [viewerAsset.id] });
       expect(deniedRes.status).toBe(400);
 
-      // Step 5b: a manager with NO album participant role at all — spaceEditor, a space
-      // Editor of the linked space — removes the SAME asset via the isSpaceLinked arm.
-      const managerRes = await request(app)
+      // Step 5b: a space Editor of the linked space with NO album participant role. The album-level
+      // `AlbumAssetDelete` gate passes via the isSpaceLinked arm (HTTP 200), but removal is applied
+      // per asset: the shared `removeAssets` util only bypasses per-asset ownership for a caller who
+      // holds `Permission.AlbumDelete` on the album (i.e. the album OWNER); otherwise each asset is
+      // re-checked against `Permission.AssetShare` (owner ∪ partner). The space Editor owns neither
+      // the album nor this asset, so the item is denied in the body (success:false / no_permission)
+      // even though the request is 200. This is why the web toolbar's `canRemoveFromAlbum = canManage`
+      // is a UI-affordance gate, not a promise that every selected asset is removable — the server is
+      // still the per-asset authority (same as the pre-existing space-album behaviour).
+      const spaceEditorRes = await request(app)
         .delete(`/albums/${album.id}/assets`)
         .set(authHeaders(ctx.spaceEditor))
         .send({ ids: [viewerAsset.id] });
-      expect(managerRes.status).toBe(200);
-      expect((managerRes.body as Array<{ id: string; success: boolean }>)[0]).toMatchObject({
+      expect(spaceEditorRes.status).toBe(200);
+      expect((spaceEditorRes.body as Array<{ id: string; success: boolean; error?: string }>)[0]).toMatchObject({
+        id: viewerAsset.id,
+        success: false,
+        error: BulkIdErrorReason.NoPermission,
+      });
+
+      // Step 5c: the album OWNER (spaceOwner) removes the SAME asset. Owning the album grants
+      // `Permission.AlbumDelete`, which bypasses the per-asset `AssetShare` check — so the item is
+      // actually removed (success:true). This is the arm that genuinely GRANTS removal.
+      const ownerRes = await request(app)
+        .delete(`/albums/${album.id}/assets`)
+        .set(authHeaders(ctx.spaceOwner))
+        .send({ ids: [viewerAsset.id] });
+      expect(ownerRes.status).toBe(200);
+      expect((ownerRes.body as Array<{ id: string; success: boolean }>)[0]).toMatchObject({
         id: viewerAsset.id,
         success: true,
       });

--- a/e2e/src/specs/server/api/spaces-selection-actions.e2e-spec.ts
+++ b/e2e/src/specs/server/api/spaces-selection-actions.e2e-spec.ts
@@ -1,0 +1,318 @@
+/**
+ * Slice 1 — Server/API RBAC matrix for the selection-toolbar-consistency spec.
+ *
+ * Source: docs/superpowers/specs/2026-07-24-selection-toolbar-consistency-design.md,
+ * "### Server/API RBAC matrix (Slice 1 — runs first, gates now RESOLVED)". This suite is the
+ * regression tripwire for the RBAC gate decisions the web capability rule engine (Slice 2) depends
+ * on: Q1/Q2 (Share / Add-to-album are owner∪partner-only via `Permission.AssetShare`), decision C
+ * (space-album Remove-from-album is role-gated, ownership grants nothing), and Q5 (an owner's own
+ * mutations are never blocked just because the asset is album-path in a space).
+ *
+ * Fixture: `buildSpaceContext()` (src/actors.ts) gives spaceOwner/spaceEditor/spaceViewer/
+ * spaceNonMember, a space owned by spaceOwner, and `spaceAssetId` — an asset OWNED by spaceOwner
+ * and added DIRECTLY to the space (`shared_space_asset`). Every action below targets that asset
+ * unless the action is destructive, in which case a dedicated throwaway asset is used instead (see
+ * inline notes) so earlier assertions in this file never depend on execution order.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────────────────────
+ * TWO CORRECTIONS vs. the design doc's literal "Server/API RBAC matrix" text (verified against
+ * the CURRENT server source, not just the doc's summary — flagged for whoever reviews this slice):
+ *
+ * 1. Favorite / metadata update of spaceAssetId is NOT "owner-only, others → 4xx". `PUT /assets`
+ *    (bulk update) checks `Permission.AssetUpdate`, which is `isOwner ∪ checkSpaceEditAccess`
+ *    (server/src/utils/access.ts:155-159). `checkSpaceEditAccess` (access.repository.ts:488-527)
+ *    grants any space member with role Editor/Owner write access to every asset directly in that
+ *    space's pool (`shared_space_asset`) — REGARDLESS of who owns the specific asset. The only
+ *    restriction is a dedicated guard for `visibility`/`livePhotoVideoId` (asset.service.ts:214-224,
+ *    "rbac-3"), whose own comment says explicitly: "other metadata (description/rating/…) stays
+ *    editor-allowed." `isFavorite` is not part of that guard either (asset.service.ts:298-329).
+ *    So for spaceAssetId (owned by spaceOwner, direct-add to the space): spaceOwner AND spaceEditor
+ *    both succeed; spaceViewer (role below Editor) and spaceNonMember (no membership) are rejected.
+ *    This is corroborated by shared-space.service.ts:668-671's own comment describing exactly this
+ *    escalation path ("gaining AssetUpdate over the owner's assets via checkSpaceEditAccess").
+ *    Delete is unaffected — `Permission.AssetDelete` is pure `checkOwnerAccess` with no space arm
+ *    (access.ts:161-163), so Delete really is owner-only, matching the design doc there.
+ *
+ * 2. Add-to-album of a non-owned spaceAssetId into the actor's OWN (non-space) album does NOT
+ *    return an HTTP 4xx for a non-owner. `PUT /albums/:id/assets` (album.service.ts `addAssets`,
+ *    lines 253-262) only throws (400) if the actor lacks `AlbumAssetCreate` on the target ALBUM —
+ *    trivially true here since every actor targets an album THEY just created. The per-ASSET
+ *    `AssetShare` gate is applied via the non-throwing `checkAccess` (utils/asset.util.ts `addAssets`
+ *    helper, lines 33-71) and reported per-item in the response body
+ *    (`BulkIdResponseDto[]`: `{id, success, error}`), not as a request-level status code. So every
+ *    actor gets HTTP 200; only the body's `success`/`error` fields differ (owner: success=true;
+ *    others: success=false, error='no_permission'). Asserted on the body below rather than status.
+ * ─────────────────────────────────────────────────────────────────────────────────────────────
+ */
+
+import { AlbumUserRole, BulkIdErrorReason, SharedLinkType, addUsersToAlbum } from '@immich/sdk';
+import { authHeaders, buildSpaceContext, forEachActor, type SpaceContext } from 'src/actors';
+import { app, asBearerAuth, utils } from 'src/utils';
+import request from 'supertest';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+describe('Server/API RBAC matrix — selection-toolbar consistency (Slice 1)', () => {
+  let ctx: SpaceContext;
+
+  // FIXTURE LIFETIME: ctx is built once and treated as read-only by every `it` below except
+  // where a describe block explicitly creates its own dedicated (throwaway) assets/albums for a
+  // destructive action, so no test here depends on another test's execution order.
+  beforeAll(async () => {
+    await utils.resetDatabase();
+    ctx = await buildSpaceContext();
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 1. Download — GET /assets/:id/original (Permission.AssetDownload)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('Download — GET /assets/:id/original', () => {
+    it('Given spaceAssetId (owned by spaceOwner, direct space member), When each actor downloads it, Then owner/editor/viewer succeed and non-member is rejected', async () => {
+      await forEachActor(
+        [ctx.spaceOwner, ctx.spaceEditor, ctx.spaceViewer, ctx.spaceNonMember],
+        (actor) => request(app).get(`/assets/${ctx.spaceAssetId}/original`).set(authHeaders(actor)),
+        { spaceOwner: 200, spaceEditor: 200, spaceViewer: 200, spaceNonMember: 400 },
+      );
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 2. Create-shared-link — POST /shared-links (type=INDIVIDUAL) (Permission.AssetShare)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('Create-shared-link — POST /shared-links (type=INDIVIDUAL, assetIds=[spaceAssetId])', () => {
+    it('Given spaceAssetId owned by spaceOwner, When each actor creates an individual shared link referencing it, Then only the owner succeeds (AssetShare = owner ∪ partner only, no album/space arm — access.ts:127-131)', async () => {
+      await forEachActor(
+        [ctx.spaceOwner, ctx.spaceEditor, ctx.spaceViewer, ctx.spaceNonMember],
+        (actor) =>
+          request(app)
+            .post('/shared-links')
+            .set(authHeaders(actor))
+            .send({ type: SharedLinkType.Individual, assetIds: [ctx.spaceAssetId] }),
+        { spaceOwner: 201, spaceEditor: 400, spaceViewer: 400, spaceNonMember: 400 },
+      );
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 3. Add-to-album — PUT /albums/:id/assets, into the actor's OWN (non-space) album
+  //    See file-level correction #2: status is 200 for everyone; the body differs.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe("Add-to-album — PUT /albums/:id/assets (each actor's own brand-new, non-space album)", () => {
+    it("Given each actor creates their own album, When they try to add spaceAssetId to it, Then the request itself is 200 for everyone (they own the target album) but only the owner's item succeeds — others get success:false/no_permission (AssetShare gate, applied per-asset, non-throwing)", async () => {
+      const actors = [ctx.spaceOwner, ctx.spaceEditor, ctx.spaceViewer, ctx.spaceNonMember];
+
+      for (const actor of actors) {
+        const album = await utils.createAlbum(actor.token!, { albumName: `slice1-add-to-album-${actor.id}` });
+
+        const res = await request(app)
+          .put(`/albums/${album.id}/assets`)
+          .set(authHeaders(actor))
+          .send({ ids: [ctx.spaceAssetId] });
+
+        expect(res.status, `actor=${actor.id} unexpected HTTP status: ${JSON.stringify(res.body)}`).toBe(200);
+
+        const [result] = res.body as Array<{ id: string; success: boolean; error?: string }>;
+        const expectOwnerSuccess = actor.id === 'spaceOwner';
+        expect(result.id, `actor=${actor.id} result id mismatch`).toBe(ctx.spaceAssetId);
+        expect(result.success, `actor=${actor.id} success mismatch`).toBe(expectOwnerSuccess);
+        if (!expectOwnerSuccess) {
+          expect(result.error, `actor=${actor.id} error reason mismatch`).toBe(BulkIdErrorReason.NoPermission);
+        }
+      }
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 4. Favorite — PUT /assets bulk update, isFavorite (Permission.AssetUpdate)
+  //    See file-level correction #1: editor succeeds too, not just the owner.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('Favorite — PUT /assets (bulk, isFavorite)', () => {
+    it('Given spaceAssetId, When each actor bulk-favorites it, Then owner AND editor succeed (AssetUpdate = isOwner ∪ checkSpaceEditAccess; isFavorite is not visibility-restricted) and viewer/non-member are rejected', async () => {
+      await forEachActor(
+        [ctx.spaceOwner, ctx.spaceEditor, ctx.spaceViewer, ctx.spaceNonMember],
+        (actor) =>
+          request(app)
+            .put('/assets')
+            .set(authHeaders(actor))
+            .send({ ids: [ctx.spaceAssetId], isFavorite: true }),
+        { spaceOwner: 204, spaceEditor: 204, spaceViewer: 400, spaceNonMember: 400 },
+      );
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 5. Metadata update — PUT /assets bulk update, description (Permission.AssetUpdate)
+  //    Same gate as Favorite; a non-visibility field so the rbac-3 owner-only guard never fires.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('Metadata update — PUT /assets (bulk, description)', () => {
+    it('Given spaceAssetId, When each actor bulk-updates its description, Then owner AND editor succeed (non-visibility metadata stays editor-allowed) and viewer/non-member are rejected', async () => {
+      await forEachActor(
+        [ctx.spaceOwner, ctx.spaceEditor, ctx.spaceViewer, ctx.spaceNonMember],
+        (actor) =>
+          request(app)
+            .put('/assets')
+            .set(authHeaders(actor))
+            .send({ ids: [ctx.spaceAssetId], description: `edited-by-${actor.id}` }),
+        { spaceOwner: 204, spaceEditor: 204, spaceViewer: 400, spaceNonMember: 400 },
+      );
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 6. Delete — DELETE /assets bulk delete (Permission.AssetDelete, pure checkOwnerAccess)
+  //
+  // Destructive: uses a dedicated owner-owned asset PER ACTOR (never the shared spaceAssetId),
+  // so this describe block never depends on — or breaks — execution order relative to the
+  // others above. Each dedicated asset is also added directly to the space, to mirror
+  // spaceAssetId's exact shape (owned by spaceOwner, direct space member) even though
+  // AssetDelete's owner-only gate does not actually consult space membership at all.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('Delete — DELETE /assets (bulk)', () => {
+    it('Given a dedicated owner-owned direct-space asset per actor, When each actor attempts to delete it, Then only spaceOwner succeeds (AssetDelete has no space/album arm)', async () => {
+      const deleteTargetByActor: Record<string, string> = {};
+      for (const id of ['spaceOwner', 'spaceEditor', 'spaceViewer', 'spaceNonMember']) {
+        const asset = await utils.createAsset(ctx.spaceOwner.token!);
+        await utils.addSpaceAssets(ctx.spaceOwner.token!, ctx.spaceId, [asset.id]);
+        deleteTargetByActor[id] = asset.id;
+      }
+
+      await forEachActor(
+        [ctx.spaceOwner, ctx.spaceEditor, ctx.spaceViewer, ctx.spaceNonMember],
+        (actor) =>
+          request(app)
+            .delete('/assets')
+            .set(authHeaders(actor))
+            .send({ ids: [deleteTargetByActor[actor.id]] }),
+        { spaceOwner: 204, spaceEditor: 400, spaceViewer: 400, spaceNonMember: 400 },
+      );
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 7. Remove-from-space — DELETE /shared-spaces/:id/assets (requireRole(Editor))
+  //
+  // Destructive: a dedicated owner-owned direct-space asset PER ACTOR, so the editor's and
+  // owner's successful (mutating) removals don't collide, and this block is independent of
+  // execution order too.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('Remove-from-space — DELETE /shared-spaces/:id/assets', () => {
+    it('Given a dedicated owner-owned direct-space asset per actor, When each actor attempts to remove it from the space, Then editor and owner succeed and viewer/non-member are rejected (requireRole(Editor) — role hierarchy Viewer < Editor ≤ Owner)', async () => {
+      const removeTargetByActor: Record<string, string> = {};
+      for (const id of ['spaceOwner', 'spaceEditor', 'spaceViewer', 'spaceNonMember']) {
+        const asset = await utils.createAsset(ctx.spaceOwner.token!);
+        await utils.addSpaceAssets(ctx.spaceOwner.token!, ctx.spaceId, [asset.id]);
+        removeTargetByActor[id] = asset.id;
+      }
+
+      await forEachActor(
+        [ctx.spaceEditor, ctx.spaceViewer, ctx.spaceNonMember, ctx.spaceOwner],
+        (actor) =>
+          request(app)
+            .delete(`/shared-spaces/${ctx.spaceId}/assets`)
+            .set(authHeaders(actor))
+            .send({ assetIds: [removeTargetByActor[actor.id]] }),
+        { spaceEditor: 200, spaceViewer: 403, spaceNonMember: 403, spaceOwner: 200 },
+      );
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // 8. Decision C — Remove-from-space-album: role-gated, ownership grants nothing
+  //    (Permission.AlbumAssetDelete — access.ts:247-257 / access.repository.ts:103-161)
+  //
+  // Fixture note: the task's literal framing ("a manager adds a NON-manager's asset to the
+  // space album") is not directly constructible via the ordinary add-to-album path, because
+  // `AlbumAssetCreate` on the album is easy for a manager to hold, but the per-asset
+  // `AssetShare` gate (owner ∪ partner only, see Add-to-album above) means a manager can NEVER
+  // add an asset they neither own nor have a partner-share on through the *ordinary* path — only
+  // through the #764 cross-owner-contribution mechanism, which additionally requires the asset
+  // to already be visible through the space's direct pool (`shared_space_asset`) or a linked
+  // library (shared-space.repository.ts `getContributableAssetSpaces`). Getting a NON-manager's
+  // asset into `shared_space_asset` at all hits the same wall: the space "add asset" endpoint
+  // requires the CALLER to be an Editor/Owner (`requireRole`) *and* to hold `AssetShare` on the
+  // asset (owner∪partner) — so neither a manager (doesn't own it) nor the non-manager themselves
+  // (lacks Editor+ role) can place it there. A real reproduction would need a library-linked
+  // space, which is a much heavier fixture for the same RBAC assertion.
+  //
+  // Instead, this constructs an END STATE that is behaviourally identical for the purpose of
+  // decision C (a non-manager's own asset ends up inside a space-linked album, and that member
+  // holds neither album-editor nor space-editor/owner role) via a temporarily-elevated-then-
+  // downgraded album participant:
+  //   1. spaceOwner (album owner) creates a plain album and adds spaceViewer as an ALBUM EDITOR.
+  //   2. spaceViewer adds their OWN new asset to the album (ordinary path: they own it, and they
+  //      now hold AlbumAssetCreate via the Editor participant role) — a positive-control sanity
+  //      check confirms this succeeds.
+  //   3. spaceOwner downgrades spaceViewer's album role back to Viewer (the asset stays in the
+  //      album — album_asset rows are untouched by an album_user role change).
+  //   4. spaceOwner links the album into the space.
+  //   5. spaceViewer is now a genuine non-manager (space role Viewer, album role Viewer) who owns
+  //      an asset inside a space-linked album — exactly the decision-C precondition.
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('Decision C — Remove-from-space-album (own-asset arm is DENIED; role/manager arm is GRANTED)', () => {
+    it('Given a space-linked album containing an asset owned by a downgraded (non-manager) member, When that member tries to remove their own asset, Then it is rejected (400); when a space Editor with no album role removes it, Then it succeeds (200)', async () => {
+      const album = await utils.createAlbum(ctx.spaceOwner.token!, { albumName: 'slice1-decision-c-album' });
+
+      // Step 1: temporarily elevate spaceViewer to album Editor so they can add their own asset.
+      await addUsersToAlbum(
+        {
+          id: album.id,
+          addUsersDto: { albumUsers: [{ userId: ctx.spaceViewer.userId!, role: AlbumUserRole.Editor }] },
+        },
+        { headers: asBearerAuth(ctx.spaceOwner.token!) },
+      );
+
+      // Step 2: spaceViewer (currently album-editor) adds their OWN new asset — ordinary,
+      // self-owned path. Positive control: if this doesn't succeed, the negative assertion below
+      // would be vacuous (the asset was never really in the album to begin with).
+      const viewerAsset = await utils.createAsset(ctx.spaceViewer.token!);
+      const addRes = await request(app)
+        .put(`/albums/${album.id}/assets`)
+        .set(authHeaders(ctx.spaceViewer))
+        .send({ ids: [viewerAsset.id] });
+      expect(addRes.status).toBe(200);
+      expect((addRes.body as Array<{ id: string; success: boolean }>)[0]).toMatchObject({
+        id: viewerAsset.id,
+        success: true,
+      });
+
+      // Step 3: downgrade spaceViewer back to a plain album Viewer — no longer an album manager.
+      await utils.updateAlbumUser(ctx.spaceOwner.token!, {
+        id: album.id,
+        userId: ctx.spaceViewer.userId!,
+        updateAlbumUserDto: { role: AlbumUserRole.Viewer },
+      });
+
+      // Step 4: link the album into the space.
+      await utils.linkSpaceAlbum(ctx.spaceOwner.token!, ctx.spaceId, album.id);
+
+      // Step 5a: the non-manager (spaceViewer: space role Viewer, album role Viewer) tries to
+      // remove THEIR OWN asset from the space album — AlbumAssetDelete is role-gated
+      // (isOwner(album) ∪ isShared(album, Editor) ∪ isSpaceLinked(space Owner/Editor)); none of
+      // these arms match a plain album/space Viewer, regardless of asset ownership.
+      const deniedRes = await request(app)
+        .delete(`/albums/${album.id}/assets`)
+        .set(authHeaders(ctx.spaceViewer))
+        .send({ ids: [viewerAsset.id] });
+      expect(deniedRes.status).toBe(400);
+
+      // Step 5b: a manager with NO album participant role at all — spaceEditor, a space
+      // Editor of the linked space — removes the SAME asset via the isSpaceLinked arm.
+      const managerRes = await request(app)
+        .delete(`/albums/${album.id}/assets`)
+        .set(authHeaders(ctx.spaceEditor))
+        .send({ ids: [viewerAsset.id] });
+      expect(managerRes.status).toBe(200);
+      expect((managerRes.body as Array<{ id: string; success: boolean }>)[0]).toMatchObject({
+        id: viewerAsset.id,
+        success: true,
+      });
+    });
+  });
+});

--- a/e2e/src/specs/web/spaces-albums.e2e-spec.ts
+++ b/e2e/src/specs/web/spaces-albums.e2e-spec.ts
@@ -286,6 +286,12 @@ test.describe('Spaces — Albums UI (editor flows + viewer-denied gating)', () =
       await expect(page.getByTestId('space-album-card-menu').first()).toBeVisible();
     });
 
+    // Slice 6 of docs/superpowers/specs/2026-07-24-selection-toolbar-consistency-design.md
+    // replaced the space-album detail's stripped Download+Remove-only bar with the full
+    // album-equivalent <SelectionToolbar>. RemoveFromAlbum now lives as a menu item inside the
+    // toolbar's "⋮" overflow menu (mirrors spaces-selection-toolbar-timeline.e2e-spec.ts's
+    // `openOverflowMenu`), so it must be opened before the visibility assertion below is
+    // meaningful — collapsed menu content isn't visible even when present in the DOM.
     test('viewer sees no remove-from-album affordance in the space album detail', async ({ context, page }) => {
       await utils.setAuthCookies(context, viewer.accessToken);
       await page.goto(`/spaces/${space.id}/albums/${album.id}`);
@@ -295,7 +301,9 @@ test.describe('Spaces — Albums UI (editor flows + viewer-denied gating)', () =
       await thumbnailUtils.selectButton(page, asset.id).click();
 
       await expect(page.getByTestId('add-photos-button')).not.toBeVisible();
-      await expect(page.getByTestId('album-remove-from-album')).not.toBeVisible();
+
+      await page.getByRole('button', { name: 'Menu' }).click();
+      await expect(page.getByRole('menuitem', { name: 'Remove from album' })).toHaveCount(0);
     });
 
     test('editor sees the remove-from-album affordance in the space album detail', async ({ context, page }) => {
@@ -305,7 +313,8 @@ test.describe('Spaces — Albums UI (editor flows + viewer-denied gating)', () =
       await thumbnailUtils.withAssetId(page, asset.id).hover();
       await thumbnailUtils.selectButton(page, asset.id).click();
 
-      await expect(page.getByTestId('album-remove-from-album')).toBeVisible();
+      await page.getByRole('button', { name: 'Menu' }).click();
+      await expect(page.getByRole('menuitem', { name: 'Remove from album' })).toBeVisible();
     });
   });
 });

--- a/e2e/src/specs/web/spaces-selection-toolbar-album.e2e-spec.ts
+++ b/e2e/src/specs/web/spaces-selection-toolbar-album.e2e-spec.ts
@@ -1,0 +1,229 @@
+import { AlbumUserRole, LoginResponseDto, SharedSpaceRole, addAssetsToAlbum, addUsersToAlbum } from '@immich/sdk';
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import { createUserDto } from 'src/fixtures';
+import { thumbnailUtils } from 'src/ui/specs/timeline/utils';
+import { asBearerAuth, utils } from 'src/utils';
+
+// Web E2E: Slice 6 of docs/superpowers/specs/2026-07-24-selection-toolbar-consistency-design.md —
+// cases 5-7 of the "Web e2e matrix". The space-album detail page's multi-select control bar
+// (previously a stripped Download+Remove-only bar, rbac-5/albums-8) was reversed to render the
+// same reusable <SelectionToolbar> component wired on the direct-space timeline (Slice 4) and the
+// space-person page (Slice 5), this time with BOTH `album` and `space` props set (isSpaceAlbum).
+//
+// getSelectionCapabilities' isSpaceAlbum branch (web/src/lib/managers/selection-capabilities.ts):
+//   - canSelectAll / canDownload: always true once a selection is active.
+//   - canShare / canAddToAlbum / canFavorite / canEditMetadata (incl. Delete): gated on the
+//     selection being entirely owned by the current viewer (`isAllUserOwned`) — NOT on
+//     space/album role.
+//   - canRemoveFromAlbum / canSetCover: gated on `canManage` (space.canWrite || album.isEditor) —
+//     NOT on asset ownership (decision C: AlbumAssetDelete is role-gated server-side).
+//   - canRemoveFromSpace: always false here (this is the album path, not the direct-space path).
+//
+// Each test builds its own space + album + asset via the API so tests never depend on one
+// another's mutated state or run order.
+
+// Navigates and waits for the album timeline's first thumbnail to mount (mirrors the wait
+// strategy already established in spaces-albums.e2e-spec.ts for this same route).
+async function gotoAlbumAndWaitForAsset(page: Page, url: string, assetId: string) {
+  await page.goto(url);
+  await page.waitForSelector(`[data-thumbnail-focus-container][data-asset="${assetId}"]`);
+}
+
+// Selects a single asset via its thumbnail checkbox (hover first — the checkbox overlay only
+// renders on hover) and waits for the resulting <SelectionToolbar> control bar to mount.
+async function selectAsset(page: Page, assetId: string): Promise<Locator> {
+  const thumb = thumbnailUtils.withAssetId(page, assetId);
+  await expect(thumb).toBeVisible();
+  await thumb.hover();
+  const checkbox = thumbnailUtils.selectButton(page, assetId);
+  await expect(checkbox).toBeVisible();
+  await checkbox.click();
+  await expect(page.locator('#control-bar')).toBeVisible();
+  return page.locator('#control-bar');
+}
+
+// Opens the toolbar's "⋯" overflow menu (Download, Remove-from-album, Set-cover, Delete, and the
+// metadata-edit actions all render as menu items inside it, never top-level) and returns the
+// control bar locator, now scoped to include the (now-expanded) menu content. Mirrors
+// spaces-selection-toolbar-timeline.e2e-spec.ts's identical helper.
+async function openOverflowMenu(controlBar: Locator) {
+  await controlBar.getByRole('button', { name: 'Menu' }).click();
+}
+
+test.describe('Spaces — SelectionToolbar space-album control bar (Slice 6)', () => {
+  let admin: LoginResponseDto;
+  let owner: LoginResponseDto;
+  let viewerUser: LoginResponseDto;
+  let editorUser: LoginResponseDto;
+  let memberUser: LoginResponseDto;
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+
+    [owner, viewerUser, editorUser, memberUser] = await Promise.all([
+      utils.userSetup(admin.accessToken, createUserDto.create('sta-owner')),
+      utils.userSetup(admin.accessToken, createUserDto.create('sta-viewer')),
+      utils.userSetup(admin.accessToken, createUserDto.create('sta-editor')),
+      utils.userSetup(admin.accessToken, createUserDto.create('sta-member')),
+    ]);
+  });
+
+  // Case 5: a space Viewer (no album role at all) selecting a space-album asset that belongs to
+  // another member (`owner`). isAllUserOwned is false and canManage is false (Viewer role, no
+  // album participant role) — every ownership-gated AND every manager-gated action is hidden;
+  // only the two always-on actions (Select-all, Download) remain.
+  test('viewer selecting a not-owned space-album asset sees only Select-all and Download', async ({
+    context,
+    page,
+  }) => {
+    const space = await utils.createSpace(owner.accessToken, { name: 'STA-5 Space' });
+    await utils.addSpaceMember(owner.accessToken, space.id, {
+      userId: viewerUser.userId,
+      role: SharedSpaceRole.Viewer,
+    });
+
+    const album = await utils.createAlbum(owner.accessToken, { albumName: 'STA-5 Album' });
+    const asset = await utils.createAsset(owner.accessToken);
+    await addAssetsToAlbum(
+      { id: album.id, bulkIdsDto: { ids: [asset.id] } },
+      { headers: asBearerAuth(owner.accessToken) },
+    );
+    await utils.linkSpaceAlbum(owner.accessToken, space.id, album.id);
+
+    await utils.setAuthCookies(context, viewerUser.accessToken);
+    await gotoAlbumAndWaitForAsset(page, `/spaces/${space.id}/albums/${album.id}`, asset.id);
+    const controlBar = await selectAsset(page, asset.id);
+
+    // Always-on, top-level.
+    await expect(controlBar.getByRole('button', { name: 'Select all' })).toBeVisible();
+
+    // Ownership-gated, top-level: all hidden (viewer doesn't own the asset).
+    await expect(controlBar.getByRole('button', { name: 'Share' })).toHaveCount(0);
+    await expect(controlBar.getByRole('button', { name: 'Add to album or space' })).toHaveCount(0);
+    await expect(controlBar.getByRole('button', { name: /favorite/i })).toHaveCount(0);
+
+    await openOverflowMenu(controlBar);
+
+    // Always-on, inside the "⋯" menu.
+    await expect(controlBar.getByRole('menuitem', { name: 'Download' })).toBeVisible();
+
+    // Manager-gated (Remove-from-album, Set-cover) and ownership-gated (Delete): all hidden.
+    await expect(controlBar.getByRole('menuitem', { name: 'Remove from album' })).toHaveCount(0);
+    await expect(controlBar.getByRole('menuitem', { name: 'Set as album cover' })).toHaveCount(0);
+    await expect(controlBar.getByRole('menuitem', { name: /delete/i })).toHaveCount(0);
+  });
+
+  // Case 6: a space Editor (canManage via space role alone — no album participant role at all)
+  // selecting an asset they don't own. canManage is true (Remove-from-album / Set-cover visible)
+  // but isAllUserOwned is false (Share / Add-to-album / Favorite / Delete / metadata-edit hidden)
+  // — manager and ownership gating are independent axes, exactly as selection-capabilities.ts
+  // encodes them for the space-album (isSpaceAlbum) branch.
+  test('editor (canManage) selecting a not-owned album asset sees Select-all + Download + Remove-from-album + Set-cover', async ({
+    context,
+    page,
+  }) => {
+    const space = await utils.createSpace(owner.accessToken, { name: 'STA-6 Space' });
+    await utils.addSpaceMember(owner.accessToken, space.id, {
+      userId: editorUser.userId,
+      role: SharedSpaceRole.Editor,
+    });
+
+    const album = await utils.createAlbum(owner.accessToken, { albumName: 'STA-6 Album' });
+    const asset = await utils.createAsset(owner.accessToken);
+    await addAssetsToAlbum(
+      { id: album.id, bulkIdsDto: { ids: [asset.id] } },
+      { headers: asBearerAuth(owner.accessToken) },
+    );
+    await utils.linkSpaceAlbum(owner.accessToken, space.id, album.id);
+
+    await utils.setAuthCookies(context, editorUser.accessToken);
+    await gotoAlbumAndWaitForAsset(page, `/spaces/${space.id}/albums/${album.id}`, asset.id);
+    const controlBar = await selectAsset(page, asset.id);
+
+    await expect(controlBar.getByRole('button', { name: 'Select all' })).toBeVisible();
+
+    // Ownership-gated, top-level: hidden (editor doesn't own the asset).
+    await expect(controlBar.getByRole('button', { name: 'Share' })).toHaveCount(0);
+    await expect(controlBar.getByRole('button', { name: 'Add to album or space' })).toHaveCount(0);
+    await expect(controlBar.getByRole('button', { name: /favorite/i })).toHaveCount(0);
+
+    await openOverflowMenu(controlBar);
+
+    await expect(controlBar.getByRole('menuitem', { name: 'Download' })).toBeVisible();
+    // Manager-gated: visible even though the selection isn't owned.
+    await expect(controlBar.getByRole('menuitem', { name: 'Remove from album' })).toBeVisible();
+    await expect(controlBar.getByRole('menuitem', { name: 'Set as album cover' })).toBeVisible();
+    // Ownership-gated: hidden regardless of manager status.
+    await expect(controlBar.getByRole('menuitem', { name: /delete/i })).toHaveCount(0);
+  });
+
+  // Case 7: a plain member (non-manager: space Viewer role, downgraded-back-to-Viewer album
+  // role) selecting THEIR OWN asset in the space album. isAllUserOwned is true (Share/Add-to-
+  // album/Favorite/Delete/metadata-edit all visible) but canManage is false (Remove-from-album
+  // and Set-cover hidden) — ownership grants nothing towards the manager-gated actions
+  // (decision C: AlbumAssetDelete is role-gated server-side, not ownership-gated).
+  //
+  // Fixture: `memberUser` can't add their own asset to `owner`'s album through the ordinary path
+  // (AlbumAssetCreate requires an album participant role they don't have). Reusing the decision-C
+  // trick from spaces-selection-actions.e2e-spec.ts: temporarily elevate them to album Editor,
+  // let them add their own asset, then downgrade back to Viewer before linking the album to the
+  // space — an end state behaviourally identical to "a non-manager's own asset is in a
+  // space-linked album" for the purposes of this assertion.
+  test('a non-manager member selecting their own asset in the space album sees owner actions but not Remove-from-album/Set-cover', async ({
+    context,
+    page,
+  }) => {
+    const album = await utils.createAlbum(owner.accessToken, { albumName: 'STA-7 Album' });
+
+    // Step 1: temporarily elevate memberUser to album Editor so they can add their own asset.
+    await addUsersToAlbum(
+      { id: album.id, addUsersDto: { albumUsers: [{ userId: memberUser.userId, role: AlbumUserRole.Editor }] } },
+      { headers: asBearerAuth(owner.accessToken) },
+    );
+
+    // Step 2: memberUser (currently album-editor) adds their OWN new asset — ordinary, self-owned path.
+    const ownAsset = await utils.createAsset(memberUser.accessToken);
+    await addAssetsToAlbum(
+      { id: album.id, bulkIdsDto: { ids: [ownAsset.id] } },
+      { headers: asBearerAuth(memberUser.accessToken) },
+    );
+
+    // Step 3: downgrade memberUser back to a plain album Viewer — no longer an album manager.
+    await utils.updateAlbumUser(owner.accessToken, {
+      id: album.id,
+      userId: memberUser.userId,
+      updateAlbumUserDto: { role: AlbumUserRole.Viewer },
+    });
+
+    // Step 4: create the space, add memberUser as a plain space Viewer, and link the album.
+    const space = await utils.createSpace(owner.accessToken, { name: 'STA-7 Space' });
+    await utils.addSpaceMember(owner.accessToken, space.id, {
+      userId: memberUser.userId,
+      role: SharedSpaceRole.Viewer,
+    });
+    await utils.linkSpaceAlbum(owner.accessToken, space.id, album.id);
+
+    await utils.setAuthCookies(context, memberUser.accessToken);
+    await gotoAlbumAndWaitForAsset(page, `/spaces/${space.id}/albums/${album.id}`, ownAsset.id);
+    const controlBar = await selectAsset(page, ownAsset.id);
+
+    // Ownership-gated, top-level: all visible (memberUser owns this asset).
+    await expect(controlBar.getByRole('button', { name: 'Share' })).toBeVisible();
+    await expect(controlBar.getByRole('button', { name: 'Add to album or space' })).toBeVisible();
+    await expect(controlBar.getByRole('button', { name: /favorite/i })).toBeVisible();
+
+    await openOverflowMenu(controlBar);
+
+    await expect(controlBar.getByRole('menuitem', { name: 'Download' })).toBeVisible();
+    // Ownership-gated metadata-edit + Delete: visible (owner path is never blocked by the album
+    // path — server AssetUpdate checks ownership first, access.ts:155-159).
+    await expect(controlBar.getByRole('menuitem', { name: 'Change date' })).toBeVisible();
+    await expect(controlBar.getByRole('menuitem', { name: /delete/i })).toBeVisible();
+
+    // Manager-gated: hidden — memberUser is a plain Viewer on both the space and the album.
+    await expect(controlBar.getByRole('menuitem', { name: 'Remove from album' })).toHaveCount(0);
+    await expect(controlBar.getByRole('menuitem', { name: 'Set as album cover' })).toHaveCount(0);
+  });
+});

--- a/e2e/src/specs/web/spaces-selection-toolbar-person.e2e-spec.ts
+++ b/e2e/src/specs/web/spaces-selection-toolbar-person.e2e-spec.ts
@@ -1,0 +1,125 @@
+import { LoginResponseDto, SharedSpaceRole } from '@immich/sdk';
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import { createUserDto } from 'src/fixtures';
+import { thumbnailUtils } from 'src/ui/specs/timeline/utils';
+import { utils } from 'src/utils';
+
+// Web E2E: Slice 5 of docs/superpowers/specs/2026-07-24-selection-toolbar-consistency-design.md —
+// case 8 of the "Web e2e matrix". The space-person page's multi-select control bar was replaced
+// with the same reusable <SelectionToolbar> component wired on the space timeline page (Slice 4),
+// with one deliberate difference: the space-person page passes NO `onSetCover`, so Set-cover must
+// never render there — this page has no cover action (see the design doc's "Cover note").
+//
+// This is a single smoke case (not the full role x ownership matrix already covered by the
+// timeline spec): a space Viewer selecting a person's asset they don't own sees only the two
+// always-on actions (Select-all, Download); every ownership-gated action (Share, Add-to-album,
+// Favorite, edit, Delete) and the role-gated Remove-from-space are hidden, and Set-cover never
+// appears at all.
+
+// Navigates and waits for the initial `/timeline/buckets` fetch the destination page's Timeline
+// component fires on mount, so a subsequent selection/assertion isn't racing the load.
+async function gotoAndWaitForPersonTimeline(page: Page, url: string) {
+  const bucketsResponse = page.waitForResponse((response) => response.url().includes('/timeline/buckets'));
+  await page.goto(url);
+  await bucketsResponse;
+  await page.waitForSelector('[data-testid="person-timeline-header"]');
+}
+
+// Selects a single asset via its thumbnail checkbox (hover first — the checkbox overlay only
+// renders on hover) and waits for the resulting <SelectionToolbar> control bar to mount.
+async function selectAsset(page: Page, assetId: string): Promise<Locator> {
+  const thumb = thumbnailUtils.withAssetId(page, assetId);
+  await expect(thumb).toBeVisible();
+  await thumb.hover();
+  const checkbox = thumbnailUtils.selectButton(page, assetId);
+  await expect(checkbox).toBeVisible();
+  await checkbox.click();
+  await expect(page.locator('#control-bar')).toBeVisible();
+  return page.locator('#control-bar');
+}
+
+// Opens the toolbar's "⋯" overflow menu (Download, Delete, Set-cover, and the metadata-edit
+// actions all render as menu items inside it, never top-level) and returns the control bar
+// locator, now scoped to include the (now-expanded) menu content.
+async function openOverflowMenu(controlBar: Locator) {
+  await controlBar.getByRole('button', { name: 'Menu' }).click();
+}
+
+test.describe('Spaces — SelectionToolbar space-person control bar (Slice 5)', () => {
+  let admin: LoginResponseDto;
+  let owner: LoginResponseDto;
+  let viewer: LoginResponseDto;
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+
+    [owner, viewer] = await Promise.all([
+      utils.userSetup(admin.accessToken, createUserDto.create('sttp-owner')),
+      utils.userSetup(admin.accessToken, createUserDto.create('sttp-viewer')),
+    ]);
+  });
+
+  // Case 8: a space Viewer selecting a person's asset that belongs to another member (`owner`).
+  // isAllUserOwned is false and space.canWrite is false (Viewer role) — every ownership-gated AND
+  // every role-gated action is hidden, and Set-cover never appears (no onSetCover on this page).
+  test("viewer selecting a space person's asset (not theirs) sees only Select-all and Download", async ({
+    context,
+    page,
+  }) => {
+    const db = await utils.connectDatabase();
+
+    const space = await utils.createSpace(owner.accessToken, { name: 'STTP-8 Space' });
+    await utils.addSpaceMember(owner.accessToken, space.id, { userId: viewer.userId, role: SharedSpaceRole.Viewer });
+
+    const asset = await utils.createAsset(owner.accessToken);
+    await utils.addSpaceAssets(owner.accessToken, space.id, [asset.id]);
+
+    // Wire a shared_space_person for this asset (mirrors shared-space-person-profile.e2e-spec.ts):
+    // create a real person + face identity for the asset, then project it into the space as a
+    // shared_space_person joined on that identity.
+    const person = await utils.createPerson(owner.accessToken, { name: 'STTP-8 Person' });
+    const faceId = await utils.createFace({ assetId: asset.id, personId: person.id });
+    const identityResult = await db.query(`SELECT "identityId" FROM "person" WHERE id = $1`, [person.id]);
+    const identityId = identityResult.rows[0].identityId as string;
+
+    const spacePersonResult = await db.query(
+      `INSERT INTO "shared_space_person"
+         ("spaceId", name, "isHidden", "faceCount", "assetCount", "representativeFaceId", "identityId", "type")
+       VALUES ($1, 'STTP-8 Person', false, 1, 1, $2, $3, 'person')
+       RETURNING id`,
+      [space.id, faceId, identityId],
+    );
+    const spacePersonId = spacePersonResult.rows[0].id as string;
+    await db.query(`INSERT INTO "shared_space_person_face" ("personId", "assetFaceId") VALUES ($1, $2)`, [
+      spacePersonId,
+      faceId,
+    ]);
+
+    await utils.setAuthCookies(context, viewer.accessToken);
+    await gotoAndWaitForPersonTimeline(page, `/spaces/${space.id}/people/${spacePersonId}`);
+    const controlBar = await selectAsset(page, asset.id);
+
+    // Always-on, top-level.
+    await expect(controlBar.getByRole('button', { name: 'Select all' })).toBeVisible();
+
+    // Ownership-gated, top-level: all hidden (viewer doesn't own the asset).
+    await expect(controlBar.getByRole('button', { name: 'Share' })).toHaveCount(0);
+    await expect(controlBar.getByRole('button', { name: 'Add to album or space' })).toHaveCount(0);
+    await expect(controlBar.getByRole('button', { name: /favorite/i })).toHaveCount(0);
+
+    // Role-gated, top-level: hidden (Viewer has no write access to the space).
+    await expect(controlBar.getByRole('button', { name: 'Remove from space' })).toHaveCount(0);
+
+    await openOverflowMenu(controlBar);
+
+    // Always-on, inside the "⋯" menu.
+    await expect(controlBar.getByRole('menuitem', { name: 'Download' })).toBeVisible();
+
+    // Ownership-gated (Delete): hidden. Set-cover: never rendered on this page at all — the
+    // page passes no `onSetCover`, so it's absent even though it would otherwise be a menu item.
+    await expect(controlBar.getByRole('menuitem', { name: /delete/i })).toHaveCount(0);
+    await expect(controlBar.getByRole('menuitem', { name: 'Set as space cover' })).toHaveCount(0);
+  });
+});

--- a/e2e/src/specs/web/spaces-selection-toolbar-timeline.e2e-spec.ts
+++ b/e2e/src/specs/web/spaces-selection-toolbar-timeline.e2e-spec.ts
@@ -82,7 +82,7 @@ test.describe('Spaces — SelectionToolbar timeline control bar (Slice 4)', () =
   // belongs to `owner`, not `viewer`) and space.canWrite is false (Viewer role) — every
   // ownership-gated AND every role-gated action is hidden. Only the two always-on actions
   // (Select-all, Download) remain.
-  test('viewer selecting the owner\'s asset sees only Select-all and Download', async ({ context, page }) => {
+  test("viewer selecting the owner's asset sees only Select-all and Download", async ({ context, page }) => {
     const space = await createDirectSpaceFixture(
       owner.accessToken,
       [{ userId: viewer.userId, role: SharedSpaceRole.Viewer }],

--- a/e2e/src/specs/web/spaces-selection-toolbar-timeline.e2e-spec.ts
+++ b/e2e/src/specs/web/spaces-selection-toolbar-timeline.e2e-spec.ts
@@ -1,0 +1,201 @@
+import { LoginResponseDto, SharedSpaceResponseDto, SharedSpaceRole } from '@immich/sdk';
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import { createUserDto } from 'src/fixtures';
+import { thumbnailUtils } from 'src/ui/specs/timeline/utils';
+import { utils } from 'src/utils';
+
+// Web E2E: Slice 4 of docs/superpowers/specs/2026-07-24-selection-toolbar-consistency-design.md —
+// the space timeline page's multi-select control bar was replaced with the reusable
+// <SelectionToolbar> component, gated by the pure `getSelectionCapabilities` rule engine
+// (web/src/lib/managers/selection-capabilities.ts). These tests exercise the resulting button
+// set for a direct-space surface across the role x ownership matrix the rule engine encodes:
+//
+//   - canSelectAll / canDownload: always true once a selection is active, regardless of role.
+//   - canShare / canAddToAlbum / canFavorite / canEditMetadata (incl. Delete): gated on the
+//     selection being entirely owned by the current viewer (`isAllUserOwned`), NOT on space role.
+//   - canRemoveFromSpace / canSetCover: gated on the space role being Editor or Owner
+//     (`space.canWrite`), NOT on asset ownership.
+//
+// Each test builds its own space + members + asset via the API so tests never depend on one
+// another's mutated state or run order.
+
+async function createDirectSpaceFixture(
+  ownerToken: string,
+  members: { userId: string; role: SharedSpaceRole }[],
+  namePrefix: string,
+): Promise<SharedSpaceResponseDto> {
+  const space = await utils.createSpace(ownerToken, { name: `${namePrefix} Space` });
+  for (const member of members) {
+    await utils.addSpaceMember(ownerToken, space.id, { userId: member.userId, role: member.role });
+  }
+  return space;
+}
+
+// Navigates and waits for the initial `/timeline/buckets` fetch the destination page's Timeline
+// component fires on mount, so a subsequent selection/assertion isn't racing the load.
+async function gotoAndWaitForTimeline(page: Page, url: string) {
+  const bucketsResponse = page.waitForResponse((response) => response.url().includes('/timeline/buckets'));
+  await page.goto(url);
+  await bucketsResponse;
+  await page.waitForSelector('[data-testid="discovery-timeline"]');
+}
+
+// Selects a single asset via its thumbnail checkbox (hover first — the checkbox overlay only
+// renders on hover) and waits for the resulting <SelectionToolbar> control bar to mount.
+async function selectAsset(page: Page, assetId: string): Promise<Locator> {
+  const thumb = thumbnailUtils.withAssetId(page, assetId);
+  await expect(thumb).toBeVisible();
+  await thumb.hover();
+  const checkbox = thumbnailUtils.selectButton(page, assetId);
+  await expect(checkbox).toBeVisible();
+  await checkbox.click();
+  await expect(page.locator('#control-bar')).toBeVisible();
+  return page.locator('#control-bar');
+}
+
+// Opens the toolbar's "⋯" overflow menu (Download, Delete, Set-cover, and the metadata-edit
+// actions all render as menu items inside it, never top-level) and returns the control bar
+// locator, now scoped to include the (now-expanded) menu content.
+async function openOverflowMenu(controlBar: Locator) {
+  await controlBar.getByRole('button', { name: 'Menu' }).click();
+}
+
+test.describe('Spaces — SelectionToolbar timeline control bar (Slice 4)', () => {
+  let admin: LoginResponseDto;
+  let owner: LoginResponseDto;
+  let editor: LoginResponseDto;
+  let viewer: LoginResponseDto;
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+
+    [owner, editor, viewer] = await Promise.all([
+      utils.userSetup(admin.accessToken, createUserDto.create('stt-owner')),
+      utils.userSetup(admin.accessToken, createUserDto.create('stt-editor')),
+      utils.userSetup(admin.accessToken, createUserDto.create('stt-viewer')),
+    ]);
+  });
+
+  // Case 1: a space Viewer selecting the owner's asset. isAllUserOwned is false (the asset
+  // belongs to `owner`, not `viewer`) and space.canWrite is false (Viewer role) — every
+  // ownership-gated AND every role-gated action is hidden. Only the two always-on actions
+  // (Select-all, Download) remain.
+  test('viewer selecting the owner\'s asset sees only Select-all and Download', async ({ context, page }) => {
+    const space = await createDirectSpaceFixture(
+      owner.accessToken,
+      [{ userId: viewer.userId, role: SharedSpaceRole.Viewer }],
+      'STT-1',
+    );
+    const asset = await utils.createAsset(owner.accessToken);
+    await utils.addSpaceAssets(owner.accessToken, space.id, [asset.id]);
+
+    await utils.setAuthCookies(context, viewer.accessToken);
+    await gotoAndWaitForTimeline(page, `/spaces/${space.id}`);
+    const controlBar = await selectAsset(page, asset.id);
+
+    // Always-on, top-level.
+    await expect(controlBar.getByRole('button', { name: 'Select all' })).toBeVisible();
+
+    // Ownership-gated, top-level: all hidden (viewer doesn't own the asset).
+    await expect(controlBar.getByRole('button', { name: 'Share' })).toHaveCount(0);
+    await expect(controlBar.getByRole('button', { name: 'Add to album or space' })).toHaveCount(0);
+    await expect(controlBar.getByRole('button', { name: /favorite/i })).toHaveCount(0);
+
+    // Role-gated, top-level: hidden (Viewer has no write access to the space).
+    await expect(controlBar.getByRole('button', { name: 'Remove from space' })).toHaveCount(0);
+
+    await openOverflowMenu(controlBar);
+
+    // Always-on, inside the "⋯" menu.
+    await expect(controlBar.getByRole('menuitem', { name: 'Download' })).toBeVisible();
+
+    // Ownership-gated (Delete) and role-gated (Set cover), inside the menu: both hidden.
+    await expect(controlBar.getByRole('menuitem', { name: /delete/i })).toHaveCount(0);
+    await expect(controlBar.getByRole('menuitem', { name: 'Set as space cover' })).toHaveCount(0);
+  });
+
+  // Case 2: a space Editor selecting an asset THEY uploaded and added themselves. isAllUserOwned
+  // is true AND space.canWrite is true — every gated action is visible: the full set.
+  test('editor selecting their own asset sees the full action set', async ({ context, page }) => {
+    const space = await createDirectSpaceFixture(
+      owner.accessToken,
+      [{ userId: editor.userId, role: SharedSpaceRole.Editor }],
+      'STT-2',
+    );
+    const asset = await utils.createAsset(editor.accessToken);
+    await utils.addSpaceAssets(editor.accessToken, space.id, [asset.id]);
+
+    await utils.setAuthCookies(context, editor.accessToken);
+    await gotoAndWaitForTimeline(page, `/spaces/${space.id}`);
+    const controlBar = await selectAsset(page, asset.id);
+
+    await expect(controlBar.getByRole('button', { name: 'Select all' })).toBeVisible();
+    await expect(controlBar.getByRole('button', { name: 'Share' })).toBeVisible();
+    await expect(controlBar.getByRole('button', { name: 'Add to album or space' })).toBeVisible();
+    await expect(controlBar.getByRole('button', { name: /favorite/i })).toBeVisible();
+    await expect(controlBar.getByRole('button', { name: 'Remove from space' })).toBeVisible();
+
+    await openOverflowMenu(controlBar);
+
+    await expect(controlBar.getByRole('menuitem', { name: 'Download' })).toBeVisible();
+    await expect(controlBar.getByRole('menuitem', { name: /delete/i })).toBeVisible();
+    await expect(controlBar.getByRole('menuitem', { name: 'Set as space cover' })).toBeVisible();
+  });
+
+  // Case 3: a space Editor selecting the owner's (not their own) asset. isAllUserOwned is false
+  // (ownership-gated actions hidden: Share/Add-to-album/Favorite/Delete) but space.canWrite is
+  // still true (role-gated actions visible: Remove-from-space/Set-cover) — ownership and role
+  // gating are independent axes, exactly as selection-capabilities.ts encodes them.
+  test("editor selecting the owner's asset sees only role-gated actions", async ({ context, page }) => {
+    const space = await createDirectSpaceFixture(
+      owner.accessToken,
+      [{ userId: editor.userId, role: SharedSpaceRole.Editor }],
+      'STT-3',
+    );
+    const asset = await utils.createAsset(owner.accessToken);
+    await utils.addSpaceAssets(owner.accessToken, space.id, [asset.id]);
+
+    await utils.setAuthCookies(context, editor.accessToken);
+    await gotoAndWaitForTimeline(page, `/spaces/${space.id}`);
+    const controlBar = await selectAsset(page, asset.id);
+
+    await expect(controlBar.getByRole('button', { name: 'Select all' })).toBeVisible();
+    await expect(controlBar.getByRole('button', { name: 'Remove from space' })).toBeVisible();
+
+    await expect(controlBar.getByRole('button', { name: 'Share' })).toHaveCount(0);
+    await expect(controlBar.getByRole('button', { name: 'Add to album or space' })).toHaveCount(0);
+    await expect(controlBar.getByRole('button', { name: /favorite/i })).toHaveCount(0);
+
+    await openOverflowMenu(controlBar);
+
+    await expect(controlBar.getByRole('menuitem', { name: 'Download' })).toBeVisible();
+    await expect(controlBar.getByRole('menuitem', { name: 'Set as space cover' })).toBeVisible();
+    await expect(controlBar.getByRole('menuitem', { name: /delete/i })).toHaveCount(0);
+  });
+
+  // Case 4: the space Owner selecting their own asset. Both axes are satisfied (owner owns the
+  // asset, and Owner role always has write access) — the full set, same as case 2.
+  test('owner selecting their own asset sees the full action set', async ({ context, page }) => {
+    const space = await createDirectSpaceFixture(owner.accessToken, [], 'STT-4');
+    const asset = await utils.createAsset(owner.accessToken);
+    await utils.addSpaceAssets(owner.accessToken, space.id, [asset.id]);
+
+    await utils.setAuthCookies(context, owner.accessToken);
+    await gotoAndWaitForTimeline(page, `/spaces/${space.id}`);
+    const controlBar = await selectAsset(page, asset.id);
+
+    await expect(controlBar.getByRole('button', { name: 'Select all' })).toBeVisible();
+    await expect(controlBar.getByRole('button', { name: 'Share' })).toBeVisible();
+    await expect(controlBar.getByRole('button', { name: 'Add to album or space' })).toBeVisible();
+    await expect(controlBar.getByRole('button', { name: /favorite/i })).toBeVisible();
+    await expect(controlBar.getByRole('button', { name: 'Remove from space' })).toBeVisible();
+
+    await openOverflowMenu(controlBar);
+
+    await expect(controlBar.getByRole('menuitem', { name: 'Download' })).toBeVisible();
+    await expect(controlBar.getByRole('menuitem', { name: /delete/i })).toBeVisible();
+    await expect(controlBar.getByRole('menuitem', { name: 'Set as space cover' })).toBeVisible();
+  });
+});

--- a/web/src/lib/components/timeline/SelectionToolbar.spec.ts
+++ b/web/src/lib/components/timeline/SelectionToolbar.spec.ts
@@ -136,7 +136,7 @@ beforeEach(() => {
 });
 
 describe('SelectionToolbar', () => {
-  it('Given a space viewer browsing another member\'s asset in a direct space, When the toolbar renders, Then only Select-all and Download are shown', () => {
+  it("Given a space viewer browsing another member's asset in a direct space, When the toolbar renders, Then only Select-all and Download are shown", () => {
     renderToolbar({
       timelineManager: fakeTimelineManager,
       assetInteraction: makeAssetInteraction({

--- a/web/src/lib/components/timeline/SelectionToolbar.spec.ts
+++ b/web/src/lib/components/timeline/SelectionToolbar.spec.ts
@@ -1,0 +1,236 @@
+import type { AlbumResponseDto, AssetVisibility as AssetVisibilityType } from '@immich/sdk';
+import { AlbumUserRole, AssetVisibility } from '@immich/sdk';
+import { render, screen } from '@testing-library/svelte';
+import type { Component } from 'svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import TestWrapper from '$lib/components/TestWrapper.svelte';
+import type { AssetMultiSelectManager } from '$lib/managers/asset-multi-select-manager.svelte';
+import type { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+import type { TimelineAsset } from '$lib/managers/timeline-manager/types';
+import type { TimelineDateTime } from '$lib/utils/timeline-util';
+import SelectionToolbar from './SelectionToolbar.svelte';
+
+// Mirrors the (unexported) Props interface declared inside SelectionToolbar.svelte —
+// just enough shape for this spec file's own type-checking of test fixtures.
+interface ToolbarTestProps {
+  timelineManager: TimelineManager;
+  assetInteraction: AssetMultiSelectManager;
+  album?: AlbumResponseDto;
+  space?: { id: string; canWrite: boolean };
+  downloadFilename?: string;
+  onRemove?: (assetIds: string[]) => void;
+  onSetCover?: () => void;
+  onFavorite?: (ids: string[], isFavorite: boolean) => void;
+  onArchive?: (ids: string[], visibility: AssetVisibilityType) => void;
+  onAssetDelete?: (assetIds: string[]) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Mocks — the two singletons SelectionToolbar (or a component it renders)
+// reads eagerly at render time. Every leaf action component is rendered for
+// real (per the task's "PREFER real rendering" guidance): none of them read
+// a problematic singleton at render time EXCEPT DeleteAssetsAction, which
+// derives `force` from `featureFlagsManager.value.trash` — that getter
+// throws until initialized, so it must be mocked. `authManager` is read
+// directly by SelectionToolbar itself to build the CommandContext.
+// ---------------------------------------------------------------------------
+
+const { mockUser, mockPreferences } = vi.hoisted(() => ({
+  mockUser: { current: { id: 'me', isAdmin: false } as { id: string; isAdmin: boolean } | null },
+  mockPreferences: { current: { tags: { enabled: true } } },
+}));
+
+vi.mock('$lib/managers/auth-manager.svelte', () => ({
+  authManager: {
+    get authenticated() {
+      return mockUser.current !== null;
+    },
+    get user() {
+      return mockUser.current;
+    },
+    get preferences() {
+      return mockPreferences.current;
+    },
+  },
+}));
+
+vi.mock('$lib/managers/feature-flags-manager.svelte', () => ({
+  featureFlagsManager: {
+    value: { trash: true },
+  },
+}));
+
+const dateTime: TimelineDateTime = { year: 2024, month: 1, day: 1, hour: 0, minute: 0, second: 0, millisecond: 0 };
+
+function makeAsset(overrides: Partial<TimelineAsset> = {}): TimelineAsset {
+  return {
+    id: 'asset-1',
+    ownerId: 'me',
+    ratio: 1,
+    thumbhash: null,
+    localDateTime: dateTime,
+    createdAt: dateTime,
+    fileCreatedAt: dateTime,
+    visibility: AssetVisibility.Timeline,
+    isFavorite: false,
+    isTrashed: false,
+    isVideo: false,
+    isImage: true,
+    stack: null,
+    duration: null,
+    projectionType: null,
+    livePhotoVideoId: null,
+    city: null,
+    country: null,
+    people: null,
+    ...overrides,
+  };
+}
+
+type FakeAssetInteraction = Pick<
+  AssetMultiSelectManager,
+  'selectionActive' | 'assets' | 'isAllUserOwned' | 'isAllFavorite' | 'isAllArchived' | 'selectAll'
+> & { clear: () => void };
+
+function makeAssetInteraction(overrides: Partial<FakeAssetInteraction> = {}): AssetMultiSelectManager {
+  const base: FakeAssetInteraction = {
+    selectionActive: true,
+    assets: [makeAsset()],
+    isAllUserOwned: true,
+    isAllFavorite: false,
+    isAllArchived: false,
+    selectAll: false,
+    clear: () => {},
+    ...overrides,
+  };
+  return base as unknown as AssetMultiSelectManager;
+}
+
+// `overrides` is deliberately loose (not Partial<AlbumResponseDto>) — fixtures only ever
+// need to override a couple of fields (e.g. albumUsers with minimal {id}-only users), and
+// AlbumResponseDto's nested UserResponseDto is not worth reproducing in full here.
+function makeAlbum(overrides: Record<string, unknown> = {}): AlbumResponseDto {
+  return {
+    id: 'album-1',
+    albumName: 'Album',
+    albumUsers: [{ user: { id: 'owner-1' }, role: AlbumUserRole.Owner }],
+    ...overrides,
+  } as unknown as AlbumResponseDto;
+}
+
+const fakeTimelineManager = {} as unknown as TimelineManager;
+
+// SelectionToolbar renders real @immich/ui IconButtons, which resolve a
+// bits-ui Tooltip against a "Tooltip.Provider" context. TestWrapper supplies
+// it (see other *.spec.ts files rendering real IconButton-based trees).
+function renderToolbar(props: ToolbarTestProps) {
+  return render(TestWrapper as Component<{ component: typeof SelectionToolbar; componentProps: typeof props }>, {
+    component: SelectionToolbar,
+    componentProps: props,
+  });
+}
+
+beforeEach(() => {
+  mockUser.current = { id: 'me', isAdmin: false };
+  mockPreferences.current = { tags: { enabled: true } };
+});
+
+describe('SelectionToolbar', () => {
+  it('Given a space viewer browsing another member\'s asset in a direct space, When the toolbar renders, Then only Select-all and Download are shown', () => {
+    renderToolbar({
+      timelineManager: fakeTimelineManager,
+      assetInteraction: makeAssetInteraction({
+        isAllUserOwned: false,
+        assets: [makeAsset({ id: 'asset-1', ownerId: 'other' })],
+      }),
+      space: { id: 'space-1', canWrite: false },
+    });
+
+    expect(screen.getByLabelText('select_all')).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'download' })).toBeInTheDocument();
+
+    expect(screen.queryByLabelText('share')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('add_to_album_or_space')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('to_favorite')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('remove_from_favorites')).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'delete' })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('remove_from_space')).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'set_as_space_cover' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'set_as_album_cover' })).not.toBeInTheDocument();
+  });
+
+  it('Given a space editor selecting their own single asset in a direct space, When the toolbar renders, Then Share/Add-to-album/Favorite/Delete/Remove-from-space/Cover are all shown', () => {
+    renderToolbar({
+      timelineManager: fakeTimelineManager,
+      assetInteraction: makeAssetInteraction({
+        isAllUserOwned: true,
+        assets: [makeAsset({ id: 'asset-1', ownerId: 'me' })],
+      }),
+      space: { id: 'space-1', canWrite: true },
+      onSetCover: vi.fn(),
+      onRemove: vi.fn(),
+      onFavorite: vi.fn(),
+      onArchive: vi.fn(),
+      onAssetDelete: vi.fn(),
+    });
+
+    expect(screen.getByLabelText('select_all')).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'download' })).toBeInTheDocument();
+    expect(screen.getByLabelText('share')).toBeInTheDocument();
+    expect(screen.getByLabelText('add_to_album_or_space')).toBeInTheDocument();
+    expect(screen.getByLabelText('to_favorite')).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'delete' })).toBeInTheDocument();
+    expect(screen.getByLabelText('remove_from_space')).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'set_as_space_cover' })).toBeInTheDocument();
+  });
+
+  it('Given the space-person surface (same editor+own-asset context but no onSetCover passed), When the toolbar renders, Then Cover is absent even though caps.canSetCover is true', () => {
+    renderToolbar({
+      timelineManager: fakeTimelineManager,
+      assetInteraction: makeAssetInteraction({
+        isAllUserOwned: true,
+        assets: [makeAsset({ id: 'asset-1', ownerId: 'me' })],
+      }),
+      space: { id: 'space-1', canWrite: true },
+      // onSetCover intentionally omitted — mirrors the space-person page, which has no cover action.
+      onRemove: vi.fn(),
+      onFavorite: vi.fn(),
+    });
+
+    expect(screen.getByLabelText('share')).toBeInTheDocument();
+    expect(screen.getByLabelText('remove_from_space')).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'set_as_space_cover' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'set_as_album_cover' })).not.toBeInTheDocument();
+  });
+
+  it('Given a space-album manager viewing a not-owned asset, When the toolbar renders, Then Remove-from-album is shown and Remove-from-space is absent', () => {
+    renderToolbar({
+      timelineManager: fakeTimelineManager,
+      assetInteraction: makeAssetInteraction({
+        isAllUserOwned: false,
+        assets: [makeAsset({ id: 'asset-1', ownerId: 'other' })],
+      }),
+      album: makeAlbum({ albumUsers: [{ user: { id: 'owner-1' }, role: AlbumUserRole.Owner }] }),
+      space: { id: 'space-1', canWrite: true },
+      onRemove: vi.fn(),
+    });
+
+    expect(screen.getByLabelText('select_all')).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'download' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'remove_from_album' })).toBeInTheDocument();
+    expect(screen.queryByLabelText('remove_from_space')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('share')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('to_favorite')).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: 'delete' })).not.toBeInTheDocument();
+  });
+
+  it('Given no active selection, When the toolbar renders, Then nothing is rendered', () => {
+    const { container } = renderToolbar({
+      timelineManager: fakeTimelineManager,
+      assetInteraction: makeAssetInteraction({ selectionActive: false, assets: [] }),
+    });
+
+    expect(screen.queryByLabelText('menu')).not.toBeInTheDocument();
+    expect(container.querySelector('#control-bar')).not.toBeInTheDocument();
+  });
+});

--- a/web/src/lib/components/timeline/SelectionToolbar.svelte
+++ b/web/src/lib/components/timeline/SelectionToolbar.svelte
@@ -1,0 +1,225 @@
+<script lang="ts">
+  import ButtonContextMenu from '$lib/components/shared-components/context-menu/ButtonContextMenu.svelte';
+  import MenuOption from '$lib/components/shared-components/context-menu/MenuOption.svelte';
+  import ArchiveAction from '$lib/components/timeline/actions/ArchiveAction.svelte';
+  import ChangeDate from '$lib/components/timeline/actions/ChangeDateAction.svelte';
+  import ChangeDescription from '$lib/components/timeline/actions/ChangeDescriptionAction.svelte';
+  import ChangeLocation from '$lib/components/timeline/actions/ChangeLocationAction.svelte';
+  import CreateSharedLink from '$lib/components/timeline/actions/CreateSharedLinkAction.svelte';
+  import DeleteAssets from '$lib/components/timeline/actions/DeleteAssetsAction.svelte';
+  import DownloadAction from '$lib/components/timeline/actions/DownloadAction.svelte';
+  import FavoriteAction from '$lib/components/timeline/actions/FavoriteAction.svelte';
+  import RemoveFromAlbum from '$lib/components/timeline/actions/RemoveFromAlbumAction.svelte';
+  import RemoveFromSpaceAction from '$lib/components/timeline/actions/RemoveFromSpaceAction.svelte';
+  import RotateAction from '$lib/components/timeline/actions/RotateAction.svelte';
+  import SelectAllAssets from '$lib/components/timeline/actions/SelectAllAction.svelte';
+  import SetVisibilityAction from '$lib/components/timeline/actions/SetVisibilityAction.svelte';
+  import TagAction from '$lib/components/timeline/actions/TagAction.svelte';
+  import AssetSelectControlBar from '$lib/components/timeline/AssetSelectControlBar.svelte';
+  import type { AssetMultiSelectManager } from '$lib/managers/asset-multi-select-manager.svelte';
+  import { authManager } from '$lib/managers/auth-manager.svelte';
+  import type {
+    AlbumContext,
+    CommandContext,
+    SelectionCommandContext,
+    SpaceContext,
+  } from '$lib/managers/command-context-manager.svelte';
+  import { getSelectionCapabilities } from '$lib/managers/selection-capabilities';
+  import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
+  import { getAssetBulkActions } from '$lib/services/asset.service';
+  import type { OnArchive, OnDelete, OnFavorite, OnSetVisibility, OnUndoDelete } from '$lib/utils/actions';
+  import { AlbumUserRole, type AlbumResponseDto, type SharedSpaceResponseDto } from '@immich/sdk';
+  import { ActionButton, CommandPaletteDefaultProvider } from '@immich/ui';
+  import { mdiDotsVertical, mdiImageOutline } from '@mdi/js';
+  import { t } from 'svelte-i18n';
+
+  /**
+   * Reusable multi-select action bar, gated by the pure `getSelectionCapabilities`
+   * rule engine (see `$lib/managers/selection-capabilities.ts`). Unlike the
+   * personal/album/space pages, this component does NOT depend on
+   * `registerSelectionContext` / `registerAlbumContext` / `registerSpaceContext`
+   * being called — it derives its own minimal `CommandContext` from explicit
+   * props + the `assetInteraction` (assetMultiSelectManager) singleton, so it
+   * also works on surfaces (space-person, space-album) that register none of
+   * those contexts.
+   *
+   * See `docs/superpowers/specs/2026-07-24-selection-toolbar-consistency-design.md`.
+   */
+  interface Props {
+    timelineManager: TimelineManager;
+    assetInteraction: AssetMultiSelectManager;
+    /** Present on album surfaces (regular album OR space album). */
+    album?: AlbumResponseDto;
+    /** Present on space surfaces (direct space OR space album). */
+    space?: { id: string; canWrite: boolean };
+    downloadFilename?: string;
+    /** Remove-from-album / remove-from-space result handler. */
+    onRemove?: (assetIds: string[]) => void;
+    /** Cover setter. Absent ⇒ no cover button (e.g. the space-person page passes none). */
+    onSetCover?: () => void;
+    onFavorite?: OnFavorite;
+    onArchive?: OnArchive;
+    onVisibilitySet?: OnSetVisibility;
+    onAssetDelete?: OnDelete;
+    onUndoDelete?: OnUndoDelete;
+  }
+
+  let {
+    timelineManager,
+    assetInteraction,
+    album,
+    space,
+    downloadFilename,
+    onRemove,
+    onSetCover,
+    onFavorite,
+    onArchive,
+    onVisibilitySet,
+    onAssetDelete,
+    onUndoDelete,
+  }: Props = $props();
+
+  // RemoveFromAlbumAction's `album` prop is `$bindable()` — it reassigns it locally
+  // after re-fetching album info post-removal. Mirror that with a writable $derived
+  // rather than binding the prop directly (props aren't guaranteed assignable
+  // targets, and this keeps the fallback well-typed when `album` is undefined).
+  // Reassigning a $derived locally overrides it until `album` itself changes again.
+  // The fallback branch is never actually rendered/read: RemoveFromAlbum only
+  // renders when the real `album` prop is present (see the `{:else if ... &&
+  // album}` gate below).
+  const EMPTY_ALBUM = {} as AlbumResponseDto;
+  let localAlbum = $derived(album ?? EMPTY_ALBUM);
+
+  const currentUserId = $derived(authManager.authenticated ? authManager.user.id : null);
+
+  // Mirrors registerAlbumContext's isOwner/isEditor derivation in
+  // command-context-manager.svelte.ts, applied to the `album` prop directly
+  // instead of a registered context.
+  const albumCtx = $derived.by((): AlbumContext | null => {
+    if (!album) {
+      return null;
+    }
+    const albumUsers = album.albumUsers ?? [];
+    const ownerId =
+      albumUsers.find(({ role }) => role === AlbumUserRole.Owner)?.user.id ?? albumUsers[0]?.user.id ?? '';
+    const isMember = currentUserId !== null && albumUsers.some((u) => u.user.id === currentUserId);
+    const isEditor =
+      currentUserId !== null &&
+      albumUsers.some(
+        (u) => u.user.id === currentUserId && (u.role === AlbumUserRole.Owner || u.role === AlbumUserRole.Editor),
+      );
+    return {
+      id: album.id,
+      albumName: album.albumName,
+      ownerId,
+      isOwner: currentUserId !== null && currentUserId === ownerId,
+      isEditor,
+      isMember,
+      raw: album,
+    };
+  });
+
+  const spaceCtx = $derived.by((): SpaceContext | null => {
+    if (!space) {
+      return null;
+    }
+    return {
+      id: space.id,
+      name: '',
+      createdById: '',
+      isOwner: false,
+      isMember: true,
+      canWrite: space.canWrite,
+      raw: {} as SharedSpaceResponseDto,
+      members: [],
+    };
+  });
+
+  const selectionCtx = $derived.by((): SelectionCommandContext | null => {
+    if (!assetInteraction.selectionActive) {
+      return null;
+    }
+    return {
+      assets: assetInteraction.assets,
+      selectedAssetIds: assetInteraction.assets.map((asset) => asset.id),
+      ownedAssets: [],
+      ownedSelectedAssetIds: [],
+      canAddToAlbum: false,
+      canAddToSpace: false,
+      isAllUserOwned: assetInteraction.isAllUserOwned,
+      isAllFavorite: assetInteraction.isAllFavorite,
+      isAllArchived: assetInteraction.isAllArchived,
+      isAllTrashed: false,
+      clearSelection: () => {},
+    };
+  });
+
+  const ctx = $derived<CommandContext>({
+    routeId: null,
+    params: {},
+    album: albumCtx,
+    space: spaceCtx,
+    selection: selectionCtx,
+    userId: currentUserId,
+    isAdmin: authManager.authenticated ? authManager.user.isAdmin : false,
+  });
+
+  const tagsEnabled = $derived(authManager.authenticated ? authManager.preferences.tags.enabled : false);
+  const caps = $derived(getSelectionCapabilities(ctx, tagsEnabled));
+</script>
+
+{#if assetInteraction.selectionActive}
+  <AssetSelectControlBar>
+    {@const Actions = getAssetBulkActions($t)}
+    <CommandPaletteDefaultProvider name={$t('assets')} actions={Object.values(Actions)} />
+    {#if caps.canShare}
+      <CreateSharedLink />
+    {/if}
+    {#if caps.canSelectAll}
+      <SelectAllAssets {timelineManager} {assetInteraction} />
+    {/if}
+    {#if caps.canAddToAlbum}
+      <ActionButton action={Actions.AddToAlbum} />
+    {/if}
+    {#if caps.canFavorite}
+      <FavoriteAction removeFavorite={assetInteraction.isAllFavorite} {onFavorite} />
+    {/if}
+    {#if caps.canRemoveFromSpace && space}
+      <!-- Top-level (not a menu item): RemoveFromSpaceAction has no `menuItem` variant, and the
+           direct-space pages render it top-level today. RemoveFromAlbum stays in the menu below,
+           mirroring the album page. A surface only ever has one of the two removes. -->
+      <RemoveFromSpaceAction spaceId={space.id} {onRemove} />
+    {/if}
+    <ButtonContextMenu icon={mdiDotsVertical} title={$t('menu')} offset={{ x: 175, y: 25 }}>
+      {#if caps.canDownload}
+        <DownloadAction menuItem filename={downloadFilename} />
+      {/if}
+      {#if caps.canEditMetadata}
+        <RotateAction />
+        <ChangeDate menuItem />
+        <ChangeDescription menuItem />
+        <ChangeLocation menuItem />
+        <ArchiveAction menuItem unarchive={assetInteraction.isAllArchived} {onArchive} />
+        {#if onVisibilitySet}
+          <SetVisibilityAction menuItem {onVisibilitySet} />
+        {/if}
+      {/if}
+      {#if caps.canSetCover && onSetCover}
+        {#if album}
+          <MenuOption text={$t('set_as_album_cover')} icon={mdiImageOutline} onClick={() => onSetCover?.()} />
+        {:else}
+          <MenuOption text={$t('set_as_space_cover')} icon={mdiImageOutline} onClick={() => onSetCover?.()} />
+        {/if}
+      {/if}
+      {#if caps.canTag}
+        <TagAction menuItem />
+      {/if}
+      {#if caps.canRemoveFromAlbum && album}
+        <RemoveFromAlbum menuItem bind:album={localAlbum} {onRemove} />
+      {/if}
+      {#if caps.canDelete && onAssetDelete}
+        <DeleteAssets menuItem {onAssetDelete} {onUndoDelete} />
+      {/if}
+    </ButtonContextMenu>
+  </AssetSelectControlBar>
+{/if}

--- a/web/src/lib/managers/command-context-manager.spec.ts
+++ b/web/src/lib/managers/command-context-manager.spec.ts
@@ -51,6 +51,7 @@ describe('CommandContextManager', () => {
       albumName: 'Test',
       ownerId: 'u1',
       isOwner: true,
+      isEditor: false,
       isMember: false,
       raw: { id: 'a1', albumName: 'Test', ownerId: 'u1' } as unknown as AlbumResponseDto,
     });
@@ -63,6 +64,7 @@ describe('CommandContextManager', () => {
       albumName: 'Test',
       ownerId: 'u1',
       isOwner: true,
+      isEditor: false,
       isMember: false,
       raw: { id: 'a1' } as unknown as AlbumResponseDto,
     });

--- a/web/src/lib/managers/command-context-manager.svelte.ts
+++ b/web/src/lib/managers/command-context-manager.svelte.ts
@@ -17,6 +17,8 @@ export interface AlbumContext {
   albumName: string;
   ownerId: string;
   isOwner: boolean;
+  /** Current user has an `albumUsers` role of Owner or Editor (mirrors the space-album page's `isAlbumEditor`). */
+  isEditor: boolean;
   isMember: boolean;
   /** Original DTO — passed through for handlers that open modals or call SDKs needing the full object. */
   raw: AlbumResponseDto;
@@ -198,11 +200,17 @@ export function registerAlbumContext(albumDto: () => AlbumResponseDto) {
     const ownerId =
       albumUsers.find(({ role }) => role === AlbumUserRole.Owner)?.user.id ?? albumUsers[0]?.user.id ?? '';
     const isMember = currentUserId !== null && albumUsers.some((u) => u.user.id === currentUserId);
+    const isEditor =
+      currentUserId !== null &&
+      albumUsers.some(
+        (u) => u.user.id === currentUserId && (u.role === AlbumUserRole.Owner || u.role === AlbumUserRole.Editor),
+      );
     commandContextManager.setAlbum({
       id: album.id,
       albumName: album.albumName,
       ownerId,
       isOwner: currentUserId !== null && currentUserId === ownerId,
+      isEditor,
       isMember,
       raw: album,
     });

--- a/web/src/lib/managers/command-items.spec.ts
+++ b/web/src/lib/managers/command-items.spec.ts
@@ -551,6 +551,7 @@ describe('album-context commands', () => {
       albumName: 'Test',
       ownerId: 'u-owner',
       isOwner: true,
+      isEditor: false,
       isMember: false,
       raw: baseAlbum,
     },

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -1167,6 +1167,7 @@ describe('activate("command")', () => {
       albumName: 'X',
       ownerId: 'u',
       isOwner: true,
+      isEditor: false,
       isMember: false,
       raw: { id: 'a1' } as unknown as import('@immich/sdk').AlbumResponseDto,
     });
@@ -1220,6 +1221,7 @@ describe('activate("command")', () => {
       albumName: 'X',
       ownerId: 'u',
       isOwner: true,
+      isEditor: false,
       isMember: false,
       raw: { id: 'a1' } as unknown as import('@immich/sdk').AlbumResponseDto,
     });

--- a/web/src/lib/managers/selection-capabilities.spec.ts
+++ b/web/src/lib/managers/selection-capabilities.spec.ts
@@ -1,0 +1,440 @@
+import type { AlbumResponseDto, SharedSpaceResponseDto } from '@immich/sdk';
+import { describe, expect, it } from 'vitest';
+import type {
+  AlbumContext,
+  CommandContext,
+  SelectionCommandContext,
+  SpaceContext,
+} from '$lib/managers/command-context-manager.svelte';
+import { getSelectionCapabilities, type SelectionCapabilities } from './selection-capabilities';
+
+// ---------------------------------------------------------------------------
+// Fixture factories — build the minimal CommandContext shape the pure rule
+// engine reads. Only the fields getSelectionCapabilities actually consumes
+// are meaningful; everything else is a stable default.
+// ---------------------------------------------------------------------------
+
+const makeSelection = (overrides: Partial<SelectionCommandContext> = {}): SelectionCommandContext => ({
+  assets: [],
+  selectedAssetIds: ['asset-1'],
+  ownedAssets: [],
+  ownedSelectedAssetIds: [],
+  canAddToAlbum: false,
+  canAddToSpace: false,
+  isAllUserOwned: true,
+  isAllFavorite: false,
+  isAllArchived: false,
+  isAllTrashed: false,
+  clearSelection: () => {},
+  ...overrides,
+});
+
+const makeAlbum = (overrides: Partial<AlbumContext> = {}): AlbumContext => ({
+  id: 'album-1',
+  albumName: 'Album',
+  ownerId: 'u-owner',
+  isOwner: false,
+  isEditor: false,
+  isMember: true,
+  raw: {} as unknown as AlbumResponseDto,
+  ...overrides,
+});
+
+const makeSpace = (overrides: Partial<SpaceContext> = {}): SpaceContext => ({
+  id: 'space-1',
+  name: 'Space',
+  createdById: 'u-owner',
+  isOwner: false,
+  isMember: true,
+  canWrite: false,
+  raw: {} as unknown as SharedSpaceResponseDto,
+  members: [],
+  ...overrides,
+});
+
+const makeCtx = (overrides: Partial<CommandContext> = {}): CommandContext => ({
+  routeId: null,
+  params: {},
+  album: null,
+  space: null,
+  selection: makeSelection(),
+  userId: 'u-me',
+  isAdmin: false,
+  ...overrides,
+});
+
+const ALL_FALSE: SelectionCapabilities = {
+  canSelectAll: false,
+  canDownload: false,
+  canShare: false,
+  canAddToAlbum: false,
+  canFavorite: false,
+  canEditMetadata: false,
+  canTag: false,
+  canDelete: false,
+  canSetCover: false,
+  canRemoveFromAlbum: false,
+  canRemoveFromSpace: false,
+};
+
+// ---------------------------------------------------------------------------
+// Space timeline (direct space): album === null, space !== null
+// ---------------------------------------------------------------------------
+
+describe('getSelectionCapabilities — space timeline (direct space)', () => {
+  it('E1: Given a space viewer selecting another member\'s asset, When capabilities resolve, Then only select-all and download are allowed', () => {
+    const ctx = makeCtx({
+      space: makeSpace({ canWrite: false }),
+      selection: makeSelection({ isAllUserOwned: false, selectedAssetIds: ['asset-1'] }),
+    });
+
+    expect(getSelectionCapabilities(ctx, true)).toEqual({
+      ...ALL_FALSE,
+      canSelectAll: true,
+      canDownload: true,
+    });
+  });
+
+  it('E2: Given a space editor selecting their own single asset, When capabilities resolve, Then every capability is allowed', () => {
+    const ctx = makeCtx({
+      space: makeSpace({ canWrite: true }),
+      selection: makeSelection({ isAllUserOwned: true, selectedAssetIds: ['asset-1'] }),
+    });
+
+    expect(getSelectionCapabilities(ctx, true)).toEqual({
+      canSelectAll: true,
+      canDownload: true,
+      canShare: true,
+      canAddToAlbum: true,
+      canFavorite: true,
+      canEditMetadata: true,
+      canTag: true,
+      canDelete: true,
+      canSetCover: true,
+      canRemoveFromAlbum: false,
+      canRemoveFromSpace: true,
+    });
+  });
+
+  it('E3: Given a space editor selecting another member\'s asset, When capabilities resolve, Then role actions (remove-from-space, set-cover) are allowed but owner-gated actions are denied', () => {
+    const ctx = makeCtx({
+      space: makeSpace({ canWrite: true }),
+      selection: makeSelection({ isAllUserOwned: false, selectedAssetIds: ['asset-1'] }),
+    });
+
+    expect(getSelectionCapabilities(ctx, true)).toEqual({
+      canSelectAll: true,
+      canDownload: true,
+      canShare: false,
+      canAddToAlbum: false,
+      canFavorite: false,
+      canEditMetadata: false,
+      canTag: false,
+      canDelete: false,
+      canSetCover: true,
+      canRemoveFromAlbum: false,
+      canRemoveFromSpace: true,
+    });
+  });
+
+  it('E4: Given a space owner selecting another member\'s asset, When capabilities resolve, Then role actions are allowed but owner-gated actions are denied (orthogonality: space role is independent of asset ownership)', () => {
+    const ctx = makeCtx({
+      space: makeSpace({ isOwner: true, canWrite: true }),
+      selection: makeSelection({ isAllUserOwned: false, selectedAssetIds: ['asset-1'] }),
+    });
+
+    const caps = getSelectionCapabilities(ctx, true);
+    expect(caps.canRemoveFromSpace).toBe(true);
+    expect(caps.canSetCover).toBe(true);
+    expect(caps.canShare).toBe(false);
+    expect(caps.canAddToAlbum).toBe(false);
+    expect(caps.canFavorite).toBe(false);
+    expect(caps.canEditMetadata).toBe(false);
+    expect(caps.canTag).toBe(false);
+    expect(caps.canDelete).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Space album: album !== null, space !== null
+// ---------------------------------------------------------------------------
+
+describe('getSelectionCapabilities — space album', () => {
+  it('E5: Given a space viewer who is the space album\'s album-editor, When capabilities resolve, Then canRemoveFromAlbum is allowed via album.isEditor even though the space role is a viewer', () => {
+    const ctx = makeCtx({
+      space: makeSpace({ canWrite: false }),
+      album: makeAlbum({ isOwner: false, isEditor: true }),
+      selection: makeSelection({ isAllUserOwned: false }),
+    });
+
+    expect(getSelectionCapabilities(ctx, true).canRemoveFromAlbum).toBe(true);
+  });
+
+  it('E6: Given a space editor who is not an album member, When capabilities resolve, Then canRemoveFromAlbum is allowed via space.canWrite', () => {
+    const ctx = makeCtx({
+      space: makeSpace({ canWrite: true }),
+      album: makeAlbum({ isOwner: false, isEditor: false, isMember: false }),
+      selection: makeSelection({ isAllUserOwned: false }),
+    });
+
+    expect(getSelectionCapabilities(ctx, true).canRemoveFromAlbum).toBe(true);
+  });
+
+  it('E16: Given a space viewer (non-manager) selecting their own asset in a space album, When capabilities resolve, Then owner-gated actions are allowed but canRemoveFromAlbum and canSetCover are denied (decision C: role-gated only, no own-asset arm)', () => {
+    const ctx = makeCtx({
+      space: makeSpace({ canWrite: false }),
+      album: makeAlbum({ isOwner: false, isEditor: false }),
+      selection: makeSelection({ isAllUserOwned: true, selectedAssetIds: ['asset-1'] }),
+    });
+
+    const caps = getSelectionCapabilities(ctx, true);
+    expect(caps.canShare).toBe(true);
+    expect(caps.canAddToAlbum).toBe(true);
+    expect(caps.canFavorite).toBe(true);
+    expect(caps.canEditMetadata).toBe(true);
+    expect(caps.canTag).toBe(true);
+    expect(caps.canDelete).toBe(true);
+    expect(caps.canRemoveFromAlbum).toBe(false);
+    expect(caps.canSetCover).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-cutting edge cases
+// ---------------------------------------------------------------------------
+
+describe('getSelectionCapabilities — cross-cutting edge cases', () => {
+  it('E7: Given a mixed-ownership selection (some owned, some not), When capabilities resolve, Then every owner-gated action and Share/Add-to-album are denied while select-all/download remain allowed', () => {
+    const ctx = makeCtx({ selection: makeSelection({ isAllUserOwned: false }) });
+
+    const caps = getSelectionCapabilities(ctx, true);
+    expect(caps.canSelectAll).toBe(true);
+    expect(caps.canDownload).toBe(true);
+    expect(caps.canShare).toBe(false);
+    expect(caps.canAddToAlbum).toBe(false);
+    expect(caps.canFavorite).toBe(false);
+    expect(caps.canEditMetadata).toBe(false);
+    expect(caps.canTag).toBe(false);
+    expect(caps.canDelete).toBe(false);
+  });
+
+  it('E8: Given a multi-asset selection with an otherwise fully-permitted role and ownership, When capabilities resolve, Then canSetCover is denied because set-cover requires a single selection', () => {
+    const ctx = makeCtx({
+      space: makeSpace({ canWrite: true }),
+      selection: makeSelection({ isAllUserOwned: true, selectedAssetIds: ['asset-1', 'asset-2'] }),
+    });
+
+    const caps = getSelectionCapabilities(ctx, true);
+    expect(caps.canSetCover).toBe(false);
+    expect(caps.canFavorite).toBe(true);
+    expect(caps.canRemoveFromSpace).toBe(true);
+  });
+
+  it('E9/E10: Given the selection is all-favorite or all-archived, When capabilities resolve, Then canFavorite/canEditMetadata are unchanged — the rule engine is ownership-only; favorite/archive LABEL flipping ("remove from favorites" vs "favorite") is an asset-state UI concern the component owns, not this function', () => {
+    const favoriteCaps = getSelectionCapabilities(
+      makeCtx({ selection: makeSelection({ isAllUserOwned: true, isAllFavorite: true }) }),
+      true,
+    );
+    const notFavoriteCaps = getSelectionCapabilities(
+      makeCtx({ selection: makeSelection({ isAllUserOwned: true, isAllFavorite: false }) }),
+      true,
+    );
+    expect(favoriteCaps.canFavorite).toBe(true);
+    expect(notFavoriteCaps.canFavorite).toBe(true);
+
+    const archivedCaps = getSelectionCapabilities(
+      makeCtx({ selection: makeSelection({ isAllUserOwned: true, isAllArchived: true }) }),
+      true,
+    );
+    const notArchivedCaps = getSelectionCapabilities(
+      makeCtx({ selection: makeSelection({ isAllUserOwned: true, isAllArchived: false }) }),
+      true,
+    );
+    expect(archivedCaps.canEditMetadata).toBe(true);
+    expect(notArchivedCaps.canEditMetadata).toBe(true);
+  });
+
+  it('E11: Given tagsEnabled is false, When capabilities resolve for an all-owned selection, Then canTag is denied even though every other owner-gated action is allowed', () => {
+    const ctx = makeCtx({ selection: makeSelection({ isAllUserOwned: true }) });
+
+    const caps = getSelectionCapabilities(ctx, false);
+    expect(caps.canTag).toBe(false);
+    expect(caps.canFavorite).toBe(true);
+    expect(caps.canShare).toBe(true);
+  });
+
+  it('E12: Given no registered selection (ctx.selection === null), When capabilities resolve, Then every capability is denied and no toolbar is rendered', () => {
+    const ctx = makeCtx({ selection: null });
+
+    expect(getSelectionCapabilities(ctx, true)).toEqual(ALL_FALSE);
+  });
+
+  it('E14: Given the personal timeline with an all-owned selection, When capabilities resolve, Then the full owner set is allowed but container actions (set-cover / remove) are denied because there is no album or space', () => {
+    const ctx = makeCtx({
+      album: null,
+      space: null,
+      selection: makeSelection({ isAllUserOwned: true, selectedAssetIds: ['asset-1'] }),
+    });
+
+    const caps = getSelectionCapabilities(ctx, true);
+    expect(caps.canShare).toBe(true);
+    expect(caps.canAddToAlbum).toBe(true);
+    expect(caps.canFavorite).toBe(true);
+    expect(caps.canEditMetadata).toBe(true);
+    expect(caps.canTag).toBe(true);
+    expect(caps.canDelete).toBe(true);
+    expect(caps.canSetCover).toBe(false);
+    expect(caps.canRemoveFromAlbum).toBe(false);
+    expect(caps.canRemoveFromSpace).toBe(false);
+  });
+
+  it('E15: Given a regular shared album with the album owner selecting their own single asset, When capabilities resolve, Then the full album reference model is granted', () => {
+    const ctx = makeCtx({
+      album: makeAlbum({ isOwner: true, isEditor: false }),
+      space: null,
+      selection: makeSelection({ isAllUserOwned: true, selectedAssetIds: ['asset-1'] }),
+    });
+
+    expect(getSelectionCapabilities(ctx, true)).toEqual({
+      canSelectAll: true,
+      canDownload: true,
+      canShare: true,
+      canAddToAlbum: true,
+      canFavorite: true,
+      canEditMetadata: true,
+      canTag: true,
+      canDelete: true,
+      canSetCover: true,
+      canRemoveFromAlbum: true,
+      canRemoveFromSpace: false,
+    });
+  });
+
+  it('E17: Given an admin who is neither the asset owner nor holds an album/space role, When capabilities resolve, Then the result is identical to a non-admin in the same role/ownership state (isAdmin is never consulted)', () => {
+    const base: Partial<CommandContext> = {
+      album: makeAlbum({ isOwner: false, isEditor: false }),
+      space: null,
+      selection: makeSelection({ isAllUserOwned: false }),
+    };
+
+    const adminCaps = getSelectionCapabilities(makeCtx({ ...base, isAdmin: true }), true);
+    const nonAdminCaps = getSelectionCapabilities(makeCtx({ ...base, isAdmin: false }), true);
+    expect(adminCaps).toEqual(nonAdminCaps);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Parity guard — protects against silent drift from the album reference model.
+// For equivalent role + ownership, space capability sets must equal the album
+// capability set except for the two documented, server-enforced deviations.
+// ---------------------------------------------------------------------------
+
+describe('getSelectionCapabilities — album/space parity guard', () => {
+  const roles = ['owner', 'editor', 'viewer'] as const;
+  const ownerships = [true, false] as const;
+
+  for (const role of roles) {
+    for (const isAllUserOwned of ownerships) {
+      const label = `${role} role, ${isAllUserOwned ? 'all-owned' : 'none-owned'} selection`;
+
+      it(`${label}: owner-gated + universal capabilities are identical across regular-album, space-timeline, and space-album`, () => {
+        const sel = makeSelection({ isAllUserOwned, selectedAssetIds: ['asset-1'] });
+        const canWrite = role === 'owner' || role === 'editor';
+
+        const regularAlbumCtx = makeCtx({
+          album: makeAlbum({ isOwner: role === 'owner', isEditor: role === 'editor' }),
+          space: null,
+          selection: sel,
+        });
+        const spaceTimelineCtx = makeCtx({
+          album: null,
+          space: makeSpace({ isOwner: role === 'owner', canWrite }),
+          selection: sel,
+        });
+        const spaceAlbumCtx = makeCtx({
+          album: makeAlbum({ isOwner: false, isEditor: false }),
+          space: makeSpace({ isOwner: role === 'owner', canWrite }),
+          selection: sel,
+        });
+
+        const albumCaps = getSelectionCapabilities(regularAlbumCtx, true);
+        const spaceCaps = getSelectionCapabilities(spaceTimelineCtx, true);
+        const spaceAlbumCaps = getSelectionCapabilities(spaceAlbumCtx, true);
+
+        const universalFields = [
+          'canSelectAll',
+          'canDownload',
+          'canShare',
+          'canAddToAlbum',
+          'canFavorite',
+          'canEditMetadata',
+          'canTag',
+          'canDelete',
+        ] as const;
+
+        for (const field of universalFields) {
+          expect(spaceCaps[field]).toBe(albumCaps[field]);
+          expect(spaceAlbumCaps[field]).toBe(albumCaps[field]);
+        }
+
+        // canSetCover is role+single-only (no ownership arm) — identical across every
+        // surface given the matching role -> canWrite/isOwner/isEditor mapping above.
+        expect(spaceCaps.canSetCover).toBe(albumCaps.canSetCover);
+        expect(spaceAlbumCaps.canSetCover).toBe(albumCaps.canSetCover);
+      });
+    }
+  }
+
+  it('deviation (a): on a direct-space surface, canRemoveFromAlbum is replaced by canRemoveFromSpace, which is role-only (no own-asset arm) — an editor can remove-from-space a non-owned asset, but the album-equivalent (a non-owner editor) cannot remove-from-album', () => {
+    const nonOwnedSel = makeSelection({ isAllUserOwned: false });
+    const albumEditorCtx = makeCtx({
+      album: makeAlbum({ isOwner: false, isEditor: true }),
+      space: null,
+      selection: nonOwnedSel,
+    });
+    const spaceEditorCtx = makeCtx({ album: null, space: makeSpace({ canWrite: true }), selection: nonOwnedSel });
+
+    expect(getSelectionCapabilities(albumEditorCtx, true).canRemoveFromAlbum).toBe(false);
+    expect(getSelectionCapabilities(spaceEditorCtx, true).canRemoveFromSpace).toBe(true);
+    // The field belonging to the other surface never appears.
+    expect(getSelectionCapabilities(albumEditorCtx, true).canRemoveFromSpace).toBe(false);
+    expect(getSelectionCapabilities(spaceEditorCtx, true).canRemoveFromAlbum).toBe(false);
+  });
+
+  it('deviation (b): a space album\'s canRemoveFromAlbum is canManage-only (decision C — no own-asset arm), unlike the regular album which also lets a non-manager remove their OWN asset', () => {
+    const ownAssetSel = makeSelection({ isAllUserOwned: true });
+    const albumViewerOwnAssetCtx = makeCtx({
+      album: makeAlbum({ isOwner: false, isEditor: false }),
+      space: null,
+      selection: ownAssetSel,
+    });
+    const spaceAlbumViewerOwnAssetCtx = makeCtx({
+      album: makeAlbum({ isOwner: false, isEditor: false }),
+      space: makeSpace({ canWrite: false }),
+      selection: ownAssetSel,
+    });
+
+    expect(getSelectionCapabilities(albumViewerOwnAssetCtx, true).canRemoveFromAlbum).toBe(true);
+    expect(getSelectionCapabilities(spaceAlbumViewerOwnAssetCtx, true).canRemoveFromAlbum).toBe(false);
+  });
+
+  it('Share and Add-to-album are isAllUserOwned on every surface, so personal/album/space/space-album contexts always agree', () => {
+    for (const isAllUserOwned of ownerships) {
+      const sel = makeSelection({ isAllUserOwned });
+      const personalCaps = getSelectionCapabilities(makeCtx({ selection: sel }), true);
+      const albumCaps = getSelectionCapabilities(makeCtx({ album: makeAlbum(), selection: sel }), true);
+      const spaceCaps = getSelectionCapabilities(makeCtx({ space: makeSpace(), selection: sel }), true);
+      const spaceAlbumCaps = getSelectionCapabilities(
+        makeCtx({ album: makeAlbum(), space: makeSpace(), selection: sel }),
+        true,
+      );
+
+      expect(albumCaps.canShare).toBe(personalCaps.canShare);
+      expect(spaceCaps.canShare).toBe(personalCaps.canShare);
+      expect(spaceAlbumCaps.canShare).toBe(personalCaps.canShare);
+      expect(albumCaps.canAddToAlbum).toBe(personalCaps.canAddToAlbum);
+      expect(spaceCaps.canAddToAlbum).toBe(personalCaps.canAddToAlbum);
+      expect(spaceAlbumCaps.canAddToAlbum).toBe(personalCaps.canAddToAlbum);
+    }
+  });
+});

--- a/web/src/lib/managers/selection-capabilities.spec.ts
+++ b/web/src/lib/managers/selection-capabilities.spec.ts
@@ -82,7 +82,7 @@ const ALL_FALSE: SelectionCapabilities = {
 // ---------------------------------------------------------------------------
 
 describe('getSelectionCapabilities — space timeline (direct space)', () => {
-  it('E1: Given a space viewer selecting another member\'s asset, When capabilities resolve, Then only select-all and download are allowed', () => {
+  it("E1: Given a space viewer selecting another member's asset, When capabilities resolve, Then only select-all and download are allowed", () => {
     const ctx = makeCtx({
       space: makeSpace({ canWrite: false }),
       selection: makeSelection({ isAllUserOwned: false, selectedAssetIds: ['asset-1'] }),
@@ -116,7 +116,7 @@ describe('getSelectionCapabilities — space timeline (direct space)', () => {
     });
   });
 
-  it('E3: Given a space editor selecting another member\'s asset, When capabilities resolve, Then role actions (remove-from-space, set-cover) are allowed but owner-gated actions are denied', () => {
+  it("E3: Given a space editor selecting another member's asset, When capabilities resolve, Then role actions (remove-from-space, set-cover) are allowed but owner-gated actions are denied", () => {
     const ctx = makeCtx({
       space: makeSpace({ canWrite: true }),
       selection: makeSelection({ isAllUserOwned: false, selectedAssetIds: ['asset-1'] }),
@@ -137,7 +137,7 @@ describe('getSelectionCapabilities — space timeline (direct space)', () => {
     });
   });
 
-  it('E4: Given a space owner selecting another member\'s asset, When capabilities resolve, Then role actions are allowed but owner-gated actions are denied (orthogonality: space role is independent of asset ownership)', () => {
+  it("E4: Given a space owner selecting another member's asset, When capabilities resolve, Then role actions are allowed but owner-gated actions are denied (orthogonality: space role is independent of asset ownership)", () => {
     const ctx = makeCtx({
       space: makeSpace({ isOwner: true, canWrite: true }),
       selection: makeSelection({ isAllUserOwned: false, selectedAssetIds: ['asset-1'] }),
@@ -160,7 +160,7 @@ describe('getSelectionCapabilities — space timeline (direct space)', () => {
 // ---------------------------------------------------------------------------
 
 describe('getSelectionCapabilities — space album', () => {
-  it('E5: Given a space viewer who is the space album\'s album-editor, When capabilities resolve, Then canRemoveFromAlbum is allowed via album.isEditor even though the space role is a viewer', () => {
+  it("E5: Given a space viewer who is the space album's album-editor, When capabilities resolve, Then canRemoveFromAlbum is allowed via album.isEditor even though the space role is a viewer", () => {
     const ctx = makeCtx({
       space: makeSpace({ canWrite: false }),
       album: makeAlbum({ isOwner: false, isEditor: true }),
@@ -401,7 +401,7 @@ describe('getSelectionCapabilities — album/space parity guard', () => {
     expect(getSelectionCapabilities(spaceEditorCtx, true).canRemoveFromAlbum).toBe(false);
   });
 
-  it('deviation (b): a space album\'s canRemoveFromAlbum is canManage-only (decision C — no own-asset arm), unlike the regular album which also lets a non-manager remove their OWN asset', () => {
+  it("deviation (b): a space album's canRemoveFromAlbum is canManage-only (decision C — no own-asset arm), unlike the regular album which also lets a non-manager remove their OWN asset", () => {
     const ownAssetSel = makeSelection({ isAllUserOwned: true });
     const albumViewerOwnAssetCtx = makeCtx({
       album: makeAlbum({ isOwner: false, isEditor: false }),

--- a/web/src/lib/managers/selection-capabilities.ts
+++ b/web/src/lib/managers/selection-capabilities.ts
@@ -1,0 +1,86 @@
+import type { CommandContext } from '$lib/managers/command-context-manager.svelte';
+
+/**
+ * One struct of booleans deciding which bulk-selection actions the current
+ * `CommandContext` allows. Pure and side-effect free: no `authManager`
+ * reads, no `$state`. See
+ * `docs/superpowers/specs/2026-07-24-selection-toolbar-consistency-design.md`
+ * for the rule derivation ("the regular shared album is the reference model").
+ */
+export interface SelectionCapabilities {
+  canSelectAll: boolean;
+  canDownload: boolean;
+  /** CreateSharedLink */
+  canShare: boolean;
+  canAddToAlbum: boolean;
+  canFavorite: boolean;
+  /** Rotate, ChangeDate/Description/Location, Archive, SetVisibility */
+  canEditMetadata: boolean;
+  canTag: boolean;
+  canDelete: boolean;
+  canSetCover: boolean;
+  canRemoveFromAlbum: boolean;
+  canRemoveFromSpace: boolean;
+}
+
+const NO_CAPABILITIES: SelectionCapabilities = {
+  canSelectAll: false,
+  canDownload: false,
+  canShare: false,
+  canAddToAlbum: false,
+  canFavorite: false,
+  canEditMetadata: false,
+  canTag: false,
+  canDelete: false,
+  canSetCover: false,
+  canRemoveFromAlbum: false,
+  canRemoveFromSpace: false,
+};
+
+export function getSelectionCapabilities(ctx: CommandContext, tagsEnabled: boolean): SelectionCapabilities {
+  const sel = ctx.selection;
+  if (sel === null) {
+    // No toolbar is rendered at all when there is no active selection.
+    return { ...NO_CAPABILITIES };
+  }
+
+  const album = ctx.album;
+  const space = ctx.space;
+  const isRegularAlbum = album !== null && space === null;
+  const isDirectSpace = space !== null && album === null;
+  const isSpaceAlbum = album !== null && space !== null;
+
+  // isEditorOfContext / canRemoveFromAlbum both branch on the same surface
+  // discriminators, so resolve them together instead of repeating the
+  // isRegularAlbum / isDirectSpace / isSpaceAlbum ternary chain twice.
+  let isEditorOfContext = false;
+  let canRemoveFromAlbum = false;
+  if (isRegularAlbum && album) {
+    isEditorOfContext = album.isOwner || album.isEditor;
+    canRemoveFromAlbum = album.isOwner || sel.isAllUserOwned;
+  } else if (isDirectSpace && space) {
+    isEditorOfContext = space.canWrite;
+    // canRemoveFromAlbum stays false — there is no album on a direct-space surface.
+  } else if (isSpaceAlbum && album && space) {
+    // "canManage" — space editor/owner OR album editor/owner. No own-asset arm
+    // (decision C): AlbumAssetDelete is role-gated server-side, ownership grants nothing.
+    isEditorOfContext = space.canWrite || album.isEditor;
+    canRemoveFromAlbum = space.canWrite || album.isEditor;
+  }
+
+  const canRemoveFromSpace = isDirectSpace && space !== null && space.canWrite;
+
+  return {
+    canSelectAll: true,
+    canDownload: true,
+    canShare: sel.isAllUserOwned,
+    canAddToAlbum: sel.isAllUserOwned,
+    canFavorite: sel.isAllUserOwned,
+    canEditMetadata: sel.isAllUserOwned,
+    canTag: sel.isAllUserOwned && tagsEnabled,
+    canDelete: sel.isAllUserOwned,
+    canSetCover: isEditorOfContext && sel.selectedAssetIds.length === 1,
+    canRemoveFromAlbum,
+    canRemoveFromSpace,
+  };
+}

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -17,24 +17,13 @@
   import OnEvents from '$lib/components/OnEvents.svelte';
   import SmartSearchResults from '$lib/components/search/smart-search-results.svelte';
   import ControlAppBar from '$lib/components/shared-components/ControlAppBar.svelte';
-  import ButtonContextMenu from '$lib/components/shared-components/context-menu/ButtonContextMenu.svelte';
   import SpaceNewAssetsDivider from '$lib/components/spaces/space-new-assets-divider.svelte';
   import SpaceOnboardingBanner from '$lib/components/spaces/space-onboarding-banner.svelte';
   import SpaceAssetLimitWarning from '$lib/components/spaces/space-asset-limit-warning.svelte';
-  import MenuOption from '$lib/components/shared-components/context-menu/MenuOption.svelte';
-  import ArchiveAction from '$lib/components/timeline/actions/ArchiveAction.svelte';
-  import ChangeDate from '$lib/components/timeline/actions/ChangeDateAction.svelte';
-  import ChangeDescription from '$lib/components/timeline/actions/ChangeDescriptionAction.svelte';
-  import ChangeLocation from '$lib/components/timeline/actions/ChangeLocationAction.svelte';
-  import DownloadAction from '$lib/components/timeline/actions/DownloadAction.svelte';
-  import FavoriteAction from '$lib/components/timeline/actions/FavoriteAction.svelte';
-  import RemoveFromSpaceAction from '$lib/components/timeline/actions/RemoveFromSpaceAction.svelte';
-  import SelectAllAssets from '$lib/components/timeline/actions/SelectAllAction.svelte';
-  import TagAction from '$lib/components/timeline/actions/TagAction.svelte';
-  import AssetSelectControlBar from '$lib/components/timeline/AssetSelectControlBar.svelte';
+  import SelectionToolbar from '$lib/components/timeline/SelectionToolbar.svelte';
   import Timeline from '$lib/components/timeline/Timeline.svelte';
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
-  import type { TimelineGrouping, TimelineTemporalAnchor } from '$lib/managers/timeline-manager/types';
+  import type { TimelineAsset, TimelineGrouping, TimelineTemporalAnchor } from '$lib/managers/timeline-manager/types';
   import { registerSelectionContext, registerSpaceContext } from '$lib/managers/command-context-manager.svelte';
   import { eventManager } from '$lib/managers/event-manager.svelte';
   import { globalSearchManager } from '$lib/managers/global-search-manager.svelte';
@@ -87,7 +76,7 @@
     type SmartSearchFacetsResponseDto,
   } from '@immich/sdk';
   import { IconButton, modalManager, toastManager } from '@immich/ui';
-  import { mdiDotsVertical, mdiImageOutline, mdiPlus } from '@mdi/js';
+  import { mdiImageOutline, mdiPlus } from '@mdi/js';
   import { t } from 'svelte-i18n';
   import { untrack } from 'svelte';
   import { SvelteMap } from 'svelte/reactivity';
@@ -519,7 +508,7 @@
   registerSelectionContext({
     getAssets: () => assetMultiSelectManager.assets,
     clearSelection: () => assetMultiSelectManager.clear(),
-    canAddToAlbum: () => false,
+    canAddToAlbum: () => true,
     getOnFavorite: () =>
       viewMode === 'view' && timelineManager
         ? (ids, isFavorite) => timelineManager.update(ids, (asset) => (asset.isFavorite = isFavorite))
@@ -537,6 +526,32 @@
     await refreshSpace();
     // Also revalidate layout data so the shell's Photos tab count badge updates.
     await invalidateAll();
+  };
+
+  // Mirrors the album page's `handleSetVisibility`: moving assets to/from the locked folder
+  // takes them out of this (non-locked) timeline view. Unlike remove-from-space, this isn't a
+  // space-membership change, so it doesn't touch the space's asset count.
+  const handleSetVisibility = (assetIds: string[]) => {
+    timelineManager.removeAssets(assetIds);
+    assetMultiSelectManager.clear();
+  };
+
+  // DeleteAssets already performed the server-side trash before calling this — it's a
+  // VIEW-UPDATE-only handler, mirroring the album page's `handleRemoveAssets` used for
+  // `onAssetDelete`. Deletion is not a remove-from-space, so `handleRemoveAssets` above
+  // (which also refreshes the space + revalidates layout data) is NOT reused here: the
+  // websocket-driven `on_asset_trash` → `AssetsDelete` event already triggers `refreshSpace`
+  // via the page's `<OnEvents onAssetsDelete={refreshSpace} />` (see below), so refreshing
+  // again here would be redundant.
+  const handleAssetDelete = (assetIds: string[]) => {
+    timelineManager.removeAssets(assetIds);
+  };
+
+  // Mirrors the album page's `handleUndoRemoveAssets`. There's no websocket event for restore,
+  // so re-add the assets to the local view directly; no space-count refresh is needed since
+  // undoing a delete doesn't change space membership either.
+  const handleUndoAssetDelete = (assets: TimelineAsset[]) => {
+    timelineManager.upsertAssets(assets);
   };
 
   const handleSetAsCover = async () => {
@@ -819,8 +834,8 @@
     {#if !showSearchResults}
       {#if isFilteredTimelineEmpty}
         <div class="flex flex-1 flex-col items-center justify-center gap-2" data-testid="empty-state-message">
-          <p class="text-sm text-[var(--fg-muted)]">{$t('spaces_no_filtered_assets')}</p>
-          <button type="button" class="text-sm text-[var(--primary)]" onclick={handleClearAllFilters}>
+          <p class="text-sm text-(--fg-muted)">{$t('spaces_no_filtered_assets')}</p>
+          <button type="button" class="text-sm text-(--primary)" onclick={handleClearAllFilters}>
             {$t('spaces_clear_all_filters')}
           </button>
         </div>
@@ -876,37 +891,18 @@
 
 {#if assetMultiSelectManager.selectionActive && viewMode === 'view'}
   <div class="fixed inset-s-0 top-0 z-2 w-full">
-    <AssetSelectControlBar>
-      <SelectAllAssets {timelineManager} assetInteraction={assetMultiSelectManager} />
-      {#if isEditor}
-        <RemoveFromSpaceAction spaceId={space.id} onRemove={handleRemoveAssets} />
-      {/if}
-      {#if assetMultiSelectManager.isAllUserOwned}
-        <FavoriteAction
-          removeFavorite={assetMultiSelectManager.isAllFavorite}
-          onFavorite={(ids, isFavorite) => timelineManager.update(ids, (asset) => (asset.isFavorite = isFavorite))}
-        />
-      {/if}
-      <ButtonContextMenu icon={mdiDotsVertical} title={$t('menu')} offset={{ x: 175, y: 25 }}>
-        <DownloadAction menuItem />
-        {#if assetMultiSelectManager.isAllUserOwned}
-          <ChangeDate menuItem />
-          <ChangeDescription menuItem />
-          <ChangeLocation menuItem />
-          <ArchiveAction
-            menuItem
-            unarchive={assetMultiSelectManager.isAllArchived}
-            onArchive={(ids, visibility) => timelineManager.update(ids, (asset) => (asset.visibility = visibility))}
-          />
-        {/if}
-        {#if authManager.preferences.tags.enabled && assetMultiSelectManager.isAllUserOwned}
-          <TagAction menuItem />
-        {/if}
-        {#if isEditor && assetMultiSelectManager.assets.length === 1}
-          <MenuOption text={$t('set_as_space_cover')} icon={mdiImageOutline} onClick={handleSetAsCover} />
-        {/if}
-      </ButtonContextMenu>
-    </AssetSelectControlBar>
+    <SelectionToolbar
+      {timelineManager}
+      assetInteraction={assetMultiSelectManager}
+      space={{ id: space.id, canWrite: isEditor }}
+      onRemove={handleRemoveAssets}
+      onSetCover={handleSetAsCover}
+      onFavorite={(ids, isFavorite) => timelineManager.update(ids, (asset) => (asset.isFavorite = isFavorite))}
+      onArchive={(ids, visibility) => timelineManager.update(ids, (asset) => (asset.visibility = visibility))}
+      onVisibilitySet={handleSetVisibility}
+      onAssetDelete={handleAssetDelete}
+      onUndoDelete={handleUndoAssetDelete}
+    />
   </div>
 {/if}
 

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -585,7 +585,9 @@ describe('Spaces page search URL state', () => {
 
     expect(mockRegisterSelectionContext).toHaveBeenCalledOnce();
     const options = mockRegisterSelectionContext.mock.calls[0][0];
-    expect(options.canAddToAlbum()).toBe(false);
+    // #839 slice 4: add-to-album is now enabled on the space timeline (the toolbar owner-gates it,
+    // and this flag keeps the ⌘K palette consistent with the toolbar).
+    expect(options.canAddToAlbum()).toBe(true);
     expect(options.getAssets()).toBe(mockAssetMultiSelectManager.assets);
     expect(options.getOnFavorite()).toEqual(expect.any(Function));
     expect(options.getOnArchive()).toEqual(expect.any(Function));

--- a/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { goto, onNavigate } from '$app/navigation';
+  import { goto, invalidateAll, onNavigate } from '$app/navigation';
   import UserPageLayout from '$lib/components/layouts/UserPageLayout.svelte';
   import AlbumTitle from '$lib/components/album-page/AlbumTitle.svelte';
   import AlbumDescription from '$lib/components/album-page/AlbumDescription.svelte';
@@ -15,9 +15,7 @@
   import FilterToggleButton from '$lib/components/filter-panel/filter-toggle-button.svelte';
   import ActiveFiltersBar from '$lib/components/filter-panel/active-filters-bar.svelte';
   import ControlAppBar from '$lib/components/shared-components/ControlAppBar.svelte';
-  import DownloadAction from '$lib/components/timeline/actions/DownloadAction.svelte';
-  import RemoveFromAlbum from '$lib/components/timeline/actions/RemoveFromAlbumAction.svelte';
-  import AssetSelectControlBar from '$lib/components/timeline/AssetSelectControlBar.svelte';
+  import SelectionToolbar from '$lib/components/timeline/SelectionToolbar.svelte';
   import Timeline from '$lib/components/timeline/Timeline.svelte';
   import TimelineGroupingControl from '$lib/components/timeline/TimelineGroupingControl.svelte';
   import { assetMultiSelectManager, AssetMultiSelectManager } from '$lib/managers/asset-multi-select-manager.svelte';
@@ -44,12 +42,14 @@
     AlbumUserRole,
     getAlbumInfo,
     SharedSpaceRole,
+    updateAlbumInfo,
     type AlbumResponseDto,
     type SharedSpaceMemberResponseDto,
     type SharedSpaceResponseDto,
   } from '@immich/sdk';
   import HeaderActionButton from '$lib/components/HeaderActionButton.svelte';
-  import { Icon, IconButton, modalManager } from '@immich/ui';
+  import { Icon, IconButton, modalManager, toastManager } from '@immich/ui';
+  import { handleError } from '$lib/utils/handle-error';
   import { mdiArrowLeft, mdiImageOutline, mdiImagePlusOutline } from '@mdi/js';
   import { t } from 'svelte-i18n';
   import type { PageData } from './$types';
@@ -172,6 +172,51 @@
     // selection internally before firing onRemove, so we only need to defensively clear here.
     timelineManager?.removeAssets(assetIds);
     assetMultiSelectManager.clear();
+  };
+
+  // Mirrors the space timeline page's `handleSetVisibility`: moving assets to/from the locked
+  // folder takes them out of this (non-locked) timeline view. It isn't an album-membership
+  // change (RemoveFromAlbum is the only membership mutation this route offers), so it doesn't
+  // touch album.assetCount either.
+  const handleSetVisibility = (assetIds: string[]) => {
+    timelineManager?.removeAssets(assetIds);
+    assetMultiSelectManager.clear();
+  };
+
+  // DeleteAssets already performed the server-side trash before calling this. Unlike the space
+  // timeline page (which has `<OnEvents onAssetsDelete={refreshSpace} />` to pick up
+  // server-truth counts after a trash), this page has no such websocket wiring — mirroring the
+  // space-person page's identical reasoning — so force a data reload here to keep
+  // album.assetCount in sync with the server.
+  const handleAssetDelete = (assetIds: string[]) => {
+    timelineManager?.removeAssets(assetIds);
+    void invalidateAll();
+  };
+
+  // Mirrors the space timeline page's `handleUndoAssetDelete`. There's no websocket event for
+  // restore, so re-add the assets to the local view directly; no count refresh is needed since
+  // undoing a delete doesn't change album membership either.
+  const handleUndoAssetDelete = (assets: TimelineAsset[]) => {
+    timelineManager?.upsertAssets(assets);
+  };
+
+  // Cover setter for the full toolbar's "set_as_album_cover" menu item (canManage-gated, single
+  // asset only — see getSelectionCapabilities' canSetCover). Mirrors the regular album page's
+  // `updateThumbnailUsingCurrentSelection`; this route has no dedicated SELECT_THUMBNAIL mode, so
+  // it always operates on the current bulk selection.
+  const handleSetAlbumCover = async () => {
+    const assets = assetMultiSelectManager.assets;
+    if (assets.length !== 1) {
+      return;
+    }
+    try {
+      await updateAlbumInfo({ id: album.id, updateAlbumDto: { albumThumbnailAssetId: assets[0].id } });
+      await refreshAlbum();
+      toastManager.primary($t('album_cover_updated'));
+      assetMultiSelectManager.clear();
+    } catch (error) {
+      handleError(error, $t('errors.unable_to_update_album_cover'));
+    }
   };
 
   function resetPicker() {
@@ -398,24 +443,44 @@
   {/if}
 </UserPageLayout>
 
-<!-- Browse selection control bar (shows when assets are selected in browse mode). Rendered OUTSIDE
-     UserPageLayout: its wrapper is `relative z-0`, which is a stacking context, so a control bar nested
+<!-- Browse selection toolbar (shows when assets are selected in browse mode). Rendered OUTSIDE
+     UserPageLayout: its wrapper is `relative z-0`, which is a stacking context, so a toolbar nested
      inside it (and before the Timeline) paints UNDER the asset grid and the z-1 scrubber. Matching the
-     other timeline pages (recently-added/favorites/…), the bar sits after the layout so it paints on top.
-     rbac-5/albums-8: album-path assets never grant space-editor metadata-edit (checkSpaceEditAccess
-     omits the album arm, pinned by shared-space-album-scope.guard.spec.ts). This route is entirely
-     album-path, so it intentionally exposes ONLY Download + RemoveFromAlbum — never Archive / Change
-     date/location / Tag / visibility. In the MERGED direct-space timeline those metadata-edit actions
-     are separately gated by `isAllUserOwned`, so an editor can never trigger them on a non-owned
-     album-path asset; the residual mixed-bulk case is refused server-side (400 on album-path-only ids),
-     which the client cannot pre-empt without a per-asset origin signal (none exists on TimelineAsset). -->
+     other timeline pages (recently-added/favorites/space timeline/…), the bar sits after the layout so
+     it paints on top.
+
+     rbac-5/albums-8 REVERSED (Slice 6): this route now renders the full album-equivalent
+     <SelectionToolbar> — the same component the regular album page and the direct-space/space-person
+     timelines use — instead of the stripped Download+Remove-only bar it originally shipped with. Two
+     RBAC facts make the reversal safe:
+       - Owner-gated mutations (Share/Add-to-album/Favorite/Rotate/ChangeDate/ChangeDescription/
+         ChangeLocation/Archive/SetVisibility/Tag/Delete) are gated by `sel.isAllUserOwned` in
+         getSelectionCapabilities, and the server's AssetUpdate access check (access.ts:155-159) checks
+         asset OWNERSHIP first, before any album/space role: `isOwner = checkOwnerAccess(...)` is unioned
+         with the space-editor arm, so an owner editing their own asset is NEVER blocked by the album
+         path. Exposing these actions here for an all-owned selection is exactly as safe as on the
+         regular album page.
+       - `canRemoveFromAlbum` stays `canManage`-only (space.canWrite || album.isEditor) — ownership alone
+         never grants it — because the server's `AlbumAssetDelete` is role-gated
+         (shared-space-album-scope.guard.spec.ts pins this): a non-manager can't remove even their own
+         asset from the album (decision C).
+     Space-editor cross-owner metadata edits are still never offered on a mixed/not-owned selection:
+     `isAllUserOwned` gates the whole metadata-edit block, matching the merged direct-space timeline. -->
 {#if mode === 'browse' && assetMultiSelectManager.selectionActive}
-  <AssetSelectControlBar>
-    <DownloadAction filename="{album.albumName}.zip" />
-    {#if canManage}
-      <RemoveFromAlbum bind:album onRemove={handleRemoveAssets} data-testid="album-remove-from-album" />
-    {/if}
-  </AssetSelectControlBar>
+  <SelectionToolbar
+    {timelineManager}
+    assetInteraction={assetMultiSelectManager}
+    {album}
+    space={{ id: space.id, canWrite: isSpaceEditor }}
+    downloadFilename={`${album.albumName}.zip`}
+    onRemove={handleRemoveAssets}
+    onSetCover={handleSetAlbumCover}
+    onFavorite={(ids, isFavorite) => timelineManager.update(ids, (asset) => (asset.isFavorite = isFavorite))}
+    onArchive={(ids, visibility) => timelineManager.update(ids, (asset) => (asset.visibility = visibility))}
+    onVisibilitySet={handleSetVisibility}
+    onAssetDelete={handleAssetDelete}
+    onUndoDelete={handleUndoAssetDelete}
+  />
 {/if}
 
 {#if mode === 'add'}

--- a/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/space-album-detail-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/space-album-detail-page.spec.ts
@@ -9,8 +9,10 @@ import {
 } from '@immich/sdk';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import type { Component } from 'svelte';
 import { init, register, waitLocale } from 'svelte-i18n';
 import { getAnimateMock } from '$lib/__mocks__/animate.mock';
+import TestWrapper from '$lib/components/TestWrapper.svelte';
 import { authManager } from '$lib/managers/auth-manager.svelte';
 import { addAssetsToAlbums, getAlbumAssetsActions } from '$lib/services/album.service';
 import { preferencesFactory } from '@test-data/factories/preferences-factory';
@@ -59,7 +61,7 @@ vi.mock('$lib/components/filter-panel/active-filters-bar.svelte', async () => {
   return { default: MockComponent };
 });
 
-vi.mock('$app/navigation', () => ({ goto: vi.fn(), onNavigate: vi.fn() }));
+vi.mock('$app/navigation', () => ({ goto: vi.fn(), invalidateAll: vi.fn(), onNavigate: vi.fn() }));
 
 vi.mock('$lib/components/timeline/TimelineGroupingControl.svelte', async () => {
   const { default: MockComponent } = await import('./mock-grouping-control.test-wrapper.svelte');
@@ -75,12 +77,21 @@ vi.mock('$lib/utils/timeline-zoom-navigation', () => ({
   getTimelineManagerTimeBuckets: vi.fn().mockReturnValue([]),
 }));
 
+// Slice 6: the browse selection bar now renders the full <SelectionToolbar>, which wires
+// DeleteAssetsAction — its `force` derivation reads featureFlagsManager.value.trash, which
+// throws until the (real, module-singleton) manager is initialized. Mirrors the mock already
+// used by SelectionToolbar.spec.ts and the space-person-detail-page spec.
+vi.mock('$lib/managers/feature-flags-manager.svelte', () => ({
+  featureFlagsManager: { value: { trash: true } },
+}));
+
 const { mockAssetMultiSelectManager } = vi.hoisted(() => ({
   mockAssetMultiSelectManager: {
     selectionActive: false,
     assets: [] as { id: string }[],
     clear: vi.fn(),
     isAllFavorite: false,
+    isAllArchived: false,
     isAllUserOwned: true,
   },
 }));
@@ -92,6 +103,7 @@ vi.mock('$lib/managers/asset-multi-select-manager.svelte', () => ({
     assets: { id: string }[] = [];
     clear = vi.fn();
     isAllFavorite = false;
+    isAllArchived = false;
     isAllUserOwned = true;
   },
 }));
@@ -194,9 +206,29 @@ function renderPage({
   authManager.setUser(userAdminFactory.build({ id: 'current-user-id' }));
   authManager.setPreferences(preferencesFactory.build());
 
-  return render(SpaceAlbumDetailPage, {
-    props: { data: makePageData(album, members, space) },
-  });
+  // Slice 6: the browse selection bar now renders the full <SelectionToolbar>, which (like the
+  // regular album page and the direct-space/space-person timelines) renders real @immich/ui
+  // IconButtons that resolve a bits-ui Tooltip against a "Tooltip.Provider" context. That
+  // provider only exists app-wide via the root +layout.svelte, which isn't part of this render —
+  // TestWrapper supplies it (mirrors spaces-page.spec.ts / space-person-detail-page.spec.ts).
+  return render(
+    TestWrapper as Component<{
+      component: typeof SpaceAlbumDetailPage;
+      componentProps: { data: ReturnType<typeof makePageData> };
+    }>,
+    {
+      component: SpaceAlbumDetailPage,
+      componentProps: { data: makePageData(album, members, space) },
+    },
+  );
+}
+
+// Slice 6: RemoveFromAlbum/Download/Delete/etc. now live as menu items inside the
+// <SelectionToolbar>'s "⋮" ButtonContextMenu instead of top-level in the control bar. Open it
+// before asserting on any menu item, mirroring the Slice 4/5 Playwright specs
+// (spaces-selection-toolbar-timeline.e2e-spec.ts's `openOverflowMenu`).
+async function openOverflowMenu() {
+  await fireEvent.click(screen.getByRole('button', { name: 'Menu' }));
 }
 
 describe('Space album detail page', () => {
@@ -215,6 +247,11 @@ describe('Space album detail page', () => {
     resetMockTimelineState();
     mockAssetMultiSelectManager.selectionActive = false;
     mockAssetMultiSelectManager.assets = [];
+    // Slice 6: a handful of tests below flip these to exercise ownership/manager gating
+    // independently — reset to the long-standing defaults so that leaks between tests.
+    mockAssetMultiSelectManager.isAllUserOwned = true;
+    mockAssetMultiSelectManager.isAllFavorite = false;
+    mockAssetMultiSelectManager.isAllArchived = false;
     // Restore the default getAlbumAssetsActions return after resetAllMocks clears it
     vi.mocked(getAlbumAssetsActions).mockReturnValue({
       AddAssets: {
@@ -392,18 +429,20 @@ describe('Space album detail page', () => {
     expect(screen.getByTestId('asset-select-control-bar')).toBeInTheDocument();
   });
 
-  it('in browse mode with selection active and canManage=true, RemoveFromAlbum and Download actions are wired', () => {
+  it('in browse mode with selection active and canManage=true, RemoveFromAlbum and Download actions are wired', async () => {
     mockAssetMultiSelectManager.selectionActive = true;
     renderPage({ members: [makeMember(SharedSpaceRole.Editor)] });
     // AssetSelectControlBar renders its children
     expect(screen.getByTestId('asset-select-control-bar')).toBeInTheDocument();
-    // RemoveFromAlbumAction is rendered
+
+    // RemoveFromAlbumAction and DownloadAction are now menu items inside the "⋮" overflow menu.
+    await openOverflowMenu();
     expect(screen.getByTestId('album-remove-from-album')).toBeInTheDocument();
     // DownloadAction is rendered for all members
     expect(screen.getByTestId('download-action')).toBeInTheDocument();
   });
 
-  it('in browse mode with selection active and canManage=false, control bar shown with Download but no Remove action', () => {
+  it('in browse mode with selection active and canManage=false, control bar shown with Download but no Remove action', async () => {
     mockAssetMultiSelectManager.selectionActive = true;
     renderPage({
       members: [makeMember(SharedSpaceRole.Viewer)],
@@ -418,6 +457,8 @@ describe('Space album detail page', () => {
     });
     // Control bar shows
     expect(screen.getByTestId('asset-select-control-bar')).toBeInTheDocument();
+
+    await openOverflowMenu();
     // DownloadAction is available to all members (bar is not empty for viewers)
     expect(screen.getByTestId('download-action')).toBeInTheDocument();
     // But RemoveFromAlbumAction is NOT rendered
@@ -765,7 +806,7 @@ describe('Space album detail page', () => {
 
   // ── RemoveFromAlbum gating — additional role combos ──────────────────────────
 
-  it('space=Viewer + album=Editor + selection active: RemoveFromAlbum is present', () => {
+  it('space=Viewer + album=Editor + selection active: RemoveFromAlbum is present', async () => {
     mockAssetMultiSelectManager.selectionActive = true;
     renderPage({
       members: [makeMember(SharedSpaceRole.Viewer)],
@@ -778,34 +819,71 @@ describe('Space album detail page', () => {
         ],
       }),
     });
+    await openOverflowMenu();
     expect(screen.getByTestId('album-remove-from-album')).toBeInTheDocument();
   });
 
-  it('space=Owner + default album + selection active: RemoveFromAlbum is present', () => {
+  it('space=Owner + default album + selection active: RemoveFromAlbum is present', async () => {
     mockAssetMultiSelectManager.selectionActive = true;
     renderPage({ members: [makeMember(SharedSpaceRole.Owner)] });
+    await openOverflowMenu();
     expect(screen.getByTestId('album-remove-from-album')).toBeInTheDocument();
   });
 
-  describe('rbac-5/albums-8: album-path control bar exposes no editor metadata affordances', () => {
-    // This route is entirely album-path (see the +page.svelte control-bar comment). The control
-    // bar only ever imports DownloadAction + RemoveFromAlbumAction — no Archive / ChangeDate /
-    // ChangeLocation / Tag action is wired here at all, regardless of role. These assertions pin
-    // that shape so a future change can't silently add a metadata-edit affordance to this route.
-    it('shows Download + RemoveFromAlbum for a manager and no metadata-edit affordances', () => {
+  // Slice 6 — rbac-5/albums-8 REVERSED: the browse control bar now renders the full
+  // album-equivalent <SelectionToolbar> (see the +page.svelte control-bar comment for the RBAC
+  // reasoning) instead of the stripped Download+Remove-only bar it originally shipped with.
+  // `canRemoveFromAlbum` stays `canManage`-gated (ownership grants nothing — decision C), while
+  // the metadata-edit affordances (Archive/ChangeDate/ChangeLocation/Delete/…) and Share/
+  // Add-to-album/Favorite are gated independently on `isAllUserOwned` — the same two
+  // independent axes the merged direct-space timeline and SelectionToolbar.spec.ts encode.
+  describe('Slice 6: full album-equivalent toolbar (reversal of the stripped bar)', () => {
+    it('manager + all-owned selection: Download + RemoveFromAlbum + metadata-edit + Set-cover all present', async () => {
       mockAssetMultiSelectManager.selectionActive = true;
+      mockAssetMultiSelectManager.isAllUserOwned = true;
+      mockAssetMultiSelectManager.assets = [{ id: 'asset-1' }];
       renderPage({ members: [makeMember(SharedSpaceRole.Editor)] });
 
+      expect(screen.getByRole('button', { name: 'Share' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Add to album or space' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /favorite/i })).toBeInTheDocument();
+
+      await openOverflowMenu();
       expect(screen.getByTestId('download-action')).toBeInTheDocument();
       expect(screen.getByTestId('album-remove-from-album')).toBeInTheDocument();
-      expect(screen.queryByTestId('change-date-action')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('change-location-action')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('archive-action')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('tag-action')).not.toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'Change date' })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'Change location' })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'Archive' })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'Set as album cover' })).toBeInTheDocument();
     });
 
-    it('hides RemoveFromAlbum for a non-manager (viewer) and still has no metadata-edit affordances', () => {
+    it('manager + NOT-owned selection: RemoveFromAlbum + Set-cover present (canManage-gated), metadata-edit + Delete + Share absent (ownership-gated)', async () => {
       mockAssetMultiSelectManager.selectionActive = true;
+      mockAssetMultiSelectManager.isAllUserOwned = false;
+      mockAssetMultiSelectManager.assets = [{ id: 'asset-1' }];
+      renderPage({ members: [makeMember(SharedSpaceRole.Editor)] });
+
+      expect(screen.queryByRole('button', { name: 'Share' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Add to album or space' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /favorite/i })).not.toBeInTheDocument();
+
+      await openOverflowMenu();
+      expect(screen.getByTestId('download-action')).toBeInTheDocument();
+      // canRemoveFromAlbum / canSetCover key off canManage (space.canWrite || album.isEditor),
+      // NOT ownership — both stay visible even though the selection isn't owned.
+      expect(screen.getByTestId('album-remove-from-album')).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'Set as album cover' })).toBeInTheDocument();
+      // Ownership-gated actions are hidden regardless of manager status.
+      expect(screen.queryByRole('menuitem', { name: 'Change date' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('menuitem', { name: 'Archive' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('menuitem', { name: 'Delete' })).not.toBeInTheDocument();
+    });
+
+    it('non-manager (viewer) + all-owned selection: metadata-edit affordances present, RemoveFromAlbum + Set-cover absent', async () => {
+      mockAssetMultiSelectManager.selectionActive = true;
+      mockAssetMultiSelectManager.isAllUserOwned = true;
+      mockAssetMultiSelectManager.assets = [{ id: 'asset-1' }];
       renderPage({
         members: [makeMember(SharedSpaceRole.Viewer)],
         album: makeAlbum({
@@ -818,11 +896,48 @@ describe('Space album detail page', () => {
         }),
       });
 
+      expect(screen.getByRole('button', { name: 'Share' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Add to album or space' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /favorite/i })).toBeInTheDocument();
+
+      await openOverflowMenu();
+      expect(screen.getByTestId('download-action')).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'Change date' })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'Archive' })).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument();
+
+      // canManage is false for a plain album/space Viewer — Remove and Set-cover stay hidden
+      // even though the selection is entirely their own.
       expect(screen.queryByTestId('album-remove-from-album')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('change-date-action')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('change-location-action')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('archive-action')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('tag-action')).not.toBeInTheDocument();
+      expect(screen.queryByRole('menuitem', { name: 'Set as album cover' })).not.toBeInTheDocument();
+    });
+
+    it('non-manager (viewer) + NOT-owned selection: only Select-all and Download are shown', async () => {
+      mockAssetMultiSelectManager.selectionActive = true;
+      mockAssetMultiSelectManager.isAllUserOwned = false;
+      mockAssetMultiSelectManager.assets = [{ id: 'asset-1' }];
+      renderPage({
+        members: [makeMember(SharedSpaceRole.Viewer)],
+        album: makeAlbum({
+          albumUsers: [
+            {
+              user: { id: 'current-user-id', email: 'user@example.com', name: 'Current User' } as never,
+              role: AlbumUserRole.Viewer,
+            },
+          ],
+        }),
+      });
+
+      expect(screen.getByRole('button', { name: 'Select all' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Share' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Add to album or space' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /favorite/i })).not.toBeInTheDocument();
+
+      await openOverflowMenu();
+      expect(screen.getByTestId('download-action')).toBeInTheDocument();
+      expect(screen.queryByTestId('album-remove-from-album')).not.toBeInTheDocument();
+      expect(screen.queryByRole('menuitem', { name: 'Delete' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('menuitem', { name: 'Set as album cover' })).not.toBeInTheDocument();
     });
   });
 
@@ -831,8 +946,11 @@ describe('Space album detail page', () => {
   // only `data` changes. The page has to re-seed its local album state from it, or the URL moves
   // while the timeline keeps showing the album you came from.
   describe('navigating between sibling albums (same route, new params)', () => {
+    // Rendered via TestWrapper (see renderPage), so `rerender` needs the full
+    // `{ component, componentProps }` shape, not just the inner page's props.
     const rerenderWith = (album: AlbumResponseDto, members = [makeMember()]) => ({
-      data: makePageData(album, members),
+      component: SpaceAlbumDetailPage,
+      componentProps: { data: makePageData(album, members) },
     });
 
     const albumWithRole = (id: string, role: AlbumUserRole) =>

--- a/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -557,17 +557,17 @@
 </script>
 
 <main
-  class="relative z-0 flex flex-col h-dvh overflow-hidden px-2 pt-(--navbar-height) md:px-6 md:pt-(--navbar-height-md)"
+  class="relative z-0 flex h-dvh flex-col overflow-hidden px-2 pt-(--navbar-height) md:px-6 md:pt-(--navbar-height-md)"
 >
   <!-- Sticky grouping switcher: lives outside the scrolling timeline so it stays visible (see Tags).
        mt-12 clears the taller ControlAppBar, which exceeds the --navbar-height padding reserve. -->
   <TimelineRouteGroupingBar
     grouping={timelineGrouping}
     hidden={assetMultiSelectManager.selectionActive || action === 'merge'}
-    class="shrink-0 mt-12"
+    class="mt-12 shrink-0"
     onGroupingChange={handleTimelineGroupingChange}
   />
-  <div class="relative flex-1 min-h-0">
+  <div class="relative min-h-0 flex-1">
     {#key person.id}
       <Timeline
         enableRouting={true}
@@ -625,7 +625,7 @@
                   <input
                     bind:this={nameInput}
                     bind:value={editedName}
-                    class="w-40 rounded-lg bg-gray-100 px-2 py-1 font-medium text-primary outline-hidden focus:ring-2 focus:ring-immich-primary dark:bg-immich-dark-gray dark:focus:ring-immich-dark-primary sm:w-72"
+                    class="w-40 rounded-lg bg-gray-100 px-2 py-1 font-medium text-primary outline-hidden focus:ring-2 focus:ring-immich-primary sm:w-72 dark:bg-immich-dark-gray dark:focus:ring-immich-dark-primary"
                     placeholder={$t('add_a_name')}
                     aria-label={$t('edit_name')}
                     oninput={() => void searchSpacePeople()}

--- a/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -4,25 +4,15 @@
   import { listNavigation } from '$lib/actions/list-navigation';
   import ImageThumbnail from '$lib/components/assets/thumbnail/ImageThumbnail.svelte';
   import PeopleMergeSelector from '$lib/components/people/people-merge-selector.svelte';
-  import ButtonContextMenu from '$lib/components/shared-components/context-menu/ButtonContextMenu.svelte';
   import ControlAppBar from '$lib/components/shared-components/ControlAppBar.svelte';
-  import ArchiveAction from '$lib/components/timeline/actions/ArchiveAction.svelte';
-  import ChangeDate from '$lib/components/timeline/actions/ChangeDateAction.svelte';
-  import ChangeDescription from '$lib/components/timeline/actions/ChangeDescriptionAction.svelte';
-  import ChangeLocation from '$lib/components/timeline/actions/ChangeLocationAction.svelte';
-  import DownloadAction from '$lib/components/timeline/actions/DownloadAction.svelte';
-  import FavoriteAction from '$lib/components/timeline/actions/FavoriteAction.svelte';
-  import RemoveFromSpaceAction from '$lib/components/timeline/actions/RemoveFromSpaceAction.svelte';
-  import SelectAllAssets from '$lib/components/timeline/actions/SelectAllAction.svelte';
-  import TagAction from '$lib/components/timeline/actions/TagAction.svelte';
-  import AssetSelectControlBar from '$lib/components/timeline/AssetSelectControlBar.svelte';
+  import SelectionToolbar from '$lib/components/timeline/SelectionToolbar.svelte';
   import Timeline from '$lib/components/timeline/Timeline.svelte';
   import TimelineRouteGroupingBar from '$lib/components/timeline/TimelineRouteGroupingBar.svelte';
   import { assetMultiSelectManager } from '$lib/managers/asset-multi-select-manager.svelte';
   import { authManager } from '$lib/managers/auth-manager.svelte';
   import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
-  import type { TimelineGrouping, TimelineTemporalAnchor } from '$lib/managers/timeline-manager/types';
+  import type { TimelineAsset, TimelineGrouping, TimelineTemporalAnchor } from '$lib/managers/timeline-manager/types';
   import { timeBeforeShowLoadingSpinner } from '$lib/constants';
   import PersonEditBirthDateModal from '$lib/modals/PersonEditBirthDateModal.svelte';
   import RepresentativeFacePickerModal from '$lib/modals/RepresentativeFacePickerModal.svelte';
@@ -63,7 +53,6 @@
     mdiAccountMultipleCheckOutline,
     mdiArrowLeft,
     mdiCalendarEditOutline,
-    mdiDotsVertical,
     mdiEyeOffOutline,
   } from '@mdi/js';
   import { DateTime } from 'luxon';
@@ -358,6 +347,33 @@
     setPerson({ ...person, assetCount: Math.max(0, person.assetCount - removedAssetCount) });
     setStatistics({ ...statistics, assets: Math.max(0, statistics.assets - removedAssetCount) });
     await invalidateAll();
+  };
+
+  // Mirrors the space timeline page's `handleSetVisibility`: moving assets to/from the locked
+  // folder takes them out of this (non-locked) timeline view. It isn't a space-membership
+  // change, so it doesn't touch the person's/space's asset count.
+  const handleSetVisibility = (assetIds: string[]) => {
+    timelineManager.removeAssets(assetIds);
+    assetMultiSelectManager.clear();
+  };
+
+  // DeleteAssets already performed the server-side trash before calling this. The space
+  // timeline page's equivalent handler is view-update-only because that page has an
+  // `<OnEvents onAssetsDelete={refreshSpace} />` websocket listener that re-fetches
+  // server-truth counts after a trash. This page has no such wiring, so — unlike that page —
+  // we also force a data reload here to keep the header's asset/face counts in sync with the
+  // server (rather than guessing a local decrement, since it isn't clear the server excludes
+  // trashed assets from these counts).
+  const handleAssetDelete = (assetIds: string[]) => {
+    timelineManager.removeAssets(assetIds);
+    void invalidateAll();
+  };
+
+  // Mirrors the space timeline page's `handleUndoAssetDelete`. There's no websocket event for
+  // restore, so re-add the assets to the local view directly; no count refresh is needed since
+  // undoing a delete doesn't change space membership either.
+  const handleUndoAssetDelete = (assets: TimelineAsset[]) => {
+    timelineManager.upsertAssets(assets);
   };
 
   function handleTimelineGroupingChange(grouping: TimelineGrouping) {
@@ -712,34 +728,18 @@
 
 <header>
   {#if assetMultiSelectManager.selectionActive}
-    <AssetSelectControlBar>
-      <SelectAllAssets {timelineManager} assetInteraction={assetMultiSelectManager} />
-      {#if isEditor}
-        <RemoveFromSpaceAction spaceId={space.id} onRemove={handleRemoveAssets} />
-      {/if}
-      {#if assetMultiSelectManager.isAllUserOwned}
-        <FavoriteAction
-          removeFavorite={assetMultiSelectManager.isAllFavorite}
-          onFavorite={(ids, isFavorite) => timelineManager.update(ids, (asset) => (asset.isFavorite = isFavorite))}
-        />
-      {/if}
-      <ButtonContextMenu icon={mdiDotsVertical} title={$t('menu')} offset={{ x: 175, y: 25 }}>
-        <DownloadAction menuItem filename="{person.name || space.name || 'immich'}.zip" />
-        {#if assetMultiSelectManager.isAllUserOwned}
-          <ChangeDate menuItem />
-          <ChangeDescription menuItem />
-          <ChangeLocation menuItem />
-          <ArchiveAction
-            menuItem
-            unarchive={assetMultiSelectManager.isAllArchived}
-            onArchive={(ids, visibility) => timelineManager.update(ids, (asset) => (asset.visibility = visibility))}
-          />
-        {/if}
-        {#if authManager.preferences.tags.enabled && assetMultiSelectManager.isAllUserOwned}
-          <TagAction menuItem />
-        {/if}
-      </ButtonContextMenu>
-    </AssetSelectControlBar>
+    <SelectionToolbar
+      {timelineManager}
+      assetInteraction={assetMultiSelectManager}
+      space={{ id: space.id, canWrite: isEditor }}
+      downloadFilename={`${person.name || space.name || 'immich'}.zip`}
+      onRemove={handleRemoveAssets}
+      onFavorite={(ids, isFavorite) => timelineManager.update(ids, (asset) => (asset.isFavorite = isFavorite))}
+      onArchive={(ids, visibility) => timelineManager.update(ids, (asset) => (asset.visibility = visibility))}
+      onVisibilitySet={handleSetVisibility}
+      onAssetDelete={handleAssetDelete}
+      onUndoDelete={handleUndoAssetDelete}
+    />
   {:else}
     <ControlAppBar backIcon={mdiArrowLeft} onClose={handleBack}>
       {#snippet trailing()}


### PR DESCRIPTION
Resolves the inconsistency reported in [discussion #839](https://github.com/open-noodle/gallery/discussions/839): the multi-select action toolbar differed on every surface — full on the personal timeline/albums, reduced on the Shared Space timeline/person, and gutted (Download-only, no Select-all) inside Space albums.

## Approach
The regular shared album is the reference model: give every user, on every space surface, exactly the actions they'd have on the same assets in a shared album — same per-action gates, space role → album role, Remove-from-space swapped for Remove-from-album on direct-space surfaces.

Implemented as **one rule engine + one component**, so the surfaces can't drift apart again:
- **`getSelectionCapabilities(ctx)`** — a pure, unit-tested function encoding the album model once (reuses the existing ⌘K `CommandContext` capability layer).
- **`<SelectionToolbar>`** — one component the three space pages render, deriving its inputs from props + `assetMultiSelectManager`.

**Fork-scoped: zero upstream files modified.** The upstream `photos`/`albums` pages and the shared action components are untouched — only fork-owned files change, keeping the rebase path clean.

## Per-surface outcome
| Surface | Before | After |
|---|---|---|
| Space album | Download + Remove-only (no Select-all) | Full album-equivalent toolbar |
| Space timeline | reduced (no Share/Add-to-album) | full album-equivalent |
| Space person | reduced | full album-equivalent (no cover — page has none) |

## RBAC (resolved from server code, codified in an API e2e matrix)
- **Share / Add-to-album are owner-gated** (`AssetShare` = owner∪partner only) — the toolbar never offers a button the server would reject.
- **Space-album Remove-from-album is manager-only** (`AlbumAssetDelete` is role-gated — a non-manager can't remove even their own asset).
- **`ownerId` on space-projected assets is genuine**, and an owner's mutations on their own asset are never blocked by album-path — so owner-gated actions are safe everywhere.

## Testing
- Unit: `getSelectionCapabilities` matrix (E1–E17 + album↔space parity guard); `<SelectionToolbar>` render tests.
- Server/API e2e: RBAC matrix across owner/editor/viewer/non-member.
- Web e2e (Playwright): 8 cases across the three surfaces × roles × ownership.

Design spec: `docs/superpowers/specs/2026-07-24-selection-toolbar-consistency-design.md`.

Note: mobile is a deliberate follow-up (separate codebase; will reuse these rules).