### PR TITLE
fix(branding): rebrand localized strings instead of deleting them

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,9 @@ jobs:
             machine-learning:
               - 'machine-learning/**'
               - 'mise.toml'
+            branding:
+              - 'branding/**'
+              - 'i18n/**'
             upstream-preflight:
               - '.github/workflows/test.yml'
               - 'tools/upstream-preflight/**'
@@ -243,6 +246,28 @@ jobs:
 
       - name: Run ci-unit
         run: mise run ci-unit
+
+  # Behavioural gate for the branding pipeline. ShellCheck only lints these
+  # scripts; nothing in CI ran patch_i18n() and asserted what it produces, which
+  # is how the delete-and-fall-back-to-English behaviour behind issue #844 went
+  # unnoticed. The script patches a throwaway copy of i18n/, so it needs no
+  # image tooling, no network and no build — just bash and jq.
+  branding-i18n-tests:
+    name: Test i18n Branding
+    needs: pre-job
+    if: ${{ fromJSON(needs.pre-job.outputs.should_run).branding == true }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          token: ${{ github.token }}
+
+      - name: Run i18n branding regression tests
+        run: ./branding/scripts/test-i18n-branding.sh
 
   i18n-tests:
     name: Test i18n

--- a/branding/scripts/apply-branding.sh
+++ b/branding/scripts/apply-branding.sh
@@ -86,9 +86,23 @@ patch_i18n() {
   # kaufen") and re-leaks on each Weblate sync. Patch them at build time so the
   # leak can't regress in source:
   #   - merge a per-locale branded override (overrides-<lang>.json) when present
-  #     so that language keeps a proper localized translation;
-  #   - then drop any remaining overridden key whose localized value still
-  #     contains the upstream name, so it falls back to the branded en.json.
+  #     so that language keeps a hand-written branded translation;
+  #   - then rewrite any remaining upstream name in that locale to the fork's
+  #     name, keeping the translation intact.
+  #
+  # Step 3 used to DELETE the leaking keys so the locale fell back to the branded
+  # en.json. That silently reverted ~2,100 already-translated strings to English
+  # across 69 locales — including the "Delete Permanently" body text in the
+  # mobile delete dialog, whose German translation exists but says "in Immich
+  # gesichert" (issue #844). The dialog title and buttons don't name the upstream
+  # project, so they stayed German while the one explanatory sentence flipped to
+  # English — on a destructive, irreversible action.
+  #
+  # Substituting in place is safe where deleting was not: the upstream name is a
+  # proper noun, so swapping it preserves the surrounding grammar in every
+  # language ("nicht in Immich gesichert" -> "nicht in Noodle Gallery
+  # gesichert"). Matching stays case-sensitive on purpose so lowercase
+  # identifiers (docs.immich.app, the app.immich:// OAuth scheme) are untouched.
   [[ -f "$en_overrides" ]] || return 0
 
   local locale_file lang lang_overrides
@@ -106,24 +120,21 @@ patch_i18n() {
       echo "  Merged $(jq 'length' "$lang_overrides") override keys into ${lang}.json"
     fi
 
-    # 3. Drop overridden keys that still leak the upstream name -> en fallback.
-    #    Overrides may nest (e.g. the admin.* descriptions — issue #672), so walk
-    #    the override's leaf paths and delete the leaking ones at any depth rather
-    #    than only inspecting top-level keys.
+    # 3. Rewrite every remaining upstream-name leak in this locale to the fork
+    #    name. `walk` reaches leaves at any depth, so the nested admin.*
+    #    descriptions (issue #672) are covered without enumerating override
+    #    paths. split/join is a LITERAL replace — unlike gsub, it cannot
+    #    reinterpret the name as a regex or the replacement as a capture ref.
     tmp=$(mktemp)
-    jq --slurpfile ov "$en_overrides" --arg upstream "$UPSTREAM_NAME" '
-      . as $loc
-      | [ $ov[0] | paths(scalars) as $p
-          | select(($loc | getpath($p)) as $v
-                   | ($v | type) == "string" and ($v | contains($upstream)))
-          | $p ]
-      | . as $leaking
-      | $loc | delpaths($leaking)
+    jq --arg upstream "$UPSTREAM_NAME" --arg name "$NAME" '
+      walk(if type == "string" and contains($upstream)
+           then split($upstream) | join($name)
+           else . end)
     ' "$locale_file" > "$tmp"
     chmod 644 "$tmp"
     mv "$tmp" "$locale_file"
   done
-  echo "  Stripped upstream-brand leaks from non-English locales (fallback to en.json)"
+  echo "  Rebranded upstream-name leaks in non-English locales (translations preserved)"
 }
 
 #

--- a/branding/scripts/test-i18n-branding.sh
+++ b/branding/scripts/test-i18n-branding.sh
@@ -14,8 +14,13 @@
 # copy of i18n/ and asserts that for every branded key:
 #   - en.json carries the branded English override,
 #   - locales with a per-locale override (de, fr) carry the branded translation,
-#   - every other locale drops the key so it falls back to branded English,
+#   - every other locale KEEPS its own translation with the name swapped,
 #   - no locale renders the upstream name for any overridden key.
+#
+# That third rule is issue #844. Leaking keys used to be deleted so the locale
+# fell back to branded English, which silently reverted ~2,100 already-translated
+# strings across 69 locales — so the assertions below check that a translation
+# survives, not merely that the brand name is correct.
 #
 # The working tree is never mutated (patch runs against a temp REPO_ROOT), so
 # this is safe to run locally and in CI. No image tooling or network required.
@@ -56,16 +61,6 @@ eq() { # <lang> <key> <expected> <description>
     fails=$((fails + 1))
   fi
 }
-absent() { # <lang> <key> <description>  — key must be deleted (falls back to en)
-  local got
-  got=$(jq -r --arg k "$2" 'has($k)' "$TMP/i18n/$1.json")
-  if [[ "$got" == "false" ]]; then
-    echo "  ok:   $3"
-  else
-    echo "  FAIL: $3 — ${1}.json still defines '$2' = '$(jq -r --arg k "$2" '.[$k]' "$TMP/i18n/$1.json")'"
-    fails=$((fails + 1))
-  fi
-}
 
 # Dot-path variants for nested keys (issue #672 — overrides that live under
 # .admin.*). `getpath(split("."))` resolves a dotted path into the locale object.
@@ -88,17 +83,6 @@ branded_at() { # <lang> <dotpath> <description>  — present, carries $NAME, no 
     echo "  ok:   $3"
   fi
 }
-absent_at() { # <lang> <dotpath> <description>  — leaf undefined (falls back to en)
-  local got
-  got=$(jq -r --arg k "$2" 'getpath($k | split(".")) == null' "$TMP/i18n/$1.json")
-  if [[ "$got" == "true" ]]; then
-    echo "  ok:   $3"
-  else
-    echo "  FAIL: $3 — ${1}.json still defines '$2' = '$(val_at "$1" "$2")'"
-    fails=$((fails + 1))
-  fi
-}
-
 KEY="purchase_button_buy_immich"
 
 echo "English override applied:"
@@ -109,11 +93,39 @@ eq de "$KEY" "Noodle Gallery unterstützen" 'de buy button is branded German (is
 eq fr "$KEY" "Soutenir Noodle Gallery" 'fr buy button is branded French'
 eq de purchase_panel_info_2 "$(jq -r '.purchase_panel_info_2' "$REPO/branding/i18n/overrides-de.json")" 'de purchase panel is branded German'
 
-echo "Locales without an override fall back to branded English:"
-absent es "$KEY" 'es buy button dropped -> falls back to en override'
-absent it "$KEY" 'it buy button dropped -> falls back to en override'
-absent nl "$KEY" 'nl buy button dropped -> falls back to en override'
-absent de welcome_to_immich 'de non-panel brand key dropped -> falls back to en override'
+# Issue #844: these used to be DELETED so the locale fell back to branded
+# English. That threw away a real translation for every leaking key — ~2,100
+# strings across 69 locales. They must now keep their translation with only the
+# brand name swapped.
+echo "Locales without an override keep their translation, rebranded (issue #844):"
+branded_at es "$KEY" 'es buy button stays Spanish, rebranded'
+branded_at it "$KEY" 'it buy button stays Italian, rebranded'
+branded_at nl "$KEY" 'nl buy button stays Dutch, rebranded'
+branded_at de welcome_to_immich 'de non-panel brand key stays German, rebranded'
+
+# Issue #844 verbatim: the mobile "Endgültig löschen" dialog. Its title and three
+# buttons never named the upstream project so they stayed German, while this one
+# explanatory sentence — the only part that did — was deleted and fell back to
+# English, on a destructive, irreversible action. Assert the German survives, not
+# just that the brand is right: a fallback to branded English would pass
+# branded_at on its own.
+echo "Mobile delete-dialog body keeps its translation (issue #844):"
+d844=$(val_at de delete_dialog_alert_local_non_backed_up)
+if [[ -z "$d844" ]]; then
+  echo "  FAIL: de delete_dialog_alert_local_non_backed_up is ABSENT (regressed to en fallback)"
+  fails=$((fails + 1))
+elif echo "$d844" | grep -q "$UPSTREAM_NAME"; then
+  echo "  FAIL: de delete_dialog_alert_local_non_backed_up still names '$UPSTREAM_NAME': '$d844'"
+  fails=$((fails + 1))
+elif ! echo "$d844" | grep -qF "$NAME"; then
+  echo "  FAIL: de delete_dialog_alert_local_non_backed_up is not branded '$NAME': '$d844'"
+  fails=$((fails + 1))
+elif ! echo "$d844" | grep -q "gesichert"; then
+  echo "  FAIL: de delete_dialog_alert_local_non_backed_up is no longer German: '$d844'"
+  fails=$((fails + 1))
+else
+  echo "  ok:   de delete-dialog body stays German and branded ('$d844')"
+fi
 
 # Issue #672: nine admin.* descriptions were overridden as TOP-LEVEL keys, so the
 # top-level shallow merge ('.[0] * .[1]') added dead top-level keys while the real
@@ -134,10 +146,10 @@ ADMIN_KEYS=(
 for admin_key in "${ADMIN_KEYS[@]}"; do
   branded_at en "$admin_key" "en $admin_key branded under .admin (not a dead top-level key)"
 done
-# These admin descriptions have no per-locale override, so every non-English locale
-# must drop them (their upstream-named translation) and fall back to branded en.
-absent_at de admin.theme_settings_description 'de drops admin.theme_settings_description -> falls back to en'
-absent_at fr admin.maintenance_settings_description 'fr drops admin.maintenance_settings_description -> falls back to en'
+# These admin descriptions have no per-locale override. `walk` must still reach
+# them at .admin.* depth and rebrand them in place, keeping the translation.
+branded_at de admin.theme_settings_description 'de keeps admin.theme_settings_description, rebranded'
+branded_at fr admin.maintenance_settings_description 'fr keeps admin.maintenance_settings_description, rebranded'
 
 # Issue #743 item 4: asset_offline_description exists BOTH top-level and under
 # .admin — a top-level-only override recreates the #672 bug shape (the override

--- a/branding/scripts/verify-branding.sh
+++ b/branding/scripts/verify-branding.sh
@@ -83,8 +83,9 @@ if [[ -f "$overrides_file" && -f "$i18n_file" ]]; then
 
   # Issue #703: the upstream name must not leak through *any* locale for a key
   # the fork rebrands. Non-English locales carry upstream Weblate translations
-  # of these keys; patch_i18n() either replaces them with a per-locale override
-  # or drops them so they fall back to the branded en.json. Verify every locale.
+  # of these keys; patch_i18n() replaces them with a per-locale override where
+  # one exists, then rewrites the upstream name in place everywhere else so the
+  # translation survives (issue #844). Verify every locale.
   locale_leaks=0
   for locale_file in "$REPO_ROOT"/i18n/*.json; do
     [[ -f "$locale_file" ]] || continue


### PR DESCRIPTION
Closes #844.

## What #844 actually is

Not a missing translation. The German string exists and has shipped since well before v5.2.0:

> `delete_dialog_alert_local_non_backed_up` → *"Einige Inhalte sind nicht in Immich gesichert und werden dauerhaft vom Gerät gelöscht"*

**The build deletes it.** `patch_i18n()` step 3 walked every non-English locale and dropped any key whose translated value still contained `Immich`, so the locale fell back to the branded `en.json`. The German value says "nicht in **Immich** gesichert" → deleted → the user gets the English sentence.

That is exactly the reported dialog:

| | source | shipped |
| --- | --- | --- |
| title | `delete_dialog_title` | German — no upstream name, survived |
| **body** | `delete_dialog_alert_local_non_backed_up` | **English — named Immich, deleted** |
| buttons ×3 | `cancel`, `delete_local_dialog_ok_*` | German — no upstream name, survived |

`apply-branding` runs at `gallery-build-mobile.yml:115`, the translation codegen at `:174`, so the deleted keys never reach the app.

## The reporter's hunch about a broader audit was right

This was never specific to German or to one dialog:

| | strings silently reverted to English |
| --- | --- |
| **German** | **43** |
| fr 42 · ru 42 · pl 47 · zh_Hans 46 · zh_Hant 47 · nl 48 · it 49 · es 49 | |
| **All locales** | **2,155 across 69 locales** |

Only `de` and `fr` had override files, covering 12 "purchase/buy" keys each — from #703, the same bug reported against a different string. Every other branded key in every other locale was falling back to English.

## The fix

Step 3 now **rewrites** the upstream name in place instead of deleting the key.

```diff
-      . as $loc
-      | [ $ov[0] | paths(scalars) as $p
-          | select(($loc | getpath($p)) as $v
-                   | ($v | type) == "string" and ($v | contains($upstream)))
-          | $p ]
-      | . as $leaking
-      | $loc | delpaths($leaking)
+      walk(if type == "string" and contains($upstream)
+           then split($upstream) | join($name)
+           else . end)
```

Substituting is safe where deleting was not: the upstream name is a proper noun, so swapping it preserves the surrounding grammar — *"nicht in Immich gesichert"* → *"nicht in Noodle Gallery gesichert"*.

Details that matter:

- **`split`/`join`, not `gsub`** — a literal replace, so the name can't be reinterpreted as a regex nor the replacement as a capture reference.
- **Case-sensitive**, as before — lowercase identifiers (`docs.immich.app`, the `app.immich://` OAuth scheme) are untouched.
- **`walk` reaches any depth**, so the nested `admin.*` descriptions from #672 no longer need their override paths enumerated.
- **`en.json` is deliberately excluded.** It still requires an explicit entry in `overrides-en.json`, and the whole-file scan in the test suite still fails the build if one is missing. English is the canonical branded wording; other locales only need the name swapped. Per-locale overrides still win — `de`/`fr` keep their hand-written translations, substitution is the fallback.

## Verification

- **2,155 strings preserved and rebranded** (previously deleted), **0 leaks across 89 locale files**
- `branding/scripts/test-i18n-branding.sh` updated: the four `absent`/`absent_at` assertions encoded the old delete-and-fallback contract and now assert the translation survives rebranded. The now-unused helpers are removed so the old contract can't be reintroduced by accident.
- Added a **verbatim #844 regression test** that asserts the German delete-dialog body is present, branded, *and still German* (`grep gesichert`) — checking the brand alone would pass on an English fallback, which is the bug.
- `branding/scripts/gallery-branding-check.sh` passes end to end; `shellcheck` clean on all three scripts.
- `verify-branding.sh` needed no logic change (it only asserts *no leaks*); its comment describing the old drop behaviour is corrected.

## Known limitation

7 locales inflect the name in ~20 places — `cs`, `eu`, `fi`, `hr`, `hu`, `pl`, `sl`. Finnish `"Immichin"` becomes `"Noodle Galleryin"`, which reads with a slightly wrong case ending. Germanic genitives come out correct as-is (`"Immichs"` → `"Noodle Gallerys"`). Those strings were previously **100% English**, so this is strictly better; adding an entry to `overrides-<lang>.json` fixes any that matter.

## Not included

The mobile app must be rebuilt for #844 to reach users — this only changes what the build produces.

## Also here: a CI gate for this pipeline

Nothing in CI ran `patch_i18n()` and asserted what it produces. ShellCheck lints `branding/scripts/*.sh`, and `verify-branding.sh` only runs inside the `apply-branding` composite action during image and mobile builds — which are skipped for a scripts-only PR. The delete-and-fall-back behaviour was never gated, which is how it survived.

Added a `Test i18n Branding` job that runs `test-i18n-branding.sh` on `branding/**` **and** `i18n/**` changes. The script patches a throwaway copy of `i18n/`, so it needs no image tooling, no network and no build — just bash and jq.

`i18n/**` is in the filter on purpose: the test's whole-file scan fails if a new English string carries the upstream name without a matching entry in `overrides-en.json` — exactly the gap that lets a brand leak ship in the first place.
