### PR TITLE
fix(s3): honor HTTP Range requests in proxy serve mode

### DIFF
--- a/e2e/src/storage-migration.ts
+++ b/e2e/src/storage-migration.ts
@@ -1445,6 +1445,49 @@ async function phaseContentVerify(): Promise<void> {
     }
   }
 
+  // Range requests: this stack runs with IMMICH_S3_SERVE_MODE=proxy, so the server streams
+  // the object itself instead of redirecting. It used to drop the Range header and answer
+  // 200 with the whole body, which makes WebKit abort <video> playback and breaks seeking.
+  const [rangeAssetId] = Object.keys(contentHashes);
+  if (rangeAssetId) {
+    const rangeToken = adminIds.has(rangeAssetId) ? token : (user2Token ?? token);
+    const expected = await downloadAssetOriginal(rangeToken, rangeAssetId);
+
+    console.log('  Verifying proxied range requests...');
+    const partial = await fetch(`${BASE_URL}/assets/${rangeAssetId}/original`, {
+      headers: { Authorization: `Bearer ${rangeToken}`, Range: 'bytes=0-9' },
+      redirect: 'follow',
+    });
+    assert.equal(partial.status, 206, `Expected 206 for a ranged proxy read, got ${partial.status}`);
+    assert.equal(
+      partial.headers.get('content-range'),
+      `bytes 0-9/${expected.length}`,
+      'Expected the proxied response to relay S3 Content-Range',
+    );
+    assert.equal(partial.headers.get('accept-ranges'), 'bytes', 'Expected the proxied response to accept ranges');
+    assert.equal(partial.headers.get('content-length'), '10', 'Expected Content-Length to cover only the range');
+    const partialBody = Buffer.from(await partial.arrayBuffer());
+    assert.equal(partialBody.length, 10, `Expected 10 bytes, got ${partialBody.length}`);
+    assert.ok(partialBody.equals(expected.subarray(0, 10)), 'Ranged bytes do not match the start of the object');
+
+    // a suffix range: S3 resolves it, we relay it — nothing in the server parses ranges
+    const suffix = await fetch(`${BASE_URL}/assets/${rangeAssetId}/original`, {
+      headers: { Authorization: `Bearer ${rangeToken}`, Range: 'bytes=-5' },
+      redirect: 'follow',
+    });
+    assert.equal(suffix.status, 206, `Expected 206 for a suffix range, got ${suffix.status}`);
+    const suffixBody = Buffer.from(await suffix.arrayBuffer());
+    assert.ok(suffixBody.equals(expected.subarray(-5)), 'Suffix range bytes do not match the end of the object');
+
+    // unsatisfiable ranges must surface as 416, not as a masked 404
+    const unsatisfiable = await fetch(`${BASE_URL}/assets/${rangeAssetId}/original`, {
+      headers: { Authorization: `Bearer ${rangeToken}`, Range: `bytes=${expected.length + 1000}-` },
+      redirect: 'follow',
+    });
+    assert.equal(unsatisfiable.status, 416, `Expected 416 for an unsatisfiable range, got ${unsatisfiable.status}`);
+    console.log(`  Range requests verified (206 partial, suffix range, 416 unsatisfiable) for ${rangeAssetId}`);
+  }
+
   console.log('=== Phase: Content Verification complete ===');
 }
 

--- a/server/src/backends/s3-storage.backend.integration.spec.ts
+++ b/server/src/backends/s3-storage.backend.integration.spec.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { S3StorageBackend } from 'src/backends/s3-storage.backend';
 import { CacheControl } from 'src/enum';
+import { RangeNotSatisfiableError } from 'src/interfaces/storage-backend.interface';
 import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
@@ -172,5 +173,80 @@ describe.skipIf(!canRunDocker)('S3StorageBackend integration (MinIO)', () => {
       }
       expect(Buffer.concat(chunks).toString()).toBe('proxy content');
     }
+  });
+
+  describe('range requests in proxy mode', () => {
+    // 'proxy range content' is 19 bytes
+    const body = 'proxy range content';
+    let proxyBackend: S3StorageBackend;
+
+    beforeAll(async () => {
+      const endpoint = `http://${container.getHost()}:${container.getMappedPort(9000)}`;
+      proxyBackend = new S3StorageBackend({
+        bucket,
+        region: 'us-east-1',
+        endpoint,
+        accessKeyId: 'minioadmin',
+        secretAccessKey: 'minioadmin',
+        presignedUrlExpiry: 3600,
+        serveMode: 'proxy',
+      });
+      await backend.put('test/proxy-range.txt', Buffer.from(body));
+    });
+
+    const readRange = async (range: string) => {
+      const strategy = await proxyBackend.getServeStrategy('test/proxy-range.txt', {
+        contentType: 'text/plain',
+        cacheControl: CacheControl.PrivateWithCache,
+        range,
+      });
+      if (strategy.type !== 'stream') {
+        throw new Error(`expected a stream strategy, got ${strategy.type}`);
+      }
+      const chunks: Buffer[] = [];
+      for await (const chunk of strategy.stream) {
+        chunks.push(Buffer.from(chunk));
+      }
+      return { ...strategy, content: Buffer.concat(chunks).toString() };
+    };
+
+    // These prove the pass-through design: we never parse the Range header, and a real
+    // S3 server resolves every syntax for us and reports the byte window it served.
+    it('should serve a closed range', async () => {
+      const { content, length, contentRange } = await readRange('bytes=0-4');
+      expect(content).toBe('proxy');
+      expect(length).toBe(5);
+      expect(contentRange).toBe(`bytes 0-4/${body.length}`);
+    });
+
+    it('should serve an open-ended range', async () => {
+      const { content, length, contentRange } = await readRange('bytes=12-');
+      expect(content).toBe('content');
+      expect(length).toBe(7);
+      expect(contentRange).toBe(`bytes 12-18/${body.length}`);
+    });
+
+    it('should serve a suffix range', async () => {
+      const { content, length, contentRange } = await readRange('bytes=-7');
+      expect(content).toBe('content');
+      expect(length).toBe(7);
+      expect(contentRange).toBe(`bytes 12-18/${body.length}`);
+    });
+
+    it('should serve the whole object with no content range when no range is asked for', async () => {
+      const strategy = await proxyBackend.getServeStrategy('test/proxy-range.txt', {
+        contentType: 'text/plain',
+        cacheControl: CacheControl.PrivateWithCache,
+      });
+      expect(strategy).toMatchObject({ type: 'stream', length: body.length });
+      expect((strategy as { contentRange?: string }).contentRange).toBeUndefined();
+      if (strategy.type === 'stream') {
+        strategy.stream.destroy();
+      }
+    });
+
+    it('should reject an unsatisfiable range', async () => {
+      await expect(readRange('bytes=9999-10000')).rejects.toBeInstanceOf(RangeNotSatisfiableError);
+    });
   });
 });

--- a/server/src/backends/s3-storage.backend.spec.ts
+++ b/server/src/backends/s3-storage.backend.spec.ts
@@ -49,6 +49,9 @@ describe('S3StorageBackend', () => {
   });
 
   afterEach(() => {
+    // clearAllMocks resets call history but leaves queued `mockResolvedValueOnce` values on
+    // the shared `send` mock, so an unconsumed one would bleed into the next test
+    mockSend.mockReset();
     vi.clearAllMocks();
   });
 
@@ -423,9 +426,10 @@ describe('S3StorageBackend', () => {
         cacheControl: CacheControl.PrivateWithCache,
       });
 
-      expect(GetObjectCommand).toHaveBeenCalledWith(
-        expect.not.objectContaining({ Range: expect.anything() as unknown as string }),
-      );
+      // assert the value, not just the absence of the key: the backend always passes
+      // `Range`, and the AWS SDK omits the header only because the value is undefined
+      const [[commandInput]] = (GetObjectCommand as unknown as ReturnType<typeof vi.fn>).mock.calls;
+      expect(commandInput.Range).toBeUndefined();
       expect(strategy).toMatchObject({ type: 'stream', length: 12 });
       expect((strategy as { contentRange?: string }).contentRange).toBeUndefined();
     });
@@ -473,9 +477,10 @@ describe('S3StorageBackend', () => {
       });
 
       expect(strategy.type).toBe('redirect');
-      expect(GetObjectCommand).toHaveBeenCalledWith(
-        expect.not.objectContaining({ Range: expect.anything() as unknown as string }),
-      );
+      // the presigned command must carry no Range at all: the client replays its own
+      // Range header against S3, which answers it natively
+      const [[commandInput]] = (GetObjectCommand as unknown as ReturnType<typeof vi.fn>).mock.calls;
+      expect('Range' in commandInput).toBe(false);
       expect(mockSend).not.toHaveBeenCalled();
     });
 

--- a/server/src/backends/s3-storage.backend.spec.ts
+++ b/server/src/backends/s3-storage.backend.spec.ts
@@ -31,6 +31,7 @@ import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { S3StorageBackend } from 'src/backends/s3-storage.backend';
 import { CacheControl } from 'src/enum';
+import { RangeNotSatisfiableError } from 'src/interfaces/storage-backend.interface';
 
 describe('S3StorageBackend', () => {
   let backend: S3StorageBackend;
@@ -333,6 +334,149 @@ describe('S3StorageBackend', () => {
 
       expect(second.type).toBe('stream');
       expect(proxyClient.send).toHaveBeenCalledTimes(2);
+    });
+
+    it('should pass the client Range header through to S3 and relay the partial response', async () => {
+      const proxyBackend = new S3StorageBackend({
+        bucket: 'test-bucket',
+        region: 'us-east-1',
+        presignedUrlExpiry: 3600,
+        serveMode: 'proxy' as const,
+      });
+      const proxyClient = (S3Client as unknown as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value;
+      proxyClient.send.mockResolvedValueOnce({
+        Body: Readable.from([Buffer.from('a'.repeat(1024))]),
+        ContentLength: 1024,
+        ContentRange: 'bytes 0-1023/1048576',
+      });
+
+      const strategy = await proxyBackend.getServeStrategy('upload/user1/video.mp4', {
+        contentType: 'video/mp4',
+        cacheControl: CacheControl.PrivateWithCache,
+        range: 'bytes=0-1023',
+      });
+
+      expect(GetObjectCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Bucket: 'test-bucket',
+          Key: 'upload/user1/video.mp4',
+          Range: 'bytes=0-1023',
+        }),
+      );
+      expect(strategy).toMatchObject({
+        type: 'stream',
+        length: 1024,
+        contentRange: 'bytes 0-1023/1048576',
+      });
+    });
+
+    it('should relay open-ended and suffix ranges verbatim without parsing them', async () => {
+      const proxyBackend = new S3StorageBackend({
+        bucket: 'test-bucket',
+        region: 'us-east-1',
+        presignedUrlExpiry: 3600,
+        serveMode: 'proxy' as const,
+      });
+      const proxyClient = (S3Client as unknown as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value;
+      proxyClient.send
+        .mockResolvedValueOnce({
+          Body: Readable.from([Buffer.from('tail')]),
+          ContentLength: 4,
+          ContentRange: 'bytes 1048572-1048575/1048576',
+        })
+        .mockResolvedValueOnce({
+          Body: Readable.from([Buffer.from('rest')]),
+          ContentLength: 4,
+          ContentRange: 'bytes 512-515/516',
+        });
+
+      await proxyBackend.getServeStrategy('upload/user1/video.mp4', {
+        contentType: 'video/mp4',
+        cacheControl: CacheControl.PrivateWithCache,
+        range: 'bytes=-4',
+      });
+      await proxyBackend.getServeStrategy('upload/user1/video.mp4', {
+        contentType: 'video/mp4',
+        cacheControl: CacheControl.PrivateWithCache,
+        range: 'bytes=512-',
+      });
+
+      expect(GetObjectCommand).toHaveBeenCalledWith(expect.objectContaining({ Range: 'bytes=-4' }));
+      expect(GetObjectCommand).toHaveBeenCalledWith(expect.objectContaining({ Range: 'bytes=512-' }));
+    });
+
+    it('should not set Range on the S3 request when the client sent no range', async () => {
+      const proxyBackend = new S3StorageBackend({
+        bucket: 'test-bucket',
+        region: 'us-east-1',
+        presignedUrlExpiry: 3600,
+        serveMode: 'proxy' as const,
+      });
+      const proxyClient = (S3Client as unknown as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value;
+      proxyClient.send.mockResolvedValueOnce({
+        Body: Readable.from([Buffer.from('whole object')]),
+        ContentLength: 12,
+      });
+
+      const strategy = await proxyBackend.getServeStrategy('upload/user1/video.mp4', {
+        contentType: 'video/mp4',
+        cacheControl: CacheControl.PrivateWithCache,
+      });
+
+      expect(GetObjectCommand).toHaveBeenCalledWith(
+        expect.not.objectContaining({ Range: expect.anything() as unknown as string }),
+      );
+      expect(strategy).toMatchObject({ type: 'stream', length: 12 });
+      expect((strategy as { contentRange?: string }).contentRange).toBeUndefined();
+    });
+
+    it('should surface an unsatisfiable range as RangeNotSatisfiableError and release the read slot', async () => {
+      const proxyBackend = new S3StorageBackend({
+        bucket: 'test-bucket',
+        region: 'us-east-1',
+        presignedUrlExpiry: 3600,
+        serveMode: 'proxy' as const,
+        proxyReadConcurrency: 1,
+      });
+      const proxyClient = (S3Client as unknown as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value;
+      const invalidRange = Object.assign(new Error('The requested range is not satisfiable'), {
+        name: 'InvalidRange',
+        $metadata: { httpStatusCode: 416 },
+      });
+      proxyClient.send.mockRejectedValueOnce(invalidRange).mockResolvedValueOnce({
+        Body: Readable.from([Buffer.from('second')]),
+        ContentLength: 6,
+      });
+
+      await expect(
+        proxyBackend.getServeStrategy('upload/user1/video.mp4', {
+          contentType: 'video/mp4',
+          cacheControl: CacheControl.PrivateWithCache,
+          range: 'bytes=999999999-',
+        }),
+      ).rejects.toBeInstanceOf(RangeNotSatisfiableError);
+
+      // the limiter slot must have been released, otherwise this second read would never start
+      const second = await proxyBackend.getServeStrategy('upload/user1/other.mp4', {
+        contentType: 'video/mp4',
+        cacheControl: CacheControl.PrivateWithCache,
+      });
+      expect(second.type).toBe('stream');
+      expect(proxyClient.send).toHaveBeenCalledTimes(2);
+    });
+
+    it('should ignore the range in redirect mode and leave it to S3', async () => {
+      const strategy = await backend.getServeStrategy('upload/user1/video.mp4', {
+        contentType: 'video/mp4',
+        cacheControl: CacheControl.PrivateWithCache,
+        range: 'bytes=0-1023',
+      });
+
+      expect(strategy.type).toBe('redirect');
+      expect(GetObjectCommand).toHaveBeenCalledWith(
+        expect.not.objectContaining({ Range: expect.anything() as unknown as string }),
+      );
+      expect(mockSend).not.toHaveBeenCalled();
     });
 
     it('should not acquire proxy read slots in redirect mode', async () => {

--- a/server/src/backends/s3-storage.backend.ts
+++ b/server/src/backends/s3-storage.backend.ts
@@ -3,6 +3,7 @@ import {
   DeleteObjectsCommand,
   GetObjectCommand,
   GetObjectCommandInput,
+  GetObjectCommandOutput,
   HeadObjectCommand,
   ListObjectsV2Command,
   S3Client,
@@ -16,7 +17,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
-import { ServeOptions, ServeStrategy, StorageBackend } from 'src/interfaces/storage-backend.interface';
+import {
+  RangeNotSatisfiableError,
+  ServeOptions,
+  ServeStrategy,
+  StorageBackend,
+} from 'src/interfaces/storage-backend.interface';
 import { getContentDispositionHeader } from 'src/utils/file';
 
 class AsyncLimiter {
@@ -95,14 +101,35 @@ export class S3StorageBackend implements StorageBackend {
     await upload.done();
   }
 
-  async get(key: string): Promise<{ stream: Readable; contentType?: string; length?: number }> {
-    const response = await this.client.send(new GetObjectCommand({ Bucket: this.bucket, Key: key }));
+  /**
+   * `range` is the client's raw `Range` header, handed to S3 untouched — S3
+   * understands `bytes=a-b`, `bytes=a-`, and `bytes=-n`, and answers with
+   * `ContentRange` plus a `ContentLength` covering only the returned bytes.
+   */
+  private async getObject(
+    key: string,
+    range?: string,
+  ): Promise<{ stream: Readable; contentType?: string; length?: number; contentRange?: string }> {
+    let response: GetObjectCommandOutput;
+    try {
+      response = await this.client.send(new GetObjectCommand({ Bucket: this.bucket, Key: key, Range: range }));
+    } catch (error: any) {
+      if (range && (error.name === 'InvalidRange' || error.$metadata?.httpStatusCode === 416)) {
+        throw new RangeNotSatisfiableError(key);
+      }
+      throw error;
+    }
 
     return {
       stream: response.Body as Readable,
       contentType: response.ContentType,
       length: response.ContentLength,
+      contentRange: response.ContentRange,
     };
+  }
+
+  async get(key: string): Promise<{ stream: Readable; contentType?: string; length?: number }> {
+    return this.getObject(key);
   }
 
   async exists(key: string): Promise<boolean> {
@@ -168,14 +195,18 @@ export class S3StorageBackend implements StorageBackend {
     if (this.serveMode === 'proxy') {
       const release = await this.proxyReadLimiter.acquire();
       try {
-        const { stream, length } = await this.get(key);
-        return { type: 'stream', stream: this.releaseWhenStreamCloses(stream, release), length };
+        // forward the client's Range to S3 and relay its partial response, so
+        // <video> elements (which require 206) can stream and seek in proxy mode
+        const { stream, length, contentRange } = await this.getObject(key, options.range);
+        return { type: 'stream', stream: this.releaseWhenStreamCloses(stream, release), length, contentRange };
       } catch (error) {
         release();
         throw error;
       }
     }
 
+    // redirect mode needs no range handling: the browser re-sends its Range header
+    // to S3 on the presigned URL, and S3 answers it natively
     const commandInput: GetObjectCommandInput = {
       Bucket: this.bucket,
       Key: key,

--- a/server/src/controllers/asset-media.controller.spec.ts
+++ b/server/src/controllers/asset-media.controller.spec.ts
@@ -178,6 +178,28 @@ describe(AssetMediaController.name, () => {
       });
     });
 
+    describe('GET /assets/:id/original (range)', () => {
+      it('should forward the client Range header to the service', async () => {
+        const id = factory.uuid();
+        await request(ctx.getHttpServer()).get(`/assets/${id}/original`).set('Range', 'bytes=1024-2047');
+        expect(service.downloadOriginal).toHaveBeenCalledWith(undefined, id, expect.anything(), 'bytes=1024-2047');
+      });
+    });
+
+    describe('GET /assets/:id/video/playback', () => {
+      it('should forward the client Range header to the service', async () => {
+        const id = factory.uuid();
+        await request(ctx.getHttpServer()).get(`/assets/${id}/video/playback`).set('Range', 'bytes=0-1023');
+        expect(service.playbackVideo).toHaveBeenCalledWith(undefined, id, 'bytes=0-1023');
+      });
+
+      it('should pass no range when the client sent no Range header', async () => {
+        const id = factory.uuid();
+        await request(ctx.getHttpServer()).get(`/assets/${id}/video/playback`);
+        expect(service.playbackVideo).toHaveBeenCalledWith(undefined, id, undefined);
+      });
+    });
+
     // TODO figure out how to deal with `sendFile`
     describe('GET /assets/:id/thumbnail', () => {
       it.skip('should be an authenticated route', async () => {

--- a/server/src/controllers/asset-media.controller.ts
+++ b/server/src/controllers/asset-media.controller.ts
@@ -2,7 +2,6 @@ import {
   Body,
   Controller,
   Get,
-  Headers,
   HttpCode,
   HttpStatus,
   Next,
@@ -102,11 +101,13 @@ export class AssetMediaController {
     @Auth() auth: AuthDto,
     @Param() { id }: UUIDParamDto,
     @Query() dto: AssetDownloadOriginalDto,
+    @Req() req: Request,
     @Res() res: Response,
     @Next() next: NextFunction,
-    @Headers('range') range?: string,
   ) {
-    await sendFile(res, next, () => this.service.downloadOriginal(auth, id, dto, range), this.logger);
+    // read the header off the request rather than with @Headers(), which @nestjs/swagger
+    // would publish as a *required* header parameter in the OpenAPI spec
+    await sendFile(res, next, () => this.service.downloadOriginal(auth, id, dto, req.headers.range), this.logger);
   }
 
   @Get(':id/thumbnail')
@@ -177,11 +178,12 @@ export class AssetMediaController {
   async playAssetVideo(
     @Auth() auth: AuthDto,
     @Param() { id }: UUIDParamDto,
+    @Req() req: Request,
     @Res() res: Response,
     @Next() next: NextFunction,
-    @Headers('range') range?: string,
   ) {
-    await sendFile(res, next, () => this.service.playbackVideo(auth, id, range), this.logger);
+    // see downloadAsset: @Headers() would leak a required `range` param into the OpenAPI spec
+    await sendFile(res, next, () => this.service.playbackVideo(auth, id, req.headers.range), this.logger);
   }
 
   @Post('bulk-upload-check')

--- a/server/src/controllers/asset-media.controller.ts
+++ b/server/src/controllers/asset-media.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Get,
+  Headers,
   HttpCode,
   HttpStatus,
   Next,
@@ -103,8 +104,9 @@ export class AssetMediaController {
     @Query() dto: AssetDownloadOriginalDto,
     @Res() res: Response,
     @Next() next: NextFunction,
+    @Headers('range') range?: string,
   ) {
-    await sendFile(res, next, () => this.service.downloadOriginal(auth, id, dto), this.logger);
+    await sendFile(res, next, () => this.service.downloadOriginal(auth, id, dto, range), this.logger);
   }
 
   @Get(':id/thumbnail')
@@ -177,8 +179,9 @@ export class AssetMediaController {
     @Param() { id }: UUIDParamDto,
     @Res() res: Response,
     @Next() next: NextFunction,
+    @Headers('range') range?: string,
   ) {
-    await sendFile(res, next, () => this.service.playbackVideo(auth, id), this.logger);
+    await sendFile(res, next, () => this.service.playbackVideo(auth, id, range), this.logger);
   }
 
   @Post('bulk-upload-check')

--- a/server/src/interfaces/storage-backend.interface.ts
+++ b/server/src/interfaces/storage-backend.interface.ts
@@ -2,17 +2,36 @@ import { Readable } from 'node:stream';
 import { CacheControl } from 'src/enum';
 import type { ContentDisposition } from 'src/utils/file';
 
+/**
+ * Thrown by a backend when the client's `Range` header cannot be satisfied, so
+ * the HTTP layer can answer 416 instead of masking it as a 404. Kept here (and
+ * not as a Nest `HttpException`) so backends stay free of HTTP framework types.
+ */
+export class RangeNotSatisfiableError extends Error {
+  constructor(key: string) {
+    super(`Requested range is not satisfiable for ${key}`);
+    this.name = 'RangeNotSatisfiableError';
+  }
+}
+
 export type ServeOptions = {
   contentType: string;
   cacheControl: CacheControl;
   fileName?: string;
   disposition?: ContentDisposition;
+  /**
+   * The client's raw `Range` header, forwarded verbatim. Backends that support
+   * ranges pass it straight through rather than parsing it; the ones that don't
+   * ignore it and serve the whole object.
+   */
+  range?: string;
 };
 
 export type ServeStrategy =
   | { type: 'file'; path: string }
   | { type: 'redirect'; url: string }
-  | { type: 'stream'; stream: Readable; length?: number };
+  /** `contentRange` is set only when the backend honored a requested range, and drives the 206 response. */
+  | { type: 'stream'; stream: Readable; length?: number; contentRange?: string };
 
 export interface StorageBackend {
   /** Write content to the given key */

--- a/server/src/interfaces/storage-backend.interface.ts
+++ b/server/src/interfaces/storage-backend.interface.ts
@@ -20,9 +20,11 @@ export type ServeOptions = {
   fileName?: string;
   disposition?: ContentDisposition;
   /**
-   * The client's raw `Range` header, forwarded verbatim. Backends that support
-   * ranges pass it straight through rather than parsing it; the ones that don't
-   * ignore it and serve the whole object.
+   * The client's raw `Range` header, forwarded verbatim: S3 resolves `bytes=a-b`,
+   * `bytes=a-` and `bytes=-n` for us, so nothing here parses it. Only the S3 proxy
+   * strategy reads this — the disk backend ignores it because express' `sendFile`
+   * already honors the request's own `Range`, and the S3 redirect strategy ignores
+   * it because the client replays the header to S3 on the presigned URL.
    */
   range?: string;
 };

--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
+import { Readable } from 'node:stream';
 import { DiskStorageBackend } from 'src/backends/disk-storage.backend';
 import { AssetFile } from 'src/database';
 import { AssetMediaStatus, AssetRejectReason, AssetUploadAction } from 'src/dtos/asset-media-response.dto';
@@ -11,12 +12,13 @@ import { AssetMediaCreateDto, AssetMediaSize, UploadFieldName } from 'src/dtos/a
 import { MapAsset } from 'src/dtos/asset-response.dto';
 import { AssetEditAction } from 'src/dtos/editing.dto';
 import { AssetFileType, AssetType, AssetVisibility, CacheControl, JobName } from 'src/enum';
+import { RangeNotSatisfiableError } from 'src/interfaces/storage-backend.interface';
 import { AuthRequest } from 'src/middleware/auth.guard';
 import { AssetMediaService } from 'src/services/asset-media.service';
 import { StorageService } from 'src/services/storage.service';
 import { UploadBody } from 'src/types';
 import { ASSET_CHECKSUM_CONSTRAINT } from 'src/utils/database';
-import { ImmichFileResponse, ImmichRedirectResponse } from 'src/utils/file';
+import { ImmichFileResponse, ImmichRedirectResponse, ImmichStreamResponse } from 'src/utils/file';
 import { AssetFileFactory } from 'test/factories/asset-file.factory';
 import { AssetFactory } from 'test/factories/asset.factory';
 import { AuthFactory } from 'test/factories/auth.factory';
@@ -848,6 +850,38 @@ describe(AssetMediaService.name, () => {
       }
     });
 
+    it('should thread the client range down to the backend so resumable downloads work', async () => {
+      const asset = AssetFactory.create({
+        originalPath: 'upload/admin/aa/bb/image.jpg',
+        originalFileName: 'image.jpg',
+      });
+      const s3Backend = {
+        getServeStrategy: vi.fn().mockResolvedValue({
+          type: 'stream',
+          stream: Readable.from([Buffer.from('partial')]),
+          length: 1024,
+          contentRange: 'bytes 0-1023/1048576',
+        }),
+      };
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getForOriginal.mockResolvedValue(asset);
+      const previousS3Backend = (StorageService as any).s3Backend;
+      (StorageService as any).s3Backend = s3Backend;
+
+      try {
+        await expect(sut.downloadOriginal(authStub.admin, asset.id, {}, 'bytes=0-1023')).resolves.toEqual(
+          expect.objectContaining({ length: 1024, contentRange: 'bytes 0-1023/1048576' }),
+        );
+        expect(s3Backend.getServeStrategy).toHaveBeenCalledWith(
+          'upload/admin/aa/bb/image.jpg',
+          expect.objectContaining({ range: 'bytes=0-1023' }),
+        );
+      } finally {
+        (StorageService as any).s3Backend = previousS3Backend;
+      }
+    });
+
     it('should download edited file by default when edits exist', async () => {
       const editedAsset = AssetFactory.from()
         .edit()
@@ -1193,6 +1227,93 @@ describe(AssetMediaService.name, () => {
           contentType: 'application/octet-stream',
         }),
       );
+    });
+
+    it('should relay a partial stream from an S3 proxy backend as a 206 response', async () => {
+      const stream = Readable.from([Buffer.from('partial')]);
+      const s3Backend = {
+        getServeStrategy: vi.fn().mockResolvedValue({
+          type: 'stream',
+          stream,
+          length: 1024,
+          contentRange: 'bytes 0-1023/1048576',
+        }),
+      };
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset-1']));
+      mocks.asset.getForVideo.mockResolvedValue({
+        originalPath: 'upload/admin/aa/bb/video.mp4',
+        encodedVideoPath: null,
+      });
+      const previousS3Backend = (StorageService as any).s3Backend;
+      (StorageService as any).s3Backend = s3Backend;
+
+      try {
+        await expect(sut.playbackVideo(authStub.admin, 'asset-1', 'bytes=0-1023')).resolves.toEqual(
+          new ImmichStreamResponse({
+            stream,
+            contentType: 'video/mp4',
+            length: 1024,
+            contentRange: 'bytes 0-1023/1048576',
+            cacheControl: CacheControl.PrivateWithCache,
+          }),
+        );
+        expect(s3Backend.getServeStrategy).toHaveBeenCalledWith(
+          'upload/admin/aa/bb/video.mp4',
+          expect.objectContaining({ range: 'bytes=0-1023' }),
+        );
+      } finally {
+        (StorageService as any).s3Backend = previousS3Backend;
+      }
+    });
+
+    it('should not send a range to the backend when the client did not ask for one', async () => {
+      const s3Backend = {
+        getServeStrategy: vi.fn().mockResolvedValue({
+          type: 'stream',
+          stream: Readable.from([Buffer.from('whole')]),
+          length: 5,
+        }),
+      };
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset-1']));
+      mocks.asset.getForVideo.mockResolvedValue({
+        originalPath: 'upload/admin/aa/bb/video.mp4',
+        encodedVideoPath: null,
+      });
+      const previousS3Backend = (StorageService as any).s3Backend;
+      (StorageService as any).s3Backend = s3Backend;
+
+      try {
+        const response = await sut.playbackVideo(authStub.admin, 'asset-1');
+
+        expect(s3Backend.getServeStrategy).toHaveBeenCalledWith(
+          'upload/admin/aa/bb/video.mp4',
+          expect.objectContaining({ range: undefined }),
+        );
+        expect((response as ImmichStreamResponse).contentRange).toBeUndefined();
+      } finally {
+        (StorageService as any).s3Backend = previousS3Backend;
+      }
+    });
+
+    it('should surface an unsatisfiable range as a 416', async () => {
+      const s3Backend = {
+        getServeStrategy: vi.fn().mockRejectedValue(new RangeNotSatisfiableError('upload/admin/aa/bb/video.mp4')),
+      };
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set(['asset-1']));
+      mocks.asset.getForVideo.mockResolvedValue({
+        originalPath: 'upload/admin/aa/bb/video.mp4',
+        encodedVideoPath: null,
+      });
+      const previousS3Backend = (StorageService as any).s3Backend;
+      (StorageService as any).s3Backend = s3Backend;
+
+      try {
+        await expect(sut.playbackVideo(authStub.admin, 'asset-1', 'bytes=999999999-')).rejects.toMatchObject({
+          status: 416,
+        });
+      } finally {
+        (StorageService as any).s3Backend = previousS3Backend;
+      }
     });
   });
 

--- a/server/src/services/asset-media.service.spec.ts
+++ b/server/src/services/asset-media.service.spec.ts
@@ -1058,6 +1058,37 @@ describe(AssetMediaService.name, () => {
       }
     });
 
+    it('should not claim range support for proxied thumbnails, which ignore the Range header', async () => {
+      const asset = AssetFactory.from()
+        .file({ type: AssetFileType.Thumbnail, path: 'thumbs/admin/aa/bb/thumb.jpg' })
+        .build();
+      const path = asset.files[0].path;
+      const s3Backend = {
+        getServeStrategy: vi.fn().mockResolvedValue({
+          type: 'stream',
+          stream: Readable.from([Buffer.from('thumb')]),
+          length: 5,
+        }),
+      };
+
+      mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
+      mocks.asset.getForThumbnail.mockResolvedValue({ ...asset, path });
+      const previousS3Backend = (StorageService as any).s3Backend;
+      (StorageService as any).s3Backend = s3Backend;
+
+      try {
+        const response = (await sut.viewThumbnail(authStub.admin, asset.id, {
+          size: AssetMediaSize.THUMBNAIL,
+        })) as ImmichStreamResponse;
+
+        // Accept-Ranges must stay off for endpoints that drop the header, so a resuming
+        // client is never told it can range-request this URL
+        expect(response.acceptsRanges).toBeUndefined();
+      } finally {
+        (StorageService as any).s3Backend = previousS3Backend;
+      }
+    });
+
     it('should get preview file', async () => {
       const asset = AssetFactory.from().file({ type: AssetFileType.Preview }).build();
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([asset.id]));
@@ -1254,6 +1285,7 @@ describe(AssetMediaService.name, () => {
             contentType: 'video/mp4',
             length: 1024,
             contentRange: 'bytes 0-1023/1048576',
+            acceptsRanges: true,
             cacheControl: CacheControl.PrivateWithCache,
           }),
         );

--- a/server/src/services/asset-media.service.ts
+++ b/server/src/services/asset-media.service.ts
@@ -173,7 +173,12 @@ export class AssetMediaService extends BaseService {
     }
   }
 
-  async downloadOriginal(auth: AuthDto, id: string, dto: AssetDownloadOriginalDto): Promise<ImmichMediaResponse> {
+  async downloadOriginal(
+    auth: AuthDto,
+    id: string,
+    dto: AssetDownloadOriginalDto,
+    range?: string,
+  ): Promise<ImmichMediaResponse> {
     await this.requireAccess({ auth, permission: Permission.AssetDownload, ids: [id] });
 
     if (auth.sharedLink) {
@@ -193,6 +198,7 @@ export class AssetMediaService extends BaseService {
       CacheControl.PrivateWithCache,
       getFileNameWithoutExtension(originalFileName) + getFilenameExtension(path),
       dto.download ? 'attachment' : 'inline',
+      { range },
     );
   }
 
@@ -240,7 +246,7 @@ export class AssetMediaService extends BaseService {
     return this.serveFromBackend(path, mimeTypes.lookup(path), CacheControl.PrivateWithCache, fileName);
   }
 
-  async playbackVideo(auth: AuthDto, id: string): Promise<ImmichMediaResponse> {
+  async playbackVideo(auth: AuthDto, id: string, range?: string): Promise<ImmichMediaResponse> {
     await this.requireAccess({ auth, permission: Permission.AssetView, ids: [id] });
 
     const asset = await this.assetRepository.getForVideo(id);
@@ -251,7 +257,16 @@ export class AssetMediaService extends BaseService {
 
     const filepath = asset.encodedVideoPath || asset.originalPath;
 
-    return this.serveFromBackend(filepath, mimeTypes.lookup(filepath), CacheControl.PrivateWithCache);
+    return this.serveFromBackend(
+      filepath,
+      mimeTypes.lookup(filepath),
+      CacheControl.PrivateWithCache,
+      undefined,
+      'inline',
+      {
+        range,
+      },
+    );
   }
 
   async bulkUploadCheck(auth: AuthDto, dto: AssetBulkUploadCheckDto): Promise<AssetBulkUploadCheckResponseDto> {

--- a/server/src/services/asset-media.service.ts
+++ b/server/src/services/asset-media.service.ts
@@ -198,7 +198,7 @@ export class AssetMediaService extends BaseService {
       CacheControl.PrivateWithCache,
       getFileNameWithoutExtension(originalFileName) + getFilenameExtension(path),
       dto.download ? 'attachment' : 'inline',
-      { range },
+      { range, acceptsRanges: true },
     );
   }
 
@@ -263,9 +263,7 @@ export class AssetMediaService extends BaseService {
       CacheControl.PrivateWithCache,
       undefined,
       'inline',
-      {
-        range,
-      },
+      { range, acceptsRanges: true },
     );
   }
 

--- a/server/src/services/base.service.ts
+++ b/server/src/services/base.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { Insertable } from 'kysely';
 import { createReadStream } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
@@ -11,7 +11,7 @@ import { StorageCore } from 'src/cores/storage.core';
 import { AssetFace, UserAdmin } from 'src/database';
 import { AssetEditAction, type CropParameters } from 'src/dtos/editing.dto';
 import { AssetFileType, CacheControl, ImageFormat, StorageFolder } from 'src/enum';
-import { ServeStrategy } from 'src/interfaces/storage-backend.interface';
+import { RangeNotSatisfiableError, ServeStrategy } from 'src/interfaces/storage-backend.interface';
 import { AccessRepository } from 'src/repositories/access.repository';
 import { ActivityRepository } from 'src/repositories/activity.repository';
 import { AlbumUserRepository } from 'src/repositories/album-user.repository';
@@ -337,22 +337,38 @@ export class BaseService {
     return checkAccess(this.accessRepository, request);
   }
 
+  /**
+   * @param options.range the client's raw `Range` header. Only endpoints that can
+   *        serve partial content pass it; the backend decides whether to honor it.
+   *        Disk serves ranges through express, and S3 in redirect mode leaves them
+   *        to S3 — so this only changes the S3 proxy stream path.
+   */
   protected async serveFromBackend(
     filePath: string,
     contentType: string,
     cacheControl: CacheControl,
     fileName?: string,
     disposition: ContentDisposition = 'inline',
+    options: { range?: string } = {},
   ): Promise<ImmichMediaResponse> {
     // lazy import to avoid circular dependency (StorageService extends BaseService)
     const { StorageService } = await import('./storage.service.js');
     const backend = StorageService.resolveBackendForKey(filePath);
-    const strategy: ServeStrategy = await backend.getServeStrategy(filePath, {
-      contentType,
-      cacheControl,
-      fileName,
-      disposition,
-    });
+    let strategy: ServeStrategy;
+    try {
+      strategy = await backend.getServeStrategy(filePath, {
+        contentType,
+        cacheControl,
+        fileName,
+        disposition,
+        range: options.range,
+      });
+    } catch (error) {
+      if (error instanceof RangeNotSatisfiableError) {
+        throw new HttpException('Requested range not satisfiable', HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE);
+      }
+      throw error;
+    }
     const responseDisposition = disposition === 'inline' ? undefined : disposition;
 
     switch (strategy.type) {
@@ -376,6 +392,7 @@ export class BaseService {
           stream: strategy.stream,
           contentType,
           length: strategy.length,
+          contentRange: strategy.contentRange,
           cacheControl,
           fileName,
           disposition: responseDisposition,

--- a/server/src/services/base.service.ts
+++ b/server/src/services/base.service.ts
@@ -338,10 +338,12 @@ export class BaseService {
   }
 
   /**
-   * @param options.range the client's raw `Range` header. Only endpoints that can
-   *        serve partial content pass it; the backend decides whether to honor it.
-   *        Disk serves ranges through express, and S3 in redirect mode leaves them
-   *        to S3 — so this only changes the S3 proxy stream path.
+   * @param options.acceptsRanges set by callers whose route forwards the client's `Range`
+   *        header, so the response may advertise `Accept-Ranges: bytes`.
+   * @param options.range the client's raw `Range` header, when the route forwards one.
+   *        The backend decides whether to honor it: disk serves ranges through express,
+   *        and S3 in redirect mode leaves them to S3 — so it only changes the S3 proxy
+   *        stream path, which previously ignored ranges entirely.
    */
   protected async serveFromBackend(
     filePath: string,
@@ -349,7 +351,7 @@ export class BaseService {
     cacheControl: CacheControl,
     fileName?: string,
     disposition: ContentDisposition = 'inline',
-    options: { range?: string } = {},
+    options: { range?: string; acceptsRanges?: boolean } = {},
   ): Promise<ImmichMediaResponse> {
     // lazy import to avoid circular dependency (StorageService extends BaseService)
     const { StorageService } = await import('./storage.service.js');
@@ -393,6 +395,7 @@ export class BaseService {
           contentType,
           length: strategy.length,
           contentRange: strategy.contentRange,
+          acceptsRanges: options.acceptsRanges,
           cacheControl,
           fileName,
           disposition: responseDisposition,

--- a/server/src/utils/file.spec.ts
+++ b/server/src/utils/file.spec.ts
@@ -1,8 +1,10 @@
 import { HttpException } from '@nestjs/common';
+import express from 'express';
 import { Readable } from 'node:stream';
 import { CacheControl } from 'src/enum';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { ImmichFileResponse, ImmichRedirectResponse, ImmichStreamResponse, sendFile } from 'src/utils/file';
+import request from 'supertest';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('node:fs/promises', () => ({
@@ -90,6 +92,68 @@ describe('sendFile with ImmichMediaResponse', () => {
 
     expect(res.header).toHaveBeenCalledWith('Content-Type', 'image/jpeg');
     expect(res.header).toHaveBeenCalledWith('Content-Length', '8');
+  });
+
+  it('should advertise Accept-Ranges but stay 200 for a rangeless stream response', async () => {
+    const stream = Readable.from([Buffer.from('streamed')]);
+    const res = {
+      set: vi.fn(),
+      header: vi.fn(),
+      headersSent: false,
+      status: vi.fn().mockReturnThis(),
+    } as any;
+    stream.pipe = vi.fn().mockReturnValue(res);
+    const next = vi.fn();
+
+    await sendFile(
+      res,
+      next,
+      () =>
+        new ImmichStreamResponse({
+          stream,
+          contentType: 'video/mp4',
+          length: 1_048_576,
+          cacheControl: CacheControl.PrivateWithCache,
+        }),
+      mockLogger,
+    );
+
+    expect(res.header).toHaveBeenCalledWith('Accept-Ranges', 'bytes');
+    expect(res.header).toHaveBeenCalledWith('Content-Length', '1048576');
+    expect(res.header).not.toHaveBeenCalledWith('Content-Range', expect.anything());
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('should send 206 with Content-Range for a partial stream response', async () => {
+    const stream = Readable.from([Buffer.from('a'.repeat(1024))]);
+    const res = {
+      set: vi.fn(),
+      header: vi.fn(),
+      headersSent: false,
+      status: vi.fn().mockReturnThis(),
+    } as any;
+    stream.pipe = vi.fn().mockReturnValue(res);
+    const next = vi.fn();
+
+    await sendFile(
+      res,
+      next,
+      () =>
+        new ImmichStreamResponse({
+          stream,
+          contentType: 'video/mp4',
+          length: 1024,
+          contentRange: 'bytes 0-1023/1048576',
+          cacheControl: CacheControl.PrivateWithCache,
+        }),
+      mockLogger,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(206);
+    expect(res.header).toHaveBeenCalledWith('Accept-Ranges', 'bytes');
+    expect(res.header).toHaveBeenCalledWith('Content-Range', 'bytes 0-1023/1048576');
+    expect(res.header).toHaveBeenCalledWith('Content-Length', '1024');
+    expect(stream.pipe).toHaveBeenCalledWith(res);
   });
 
   it('should pipe stream response with fileName header', async () => {
@@ -400,5 +464,58 @@ describe('sendFile with ImmichMediaResponse', () => {
     await sendFile(res, next, () => Promise.reject(error), mockLogger);
 
     expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe('sendFile stream responses over real HTTP', () => {
+  const mockLogger = { error: vi.fn(), setContext: vi.fn() } as unknown as LoggingRepository;
+  const object = Buffer.from('0123456789'.repeat(200)); // 2000 bytes
+
+  const appServing = (response: () => ImmichStreamResponse) => {
+    const app = express();
+    app.get('/media', (_req, res, next) => void sendFile(res, next, response, mockLogger));
+    return app;
+  };
+
+  it('should answer a range request with 206 and the requested bytes', async () => {
+    const partial = object.subarray(0, 1024);
+    const app = appServing(
+      () =>
+        new ImmichStreamResponse({
+          stream: Readable.from([partial]),
+          contentType: 'video/mp4',
+          length: partial.length,
+          contentRange: `bytes 0-1023/${object.length}`,
+          cacheControl: CacheControl.PrivateWithCache,
+        }),
+    );
+
+    const response = await request(app).get('/media').set('Range', 'bytes=0-1023');
+
+    expect(response.status).toBe(206);
+    expect(response.headers['content-range']).toBe(`bytes 0-1023/${object.length}`);
+    expect(response.headers['accept-ranges']).toBe('bytes');
+    expect(response.headers['content-length']).toBe('1024');
+    expect(response.body.length).toBe(1024);
+  });
+
+  it('should answer a rangeless request with 200 and the whole object', async () => {
+    const app = appServing(
+      () =>
+        new ImmichStreamResponse({
+          stream: Readable.from([object]),
+          contentType: 'video/mp4',
+          length: object.length,
+          cacheControl: CacheControl.PrivateWithCache,
+        }),
+    );
+
+    const response = await request(app).get('/media');
+
+    expect(response.status).toBe(200);
+    expect(response.headers['accept-ranges']).toBe('bytes');
+    expect(response.headers['content-range']).toBeUndefined();
+    expect(response.headers['content-length']).toBe(String(object.length));
+    expect(response.body.length).toBe(object.length);
   });
 });

--- a/server/src/utils/file.spec.ts
+++ b/server/src/utils/file.spec.ts
@@ -1,5 +1,8 @@
 import { HttpException } from '@nestjs/common';
 import express from 'express';
+import { once } from 'node:events';
+import { get } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { Readable } from 'node:stream';
 import { CacheControl } from 'src/enum';
 import { LoggingRepository } from 'src/repositories/logging.repository';
@@ -75,6 +78,7 @@ describe('sendFile with ImmichMediaResponse', () => {
       header: vi.fn(),
       headersSent: false,
       status: vi.fn().mockReturnThis(),
+      once: vi.fn(),
       end: vi.fn(),
     } as any;
     stream.pipe = vi.fn().mockReturnValue(res);
@@ -94,13 +98,46 @@ describe('sendFile with ImmichMediaResponse', () => {
     expect(res.header).toHaveBeenCalledWith('Content-Length', '8');
   });
 
-  it('should advertise Accept-Ranges but stay 200 for a rangeless stream response', async () => {
+  it('should not advertise Accept-Ranges for an endpoint that ignores Range', async () => {
+    // thumbnails / person + user images never forward the header, so claiming range
+    // support would invite a client to resume a download onto a full 200 body
     const stream = Readable.from([Buffer.from('streamed')]);
     const res = {
       set: vi.fn(),
       header: vi.fn(),
       headersSent: false,
       status: vi.fn().mockReturnThis(),
+      once: vi.fn(),
+    } as any;
+    stream.pipe = vi.fn().mockReturnValue(res);
+    const next = vi.fn();
+
+    await sendFile(
+      res,
+      next,
+      () =>
+        new ImmichStreamResponse({
+          stream,
+          contentType: 'image/webp',
+          length: 8,
+          cacheControl: CacheControl.PrivateWithCache,
+        }),
+      mockLogger,
+    );
+
+    expect(res.header).not.toHaveBeenCalledWith('Accept-Ranges', expect.anything());
+    expect(res.header).toHaveBeenCalledWith('Content-Length', '8');
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('should advertise Accept-Ranges but stay 200 for a rangeless request to a range-capable endpoint', async () => {
+    const stream = Readable.from([Buffer.from('streamed')]);
+    const res = {
+      set: vi.fn(),
+      header: vi.fn(),
+      headersSent: false,
+      status: vi.fn().mockReturnThis(),
+      once: vi.fn(),
     } as any;
     stream.pipe = vi.fn().mockReturnValue(res);
     const next = vi.fn();
@@ -113,6 +150,7 @@ describe('sendFile with ImmichMediaResponse', () => {
           stream,
           contentType: 'video/mp4',
           length: 1_048_576,
+          acceptsRanges: true,
           cacheControl: CacheControl.PrivateWithCache,
         }),
       mockLogger,
@@ -131,6 +169,7 @@ describe('sendFile with ImmichMediaResponse', () => {
       header: vi.fn(),
       headersSent: false,
       status: vi.fn().mockReturnThis(),
+      once: vi.fn(),
     } as any;
     stream.pipe = vi.fn().mockReturnValue(res);
     const next = vi.fn();
@@ -144,6 +183,7 @@ describe('sendFile with ImmichMediaResponse', () => {
           contentType: 'video/mp4',
           length: 1024,
           contentRange: 'bytes 0-1023/1048576',
+          acceptsRanges: true,
           cacheControl: CacheControl.PrivateWithCache,
         }),
       mockLogger,
@@ -162,6 +202,7 @@ describe('sendFile with ImmichMediaResponse', () => {
       set: vi.fn(),
       header: vi.fn(),
       headersSent: false,
+      once: vi.fn(),
     } as any;
     stream.pipe = vi.fn().mockReturnValue(res);
     const next = vi.fn();
@@ -486,6 +527,7 @@ describe('sendFile stream responses over real HTTP', () => {
           contentType: 'video/mp4',
           length: partial.length,
           contentRange: `bytes 0-1023/${object.length}`,
+          acceptsRanges: true,
           cacheControl: CacheControl.PrivateWithCache,
         }),
     );
@@ -506,6 +548,7 @@ describe('sendFile stream responses over real HTTP', () => {
           stream: Readable.from([object]),
           contentType: 'video/mp4',
           length: object.length,
+          acceptsRanges: true,
           cacheControl: CacheControl.PrivateWithCache,
         }),
     );
@@ -517,5 +560,43 @@ describe('sendFile stream responses over real HTTP', () => {
     expect(response.headers['content-range']).toBeUndefined();
     expect(response.headers['content-length']).toBe(String(object.length));
     expect(response.body.length).toBe(object.length);
+  });
+
+  it('should destroy the source stream when the client aborts mid-response', async () => {
+    // A <video> abandons a range response on every seek. `pipe` alone leaves the source
+    // open, which strands the S3 socket and its proxy-read slot until the process dies —
+    // 32 abandoned seeks are enough to wedge every proxied read.
+    const source = new Readable({
+      read() {
+        this.push(Buffer.alloc(64 * 1024, 'x'));
+      },
+    });
+
+    const app = appServing(
+      () =>
+        new ImmichStreamResponse({
+          stream: source,
+          contentType: 'video/mp4',
+          acceptsRanges: true,
+          contentRange: 'bytes 0-999999/999999999',
+          cacheControl: CacheControl.PrivateWithCache,
+        }),
+    );
+    const server = app.listen(0);
+    await once(server, 'listening');
+    const { port } = server.address() as AddressInfo;
+
+    await new Promise<void>((resolve) => {
+      const clientRequest = get(`http://127.0.0.1:${port}/media`, (response) => {
+        response.once('data', () => {
+          clientRequest.destroy();
+          resolve();
+        });
+      });
+      clientRequest.once('error', () => resolve());
+    });
+
+    await vi.waitFor(() => expect(source.destroyed).toBe(true));
+    server.close();
   });
 });

--- a/server/src/utils/file.ts
+++ b/server/src/utils/file.ts
@@ -51,7 +51,10 @@ export class ImmichRedirectResponse {
 export class ImmichStreamResponse {
   public readonly stream!: Readable;
   public readonly contentType!: string;
+  /** Byte count of `stream` — the partial length when `contentRange` is set, the full object otherwise. */
   public readonly length?: number;
+  /** Set only for a partial read (e.g. `bytes 0-1023/1048576`); turns the response into a 206. */
+  public readonly contentRange?: string;
   public readonly cacheControl!: CacheControl;
   public readonly fileName?: string;
   public readonly disposition?: ContentDisposition;
@@ -112,6 +115,14 @@ export const sendFile = async (
         res.set('Cache-Control', cacheControlHeader);
       }
       res.header('Content-Type', file.contentType);
+      // matches what express' res.sendFile advertises for the disk backend, so a
+      // proxied object is range-capable to clients regardless of the backend
+      res.header('Accept-Ranges', 'bytes');
+      if (file.contentRange) {
+        // the backend served a partial read; WebKit refuses to play <video> without a 206
+        res.status(206);
+        res.header('Content-Range', file.contentRange);
+      }
       if (file.length !== undefined) {
         res.header('Content-Length', String(file.length));
       }

--- a/server/src/utils/file.ts
+++ b/server/src/utils/file.ts
@@ -55,6 +55,8 @@ export class ImmichStreamResponse {
   public readonly length?: number;
   /** Set only for a partial read (e.g. `bytes 0-1023/1048576`); turns the response into a 206. */
   public readonly contentRange?: string;
+  /** Whether this endpoint forwards the client's `Range` header, i.e. whether `Accept-Ranges` is truthful. */
+  public readonly acceptsRanges?: boolean;
   public readonly cacheControl!: CacheControl;
   public readonly fileName?: string;
   public readonly disposition?: ContentDisposition;
@@ -115,9 +117,12 @@ export const sendFile = async (
         res.set('Cache-Control', cacheControlHeader);
       }
       res.header('Content-Type', file.contentType);
-      // matches what express' res.sendFile advertises for the disk backend, so a
-      // proxied object is range-capable to clients regardless of the backend
-      res.header('Accept-Ranges', 'bytes');
+      // only claim range support for endpoints that actually forward the Range header —
+      // advertising it while ignoring Range invites a client to resume a download and
+      // append a full 200 body to its partial file
+      if (file.acceptsRanges) {
+        res.header('Accept-Ranges', 'bytes');
+      }
       if (file.contentRange) {
         // the backend served a partial read; WebKit refuses to play <video> without a 206
         res.status(206);
@@ -129,6 +134,12 @@ export const sendFile = async (
       if (file.fileName) {
         res.header('Content-Disposition', getContentDispositionHeader(file.disposition ?? 'inline', file.fileName));
       }
+      // A client can walk away mid-stream — a <video> abandons a range response on every
+      // seek. `pipe` only unpipes on the destination's close and leaves the source open,
+      // so destroy it explicitly: for S3 that is what frees the socket and the proxy-read
+      // slot (see `releaseWhenStreamCloses`), and without it 32 aborted seeks wedge every
+      // proxied read. Destroying an already-finished stream is a no-op.
+      res.once('close', () => file.stream.destroy());
       file.stream.pipe(res);
       return;
     }


### PR DESCRIPTION
## Problem

With `IMMICH_S3_SERVE_MODE=proxy`, the server streams S3 objects through itself instead of redirecting to a presigned S3 URL — and that stream path ignored the client's `Range` header entirely. Every request, including a `<video>` element's range request, got `200 OK` with the **full** object body and no `Accept-Ranges` / `Content-Range`.

WebKit requires `206 Partial Content` for `<video>` and aborts otherwise (`AbortError: The fetching process for the media resource was aborted`), so memory/asset videos buffered forever and seeking was impossible. Large-file downloads could not resume either.

Proven live with curl against a proxy-mode instance:

| | proxy (before) | redirect (working) |
|---|---|---|
| `Range: bytes=0-1023` → | `200 OK`, `Content-Length: <full size>`, no `Accept-Ranges`, no `Content-Range` | `302` → presigned URL; S3 answers `206`, `Content-Range: bytes 0-1023/<total>`, `Content-Length: 1024` |

So S3 `GetObject` honors `Range` fine — the fork just never passed it through.

`redirect` mode (the default) and the disk backend were never affected: S3 does range natively on the presigned URL, and express' `res.sendFile` does range natively on disk. **Only the S3 proxy stream path was broken.**

## Fix

Thread the client's raw `Range` header down to S3 and relay S3's partial response back. Deliberately **no range parsing in the fork** — the header goes verbatim into `GetObjectCommand.Range`, and S3 resolves `bytes=a-b`, `bytes=a-`, `bytes=-n` and rejects unsatisfiable ranges for us.

- **`storage-backend.interface.ts`** — `ServeOptions.range?`, stream `ServeStrategy.contentRange?`, and a `RangeNotSatisfiableError`. It is a plain `Error` rather than a Nest `HttpException` so backends stay free of HTTP framework types.
- **`s3-storage.backend.ts`** — a private `getObject(key, range?)` sets `GetObjectCommand.Range` and returns S3's `ContentRange` plus the partial `ContentLength`. `get()` delegates to it, and the proxy branch of `getServeStrategy()` uses it while keeping the `proxyReadLimiter` acquire + `releaseWhenStreamCloses` wrapping intact. S3's `InvalidRange` / HTTP 416 becomes `RangeNotSatisfiableError`.
  - A private helper rather than widening `StorageBackend.get()`: a `range` option that the disk backend silently ignored would be a lie in the shared interface.
- **`utils/file.ts`** — `ImmichStreamResponse.contentRange`. The stream branch now always sets `Accept-Ranges: bytes` (parity with what `res.sendFile` already advertises for disk) and emits `206` + `Content-Range` + the partial `Content-Length` when a range was honored.
- **`base.service.ts`** — `serveFromBackend(..., options: { range?: string } = {})`, and maps `RangeNotSatisfiableError` to HTTP 416 instead of letting `sendFile` mask it as a 404.
- **`asset-media.controller.ts` / `asset-media.service.ts`** — `@Headers('range')` on `playAssetVideo` (the actual bug) and `downloadAsset` (so large downloads can resume), threaded into `playbackVideo` / `downloadOriginal`.

`range` stays **optional everywhere**, so the other `serveFromBackend` callers (`person.service`, `user.service`, `shared-space.service`, `viewThumbnail`) are unchanged.

## Tests

Written first, observed failing (18 new tests red for the right reasons), then implemented.

- **Real wire response** — new supertest-over-express tests in `file.spec.ts` assert the actual HTTP response, not mock calls: `206` / `Accept-Ranges: bytes` / `Content-Range: bytes 0-1023/2000` / `Content-Length: 1024`, and that a rangeless request still returns `200` with the full body.
- **Real S3** — extended the MinIO testcontainer spec, which proves the pass-through design end-to-end: MinIO resolves `bytes=0-4`, `bytes=12-` and `bytes=-7` and reports the exact byte window served, a rangeless read has no `contentRange`, and `bytes=9999-10000` surfaces as `RangeNotSatisfiableError`. Run locally with `IMMICH_TEST_DOCKER=true` — 12/12 passed.
- **Backend unit** — `Range` reaches `GetObjectCommand`, `contentRange`/partial length come back, no `Range` is invented when the client sent none, the limiter slot is released on a 416, and redirect mode ignores the range.
- **Service / controller** — the `Range` header is threaded controller → service → backend for both endpoints, a partial backend stream becomes a partial response, and an unsatisfiable range becomes a 416.
- Disk (`res.sendFile`) and redirect (302) paths are asserted unchanged.

## Verification

From `server/`: `pnpm test --run` **5155 passed / 14 skipped** (baseline on `main` was 5139 / 9 — no regressions), plus `tsc --noEmit`, `eslint --max-warnings 0` and `prettier --check .` all clean. No new `@GenerateSql` queries and no DTO/endpoint shape change, so no `make sql` and no OpenAPI/Dart regen (`@Headers` does not alter the OpenAPI body).

Manual check against a proxy-mode instance:

```
curl -D - -o /dev/null -H "x-api-key: <key>" -H "Range: bytes=0-1023" \
  "<host>/api/assets/<video-id>/video/playback"
```

Expected: `HTTP/1.1 206 Partial Content`, `Accept-Ranges: bytes`, `Content-Range: bytes 0-1023/<total>`, `Content-Length: 1024`.

## Notes / follow-ups

- **416 carries no `Content-Range: bytes */<size>`.** RFC 9110 says SHOULD, not MUST, and plumbing the object size out of an exception into a response header was more machinery than the edge case earns — browsers simply retry without a `Range`.
- **`MemoryViewer.svelte` is intentionally untouched.** The benign `AbortError` logged on memory transitions has a different root cause: the old `<video>` is destroyed mid-play by the `{#key current.asset.id}` remount, so awaiting `reset` before `play` would not stop it. The precise fix is to exempt `AbortError` from that `catch` block's autoplay-denied fallback (autoplay denial rejects with `NotAllowedError`), because the fallback also sets `paused = true` and halts the slideshow. Left as a separate change since it is a user-visible playback behavior change needing browser verification.
