### PR TITLE
fix(spaces): stop a suggestion merge from also renaming the person (#859)

### DIFF
--- a/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -224,8 +224,10 @@
   };
 
   const selectSuggestedPerson = async (suggestedPerson: SharedSpacePersonResponseDto) => {
-    cancelPreviousSearch();
-    suggestedPeople = [];
+    // Close the name editor before prompting: picking a suggestion means "merge", not "rename", and the
+    // prompt is portalled outside the header, so confirming it would otherwise register as the
+    // click-outside-to-save gesture and commit an unrelated rename alongside the merge (issue #859).
+    cancelEditingName();
 
     const isConfirm = await modalManager.showDialog({ prompt: $t('merge_people_prompt') });
     if (!isConfirm) {
@@ -255,8 +257,6 @@
       await goto(getSpacePersonRoute(suggestedPerson.id), { replaceState: true });
     } catch (error) {
       handleError(error, $t('cannot_merge_people'));
-    } finally {
-      isEditingName = false;
     }
   };
 

--- a/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/space-person-detail-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/space-person-detail-page.spec.ts
@@ -729,6 +729,62 @@ describe('Spaces person detail page', () => {
     expect(gotoMock).not.toHaveBeenCalledWith('/spaces/space-1/people/person-2', { replaceState: true });
   });
 
+  it('never renames the person while confirming an autosuggest merge outside the name editor (#859)', async () => {
+    sdkMock.isHttpError.mockImplementation((error) => !!(error as { __http?: boolean })?.__http);
+    const person = makePerson({ id: 'person-1', name: '' });
+    const existingPerson = makePerson({ id: 'person-2', name: 'Ange' });
+    sdkMock.getSpacePeople.mockResolvedValue([existingPerson]);
+    sdkMock.updateSpacePerson.mockResolvedValue({ ...person, name: 'Ange' });
+    sdkMock.mergeSpacePeople.mockRejectedValueOnce({
+      __http: true,
+      status: 403,
+      data: { code: 'cross_owner_merge_blocked', message: 'An administrator can enable it.' },
+      message: 'raw',
+    });
+    // The merge prompt is portalled outside the person header, so the click that confirms it lands
+    // outside the name editor — the same "click outside to save" gesture that commits a rename.
+    let confirmMerge: (confirmed: boolean) => void = () => {};
+    vi.mocked(modalManager.showDialog).mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        confirmMerge = resolve;
+      }),
+    );
+    renderPage({ person });
+
+    await userEvent.click(screen.getByText('add_a_name'));
+    await userEvent.type(screen.getByPlaceholderText('add_a_name'), 'Ange');
+    await userEvent.click(await screen.findByRole('button', { name: 'Ange' }));
+    await fireEvent.mouseDown(document.body);
+    confirmMerge(true);
+
+    await waitFor(() => expect(toastManager.danger).toHaveBeenCalled());
+    expect(sdkMock.updateSpacePerson).not.toHaveBeenCalled();
+    expect(toastManager.success).not.toHaveBeenCalled();
+  });
+
+  it('never renames the person when the autosuggest merge prompt is dismissed outside the name editor (#859)', async () => {
+    const person = makePerson({ id: 'person-1', name: '' });
+    const existingPerson = makePerson({ id: 'person-2', name: 'Ange' });
+    sdkMock.getSpacePeople.mockResolvedValue([existingPerson]);
+    sdkMock.updateSpacePerson.mockResolvedValue({ ...person, name: 'Ange' });
+    let dismissMerge: (confirmed: boolean) => void = () => {};
+    vi.mocked(modalManager.showDialog).mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        dismissMerge = resolve;
+      }),
+    );
+    renderPage({ person });
+
+    await userEvent.click(screen.getByText('add_a_name'));
+    await userEvent.type(screen.getByPlaceholderText('add_a_name'), 'Ange');
+    await userEvent.click(await screen.findByRole('button', { name: 'Ange' }));
+    await fireEvent.mouseDown(document.body);
+    dismissMerge(false);
+
+    await waitFor(() => expect(sdkMock.mergeSpacePeople).not.toHaveBeenCalled());
+    expect(sdkMock.updateSpacePerson).not.toHaveBeenCalled();
+  });
+
   it('re-runs an autosuggest merge with the cross-owner acknowledgement once the user confirms', async () => {
     sdkMock.isHttpError.mockImplementation((error) => !!(error as { __http?: boolean })?.__http);
     const person = makePerson({ id: 'person-1', name: '' });


### PR DESCRIPTION
Fixes #859.

## The bug

Merging a person as a Space Editor showed two contradictory toasts at once — "Successful — Name was changed successfully" and the cross-owner merge error — and silently renamed the person.

## Root cause

Two unrelated actions fired from one click, on the shared-space person page.

The name editor uses `use:clickOutside={{ onOutclick: () => void saveName() }}` (click-outside-to-save). `selectSuggestedPerson()` left the editor open while awaiting `modalManager.showDialog({ prompt: merge_people_prompt })`. That prompt is portalled to `document.body`, i.e. **outside** the watched element — so the click on **Confirm** was seen as a click-outside and ran `saveName()`, committing a rename to the typed name plus its success toast. The merge then ran and hit the cross-owner block, giving the error toast.

Toasts render in insertion order top-down, so success came first and error second — matching the ordering in the issue's screenshot (the global people page would produce the reverse order).

The cancel path was worse: dismissing the prompt also renamed the person, silently, with no merge attempted at all.

## Fix

`selectSuggestedPerson()` now calls `cancelEditingName()` up front — picking a suggestion means "merge", not "rename", so `saveName()` short-circuits on its `!isEditingName` guard. This matches how the global person page already ends the edit before opening its merge modal. The now-dead `finally { isEditingName = false }` is removed.

## Tests

Two tests added to `space-person-detail-page.spec.ts`, each watched failing against the unfixed page (`updateSpacePerson` called with `{ name: 'Ange' }`) before the fix:

- `never renames the person while confirming an autosuggest merge outside the name editor (#859)` — no rename call, no success toast when the merge is blocked
- `never renames the person when the autosuggest merge prompt is dismissed outside the name editor (#859)`

Full web unit suite green (3948 passed), `check:typescript` clean, eslint + prettier clean on changed files.

## Out of scope (deliberate)

- **The merge being blocked is by design.** Merging two space people collapses the underlying owners' personal people, so `collapsedOwnerIds` is non-empty and `assertDestructiveCollapseAllowed` (#733) blocks it unless an admin enables `mergePeopleAcrossOwners`. Whether Editors should be able to merge without that toggle is a policy decision, not a bug fix.
- **The global people page** can still show a rename-success after a blocked merge: the suggestion modal deliberately stays open on a block (an existing test asserts `onClose` is not called) and dismissing it falls through to the rename. Closing that path needs the modal to distinguish "blocked" from "declined" across three call sites — a #733 contract change, better as a follow-up.