### PR TITLE
fix(web): stop duplicate keys wedging People page infinite scroll

### DIFF
--- a/web/src/lib/utils/people-utils.spec.ts
+++ b/web/src/lib/utils/people-utils.spec.ts
@@ -3,7 +3,13 @@ import { get } from 'svelte/store';
 import type { Faces } from '$lib/managers/asset-viewer-manager.svelte';
 import { PeopleSortBy, peopleViewSettings } from '$lib/stores/preferences.store';
 import type { Size } from '$lib/utils/container-utils';
-import { getBoundingBox, sortPeople, sortPeopleForManagement, zoomImageToBase64 } from '$lib/utils/people-utils';
+import {
+  appendUniqueById,
+  getBoundingBox,
+  sortPeople,
+  sortPeopleForManagement,
+  zoomImageToBase64,
+} from '$lib/utils/people-utils';
 
 const makeFace = (overrides: Partial<Faces> = {}): Faces => ({
   id: 'face-1',
@@ -186,6 +192,40 @@ describe('sortPeople', () => {
     for (const mode of [PeopleSortBy.PhotoCount, PeopleSortBy.Name]) {
       expect(sortPeople(people, mode).map((person) => person.id)).toEqual(['visible', 'hidden-fav']);
     }
+  });
+});
+
+describe('appendUniqueById', () => {
+  it('appends rows that are not loaded yet', () => {
+    expect(appendUniqueById([{ id: 'a' }, { id: 'b' }], [{ id: 'c' }])).toEqual([
+      { id: 'a' },
+      { id: 'b' },
+      { id: 'c' },
+    ]);
+  });
+
+  it('drops incoming rows that are already loaded', () => {
+    expect(appendUniqueById([{ id: 'a' }, { id: 'b' }], [{ id: 'b' }, { id: 'c' }])).toEqual([
+      { id: 'a' },
+      { id: 'b' },
+      { id: 'c' },
+    ]);
+  });
+
+  it('keeps the already-loaded row rather than the incoming copy', () => {
+    const loaded = { id: 'a', name: 'renamed locally' };
+
+    expect(appendUniqueById([loaded], [{ id: 'a', name: 'stale' }])).toEqual([loaded]);
+  });
+
+  it('drops duplicates within a single incoming batch', () => {
+    expect(appendUniqueById([], [{ id: 'a' }, { id: 'a' }, { id: 'b' }])).toEqual([{ id: 'a' }, { id: 'b' }]);
+  });
+
+  it('returns the existing array untouched when every incoming row is a duplicate', () => {
+    const existing = [{ id: 'a' }];
+
+    expect(appendUniqueById(existing, [{ id: 'a' }])).toBe(existing);
   });
 });
 

--- a/web/src/lib/utils/people-utils.ts
+++ b/web/src/lib/utils/people-utils.ts
@@ -63,6 +63,31 @@ export function sortPeople<T extends SortablePerson>(people: T[], sortBy: People
   return [...people].sort((a, b) => comparePeople(a, b, sortBy));
 }
 
+/**
+ * Appends a freshly fetched page onto the already-loaded rows, skipping ids that are present.
+ *
+ * Paginated people lists render in a keyed `{#each}`, and a single repeated id throws
+ * `each_key_duplicate` — which stops the block updating for the rest of the session, so the grid
+ * freezes while requests keep firing. The server pages with OFFSET over an ordering that keys on
+ * favourite status, name and visible asset count, so a rename or a background face job between two
+ * page requests can shift the window and re-emit a row an earlier page already returned. Existing
+ * rows win, because they may carry edits made since they were fetched.
+ */
+export function appendUniqueById<T extends { id: string }>(existing: T[], incoming: T[]): T[] {
+  const seen = new Set(existing.map((item) => item.id));
+  const additions: T[] = [];
+
+  for (const item of incoming) {
+    if (seen.has(item.id)) {
+      continue;
+    }
+    seen.add(item.id);
+    additions.push(item);
+  }
+
+  return additions.length === 0 ? existing : [...existing, ...additions];
+}
+
 export function comparePeopleForManagement(a: SortablePerson, b: SortablePerson): number {
   return comparePeople(a, b, PeopleSortBy.Name);
 }

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -25,7 +25,7 @@
   import { getGlobalPersonHref, getGlobalPersonThumbnailUrl } from '$lib/utils/global-person-route';
   import { handleError } from '$lib/utils/handle-error';
   import { clearQueryParam } from '$lib/utils/navigation';
-  import { sortPeople } from '$lib/utils/people-utils';
+  import { appendUniqueById, sortPeople } from '$lib/utils/people-utils';
   import { formatPeopleHeaderDescription } from '$lib/utils/people-statistics';
   import {
     getAllPeople,
@@ -68,6 +68,10 @@
   let editingPerson: PersonResponseDto | null = $state(null);
   let searchedPeopleLocal: PersonResponseDto[] = $state([]);
   let searchPeopleElement = $state<ReturnType<typeof SearchPeople>>();
+  // The grid has two independent next-page triggers (the IntersectionObserver and the rAF sentinel
+  // re-check), and both are gated on the `loading` prop below. Without it the same page is fetched
+  // concurrently and appended twice.
+  let loadingPage = $state(false);
 
   onMount(() => {
     const getSearchedPeople = $page.url.searchParams.get(QueryParameter.SEARCHED_PEOPLE);
@@ -96,6 +100,7 @@
           pagesToLoad = Number.parseInt(newNextPage) - nextPage;
 
         if (pagesToLoad) {
+          loadingPage = true;
           handlePromiseError(
             Promise.all(
               Array.from({ length: pagesToLoad }).map((_, i) => {
@@ -106,14 +111,18 @@
                   size: PEOPLE_PAGE_SIZE,
                 });
               }),
-            ).then((pages) => {
-              for (const page of pages) {
-                people = people.concat(page.people);
-              }
-              currentPage = startingPage + pagesToLoad - 1;
-              nextPage = pages.at(-1)?.hasNextPage ? startingPage + pagesToLoad : null;
-              resolve(); // wait until extra pages are loaded
-            }),
+            )
+              .then((pages) => {
+                for (const page of pages) {
+                  people = appendUniqueById(people, page.people);
+                }
+                currentPage = startingPage + pagesToLoad - 1;
+                nextPage = pages.at(-1)?.hasNextPage ? startingPage + pagesToLoad : null;
+                resolve(); // wait until extra pages are loaded
+              })
+              .finally(() => {
+                loadingPage = false;
+              }),
           );
         } else {
           resolve();
@@ -123,10 +132,11 @@
     });
 
   const loadNextPage = async () => {
-    if (!nextPage) {
+    if (loadingPage || !nextPage) {
       return;
     }
 
+    loadingPage = true;
     try {
       const { people: newPeople, hasNextPage } = await getAllPeople({
         withHidden: true,
@@ -134,13 +144,15 @@
         page: nextPage,
         size: PEOPLE_PAGE_SIZE,
       });
-      people = people.concat(newPeople);
+      people = appendUniqueById(people, newPeople);
       if (nextPage !== null) {
         currentPage = nextPage;
       }
       nextPage = hasNextPage ? nextPage + 1 : null;
     } catch (error) {
       handleError(error, $t('errors.failed_to_load_people'));
+    } finally {
+      loadingPage = false;
     }
   };
 
@@ -469,6 +481,7 @@
       people={showPeople}
       {toManagedPerson}
       hasNextPage={!!nextPage && !searchName}
+      loading={loadingPage}
       {loadNextPage}
       canEditNames={canEditName}
       canShowActions={isPersonalPrimary}

--- a/web/src/routes/(user)/people/people-page.spec.ts
+++ b/web/src/routes/(user)/people/people-page.spec.ts
@@ -3,6 +3,7 @@ import {
   SharedSpaceRole,
   Type,
   type PeopleFaceStatisticsResponseDto,
+  type PeopleResponseDto,
   type PeopleStatisticsResponseDto,
   type PersonResponseDto,
   type SharedSpacePersonResponseDto,
@@ -133,6 +134,46 @@ function renderPage(
       },
     },
   });
+}
+
+/**
+ * Renders the page with page 1 loaded and a second page available, and hands back a trigger that
+ * reports the infinite-scroll sentinel as intersecting so pagination can be driven deterministically.
+ */
+function renderPaginatedPage() {
+  let intersectionCallback: IntersectionObserverCallback | undefined;
+  let observedSentinel: Element | undefined;
+  vi.stubGlobal(
+    'IntersectionObserver',
+    vi.fn(function (callback: IntersectionObserverCallback) {
+      intersectionCallback = callback;
+      return {
+        observe: (element: Element) => (observedSentinel = element),
+        disconnect: vi.fn(),
+        unobserve: vi.fn(),
+        takeRecords: vi.fn(),
+      };
+    }),
+  );
+
+  const rendered = renderPage(
+    [
+      makePerson({ id: 'p1', name: 'Alice', numberOfAssets: 5 }),
+      makePerson({ id: 'p2', name: 'Bob', numberOfAssets: 4 }),
+    ],
+    { total: 4, hidden: 0, detectedFaceCount: 0 },
+    true,
+  );
+
+  const intersect = async () => {
+    await waitFor(() => expect(observedSentinel).toBeDefined());
+    intersectionCallback?.(
+      [{ target: observedSentinel, isIntersecting: true } as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    );
+  };
+
+  return { ...rendered, intersect };
 }
 
 describe('Global people page', () => {
@@ -613,37 +654,8 @@ describe('Global people page', () => {
       hasNextPage: false,
     });
 
-    // Drive the infinite-scroll sentinel deterministically: capture the grid's IntersectionObserver
-    // callback and the element it observes, then report an intersection.
-    let intersectionCallback: IntersectionObserverCallback | undefined;
-    let observedSentinel: Element | undefined;
-    vi.stubGlobal(
-      'IntersectionObserver',
-      vi.fn(function (callback: IntersectionObserverCallback) {
-        intersectionCallback = callback;
-        return {
-          observe: (element: Element) => (observedSentinel = element),
-          disconnect: vi.fn(),
-          unobserve: vi.fn(),
-          takeRecords: vi.fn(),
-        };
-      }),
-    );
-
-    renderPage(
-      [
-        makePerson({ id: 'p1', name: 'Alice', numberOfAssets: 5 }),
-        makePerson({ id: 'p2', name: 'Bob', numberOfAssets: 4 }),
-      ],
-      { total: 4, hidden: 0, detectedFaceCount: 0 },
-      true,
-    );
-
-    await waitFor(() => expect(observedSentinel).toBeDefined());
-    intersectionCallback?.(
-      [{ target: observedSentinel, isIntersecting: true } as IntersectionObserverEntry],
-      {} as IntersectionObserver,
-    );
+    const { intersect } = renderPaginatedPage();
+    await intersect();
 
     await waitFor(() => {
       expect(sdkMock.getAllPeople).toHaveBeenCalledWith({
@@ -662,5 +674,95 @@ describe('Global people page', () => {
     expect(screen.getByDisplayValue('Alice')).toBeInTheDocument();
     expect(screen.getByDisplayValue('Bob')).toBeInTheDocument();
     expect(screen.getAllByPlaceholderText('add_a_name')).toHaveLength(4);
+  });
+
+  it('requests a page only once while that request is still in flight', async () => {
+    // The grid has two independent next-page triggers (the IntersectionObserver and the rAF
+    // sentinel re-check) and both are gated on `loading`. Without an in-flight guard the same
+    // page is fetched twice, both responses are appended, and the duplicate ids blow up the
+    // keyed {#each} — the grid then stops rendering while requests keep firing.
+    let resolvePage2: ((value: PeopleResponseDto) => void) | undefined;
+    sdkMock.getAllPeople.mockReturnValue(
+      new Promise<PeopleResponseDto>((resolve) => {
+        resolvePage2 = resolve;
+      }),
+    );
+
+    const { intersect } = renderPaginatedPage();
+    await intersect();
+    await intersect();
+
+    expect(sdkMock.getAllPeople).toHaveBeenCalledTimes(1);
+
+    resolvePage2!({
+      people: [
+        makePerson({ id: 'p3', name: 'Carol', numberOfAssets: 3 }),
+        makePerson({ id: 'p4', name: 'Dave', numberOfAssets: 2 }),
+      ],
+      total: 4,
+      hidden: 0,
+      hasNextPage: false,
+    });
+
+    await waitFor(() => expect(screen.getByDisplayValue('Carol')).toBeInTheDocument());
+    expect(screen.getAllByPlaceholderText('add_a_name')).toHaveLength(4);
+  });
+
+  it('releases the in-flight guard so scrolling keeps paging past the second page', async () => {
+    // The guard must gate concurrent requests for the SAME page without wedging the cascade.
+    sdkMock.getAllPeople
+      .mockResolvedValueOnce({
+        people: [makePerson({ id: 'p3', name: 'Carol', numberOfAssets: 3 })],
+        total: 4,
+        hidden: 0,
+        hasNextPage: true,
+      })
+      .mockResolvedValueOnce({
+        people: [makePerson({ id: 'p4', name: 'Dave', numberOfAssets: 2 })],
+        total: 4,
+        hidden: 0,
+        hasNextPage: false,
+      });
+
+    const { intersect } = renderPaginatedPage();
+    await intersect();
+    await waitFor(() => expect(screen.getByDisplayValue('Carol')).toBeInTheDocument());
+
+    await intersect();
+
+    await waitFor(() => expect(screen.getByDisplayValue('Dave')).toBeInTheDocument());
+    expect(sdkMock.getAllPeople).toHaveBeenNthCalledWith(2, {
+      withHidden: true,
+      withSharedSpaces: true,
+      page: 3,
+      size: PEOPLE_PAGE_SIZE,
+    });
+    expect(screen.getAllByPlaceholderText('add_a_name')).toHaveLength(4);
+  });
+
+  it('renders each person once when the server repeats a row across the page boundary', async () => {
+    // OFFSET pagination is not a snapshot: the accessible-people ORDER BY keys on favourite
+    // status, name and visible asset count, so a rename or a background face job between page
+    // requests can shift the window and re-emit a row that page 1 already returned. That must
+    // not wedge the keyed {#each}.
+    sdkMock.getAllPeople.mockResolvedValue({
+      people: [
+        makePerson({ id: 'p2', name: 'Bob', numberOfAssets: 4 }),
+        makePerson({ id: 'p3', name: 'Carol', numberOfAssets: 3 }),
+      ],
+      total: 3,
+      hidden: 0,
+      hasNextPage: false,
+    });
+
+    const { intersect } = renderPaginatedPage();
+    await intersect();
+
+    await waitFor(() => expect(screen.getByDisplayValue('Carol')).toBeInTheDocument());
+    expect(screen.getAllByPlaceholderText('add_a_name').map((input) => (input as HTMLInputElement).value)).toEqual([
+      'Alice',
+      'Bob',
+      'Carol',
+    ]);
   });
 });


### PR DESCRIPTION
## Problem

Scrolling the People page stops rendering new rows partway down while the network tab keeps showing `getAllPeople` requests, and the console fills with:

```
Svelte error: each_key_duplicate
Keyed each block has duplicate key `<id>` at indexes N and N+1
  in people-grid.svelte → people-management-grid.svelte → +page.svelte
```

## Root cause

`people-grid.svelte` has **two** independent next-page triggers — the `IntersectionObserver` and the rAF sentinel-visibility re-check — and both are gated on its `loading` prop. The global People page never passed `loading`, and `loadNextPage()` had no in-flight guard, so `loading` was permanently `false`.

The observer effect also re-runs whenever `nextPage` changes (the `hasNextPage` prop getter reads it), which tears down and recreates the observer — and a fresh `IntersectionObserver` immediately re-reports the still-visible sentinel as intersecting. So the same page gets requested twice concurrently, both responses are unconditionally `concat`-ed, and the duplicate ids blow up the keyed `{#each}`. Once it throws, the block stops updating for the rest of the session: the grid freezes while requests keep firing.

Both sibling consumers already honour the contract — `spaces/[spaceId]/people/+page.svelte` and `people-visibility-modal.svelte` pass `loading` and guard with `if (loading || !hasMore) return;`. The global People page was the only one that skipped it.

**Why it started showing up now:** the server default `size` is 500 (`person.dto.ts`). Before #801 every `getAllPeople` call on this page omitted `size`, so `hasNextPage` was false unless a user had more than 500 accessible people — infinite scroll effectively never ran and the race stayed latent. #801 dropped the page size to 150, so anyone with more than 150 people now paginates on every scroll.

Server-side pagination is **not** at fault: `getAccessiblePeopleIdentityPage` orders on a unique `identityId` tiebreaker and emits exactly one row per identity.

## Fix

- `loadingPage` state guards `loadNextPage` and `loadInitialScroll`'s catch-up batch, wired through as `loading={loadingPage}`.
- New `appendUniqueById()` helper used for every append, as defense in depth. OFFSET pagination is not a snapshot, and the accessible-people `ORDER BY` keys on favourite status, name and visible asset count — so a rename or a background face job between two page requests can shift the window and re-emit a row an earlier page already returned. A single repeated id permanently wedges the page, so it is worth being unwedgeable.

## Tests

Both repro tests were written first and confirmed RED against the unfixed code:

- `requests a page only once while that request is still in flight` — failed with `expected "vi.fn()" to be called 1 times, but got 2 times`
- `renders each person once when the server repeats a row across the page boundary` — failed with the `each_key_duplicate` crash above

Plus `releases the in-flight guard so scrolling keeps paging past the second page`, proving the guard does not wedge the cascade, and 5 unit tests for `appendUniqueById`. The pre-existing pagination test was folded onto a shared `renderPaginatedPage()` helper rather than a third copy of the observer stub.

**Verification:** 3861 web tests pass (292 files), `tsc --noEmit` clean, eslint clean on touched files, prettier clean.