### PR TITLE
test: verify RC cleanup on close (do not merge)

### DIFF
--- a/docs/superpowers/specs/2026-07-25-pr-rc-incrementing-tags-design.md
+++ b/docs/superpowers/specs/2026-07-25-pr-rc-incrementing-tags-design.md
@@ -285,3 +285,5 @@ behaviour.
 - Deleting RC tags when the `rc` label is removed from an open PR (close is the lifecycle boundary).
 - Retention while the PR is open — all RCs are kept until close. Revisit only if GHCR gets noisy.
 - An interim "building…" comment before the build completes.
+
+<!-- scratch branch for verifying RC cleanup on close; not for merge -->


### PR DESCRIPTION
Throwaway PR to verify that `gallery-pr-rc-cleanup.yml` deletes RC images when a PR is **closed** (not merged), now that it runs on `pull_request_target`.

Synthetic RC tags are pushed for this PR number instead of running a real 40-minute RC build. A control tag on a neighbouring PR number is also created and must survive, proving the prefix anchoring.

**Do not merge — this will be closed.**