### PR TITLE
ci(rc): run RC cleanup on pull_request_target so it survives the merge

### DIFF
--- a/.github/workflows/gallery-pr-rc-cleanup.yml
+++ b/.github/workflows/gallery-pr-rc-cleanup.yml
@@ -10,9 +10,22 @@ name: PR Release Candidate Cleanup
 # Kept out of gallery-pr-rc-comment.yml on purpose: a `closed` event must not join
 # that workflow's per-PR `cancel-in-progress` concurrency group and cancel a build
 # that is still pushing, and `packages: write` stays scoped to this workflow alone.
+#
+# `pull_request_target`, NOT `pull_request`: a `pull_request` run reads its own
+# workflow definition from `refs/pull/<n>/merge`, which GitHub DELETES when the PR
+# merges. Losing that race means the run fails at startup with zero jobs ("workflow
+# file issue") and the PR's RC tags are orphaned forever — re-running cannot help,
+# because the ref is permanently gone. Observed on PR #845's own merge, which took
+# `cache-cleanup.yml` (same trigger, untouched for months) down with it.
+# `pull_request_target` reads the workflow from the base branch, which always exists.
+#
+# The usual `pull_request_target` danger — running untrusted PR code with a
+# write-capable token — does not apply: this workflow never checks out the PR and
+# never executes anything from it. It is one first-party github-script step whose
+# only PR-derived input is the PR number, an integer.
 
 on:
-  pull_request:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] nothing from the PR is checked out or executed
     types: [closed]
 
 concurrency:
@@ -24,9 +37,12 @@ permissions: {}
 jobs:
   cleanup:
     name: Delete RC images
-    # Fork PRs get a read-only token and could not delete anyway. Deliberately NOT
-    # gated on the `rc`/`rc-ml` label: a label removed before closing would otherwise
-    # orphan that PR's tags forever. With nothing to delete this is a cheap no-op.
+    # Same-repo only because RC images only ever exist for same-repo PRs — the build
+    # workflow skips forks. (Under `pull_request_target` the token would in fact be
+    # write-capable for a fork PR; the guard is now about not making pointless API
+    # calls, not about permissions.) Deliberately NOT gated on the `rc`/`rc-ml` label:
+    # a label removed before closing would otherwise orphan that PR's tags forever.
+    # With nothing to delete this is a cheap no-op.
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:

--- a/docs/superpowers/specs/2026-07-25-pr-rc-incrementing-tags-design.md
+++ b/docs/superpowers/specs/2026-07-25-pr-rc-incrementing-tags-design.md
@@ -199,11 +199,30 @@ to name.
 
 ```yaml
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 ```
 
-Same trigger `cache-cleanup.yml` already uses. Kept in its own file rather than as a job in
+**`pull_request_target`, not `pull_request`** — corrected after PR #845's own merge. A
+`pull_request` run reads its own workflow definition from `refs/pull/<n>/merge`, which GitHub
+**deletes when the PR merges**. Lose that race and the run fails at startup with zero jobs
+("This run likely failed because of a workflow file issue"), the PR's RC tags are orphaned
+forever, and re-running cannot help because the ref is permanently gone (confirmed: attempt 2
+failed identically, and `refs/pull/845/merge` returns 404). The same merge took
+`cache-cleanup.yml` down with it — same trigger, untouched for months, 19/20 prior successes —
+which is what rules out the workflow file itself. It usually works, which makes it worse: the
+failure is intermittent and silent.
+
+`pull_request_target` reads the workflow from the base branch, which always exists.
+
+The usual `pull_request_target` hazard — running untrusted PR code with a write-capable token —
+does not apply: the job never checks out the PR and never executes anything from it. It is one
+first-party `github-script` step whose only PR-derived input is the PR number, an integer
+interpolated into a regex. zizmor's `dangerous-triggers` audit is suppressed inline with that
+justification, matching the existing `# zizmor: ignore[...]` precedent in `gallery-rc-build.yml`.
+`auto-close.yml` and `close-duplicates.yml` already use `pull_request_target` in this repo.
+
+Kept in its own file rather than as a job in
 `gallery-pr-rc-comment.yml` so a PR-close event does not join the build workflow's
 `cancel-in-progress` group and cancel an in-flight build, and so `packages: write` is scoped to
 this workflow alone.


### PR DESCRIPTION
Follow-up to #845, which shipped with a defect its own merge exposed.

## The bug

A `pull_request`-triggered run reads its **own workflow definition** from `refs/pull/<n>/merge` — and GitHub deletes that ref when the PR merges. Lose the race and the run fails at startup with zero jobs ("This run likely failed because of a workflow file issue"), so the PR's RC tags are orphaned forever.

Re-running cannot recover it: the ref is permanently gone. I tried — attempt 2 failed identically, and `refs/pull/845/merge` now returns 404.

Observed on #845's own merge (run 30157742879). It deleted nothing. The `pr-845` images are gone only because an earlier validation run had already removed them when I closed the PR the first time.

## Why this isn't the workflow file

The same merge took **`cache-cleanup.yml`** down with it (run 30157742849) — same trigger, untouched for months, 19/20 prior successes. `actionlint` over merged `main` flags nothing in either RC workflow.

Two other things failed in the same minute for unrelated reasons, so ruling them out explicitly: `Zizmor [push]` startup-failed because it calls an external reusable workflow (`immich-app/devtools@f852dea`), and `CodeQL (javascript)` / `Docs Build` were **cancelled**, not failed. (`Test [push]` is red on main but was already red on `b19653e28`, so it predates all of this.)

It usually works — #842's cleanup succeeded on merge at 09:36 — which is what makes it dangerous. The failure is intermittent and silent.

## The fix

`pull_request_target: types: [closed]` reads the workflow from the base branch, which always exists.

The usual `pull_request_target` hazard — running untrusted PR code with a write-capable token — does not apply here. The job never checks out the PR and never executes anything from it. It is one first-party `github-script` step whose only PR-derived input is the PR number, an integer interpolated into a regex. zizmor's `dangerous-triggers` audit is suppressed inline with that justification, matching the existing `# zizmor: ignore[...]` precedent in `gallery-rc-build.yml`. `auto-close.yml` and `close-duplicates.yml` already use `pull_request_target` in this repo.

The `head.repo.full_name` guard stays, but its rationale changed: under `pull_request_target` a fork PR's token *would* be write-capable, so the guard is now about not making pointless API calls (RC images only ever exist for same-repo PRs) rather than about permissions. Comment updated to say so.

## Verification

- The `github-script` body is **byte-identical** to the version validated in #845 — diffed, not assumed. Deletion logic is unchanged, so its harness coverage still applies; I re-ran it anyway (selection correct, 403 still fails the job).
- `actionlint` (with shellcheck): clean. `zizmor --offline`: no findings, 1 justified inline ignore.

## What this does not prove

The cleanup path has still never run to completion on a real **merge** — only on a plain close. This PR's own merge is the test. If its cleanup run starts and completes (it has no RC tags, so it should log "no RC versions" and succeed), that's the confirmation. I'll check after merge rather than claim it now.