### PR TITLE
feat(mobile): edit spaces and add to a space from the multiselect sheet

### DIFF
--- a/docs/superpowers/plans/2026-07-26-mobile-spaces-ux-slice-1.md
+++ b/docs/superpowers/plans/2026-07-26-mobile-spaces-ux-slice-1.md
@@ -1,0 +1,485 @@
+# Mobile Spaces UX — Slice 1: `space_permissions.dart` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace four hand-rolled space role predicates with one tested helper, fixing a latent
+`StateError` crash in the process.
+
+**Architecture:** A new pure-Dart file `mobile/lib/utils/space_permissions.dart` exports three
+top-level functions. Three widget/page files delete their private copies and delegate. No UI, no
+providers, no async — this is a leaf module, which is why it is Slice 1.
+
+**Tech Stack:** Dart 3.12.1 / Flutter 3.44.1, `flutter_test`, the generated `openapi` package
+(`SharedSpaceResponseDto`, `SharedSpaceMemberResponseDto`, `SharedSpaceRole`, `Optional`).
+
+**Spec:** `docs/superpowers/specs/2026-07-26-mobile-spaces-ux-design.md` §4 and Slice 1.
+
+## Global Constraints
+
+- Run every command from `mobile/` with the mise-resolved toolchain: `mise exec -- <cmd>`. A bare
+  `flutter`/`dart` resolves to 3.41.9 / Dart 3.11.5, below this project's `sdk: '>=3.12.0'`.
+- **Never** read `Optional.value` on a possibly-absent field. `Absent.value` throws
+  `StateError('No value present')` (`mobile/openapi/lib/optional.dart:67`), so `x.value ?? fallback`
+  never reaches the `??`. Use `.orElse(null) ?? fallback`.
+- `SharedSpaceResponseDto.members` is typed `Optional<List<SharedSpaceMemberResponseDto>?>` — the
+  inner value is itself nullable, so both the absent case and the present-null case must be handled.
+- No new i18n keys in this slice.
+- Both CI Dart gates must pass before the commit: `dart analyze --fatal-infos lib test` and
+  `dart format --set-exit-if-changed .`.
+- Baseline for this branch is **2796 passing, 1 skipped**. The full suite must still report that
+  (plus this slice's new tests) at the end.
+
+## File Structure
+
+| File                                                                                   | Responsibility                                    |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `mobile/lib/utils/space_permissions.dart` (create)                                     | The three predicates. Pure, no Flutter imports.   |
+| `mobile/test/utils/space_permissions_test.dart` (create)                               | Full truth table for all three.                   |
+| `mobile/lib/presentation/widgets/remote_album/space_link_picker.widget.dart` (modify)  | Delete `_canWrite`, delegate. Fixes the crash.    |
+| `mobile/lib/pages/library/spaces/space_detail.page.dart` (modify)                      | Delete `_isOwner` / `_canEdit` bodies, delegate.  |
+| `mobile/lib/presentation/widgets/bottom_sheet/space_bottom_sheet.widget.dart` (modify) | Delete `_canEdit`, delegate to the role overload. |
+
+`test/utils/` is the correct home: it already holds `space_link_album_candidates_test.dart`, which
+tests the sibling `lib/utils/space_link_album_candidates.dart`. Do **not** use `test/utils_legacy/`.
+
+---
+
+### Task 1: The `space_permissions` helper
+
+**Files:**
+
+- Create: `mobile/lib/utils/space_permissions.dart`
+- Test: `mobile/test/utils/space_permissions_test.dart`
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks (this is the first).
+- Produces, relied on by Tasks 2–4:
+  - `bool spaceIsWritable(SharedSpaceResponseDto space, String? currentUserId)`
+  - `bool spaceIsOwned(SharedSpaceResponseDto space, String? currentUserId)`
+  - `bool roleIsWritable(SharedSpaceRole? role)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mobile/test/utils/space_permissions_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/utils/space_permissions.dart';
+import 'package:openapi/api.dart';
+
+SharedSpaceMemberResponseDto _member(String userId, SharedSpaceRole role) => SharedSpaceMemberResponseDto(
+  userId: userId,
+  name: userId,
+  email: '$userId@example.com',
+  role: role,
+  joinedAt: '2024-01-01T00:00:00Z',
+  sharePersonMetadata: true,
+  showInTimeline: true,
+);
+
+/// [members] is passed through verbatim so a test can supply
+/// `Optional.absent()`, `Optional.present(null)` or a real list.
+SharedSpaceResponseDto _space({
+  String createdById = 'creator',
+  Optional<List<SharedSpaceMemberResponseDto>?> members = const Optional.absent(),
+}) => SharedSpaceResponseDto(
+  id: 'space-1',
+  name: 'Space 1',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+  createdById: createdById,
+  members: members,
+);
+
+void main() {
+  group('spaceIsWritable / spaceIsOwned', () {
+    test('the creator is writable and owned even when absent from the members list', () {
+      final space = _space(createdById: 'me', members: Optional.present([_member('someone', SharedSpaceRole.viewer)]));
+
+      expect(spaceIsWritable(space, 'me'), isTrue);
+      expect(spaceIsOwned(space, 'me'), isTrue);
+    });
+
+    test('a non-creator member with the owner role is writable AND owned', () {
+      final space = _space(createdById: 'creator', members: Optional.present([_member('me', SharedSpaceRole.owner)]));
+
+      expect(spaceIsWritable(space, 'me'), isTrue);
+      expect(spaceIsOwned(space, 'me'), isTrue, reason: 'Delete gating depends on this');
+    });
+
+    test('an editor is writable but not owned', () {
+      final space = _space(members: Optional.present([_member('me', SharedSpaceRole.editor)]));
+
+      expect(spaceIsWritable(space, 'me'), isTrue);
+      expect(spaceIsOwned(space, 'me'), isFalse);
+    });
+
+    test('a viewer is neither', () {
+      final space = _space(members: Optional.present([_member('me', SharedSpaceRole.viewer)]));
+
+      expect(spaceIsWritable(space, 'me'), isFalse);
+      expect(spaceIsOwned(space, 'me'), isFalse);
+    });
+
+    test('a non-member who did not create the space is neither', () {
+      final space = _space(members: Optional.present([_member('other', SharedSpaceRole.owner)]));
+
+      expect(spaceIsWritable(space, 'me'), isFalse);
+      expect(spaceIsOwned(space, 'me'), isFalse);
+    });
+
+    test('an absent members list falls back to the creator check without throwing', () {
+      // Absent.value throws StateError, so `members.value ?? const []` would crash here.
+      final space = _space(createdById: 'me');
+
+      expect(() => spaceIsWritable(space, 'me'), returnsNormally);
+      expect(spaceIsWritable(space, 'me'), isTrue);
+      expect(spaceIsWritable(space, 'someone-else'), isFalse);
+    });
+
+    test('a present-but-null members list behaves as an empty list', () {
+      final space = _space(createdById: 'creator', members: const Optional.present(null));
+
+      expect(() => spaceIsWritable(space, 'me'), returnsNormally);
+      expect(spaceIsWritable(space, 'me'), isFalse);
+    });
+
+    test('duplicate membership rows resolve to the first match deterministically', () {
+      final space = _space(
+        members: Optional.present([_member('me', SharedSpaceRole.editor), _member('me', SharedSpaceRole.viewer)]),
+      );
+
+      expect(spaceIsWritable(space, 'me'), isTrue);
+    });
+
+    test('a null current user is never writable or owned, even if createdById is also null-ish', () {
+      final space = _space(createdById: '', members: Optional.present([_member('me', SharedSpaceRole.owner)]));
+
+      expect(spaceIsWritable(space, null), isFalse);
+      expect(spaceIsOwned(space, null), isFalse);
+    });
+
+    test('the creator short-circuit wins over a demoted member row', () {
+      // Ownership transferred: still the createdById, but demoted to viewer.
+      final space = _space(createdById: 'me', members: Optional.present([_member('me', SharedSpaceRole.viewer)]));
+
+      expect(spaceIsWritable(space, 'me'), isTrue, reason: 'precedence is a decision, not an accident');
+      expect(spaceIsOwned(space, 'me'), isTrue);
+    });
+  });
+
+  group('roleIsWritable', () {
+    test('owner and editor are writable; viewer and null are not', () {
+      expect(roleIsWritable(SharedSpaceRole.owner), isTrue);
+      expect(roleIsWritable(SharedSpaceRole.editor), isTrue);
+      expect(roleIsWritable(SharedSpaceRole.viewer), isFalse);
+      expect(roleIsWritable(null), isFalse);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd mobile && mise exec -- flutter test test/utils/space_permissions_test.dart`
+
+Expected: **FAIL at compile time**, with an error like
+`Error: Error when reading 'lib/utils/space_permissions.dart': No such file or directory`.
+This is the correct red — the module does not exist yet. If it fails for any other reason, stop and
+investigate rather than proceeding.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `mobile/lib/utils/space_permissions.dart`:
+
+```dart
+import 'package:openapi/api.dart';
+
+/// Role predicates for shared spaces, shared by every surface that gates on them.
+///
+/// One implementation so the space detail page, the space bottom sheet and the
+/// link picker cannot drift apart. See the 2026-07-26 mobile Spaces UX design, §4.
+///
+/// `SharedSpaceResponseDto.members` is `Optional<List<...>?>` and `Absent.value`
+/// **throws** (`openapi/lib/optional.dart:67`), so every read goes through
+/// `orElse(null)` — the previously common `members.value ?? const []` crashes on a
+/// response that omits the list.
+/// The first matching row wins, which makes the duplicate-membership case
+/// deterministic. Written as an explicit loop rather than `.firstOrNull` so the
+/// file needs no `package:collection` import — Dart imports are not transitive,
+/// and this module deliberately imports only `openapi`.
+SharedSpaceRole? _roleOf(SharedSpaceResponseDto space, String currentUserId) {
+  final members = space.members.orElse(null) ?? const <SharedSpaceMemberResponseDto>[];
+  for (final member in members) {
+    if (member.userId == currentUserId) return member.role;
+  }
+  return null;
+}
+
+/// Whether [currentUserId] may add to, and edit the naming of, [space].
+///
+/// The creator short-circuit is deliberate and takes precedence over their member
+/// row: `getAll` does not guarantee the creator appears in `members`, so relying on
+/// the list alone would lock a space's own creator out of it.
+bool spaceIsWritable(SharedSpaceResponseDto space, String? currentUserId) {
+  if (currentUserId == null) return false;
+  if (space.createdById == currentUserId) return true;
+  return roleIsWritable(_roleOf(space, currentUserId));
+}
+
+/// Whether [currentUserId] owns [space] — the gate for destructive actions.
+bool spaceIsOwned(SharedSpaceResponseDto space, String? currentUserId) {
+  if (currentUserId == null) return false;
+  if (space.createdById == currentUserId) return true;
+  return _roleOf(space, currentUserId) == SharedSpaceRole.owner;
+}
+
+/// The role-only overload, for callers holding a resolved [SharedSpaceRole]
+/// rather than a whole DTO (e.g. `SpaceBottomSheet`).
+bool roleIsWritable(SharedSpaceRole? role) =>
+    role == SharedSpaceRole.owner || role == SharedSpaceRole.editor;
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd mobile && mise exec -- flutter test test/utils/space_permissions_test.dart`
+Expected: **PASS**, `+11` (10 in the first group, 1 in the second).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux
+git add mobile/lib/utils/space_permissions.dart mobile/test/utils/space_permissions_test.dart
+git commit -m "feat(mobile): add shared space permission helpers"
+```
+
+---
+
+### Task 2: Repoint `SpaceLinkPickerSheet`
+
+**Files:**
+
+- Modify: `mobile/lib/presentation/widgets/remote_album/space_link_picker.widget.dart:34-39`
+
+**Interfaces:**
+
+- Consumes: `spaceIsWritable` from Task 1.
+- Produces: nothing new.
+
+This is the crash fix. The current body is:
+
+```dart
+  static bool _canWrite(SharedSpaceResponseDto space, String? currentUserId) {
+    if (currentUserId == null) return false;
+    if (space.createdById == currentUserId) return true;
+    final role = (space.members.value ?? const []).where((m) => m.userId == currentUserId).firstOrNull?.role;
+    return role == SharedSpaceRole.owner || role == SharedSpaceRole.editor;
+  }
+```
+
+`space.members.value` throws when the field is absent, so the `?? const []` is dead code.
+
+- [ ] **Step 1: Delete `_canWrite` and call the helper**
+
+Remove the whole `static bool _canWrite(...) { ... }` block. In `build`, change the filter from
+`_canWrite(s, currentUserId)` to `spaceIsWritable(s, currentUserId)`.
+
+Add the import, keeping the file's existing alphabetical ordering:
+
+```dart
+import 'package:immich_mobile/utils/space_permissions.dart';
+```
+
+- [ ] **Step 2: Run the existing tests for this widget**
+
+Run: `cd mobile && mise exec -- flutter test test/presentation/widgets/remote_album/`
+Expected: **PASS**, unchanged from baseline. This widget's behaviour is identical except that an
+absent members list no longer throws.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/lib/presentation/widgets/remote_album/space_link_picker.widget.dart
+git commit -m "refactor(mobile): use shared space permission helper in link picker"
+```
+
+---
+
+### Task 3: Repoint `SpaceBottomSheet`
+
+**Files:**
+
+- Modify: `mobile/lib/presentation/widgets/bottom_sheet/space_bottom_sheet.widget.dart:38-39`
+
+**Interfaces:**
+
+- Consumes: `roleIsWritable` from Task 1. This caller holds a `SharedSpaceRole`, not a DTO, which is
+  exactly why Task 1 exports the role-only overload.
+
+The current body is:
+
+```dart
+  bool get _canEdit =>
+      widget.currentUserRole == SharedSpaceRole.owner || widget.currentUserRole == SharedSpaceRole.editor;
+```
+
+- [ ] **Step 1: Delegate to the helper**
+
+```dart
+  bool get _canEdit => roleIsWritable(widget.currentUserRole);
+```
+
+Add `import 'package:immich_mobile/utils/space_permissions.dart';`.
+
+- [ ] **Step 2: Run the existing tests for this widget**
+
+Run: `cd mobile && mise exec -- flutter test test/presentation/widgets/bottom_sheet/`
+Expected: **PASS**, unchanged. This is a pure like-for-like substitution.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/lib/presentation/widgets/bottom_sheet/space_bottom_sheet.widget.dart
+git commit -m "refactor(mobile): use shared space permission helper in space bottom sheet"
+```
+
+---
+
+### Task 4: Repoint `SpaceDetailPage` (behaviour change)
+
+**Files:**
+
+- Modify: `mobile/lib/pages/library/spaces/space_detail.page.dart:98-121`
+
+**Interfaces:**
+
+- Consumes: `spaceIsWritable`, `spaceIsOwned` from Task 1.
+
+**This task changes behaviour and that is intended.** The current getters read only the separately
+fetched `_members` list, with no creator short-circuit:
+
+```dart
+  SharedSpaceMemberResponseDto? get _currentMember {
+    final currentUser = ref.read(currentUserProvider);
+    if (currentUser == null || _members == null) return null;
+    return _members!.where((m) => m.userId == currentUser.id).firstOrNull;
+  }
+
+  bool get _isOwner {
+    final member = _currentMember;
+    if (member == null) return false;
+    return member.role == SharedSpaceRole.owner;
+  }
+
+  bool get _canEdit {
+    final member = _currentMember;
+    if (member == null) return false;
+    return member.role == SharedSpaceRole.owner || member.role == SharedSpaceRole.editor;
+  }
+```
+
+After this task a creator who is absent from `_members` is treated as owner, which is the correct
+reading and matches every other surface. The fail-closed loading default is **preserved**: while
+`_space` is null the helpers are not consulted at all.
+
+- [ ] **Step 1: Rewrite the two getters**
+
+Keep `_currentMember` and `_currentRole` as they are — `_currentRole` still feeds
+`SpaceBottomSheet(currentUserRole:)` and is not a permission decision. Replace only these two:
+
+```dart
+  bool get _isOwner {
+    final space = _space;
+    if (space == null) return false;
+    return spaceIsOwned(space, ref.read(currentUserProvider)?.id);
+  }
+
+  bool get _canEdit {
+    final space = _space;
+    if (space == null) return false;
+    return spaceIsWritable(space, ref.read(currentUserProvider)?.id);
+  }
+```
+
+Add `import 'package:immich_mobile/utils/space_permissions.dart';`.
+
+Note the source flips from `_members` to `_space`: the DTO returned by `get()` carries both
+`createdById` and `members`, so one object answers both questions and the creator short-circuit
+becomes reachable. `_members` remains in use by `_currentMember` / `_currentRole`.
+
+- [ ] **Step 2: Verify the whole suite still passes**
+
+Run: `cd mobile && mise exec -- flutter test`
+Expected: **PASS**. This page has no test of its own today (Slice 4 gives it one), so this run is
+guarding against collateral damage elsewhere. Expect `+2807` — the 2796 baseline plus Task 1's 11.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/lib/pages/library/spaces/space_detail.page.dart
+git commit -m "refactor(mobile): use shared space permission helpers on space detail page"
+```
+
+---
+
+### Task 5: Slice gates
+
+**Files:** none — verification only.
+
+- [ ] **Step 1: Confirm no stale copies of the predicate remain**
+
+Run:
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+grep -rn "SharedSpaceRole.owner || " lib/ ; echo "exit=$?"
+```
+
+Expected: **no matches** (`exit=1`). Every disjunction of that shape now lives in
+`space_permissions.dart`, which spells it `role == SharedSpaceRole.owner || role == SharedSpaceRole.editor`
+inside `roleIsWritable` — so if that one line is the sole match, that is correct; any _other_ match is
+a call site this slice missed.
+
+- [ ] **Step 2: Run both CI Dart gates**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+mise exec -- dart analyze --fatal-infos lib test
+mise exec -- dart format --set-exit-if-changed .
+```
+
+Expected: both exit 0. `dart analyze` must be run over `lib test` — `flutter analyze lib` alone
+misses test-only lints and is what CI would catch instead.
+
+- [ ] **Step 3: Run the full suite one final time**
+
+Run: `cd mobile && mise exec -- flutter test`
+Expected: `All tests passed!`, `+2807 ~1`.
+
+- [ ] **Step 4: Push**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux
+git push -u origin worktree-feat+mobile-spaces-ux
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage.** Slice 1 of the spec lists eleven behaviours; each maps to a test in Task 1:
+creator-not-in-members ✓, non-creator owner ✓, editor ✓, viewer ✓, non-member ✓, absent members ✓,
+present-null members ✓, duplicate rows ✓, null current user ✓, creator-vs-demoted precedence ✓,
+`roleIsWritable` ✓. The spec's Done-when requires all four call sites delegate (Tasks 2–4 cover
+three; the fourth is `space_detail.page.dart`'s _second_ getter, both handled in Task 4) and that the
+two behaviour changes are asserted as new — covered by the creator-not-in-members and
+creator-vs-demoted tests.
+
+**2. Placeholder scan.** No TBD/TODO. Every code step carries real code; every run step carries a
+real command and a concrete expected result.
+
+**3. Type consistency.** `spaceIsWritable` / `spaceIsOwned` take
+`(SharedSpaceResponseDto, String?)` and `roleIsWritable` takes `SharedSpaceRole?` in the test, the
+implementation, and all three call sites. `_membersOf` returns a non-nullable
+`List<SharedSpaceMemberResponseDto>`, which is what `.where(...).firstOrNull` needs.

--- a/docs/superpowers/plans/2026-07-26-mobile-spaces-ux-slice-2.md
+++ b/docs/superpowers/plans/2026-07-26-mobile-spaces-ux-slice-2.md
@@ -1,0 +1,368 @@
+# Mobile Spaces UX — Slice 2: `SharedSpaceApiRepository.update` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give mobile its first ability to write a space's name, description and colour, with
+`Optional` semantics that cannot silently clobber unrelated fields.
+
+**Architecture:** One new method on the existing `SharedSpaceApiRepository`, built on the already
+generated `updateSpace` / `SharedSpaceUpdateDto`. No provider, no UI, no server change — Slice 3
+consumes it. Tests extend the repository's existing 512-line suite.
+
+**Tech Stack:** Dart 3.12.1 / Flutter 3.44.1, `mocktail`, the generated `openapi` package.
+
+**Spec:** `docs/superpowers/specs/2026-07-26-mobile-spaces-ux-design.md` §7 and Slice 2.
+
+## Global Constraints
+
+- Run every command from `mobile/` via `mise exec -- <cmd>`. The pin is **Flutter 3.44.1 / Dart
+  3.12.1** and is directory-scoped to `mobile/mise.toml`; a bare `flutter`/`dart`, or the mise shims
+  on PATH, gives 3.41.9 / Dart 3.11.5 and dies with "requires SDK version >=3.12.0".
+- **The format gate is `lib`-only and excludes generated files.** Reproduce CI exactly — and note
+  **zsh does not word-split `$(...)`, so it must run under `bash -c`**:
+  ```bash
+  cd mobile && mise exec -- bash -c 'dart format --output=none --set-exit-if-changed $(find lib -name "*.dart" -not \( -name "*.g.dart" -o -name "*.drift.dart" -o -name "*.gr.dart" \))'
+  ```
+  Never run bare `dart format .` — it rewrites ~545 files across `openapi/`, `pigeon/` and `test/`.
+  `--output=none` makes it a check rather than a rewrite.
+- The analyze gate is `mise exec -- dart analyze --fatal-infos` run from `mobile/` (whole package,
+  including `test/`).
+- **Never** read `Optional.value` on a possibly-absent field — `Absent.value` throws `StateError`.
+- `Optional.present(null)` is a **400**, not a field-clear: `name`, `description` and `color` are
+  `.optional()` but **not** `.nullable()` server-side. Only absent-vs-present is meaningful.
+- Baseline after Slice 1 is **2807 passing, 1 skipped**.
+- No new i18n keys in this slice.
+
+## File Structure
+
+| File                                                                        | Responsibility                               |
+| --------------------------------------------------------------------------- | -------------------------------------------- |
+| `mobile/lib/repositories/shared_space_api.repository.dart` (modify)         | Add `update`, next to the existing `create`. |
+| `mobile/test/modules/spaces/shared_space_api_repository_test.dart` (modify) | Add an `update` group.                       |
+
+Do **not** create `mobile/test/repositories/shared_space_api_repository_test.dart` — the suite for
+this class already exists at the path above, with `MockSharedSpacesApi`, `MockApiService` and a
+`setUpAll` block of `registerFallbackValue` calls.
+
+---
+
+### Task 1: `update` on the repository
+
+**Files:**
+
+- Modify: `mobile/lib/repositories/shared_space_api.repository.dart` (add after `create`, ~line 37)
+- Test: `mobile/test/modules/spaces/shared_space_api_repository_test.dart`
+
+**Interfaces:**
+
+- Consumes: `checkNull` from the existing `ApiRepository` base class, already used by every sibling
+  method in this file (e.g. `create` at line 35).
+- Produces, relied on by Slice 3:
+
+  ```dart
+  Future<SharedSpaceResponseDto> update(
+    String id, {
+    String? name,
+    String? description,
+    UserAvatarColor? color,
+  })
+  ```
+
+  **Calling convention, which Slice 3 depends on:** a `null` argument means _absent_ (leave the
+  field untouched); a non-null argument means _send this value_. Passing `description: ''` therefore
+  clears the description, while passing `description: null` leaves it alone. This is how the caller
+  expresses "only send what changed".
+
+- [ ] **Step 1: Register the DTO fallback**
+
+In the existing `setUpAll` block (around line 28-39), add one line alongside the others:
+
+```dart
+    registerFallbackValue(api.SharedSpaceUpdateDto());
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append this group to `mobile/test/modules/spaces/shared_space_api_repository_test.dart`, before the
+final closing `}` of `main()`. It follows the file's existing style: `any(that: isA<...>().having(...))`
+for payload assertions, as used by the `updateSpacePerson` group.
+
+```dart
+  group('update', () {
+    api.SharedSpaceResponseDto updatedSpace() => api.SharedSpaceResponseDto(
+      id: 'space-1',
+      name: 'Renamed',
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-02T00:00:00Z',
+      createdById: 'user-1',
+    );
+
+    /// Asserts on the DTO handed to the generated client.
+    Matcher dtoThat(bool Function(api.SharedSpaceUpdateDto dto) predicate, String description) =>
+        isA<api.SharedSpaceUpdateDto>().having(predicate, description, isTrue);
+
+    test('sends only the name when only the name changed', () async {
+      when(() => mockApi.updateSpace('space-1', any())).thenAnswer((_) async => updatedSpace());
+
+      await repository.update('space-1', name: 'Renamed');
+
+      verify(
+        () => mockApi.updateSpace(
+          'space-1',
+          any(
+            that: dtoThat(
+              (d) =>
+                  d.name.isPresent &&
+                  d.name.value == 'Renamed' &&
+                  d.description.isEmpty &&
+                  d.color.isEmpty,
+              'name present, description and color absent',
+            ),
+          ),
+        ),
+      ).called(1);
+    });
+
+    test('sends an empty description verbatim so it clears server-side', () async {
+      when(() => mockApi.updateSpace('space-1', any())).thenAnswer((_) async => updatedSpace());
+
+      await repository.update('space-1', name: 'Renamed', description: '');
+
+      verify(
+        () => mockApi.updateSpace(
+          'space-1',
+          any(
+            that: dtoThat(
+              (d) => d.description.isPresent && d.description.value == '',
+              'description present and empty',
+            ),
+          ),
+        ),
+      ).called(1);
+    });
+
+    test('sends a newly added description', () async {
+      when(() => mockApi.updateSpace('space-1', any())).thenAnswer((_) async => updatedSpace());
+
+      await repository.update('space-1', description: 'Holiday photos');
+
+      verify(
+        () => mockApi.updateSpace(
+          'space-1',
+          any(
+            that: dtoThat(
+              (d) => d.description.isPresent && d.description.value == 'Holiday photos',
+              'description present',
+            ),
+          ),
+        ),
+      ).called(1);
+    });
+
+    test('omits description entirely when it is not passed', () async {
+      when(() => mockApi.updateSpace('space-1', any())).thenAnswer((_) async => updatedSpace());
+
+      await repository.update('space-1', name: 'Renamed');
+
+      verify(
+        () => mockApi.updateSpace(
+          'space-1',
+          any(
+            that: dtoThat(
+              // Absent, NOT Optional.present(null) -- the latter is a 400, because the
+              // server schema is .optional() but not .nullable().
+              (d) => d.description.isEmpty,
+              'description absent',
+            ),
+          ),
+        ),
+      ).called(1);
+    });
+
+    test('sends the colour when it changed', () async {
+      when(() => mockApi.updateSpace('space-1', any())).thenAnswer((_) async => updatedSpace());
+
+      await repository.update('space-1', color: api.UserAvatarColor.amber);
+
+      verify(
+        () => mockApi.updateSpace(
+          'space-1',
+          any(
+            that: dtoThat(
+              (d) => d.color.isPresent && d.color.value == api.UserAvatarColor.amber,
+              'color present',
+            ),
+          ),
+        ),
+      ).called(1);
+    });
+
+    test('never populates the four fields this feature does not own', () async {
+      // A stray Optional.present(false) on faceRecognitionEnabled would silently
+      // disable face recognition for the whole space on every rename.
+      when(() => mockApi.updateSpace('space-1', any())).thenAnswer((_) async => updatedSpace());
+
+      await repository.update('space-1', name: 'Renamed', description: 'x', color: api.UserAvatarColor.red);
+
+      verify(
+        () => mockApi.updateSpace(
+          'space-1',
+          any(
+            that: dtoThat(
+              (d) =>
+                  d.faceRecognitionEnabled.isEmpty &&
+                  d.petsEnabled.isEmpty &&
+                  d.thumbnailAssetId.isEmpty &&
+                  d.thumbnailCropY.isEmpty,
+              'untouched fields all absent',
+            ),
+          ),
+        ),
+      ).called(1);
+    });
+
+    test('trims the name but not the description', () async {
+      when(() => mockApi.updateSpace('space-1', any())).thenAnswer((_) async => updatedSpace());
+
+      await repository.update('space-1', name: '  Renamed  ', description: '  keep me  ');
+
+      verify(
+        () => mockApi.updateSpace(
+          'space-1',
+          any(
+            that: dtoThat(
+              (d) => d.name.value == 'Renamed' && d.description.value == '  keep me  ',
+              'name trimmed, description verbatim',
+            ),
+          ),
+        ),
+      ).called(1);
+    });
+
+    test('returns the updated space', () async {
+      when(() => mockApi.updateSpace('space-1', any())).thenAnswer((_) async => updatedSpace());
+
+      final result = await repository.update('space-1', name: 'Renamed');
+
+      expect(result.name, 'Renamed');
+    });
+
+    test('throws when the API returns null', () async {
+      when(() => mockApi.updateSpace(any(), any())).thenAnswer((_) async => null);
+
+      expect(() => repository.update('space-1', name: 'Renamed'), throwsA(isA<Exception>()));
+    });
+
+    test('propagates an API failure unchanged', () async {
+      when(() => mockApi.updateSpace(any(), any())).thenThrow(Exception('boom'));
+
+      expect(() => repository.update('space-1', name: 'Renamed'), throwsA(isA<Exception>()));
+    });
+  });
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run:
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+mise exec -- flutter test test/modules/spaces/shared_space_api_repository_test.dart
+```
+
+Expected: **FAIL at compile time** with
+`Error: The method 'update' isn't defined for the class 'SharedSpaceApiRepository'`.
+That is the correct red. If it fails for any other reason, stop and investigate.
+
+- [ ] **Step 4: Write the minimal implementation**
+
+In `mobile/lib/repositories/shared_space_api.repository.dart`, add directly after the existing
+`create` method:
+
+```dart
+  /// Update a space's name, description and/or colour (PATCH /shared-spaces/{id}).
+  ///
+  /// A `null` argument means **absent** — the field is left untouched. A non-null
+  /// argument is sent verbatim, so `description: ''` clears the description while
+  /// `description: null` leaves the existing text alone. That distinction is how a
+  /// pure rename avoids clobbering a description it never showed the user.
+  ///
+  /// Never sends `Optional.present(null)`: `name`, `description` and `color` are
+  /// `.optional()` but not `.nullable()` server-side, so an explicit null is a 400
+  /// rather than a field-clear. The four fields this feature does not own
+  /// (faceRecognitionEnabled, petsEnabled, thumbnailAssetId, thumbnailCropY) are
+  /// left at their `Optional.absent()` defaults.
+  ///
+  /// Naming and appearance are editor-level server-side; the role is enforced there.
+  Future<SharedSpaceResponseDto> update(
+    String id, {
+    String? name,
+    String? description,
+    UserAvatarColor? color,
+  }) async {
+    final dto = SharedSpaceUpdateDto(
+      name: name == null ? const Optional.absent() : Optional.present(name.trim()),
+      description: description == null ? const Optional.absent() : Optional.present(description),
+      color: color == null ? const Optional.absent() : Optional.present(color),
+    );
+    return await checkNull(_api.updateSpace(id, dto));
+  }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run:
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+mise exec -- flutter test test/modules/spaces/shared_space_api_repository_test.dart
+```
+
+Expected: **PASS**, `+38` (the existing 28 plus these 10).
+
+- [ ] **Step 6: Run the slice gates**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+mise exec -- bash -c 'dart format --output=none --set-exit-if-changed $(find lib -name "*.dart" -not \( -name "*.g.dart" -o -name "*.drift.dart" -o -name "*.gr.dart" \))'
+echo "FORMAT_EXIT=$?"
+mise exec -- dart analyze --fatal-infos
+echo "ANALYZE_EXIT=$?"
+mise exec -- flutter test > /tmp/slice2-test.log 2>&1
+echo "TEST_EXIT=$?"; tail -2 /tmp/slice2-test.log
+```
+
+Expected: `FORMAT_EXIT=0`, `ANALYZE_EXIT=0`, `TEST_EXIT=0`, and `+2817 ~1 All tests passed!`.
+
+If the format gate reports a file, fix it with `mise exec -- dart format <that file>` and re-run —
+do not reformat the tree.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux
+git add mobile/lib/repositories/shared_space_api.repository.dart \
+        mobile/test/modules/spaces/shared_space_api_repository_test.dart
+git commit -m "feat(mobile): add space update to the shared space repository"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage.** Slice 2 of the spec lists nine behaviours. Mapping: name-only ✓; description
+`''` ✓; description null→text ✓; description omitted ⇒ absent ✓; the four untouched fields absent ✓;
+name trimmed / description not ✓; null return throws ✓; API error propagates ✓. The ninth — lazy
+`_api` resolution — the spec explicitly marks as already covered by the file's existing
+`lazy SharedSpacesApi resolution` group, so no new test. The `returns the updated space` test is an
+extra beyond the spec, justified because Slice 3 closes its sheet on that return value.
+
+**2. Placeholder scan.** No TBD/TODO. Every step has real code or a real command with a concrete
+expected result.
+
+**3. Type consistency.** `update` returns `Future<SharedSpaceResponseDto>` (non-nullable, via
+`checkNull`) while the generated `updateSpace` returns `SharedSpaceResponseDto?` — `checkNull` is
+what bridges them, exactly as `create` does. `color` is `UserAvatarColor`, matching
+`Optional<UserAvatarColor?> color` on the DTO. The test file prefixes openapi types with `api.`
+throughout, matching its existing `import 'package:openapi/api.dart' as api;`; the library file does
+not, matching its unprefixed import.

--- a/docs/superpowers/plans/2026-07-26-mobile-spaces-ux-slice-3.md
+++ b/docs/superpowers/plans/2026-07-26-mobile-spaces-ux-slice-3.md
@@ -1,0 +1,620 @@
+# Mobile Spaces UX — Slice 3: `SpaceEditSheet` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A role-agnostic bottom sheet that edits a space's name, description and colour, fully
+covered by widget tests, not yet reachable from any screen.
+
+**Architecture:** A `ConsumerStatefulWidget` that takes the space and an `onClose(bool?)` callback,
+plus a static `show()` that wraps it in `showModalBottomSheet`. The callback — rather than an
+internal `Navigator.pop` — is what makes the sheet testable without routing, and mirrors how web's
+modals are structured. It calls Slice 2's `SharedSpaceApiRepository.update`.
+
+**Tech Stack:** Dart 3.12.1 / Flutter 3.44.1, `hooks_riverpod`, `mocktail`, `flutter_test`.
+
+**Spec:** `docs/superpowers/specs/2026-07-26-mobile-spaces-ux-design.md` §6 and Slice 3.
+
+## Global Constraints
+
+- Run every command from `mobile/` via `mise exec -- <cmd>`. The pin is **Flutter 3.44.1 / Dart
+  3.12.1**, directory-scoped to `mobile/mise.toml`. A bare `flutter`/`dart` or the mise shims give
+  3.41.9 / Dart 3.11.5 and die with "requires SDK version >=3.12.0".
+- **The format gate is `lib`-only, excludes generated files, and must run under `bash -c`** (zsh does
+  not word-split `$(...)`):
+  ```bash
+  cd mobile && mise exec -- bash -c 'dart format --output=none --set-exit-if-changed $(find lib -name "*.dart" -not \( -name "*.g.dart" -o -name "*.drift.dart" -o -name "*.gr.dart" \))'
+  ```
+  Never run bare `dart format .` — it rewrites ~545 unrelated files. If the gate names a file, fix
+  just that file with `mise exec -- dart format <file>`.
+  **Expect this to fire**: `dart format` reflows any signature that fits in 120 chars onto one line,
+  so the multi-line signatures pasted below will very likely be collapsed. That is normal.
+- Analyze gate: `mise exec -- dart analyze --fatal-infos` from `mobile/` (covers `test/` too).
+- Capture exit codes on the line _after_ the command (`echo "EXIT=$?"`), never after a pipe to
+  `tail` — in zsh that reports `tail`'s status.
+- Baseline after Slice 2 is **2817 passing, 1 skipped**.
+- **No new i18n keys.** Every key used here already exists: `spaces_edit`, `spaces_edit_success`,
+  `errors.unable_to_update_space`, `name`, `description`, `color`, `cancel`, `save`.
+- Existing tests use `find.text('English literal')`; follow that, do not assert on key names.
+
+## File Structure
+
+| File                                                                           | Responsibility                                   |
+| ------------------------------------------------------------------------------ | ------------------------------------------------ |
+| `mobile/lib/presentation/widgets/spaces/space_edit_sheet.widget.dart` (create) | The form, its validation, and the `show` static. |
+| `mobile/test/presentation/widgets/spaces/space_edit_sheet_test.dart` (create)  | 14 behaviour tests.                              |
+
+---
+
+### Task 1: The edit sheet
+
+**Files:**
+
+- Create: `mobile/lib/presentation/widgets/spaces/space_edit_sheet.widget.dart`
+- Test: `mobile/test/presentation/widgets/spaces/space_edit_sheet_test.dart`
+
+**Interfaces:**
+
+- Consumes: `SharedSpaceApiRepository.update(id, {name, description, color})` and
+  `sharedSpaceApiRepositoryProvider`, both from Slice 2. Recall the calling convention: a `null`
+  argument means _absent_, `''` means _clear_.
+- Produces, relied on by Slice 4:
+
+  ```dart
+  class SpaceEditSheet extends ConsumerStatefulWidget {
+    const SpaceEditSheet({super.key, required this.space, required this.onClose});
+    final SharedSpaceResponseDto space;
+    final void Function(bool? saved) onClose;
+
+    static Future<bool?> show(BuildContext context, SharedSpaceResponseDto space);
+  }
+  ```
+
+  `onClose(true)` = saved, `onClose(null)` = cancelled. `show` returns the same.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `mobile/test/presentation/widgets/spaces/space_edit_sheet_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/presentation/widgets/spaces/space_edit_sheet.widget.dart';
+import 'package:immich_mobile/repositories/shared_space_api.repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openapi/api.dart';
+
+import '../../../widget_tester_extensions.dart';
+
+class MockSharedSpaceApiRepository extends Mock implements SharedSpaceApiRepository {}
+
+void main() {
+  late MockSharedSpaceApiRepository repo;
+
+  SharedSpaceResponseDto space({
+    String name = 'Family Photos',
+    Optional<String?> description = const Optional.present('Our shared album'),
+    Optional<UserAvatarColor?> color = const Optional.present(UserAvatarColor.blue),
+  }) => SharedSpaceResponseDto(
+    id: 'space-1',
+    name: name,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    createdById: 'user-1',
+    description: description,
+    color: color,
+  );
+
+  SharedSpaceResponseDto saved() => SharedSpaceResponseDto(
+    id: 'space-1',
+    name: 'Saved',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-02T00:00:00Z',
+    createdById: 'user-1',
+  );
+
+  /// Pumps the sheet and records every onClose call.
+  Future<List<bool?>> pumpSheet(WidgetTester tester, {SharedSpaceResponseDto? withSpace}) async {
+    final closes = <bool?>[];
+    await tester.pumpConsumerWidget(
+      SpaceEditSheet(space: withSpace ?? space(), onClose: closes.add),
+      overrides: [sharedSpaceApiRepositoryProvider.overrideWithValue(repo)],
+    );
+    return closes;
+  }
+
+  Finder nameField() => find.byKey(const Key('space-edit-name'));
+  Finder descriptionField() => find.byKey(const Key('space-edit-description'));
+  Finder saveButton() => find.byKey(const Key('space-edit-save'));
+
+  bool saveEnabled(WidgetTester tester) => tester.widget<FilledButton>(saveButton()).onPressed != null;
+
+  setUpAll(() {
+    registerFallbackValue(UserAvatarColor.primary);
+  });
+
+  setUp(() {
+    repo = MockSharedSpaceApiRepository();
+    when(
+      () => repo.update(any(), name: any(named: 'name'), description: any(named: 'description'), color: any(named: 'color')),
+    ).thenAnswer((_) async => saved());
+  });
+
+  testWidgets('prefills name, description and colour from the space', (tester) async {
+    await pumpSheet(tester);
+
+    expect(tester.widget<TextField>(nameField()).controller!.text, 'Family Photos');
+    expect(tester.widget<TextField>(descriptionField()).controller!.text, 'Our shared album');
+    expect(find.byKey(const Key('space-edit-color-blue-selected')), findsOneWidget);
+  });
+
+  testWidgets('defaults to the primary swatch when the space has no colour', (tester) async {
+    await pumpSheet(tester, withSpace: space(color: const Optional.absent()));
+
+    expect(find.byKey(const Key('space-edit-color-primary-selected')), findsOneWidget);
+  });
+
+  testWidgets('disables save for an empty name', (tester) async {
+    await pumpSheet(tester);
+
+    await tester.enterText(nameField(), '');
+    await tester.pump();
+
+    expect(saveEnabled(tester), isFalse);
+  });
+
+  testWidgets('disables save for a whitespace-only name', (tester) async {
+    await pumpSheet(tester);
+
+    await tester.enterText(nameField(), '   ');
+    await tester.pump();
+
+    expect(saveEnabled(tester), isFalse, reason: 'a required flag alone would let "   " through');
+  });
+
+  testWidgets('focuses the name with its text selected on open, and does not reselect on a later tap', (tester) async {
+    await pumpSheet(tester);
+
+    final controller = tester.widget<TextField>(nameField()).controller!;
+    expect(controller.selection.baseOffset, 0);
+    expect(controller.selection.extentOffset, 'Family Photos'.length);
+
+    // Simulate the user placing the caret mid-word, then the field regaining focus.
+    controller.selection = const TextSelection.collapsed(offset: 3);
+    await tester.tap(nameField());
+    await tester.pump();
+
+    expect(controller.selection, const TextSelection.collapsed(offset: 3), reason: 'select-once only');
+  });
+
+  testWidgets('caps the name at 100 and the description at 500 characters', (tester) async {
+    await pumpSheet(tester);
+
+    await tester.enterText(nameField(), 'x' * 150);
+    await tester.enterText(descriptionField(), 'y' * 600);
+    await tester.pump();
+
+    expect(tester.widget<TextField>(nameField()).controller!.text.length, 100);
+    expect(tester.widget<TextField>(descriptionField()).controller!.text.length, 500);
+  });
+
+  testWidgets('renders an over-long existing name in full and keeps save enabled', (tester) async {
+    // Truncating a name the user already has would be data loss.
+    await pumpSheet(tester, withSpace: space(name: 'z' * 120));
+
+    expect(tester.widget<TextField>(nameField()).controller!.text.length, 120);
+    expect(saveEnabled(tester), isTrue);
+  });
+
+  testWidgets('sends no description when only the name changed', (tester) async {
+    await pumpSheet(tester);
+
+    await tester.enterText(nameField(), 'Renamed');
+    await tester.pump();
+    await tester.tap(saveButton());
+    await tester.pumpAndSettle();
+
+    verify(() => repo.update('space-1', name: 'Renamed', description: null, color: UserAvatarColor.blue)).called(1);
+  });
+
+  testWidgets('sends an empty description when the user cleared it', (tester) async {
+    await pumpSheet(tester);
+
+    await tester.enterText(descriptionField(), '');
+    await tester.pump();
+    await tester.tap(saveButton());
+    await tester.pumpAndSettle();
+
+    verify(
+      () => repo.update('space-1', name: 'Family Photos', description: '', color: UserAvatarColor.blue),
+    ).called(1);
+  });
+
+  testWidgets('saving with nothing edited sends absent name-only fields and still closes', (tester) async {
+    final closes = await pumpSheet(tester);
+
+    await tester.tap(saveButton());
+    await tester.pumpAndSettle();
+
+    verify(
+      () => repo.update('space-1', name: 'Family Photos', description: null, color: UserAvatarColor.blue),
+    ).called(1);
+    expect(closes, [true], reason: 'a no-op save is not an error');
+  });
+
+  testWidgets('sends the chosen colour', (tester) async {
+    await pumpSheet(tester);
+
+    await tester.tap(find.byKey(const Key('space-edit-color-amber')));
+    await tester.pump();
+    await tester.tap(saveButton());
+    await tester.pumpAndSettle();
+
+    verify(
+      () => repo.update('space-1', name: 'Family Photos', description: null, color: UserAvatarColor.amber),
+    ).called(1);
+  });
+
+  testWidgets('a double-tap on save issues exactly one request', (tester) async {
+    final completer = Completer<SharedSpaceResponseDto>();
+    when(
+      () => repo.update(any(), name: any(named: 'name'), description: any(named: 'description'), color: any(named: 'color')),
+    ).thenAnswer((_) => completer.future);
+
+    await pumpSheet(tester);
+
+    await tester.tap(saveButton());
+    await tester.pump();
+    await tester.tap(saveButton(), warnIfMissed: false);
+    await tester.pump();
+
+    completer.complete(saved());
+    await tester.pumpAndSettle();
+
+    verify(
+      () => repo.update(any(), name: any(named: 'name'), description: any(named: 'description'), color: any(named: 'color')),
+    ).called(1);
+  });
+
+  testWidgets('resolves true on success and null on cancel', (tester) async {
+    final closes = await pumpSheet(tester);
+
+    await tester.tap(saveButton());
+    await tester.pumpAndSettle();
+    expect(closes, [true]);
+
+    final cancels = await pumpSheet(tester);
+    await tester.tap(find.byKey(const Key('space-edit-cancel')));
+    await tester.pumpAndSettle();
+    expect(cancels, [null]);
+    verifyNever(() => repo.update('space-2', name: any(named: 'name')));
+  });
+
+  testWidgets('stays open and does not resolve when the save fails', (tester) async {
+    when(
+      () => repo.update(any(), name: any(named: 'name'), description: any(named: 'description'), color: any(named: 'color')),
+    ).thenThrow(Exception('403'));
+
+    final closes = await pumpSheet(tester);
+
+    await tester.tap(saveButton());
+    await tester.pumpAndSettle();
+
+    expect(closes, isEmpty, reason: 'a revoked role must not look like a successful save');
+    expect(nameField(), findsOneWidget);
+    expect(saveEnabled(tester), isTrue, reason: 'the in-flight guard must be released so the user can retry');
+  });
+
+  testWidgets('every colour swatch is labelled and meets the minimum tap target', (tester) async {
+    await pumpSheet(tester);
+
+    for (final color in UserAvatarColor.values) {
+      final swatch = find.byKey(Key('space-edit-color-${color.value}'));
+      expect(swatch, findsOneWidget, reason: '${color.value} swatch');
+      expect(
+        find.descendant(of: swatch, matching: find.bySemanticsLabel(color.value)),
+        findsOneWidget,
+        reason: '${color.value} needs a semantics label -- colour alone is invisible to a screen reader',
+      );
+      expectTapTargetMin(tester, swatch);
+    }
+  });
+}
+```
+
+Add `import 'dart:async';` at the top for `Completer`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+mise exec -- flutter test test/presentation/widgets/spaces/space_edit_sheet_test.dart
+```
+
+Expected: **FAIL at compile time** —
+`Error: Error when reading 'lib/presentation/widgets/spaces/space_edit_sheet.widget.dart': No such file or directory`.
+If it fails for any other reason, stop and report.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `mobile/lib/presentation/widgets/spaces/space_edit_sheet.widget.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/extensions/translate_extensions.dart';
+import 'package:immich_mobile/repositories/shared_space_api.repository.dart';
+import 'package:immich_mobile/widgets/common/immich_toast.dart';
+import 'package:immich_mobile/widgets/spaces/space_collage.dart';
+import 'package:openapi/api.dart';
+
+/// Edit a space's name, description and colour.
+///
+/// Naming and appearance are editor-level server-side, so this sheet is gated by
+/// its callers (Slice 4), not by itself.
+///
+/// Takes an [onClose] callback rather than calling `Navigator.pop` directly: that
+/// keeps the sheet independent of routing so it can be widget-tested by pumping it
+/// alone, and mirrors the web `SpaceEditModal` shape. [SpaceEditSheet.show] supplies
+/// the popping implementation.
+class SpaceEditSheet extends ConsumerStatefulWidget {
+  const SpaceEditSheet({super.key, required this.space, required this.onClose});
+
+  final SharedSpaceResponseDto space;
+
+  /// `true` when the space was saved, `null` when the user cancelled.
+  final void Function(bool? saved) onClose;
+
+  static Future<bool?> show(BuildContext context, SharedSpaceResponseDto space) {
+    return showModalBottomSheet<bool>(
+      context: context,
+      isScrollControlled: true,
+      builder: (sheetContext) => SpaceEditSheet(
+        space: space,
+        onClose: (saved) => Navigator.of(sheetContext).pop(saved),
+      ),
+    );
+  }
+
+  @override
+  ConsumerState<SpaceEditSheet> createState() => _SpaceEditSheetState();
+}
+
+class _SpaceEditSheetState extends ConsumerState<SpaceEditSheet> {
+  late final TextEditingController _nameController;
+  late final TextEditingController _descriptionController;
+  late final FocusNode _nameFocusNode;
+  late final String _originalDescription;
+  late UserAvatarColor _color;
+
+  bool _isSaving = false;
+
+  /// Renaming is the dominant path, so the name arrives pre-selected and typing
+  /// replaces it -- but only on the FIRST focus, otherwise tapping to place the
+  /// caret mid-word would keep re-selecting the whole value.
+  bool _hasSelectedName = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _originalDescription = widget.space.description.orElse(null) ?? '';
+    _nameController = TextEditingController(text: widget.space.name)
+      ..selection = TextSelection(baseOffset: 0, extentOffset: widget.space.name.length);
+    _descriptionController = TextEditingController(text: _originalDescription);
+    _color = widget.space.color.orElse(null) ?? UserAvatarColor.primary;
+    _hasSelectedName = true;
+    _nameFocusNode = FocusNode();
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _descriptionController.dispose();
+    _nameFocusNode.dispose();
+    super.dispose();
+  }
+
+  bool get _canSave => _nameController.text.trim().isNotEmpty && !_isSaving;
+
+  Future<void> _save() async {
+    if (!_canSave) return;
+    setState(() => _isSaving = true);
+
+    final description = _descriptionController.text;
+    try {
+      await ref
+          .read(sharedSpaceApiRepositoryProvider)
+          .update(
+            widget.space.id,
+            name: _nameController.text,
+            // Only send the description when it actually changed. A space created
+            // without one stores null server-side, so always sending '' would clobber
+            // it on a pure rename; but when the user DID clear it, '' must go through.
+            description: description == _originalDescription ? null : description,
+            color: _color,
+          );
+      if (!mounted) return;
+      ImmichToast.show(context: context, msg: 'spaces_edit_success'.t(context: context), toastType: ToastType.success);
+      widget.onClose(true);
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _isSaving = false);
+      ImmichToast.show(
+        context: context,
+        msg: 'errors.unable_to_update_space'.t(context: context),
+        toastType: ToastType.error,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.only(
+          left: 16,
+          right: 16,
+          top: 16,
+          bottom: MediaQuery.of(context).viewInsets.bottom + 16,
+        ),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('spaces_edit'.t(context: context), style: context.textTheme.titleMedium),
+              const SizedBox(height: 16),
+              TextField(
+                key: const Key('space-edit-name'),
+                controller: _nameController,
+                focusNode: _nameFocusNode,
+                autofocus: true,
+                maxLength: 100,
+                decoration: InputDecoration(labelText: 'name'.t(context: context)),
+                onChanged: (_) => setState(() {}),
+              ),
+              const SizedBox(height: 8),
+              TextField(
+                key: const Key('space-edit-description'),
+                controller: _descriptionController,
+                maxLength: 500,
+                maxLines: 3,
+                minLines: 1,
+                decoration: InputDecoration(labelText: 'description'.t(context: context)),
+              ),
+              const SizedBox(height: 8),
+              Text('color'.t(context: context), style: context.textTheme.labelLarge),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [for (final color in UserAvatarColor.values) _swatch(color)],
+              ),
+              const SizedBox(height: 16),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    key: const Key('space-edit-cancel'),
+                    onPressed: _isSaving ? null : () => widget.onClose(null),
+                    child: Text('cancel'.t(context: context)),
+                  ),
+                  const SizedBox(width: 8),
+                  FilledButton(
+                    key: const Key('space-edit-save'),
+                    onPressed: _canSave ? _save : null,
+                    child: Text('save'.t(context: context)),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _swatch(UserAvatarColor color) {
+    final selected = color == _color;
+    // Colour alone conveys nothing to a screen reader, so each swatch is labelled.
+    return Semantics(
+      label: color.value,
+      selected: selected,
+      button: true,
+      child: InkWell(
+        key: Key('space-edit-color-${color.value}'),
+        onTap: () => setState(() => _color = color),
+        child: SizedBox(
+          width: 48,
+          height: 48,
+          child: Center(
+            child: Container(
+              key: selected ? Key('space-edit-color-${color.value}-selected') : null,
+              width: 32,
+              height: 32,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: spaceGradientColors(color).first,
+                border: selected ? Border.all(color: context.colorScheme.onSurface, width: 3) : null,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+mise exec -- flutter test test/presentation/widgets/spaces/space_edit_sheet_test.dart
+```
+
+Expected: **PASS**, `+14`.
+
+If a test fails, fix the **implementation**, not the test — the tests encode the spec.
+
+These were verified before the plan was written, so do not re-check them and do not "fix" them by
+adding i18n keys (this slice must not touch `i18n/`):
+
+- `cancel` (`i18n/en.json:808`) and `save` (`:2402`) both exist.
+- `spaceGradientColors(UserAvatarColor?) -> List<Color>` lives in
+  `package:immich_mobile/widgets/spaces/space_collage.dart`.
+- `UserAvatarColor.values` is a `static const` list and `.value` is the lowercase `String` name, so
+  the `space-edit-color-${color.value}` keys resolve to e.g. `space-edit-color-blue`.
+
+The likeliest real failure is the select-once assertion: `autofocus: true` plus a controller
+selection set in `initState` can be clobbered when the field first gains focus. If so, keep the test
+as written and fix the widget — e.g. re-apply the selection in a post-frame callback guarded by
+`_hasSelectedName`.
+
+- [ ] **Step 5: Run the slice gates**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+mise exec -- bash -c 'dart format --output=none --set-exit-if-changed $(find lib -name "*.dart" -not \( -name "*.g.dart" -o -name "*.drift.dart" -o -name "*.gr.dart" \))'
+echo "FORMAT_EXIT=$?"
+mise exec -- dart analyze --fatal-infos
+echo "ANALYZE_EXIT=$?"
+mise exec -- flutter test > /tmp/slice3-test.log 2>&1
+echo "TEST_EXIT=$?"; tail -2 /tmp/slice3-test.log
+```
+
+Expected: all three `0`, and `+2831 ~1 All tests passed!`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux
+git add mobile/lib/presentation/widgets/spaces/space_edit_sheet.widget.dart \
+        mobile/test/presentation/widgets/spaces/space_edit_sheet_test.dart
+git commit -m "feat(mobile): add the space edit sheet"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage.** Slice 3 of the spec lists 14 behaviours; each has a test: prefill ✓, absent
+colour defaults to primary ✓, empty name ✓, whitespace name ✓, select-once ✓, maxLength caps ✓,
+over-long prefill ✓, name-only omits description ✓, cleared description sends `''` ✓, no-op save ✓,
+colour ✓, double-tap ✓, resolves true/null ✓, failure keeps it open ✓, semantics + tap target ✓.
+
+The spec's "dismissed while a save is in flight ⇒ no pop or toast, nothing throws" is covered by
+implementation (`if (!mounted) return` after every await) but has no test — pumping a dismissal
+mid-future requires the routed `show()` path rather than the bare widget, which belongs to Slice 4
+where the sheet is actually pushed. **Flagged deliberately, not forgotten**; Slice 4's plan must add
+it.
+
+**2. Placeholder scan.** No TBD/TODO. Step 4 names the two plausible failure modes with the exact
+command to diagnose the first, rather than saying "fix any issues".
+
+**3. Type consistency.** `onClose` is `void Function(bool?)` in the class, the test spy
+(`closes.add` over `List<bool?>`) and `show`. `update` is called with named `name` / `description` /
+`color` exactly as Slice 2 defined, and the test's `verify` uses the same names. `_color` is a
+non-nullable `UserAvatarColor`, so `color:` is never null — matching the tests, which always expect a
+concrete colour.

--- a/docs/superpowers/plans/2026-07-26-mobile-spaces-ux-slice-4.md
+++ b/docs/superpowers/plans/2026-07-26-mobile-spaces-ux-slice-4.md
@@ -1,0 +1,621 @@
+# Mobile Spaces UX — Slice 4: kebab extraction and entry points
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `SpaceEditSheet` reachable from two places, and fix the bug where editors see no kebab
+at all.
+
+**Architecture:** Extract the space-detail kebab into its own widget so the RBAC table is testable
+without pumping a 480-line `@RoutePage()` page that has no test today — exactly the pattern the repo
+already uses for `SpaceAlbumKebab`. Then wire both entry points.
+
+**Tech Stack:** Dart 3.12.1 / Flutter 3.44.1, `hooks_riverpod`, `mocktail`, `flutter_test`.
+
+**Spec:** `docs/superpowers/specs/2026-07-26-mobile-spaces-ux-design.md` §8 and Slice 4.
+
+## Global Constraints
+
+- Run every command from `mobile/` via `mise exec -- <cmd>` (pin: Flutter 3.44.1 / Dart 3.12.1,
+  directory-scoped to `mobile/mise.toml`). A bare `flutter`/`dart` is the wrong SDK.
+- Format gate, `lib`-only, excludes generated files, **must** run under `bash -c` (zsh does not
+  word-split `$(...)`):
+  ```bash
+  cd mobile && mise exec -- bash -c 'dart format --output=none --set-exit-if-changed $(find lib -name "*.dart" -not \( -name "*.g.dart" -o -name "*.drift.dart" -o -name "*.gr.dart" \))'
+  ```
+  Never bare `dart format .`. Expect the gate to fire on new multi-line signatures that fit in 120
+  chars; fix with `mise exec -- dart format <file>` on that file only.
+- Analyze gate: `mise exec -- dart analyze --fatal-infos` from `mobile/`.
+- Capture exit codes on the line _after_ the command, never after a pipe to `tail`.
+- **`ImmichToast` schedules a 3s non-frame Timer.** Any widget test that reaches a toast must pump
+  past it or teardown fails with "A Timer is still pending". Reuse the `settleToast` helper pattern
+  from `test/presentation/widgets/spaces/space_edit_sheet_test.dart`.
+- Baseline after Slice 3 is **2832 passing, 1 skipped**.
+- **No new i18n keys.** `spaces_edit`, `spaces_delete` and `spaces_delete_confirmation` all exist.
+
+## File Structure
+
+| File                                                                             | Responsibility                         |
+| -------------------------------------------------------------------------------- | -------------------------------------- |
+| `mobile/lib/presentation/widgets/spaces/space_detail_kebab.widget.dart` (create) | Role-gated menu, no page dependencies. |
+| `mobile/test/presentation/widgets/spaces/space_detail_kebab_test.dart` (create)  | The RBAC table.                        |
+| `mobile/lib/pages/library/spaces/space_detail.page.dart` (modify)                | Use the kebab; add the edit handler.   |
+| `mobile/lib/widgets/spaces/space_card.dart` (modify)                             | Add `onLongPress`.                     |
+| `mobile/test/widgets/spaces/space_card_test.dart` (create)                       | Long-press does not also navigate.     |
+
+---
+
+### Task 1: Extract `SpaceDetailKebab`
+
+**Files:**
+
+- Create: `mobile/lib/presentation/widgets/spaces/space_detail_kebab.widget.dart`
+- Test: `mobile/test/presentation/widgets/spaces/space_detail_kebab_test.dart`
+
+**Interfaces:**
+
+- Produces, used by Task 2:
+
+  ```dart
+  class SpaceDetailKebab extends StatelessWidget {
+    const SpaceDetailKebab({
+      super.key,
+      required this.canEdit,
+      required this.canDelete,
+      required this.onEdit,
+      required this.onDelete,
+    });
+    final bool canEdit;
+    final bool canDelete;
+    final VoidCallback onEdit;
+    final VoidCallback onDelete;
+  }
+  ```
+
+  Renders nothing when `canEdit` is false. This mirrors `SpaceAlbumKebab`, which returns
+  `SizedBox.shrink()` when it has no permissions.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mobile/test/presentation/widgets/spaces/space_detail_kebab_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/presentation/widgets/spaces/space_detail_kebab.widget.dart';
+
+import '../../../widget_tester_extensions.dart';
+
+void main() {
+  Future<({List<String> events})> pumpKebab(
+    WidgetTester tester, {
+    required bool canEdit,
+    required bool canDelete,
+  }) async {
+    final events = <String>[];
+    await tester.pumpConsumerWidget(
+      SpaceDetailKebab(
+        canEdit: canEdit,
+        canDelete: canDelete,
+        onEdit: () => events.add('edit'),
+        onDelete: () => events.add('delete'),
+      ),
+    );
+    return (events: events);
+  }
+
+  Future<void> openMenu(WidgetTester tester) async {
+    await tester.tap(find.byKey(const Key('space-detail-kebab')));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('an owner sees both Edit Space and Delete Space', (tester) async {
+    await pumpKebab(tester, canEdit: true, canDelete: true);
+    await openMenu(tester);
+
+    expect(find.text('Edit Space'), findsOneWidget);
+    expect(find.text('Delete Space'), findsOneWidget);
+  });
+
+  testWidgets('an editor sees Edit Space but not Delete Space', (tester) async {
+    // The regression this slice fixes: editors previously saw no kebab at all.
+    await pumpKebab(tester, canEdit: true, canDelete: false);
+    await openMenu(tester);
+
+    expect(find.text('Edit Space'), findsOneWidget);
+    expect(find.text('Delete Space'), findsNothing);
+  });
+
+  testWidgets('a viewer sees no kebab at all', (tester) async {
+    await pumpKebab(tester, canEdit: false, canDelete: false);
+
+    expect(find.byKey(const Key('space-detail-kebab')), findsNothing);
+  });
+
+  testWidgets('selecting Edit Space invokes onEdit only', (tester) async {
+    final result = await pumpKebab(tester, canEdit: true, canDelete: true);
+    await openMenu(tester);
+
+    await tester.tap(find.text('Edit Space'));
+    await tester.pumpAndSettle();
+
+    expect(result.events, ['edit']);
+  });
+
+  testWidgets('selecting Delete Space invokes onDelete only', (tester) async {
+    final result = await pumpKebab(tester, canEdit: true, canDelete: true);
+    await openMenu(tester);
+
+    await tester.tap(find.text('Delete Space'));
+    await tester.pumpAndSettle();
+
+    expect(result.events, ['delete']);
+  });
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+mise exec -- flutter test test/presentation/widgets/spaces/space_detail_kebab_test.dart
+```
+
+Expected: compile error, `Error when reading 'lib/presentation/widgets/spaces/space_detail_kebab.widget.dart': No such file or directory`.
+
+- [ ] **Step 3: Implement**
+
+Create `mobile/lib/presentation/widgets/spaces/space_detail_kebab.widget.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:immich_mobile/extensions/translate_extensions.dart';
+
+/// Role-gated overflow menu for the space detail page.
+///
+/// Extracted from [SpaceDetailPage] so the RBAC table can be widget-tested without
+/// pumping a routed page that loads network metadata, members and a Drift timeline.
+/// Mirrors the existing [SpaceAlbumKebab].
+///
+/// Naming and appearance are editor-level server-side, so the menu itself is shown
+/// for [canEdit]; only deletion is restricted further, via [canDelete].
+class SpaceDetailKebab extends StatelessWidget {
+  const SpaceDetailKebab({
+    super.key,
+    required this.canEdit,
+    required this.canDelete,
+    required this.onEdit,
+    required this.onDelete,
+  });
+
+  final bool canEdit;
+  final bool canDelete;
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!canEdit) return const SizedBox.shrink();
+
+    return PopupMenuButton<_KebabAction>(
+      key: const Key('space-detail-kebab'),
+      onSelected: (action) => switch (action) {
+        _KebabAction.edit => onEdit(),
+        _KebabAction.delete => onDelete(),
+      },
+      itemBuilder: (context) => [
+        PopupMenuItem<_KebabAction>(
+          key: const Key('space-detail-kebab-edit'),
+          value: _KebabAction.edit,
+          child: Text('spaces_edit'.t(context: context)),
+        ),
+        if (canDelete)
+          PopupMenuItem<_KebabAction>(
+            key: const Key('space-detail-kebab-delete'),
+            value: _KebabAction.delete,
+            child: Text('spaces_delete'.t(context: context)),
+          ),
+      ],
+    );
+  }
+}
+
+enum _KebabAction { edit, delete }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Expected: `+5: All tests passed!`
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux
+git add mobile/lib/presentation/widgets/spaces/space_detail_kebab.widget.dart \
+        mobile/test/presentation/widgets/spaces/space_detail_kebab_test.dart
+git commit -m "feat(mobile): extract a role-gated space detail kebab"
+```
+
+---
+
+### Task 2: Wire the kebab and the edit sheet into the page
+
+**Files:**
+
+- Modify: `mobile/lib/pages/library/spaces/space_detail.page.dart`
+
+**Interfaces:**
+
+- Consumes: `SpaceDetailKebab` (Task 1), `SpaceEditSheet.show` (Slice 3),
+  `spaceIsWritable` / `spaceIsOwned` (Slice 1).
+
+- [ ] **Step 1: Replace the owner-only PopupMenuButton**
+
+In the `SliverAppBar`'s `actions:` list, the current block is:
+
+```dart
+            if (_isOwner)
+              PopupMenuButton<String>(
+                onSelected: (value) {
+                  if (value == 'delete') _deleteSpace();
+                },
+                itemBuilder: (context) => [const PopupMenuItem(value: 'delete', child: Text('Delete Space'))],
+              ),
+```
+
+Replace it with:
+
+```dart
+            SpaceDetailKebab(canEdit: _canEdit, canDelete: _isOwner, onEdit: _editSpace, onDelete: _deleteSpace),
+```
+
+Add the import:
+
+```dart
+import 'package:immich_mobile/presentation/widgets/spaces/space_detail_kebab.widget.dart';
+```
+
+- [ ] **Step 2: Add the `_editSpace` handler**
+
+Add next to `_deleteSpace`:
+
+```dart
+  Future<void> _editSpace() async {
+    final space = _space;
+    if (space == null) return;
+
+    final saved = await SpaceEditSheet.show(context, space);
+    if (saved != true) return;
+
+    // The grid reads sharedSpacesProvider; the app bar reads this page's own
+    // `_space`, which is network-loaded rather than Drift-backed. A sync nudge would
+    // NOT refresh the title -- nothing reads the local shared_space name column for
+    // display -- so re-fetch the metadata explicitly.
+    ref.invalidate(sharedSpacesProvider);
+    await _refreshSpaceMetadata();
+  }
+```
+
+Add the import:
+
+```dart
+import 'package:immich_mobile/presentation/widgets/spaces/space_edit_sheet.widget.dart';
+```
+
+- [ ] **Step 3: Verify the whole suite still passes**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+mise exec -- flutter test > /tmp/s4t2.log 2>&1
+echo "TEST_EXIT=$?"; tail -1 /tmp/s4t2.log
+```
+
+Expected: `TEST_EXIT=0`, `+2837 ~1`.
+
+If `_refreshSpaceMetadata` does not exist under that exact name, grep the file for the method that
+re-fetches `_space` (it is called from `_addPhotos` and from the bottom sheet's `onAssetsRemoved`)
+and use that name. Do not invent a new loader.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/lib/pages/library/spaces/space_detail.page.dart
+git commit -m "feat(mobile): let editors edit a space from the detail page"
+```
+
+---
+
+### Task 3: `SpaceCard` long-press
+
+**Files:**
+
+- Modify: `mobile/lib/widgets/spaces/space_card.dart`
+- Test: `mobile/test/widgets/spaces/space_card_test.dart` (create)
+
+**Interfaces:**
+
+- Produces: `SpaceCard` gains `final VoidCallback? onLongPress;` — optional, so the existing call
+  site in `spaces.page.dart` keeps compiling untouched.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mobile/test/widgets/spaces/space_card_test.dart`. Note the fixture must populate **every**
+`Optional` that `SpaceCard.build` reads via `.value` — `newAssetCount`, `recentAssetIds`,
+`recentAssetThumbhashes`, `color`, `members`, `assetCount`, `memberCount` — because `.value` throws
+on an absent `Optional` and would crash the render. This mirrors the comment at
+`test/presentation/pages/spaces_page_test.dart:27-32`.
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/widgets/spaces/space_card.dart';
+import 'package:openapi/api.dart';
+
+import '../../widget_tester_extensions.dart';
+
+void main() {
+  SharedSpaceResponseDto fullSpace() => SharedSpaceResponseDto(
+    id: 's1',
+    name: 'Family Photos',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    createdById: 'user-1',
+    newAssetCount: const Optional.present(0),
+    recentAssetIds: const Optional.present([]),
+    recentAssetThumbhashes: const Optional.present([]),
+    color: const Optional.present(UserAvatarColor.blue),
+    members: const Optional.present([]),
+    assetCount: const Optional.present(3),
+    memberCount: const Optional.present(2),
+  );
+
+  testWidgets('a long-press fires onLongPress and does NOT also fire onTap', (tester) async {
+    final events = <String>[];
+    await tester.pumpConsumerWidget(
+      SpaceCard(
+        space: fullSpace(),
+        onTap: () => events.add('tap'),
+        onLongPress: () => events.add('longPress'),
+      ),
+    );
+
+    await tester.longPress(find.byType(SpaceCard));
+    await tester.pumpAndSettle();
+
+    expect(events, ['longPress'], reason: 'a long-press must not navigate into the space behind the sheet');
+  });
+
+  testWidgets('a tap still fires onTap only', (tester) async {
+    final events = <String>[];
+    await tester.pumpConsumerWidget(
+      SpaceCard(
+        space: fullSpace(),
+        onTap: () => events.add('tap'),
+        onLongPress: () => events.add('longPress'),
+      ),
+    );
+
+    await tester.tap(find.byType(SpaceCard));
+    await tester.pumpAndSettle();
+
+    expect(events, ['tap']);
+  });
+
+  testWidgets('omitting onLongPress leaves tap behaviour unchanged', (tester) async {
+    final events = <String>[];
+    await tester.pumpConsumerWidget(
+      SpaceCard(space: fullSpace(), onTap: () => events.add('tap')),
+    );
+
+    await tester.longPress(find.byType(SpaceCard));
+    await tester.pumpAndSettle();
+
+    expect(events, isEmpty);
+  });
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: compile error, `No named parameter with the name 'onLongPress'`.
+
+- [ ] **Step 3: Implement**
+
+In `mobile/lib/widgets/spaces/space_card.dart`, add the field and constructor parameter, and pass it
+to the existing `GestureDetector`:
+
+```dart
+  final SharedSpaceResponseDto space;
+  final VoidCallback onTap;
+
+  /// Optional so existing call sites keep working. `GestureDetector` fires either
+  /// `onTap` or `onLongPress` for a given gesture, never both, which is what keeps a
+  /// long-press from also navigating into the space behind the sheet.
+  final VoidCallback? onLongPress;
+
+  const SpaceCard({super.key, required this.space, required this.onTap, this.onLongPress});
+```
+
+and:
+
+```dart
+    return GestureDetector(
+      onTap: onTap,
+      onLongPress: onLongPress,
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Expected: `+3: All tests passed!`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/widgets/spaces/space_card.dart mobile/test/widgets/spaces/space_card_test.dart
+git commit -m "feat(mobile): add a long-press affordance to the space card"
+```
+
+---
+
+### Task 4: Wire the card long-press to a role-gated sheet
+
+**Files:**
+
+- Modify: `mobile/lib/pages/library/spaces/spaces.page.dart`
+
+- [ ] **Step 1: Add the handler and pass it to the card**
+
+In `spaces.page.dart`, the grid builds `SpaceCard(key:..., space: space, onTap: ...)`. Add a
+`onLongPress:` that opens a role-gated sheet. Insert this helper inside `build`, next to
+`createSpaceDialog`:
+
+```dart
+    Future<void> showSpaceActions(SharedSpaceResponseDto space) async {
+      final userId = ref.read(currentUserProvider)?.id;
+      // A viewer has no actions at all, so opening an empty sheet would be worse
+      // than not reacting.
+      if (!spaceIsWritable(space, userId)) return;
+
+      await showModalBottomSheet<void>(
+        context: context,
+        builder: (sheetContext) => SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                key: const Key('space-card-action-edit'),
+                leading: const Icon(Icons.edit_outlined),
+                title: Text('spaces_edit'.t(context: sheetContext)),
+                onTap: () async {
+                  Navigator.of(sheetContext).pop();
+                  final saved = await SpaceEditSheet.show(context, space);
+                  if (saved == true) ref.invalidate(sharedSpacesProvider);
+                },
+              ),
+              if (spaceIsOwned(space, userId))
+                ListTile(
+                  key: const Key('space-card-action-delete'),
+                  leading: const Icon(Icons.delete_outline),
+                  title: Text('spaces_delete'.t(context: sheetContext)),
+                  onTap: () async {
+                    Navigator.of(sheetContext).pop();
+                    await confirmAndDeleteSpace(space);
+                  },
+                ),
+            ],
+          ),
+        ),
+      );
+    }
+```
+
+and pass `onLongPress: () => showSpaceActions(space)` to the `SpaceCard`.
+
+- [ ] **Step 2: Add the delete confirmation helper**
+
+`spaces.page.dart` has no delete path today. Add, next to `createSpaceDialog`:
+
+```dart
+    Future<void> confirmAndDeleteSpace(SharedSpaceResponseDto space) async {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: Text('spaces_delete'.t(context: ctx)),
+          content: Text('spaces_delete_confirmation'.t(context: ctx, args: {'name': space.name})),
+          actions: [
+            TextButton(onPressed: () => Navigator.of(ctx).pop(false), child: Text('cancel'.t(context: ctx))),
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(true),
+              style: TextButton.styleFrom(foregroundColor: Theme.of(ctx).colorScheme.error),
+              child: Text('delete'.t(context: ctx)),
+            ),
+          ],
+        ),
+      );
+      if (confirmed != true) return;
+
+      try {
+        await ref.read(sharedSpaceApiRepositoryProvider).delete(space.id);
+        ref.invalidate(sharedSpacesProvider);
+      } catch (e) {
+        if (context.mounted) {
+          ImmichToast.show(context: context, msg: 'Failed to delete space', toastType: ToastType.error);
+        }
+      }
+    }
+```
+
+Declare `confirmAndDeleteSpace` **before** `showSpaceActions` so the closure resolves.
+
+Add imports for `SpaceEditSheet`, `space_permissions.dart`, and `currentUserProvider` if absent.
+Check `delete` exists as a key: `grep -n '"delete":' ../i18n/en.json`. If it does not, use the
+existing literal the page already uses rather than adding a key.
+
+- [ ] **Step 3: Verify**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+mise exec -- flutter test > /tmp/s4t4.log 2>&1
+echo "TEST_EXIT=$?"; tail -1 /tmp/s4t4.log
+```
+
+Expected: `TEST_EXIT=0`, `+2840 ~1`. `spaces_page_test.dart` already pumps this page, so a
+compile or render regression here shows up immediately.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/lib/pages/library/spaces/spaces.page.dart
+git commit -m "feat(mobile): long-press a space card to edit or delete it"
+```
+
+---
+
+### Task 5: Slice gates
+
+- [ ] **Step 1: Run all three gates**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+mise exec -- bash -c 'dart format --output=none --set-exit-if-changed $(find lib -name "*.dart" -not \( -name "*.g.dart" -o -name "*.drift.dart" -o -name "*.gr.dart" \))'
+echo "FORMAT_EXIT=$?"
+mise exec -- dart analyze --fatal-infos
+echo "ANALYZE_EXIT=$?"
+mise exec -- flutter test > /tmp/s4final.log 2>&1
+echo "TEST_EXIT=$?"; tail -1 /tmp/s4final.log
+```
+
+Expected: all `0`, `+2840 ~1 All tests passed!`.
+
+- [ ] **Step 2: Confirm the old hardcoded menu is gone**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+grep -rn "Delete Space" lib/ ; echo "exit=$?"
+```
+
+Expected: **no matches** (`exit=1`) — both delete entry points now render `spaces_delete`.
+
+---
+
+## Self-Review
+
+**1. Spec coverage.** Slice 4's ten behaviours map as: owner sees both ✓, editor sees Edit only ✓,
+viewer sees no kebab ✓, loading renders nothing (covered by `canEdit:false` since the page passes
+`_canEdit`, which is false while `_space` is null) ✓, long-press as owner ✓, as editor ✓, as viewer ✓
+(the early return in `showSpaceActions`), delete confirmation ✓, save invalidates + re-fetches ✓,
+cancel does nothing ✓.
+
+**Two spec items are NOT covered by a test here and that is deliberate:** "the space was deleted by
+another member mid-flow" and Slice 3's deferred "dismissed while a save is in flight". Both need the
+routed `SpaceEditSheet.show` path on a page with no existing test harness; the page-level test rig
+does not exist and building one is larger than this slice. Both are recorded in the spec's follow-up
+section rather than silently dropped.
+
+**2. Placeholder scan.** No TBD/TODO. The two places where a name might not match reality
+(`_refreshSpaceMetadata`, the `delete` i18n key) carry the exact command to check and an explicit
+instruction not to invent a replacement.
+
+**3. Type consistency.** `SpaceDetailKebab` takes `canEdit`/`canDelete` as `bool` and
+`onEdit`/`onDelete` as `VoidCallback` in the test, the widget and the page. `onLongPress` is
+`VoidCallback?` on `SpaceCard` and is passed a zero-arg closure. `SpaceEditSheet.show` returns
+`Future<bool?>` and both callers compare against `true`.

--- a/docs/superpowers/plans/2026-07-26-mobile-spaces-ux-slice-5.md
+++ b/docs/superpowers/plans/2026-07-26-mobile-spaces-ux-slice-5.md
@@ -1,0 +1,504 @@
+# Mobile Spaces UX — Slice 5: `CollectionTarget` and dispatch
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route a selection to a space pool or a space album, with honest counts, partial-upload
+handling, and a re-entrancy guard — all testable without any UI.
+
+**Architecture:** A sealed `CollectionTarget` names the three destinations. Two new methods on the
+existing `ActionNotifier` (where upload, `ActionSource` and selection state already live) share one
+private helper. `SpaceAlbumActions.addAssets` stays the low-level call underneath.
+
+**Tech Stack:** Dart 3.12.1 / Flutter 3.44.1, `hooks_riverpod`, `mocktail`, `flutter_test`.
+
+**Spec:** `docs/superpowers/specs/2026-07-26-mobile-spaces-ux-design.md` §2, §5 and Slice 5.
+
+## Global Constraints
+
+- All commands from `mobile/` via `mise exec -- <cmd>` (Flutter 3.44.1 / Dart 3.12.1).
+- Format gate (`lib`-only, generated excluded, **must** use `bash -c` — zsh does not word-split):
+  ```bash
+  cd mobile && mise exec -- bash -c 'dart format --output=none --set-exit-if-changed $(find lib -name "*.dart" -not \( -name "*.g.dart" -o -name "*.drift.dart" -o -name "*.gr.dart" \))'
+  ```
+  Never bare `dart format .`.
+- Analyze gate: `mise exec -- dart analyze --fatal-infos` from `mobile/`.
+- Exit codes on the line _after_ the command, never after a pipe to `tail`.
+- Baseline after Slice 4 is **2840 passing, 1 skipped**.
+- No new i18n keys, no UI in this slice.
+
+## Key facts this slice depends on (already verified — do not re-derive)
+
+- `SharedSpaceApiRepository.addAssets` returns **`Future<void>`**. The endpoint is `204 NO_CONTENT`,
+  so there is **no server count** for a pool add; report the request length, as web does.
+- `SpaceAlbumActions.addAssets(albumId, ids)` returns **`Future<int>`** — the server's real
+  `added.length`, which already excludes duplicates. It also fires its own `syncRemote()` nudge.
+- `RemoteAlbumService.categorizeCandidates(assets)` returns
+  `AlbumAssetCandidates(remoteAssetIds: List<String>, localAssetsToUpload: List<LocalAsset>)`.
+- `ActionNotifier.upload(source, {assets, onAssetUploaded})` returns `ActionResult` whose `success`
+  is `successCount == assetsToUpload.length`, and calls `onAssetUploaded(asset, remoteId)` per
+  successful upload.
+- `ActionResult` is `{int count, bool success, String? error, List<String> remoteAssetIds}`.
+- `_getAssets(source)` returns `Set<BaseAsset>`; `_logger` exists on the notifier.
+
+## File Structure
+
+| File                                                                          | Responsibility                           |
+| ----------------------------------------------------------------------------- | ---------------------------------------- |
+| `mobile/lib/domain/models/collection_target.dart` (create)                    | The sealed destination type.             |
+| `mobile/lib/constants/collection.dart` (create)                               | `kMaxSpaceAssetsPerRequest`.             |
+| `mobile/lib/providers/infrastructure/action.provider.dart` (modify)           | `addToSpace`, `addToSpaceAlbum`, helper. |
+| `mobile/test/providers/infrastructure/collection_dispatch_test.dart` (create) | The dispatch table.                      |
+
+---
+
+### Task 1: `CollectionTarget` and the cap constant
+
+**Files:**
+
+- Create: `mobile/lib/domain/models/collection_target.dart`
+- Create: `mobile/lib/constants/collection.dart`
+
+**Interfaces produced** (Slices 6 and 7 depend on these exact names):
+
+```dart
+sealed class CollectionTarget { const CollectionTarget(); }
+final class AlbumTarget extends CollectionTarget { final RemoteAlbum album; }
+final class SpacePoolTarget extends CollectionTarget { final SharedSpaceResponseDto space; }
+final class SpaceAlbumTarget extends CollectionTarget { final String spaceId; final SpaceAlbum album; }
+const int kMaxSpaceAssetsPerRequest = 50000;
+```
+
+- [ ] **Step 1: Create the constant**
+
+`mobile/lib/constants/collection.dart`:
+
+```dart
+/// Maximum asset ids accepted by `POST /shared-spaces/{id}/assets` in one request.
+///
+/// Mirrors `SharedSpaceAssetAddSchema` (`server/src/dtos/shared-space.dto.ts`) and
+/// web's `MAX_SPACE_ASSETS_PER_REQUEST`. Inclusive: 50000 is allowed, 50001 is not.
+const int kMaxSpaceAssetsPerRequest = 50000;
+```
+
+- [ ] **Step 2: Create the target model**
+
+`mobile/lib/domain/models/collection_target.dart`:
+
+```dart
+import 'package:immich_mobile/domain/models/album/album.model.dart';
+import 'package:immich_mobile/domain/models/space_album.model.dart';
+import 'package:openapi/api.dart';
+
+/// Where a multi-selection can be sent.
+///
+/// Sealed so the dispatch table in `ActionNotifier` is exhaustive and checked by the
+/// compiler: adding a destination without wiring it up becomes a build error.
+sealed class CollectionTarget {
+  const CollectionTarget();
+}
+
+/// A personal or shared album. Dispatches through the existing `addToAlbum`.
+final class AlbumTarget extends CollectionTarget {
+  const AlbumTarget(this.album);
+  final RemoteAlbum album;
+}
+
+/// A space's own asset pool.
+final class SpacePoolTarget extends CollectionTarget {
+  const SpacePoolTarget(this.space);
+  final SharedSpaceResponseDto space;
+}
+
+/// An album linked to a space.
+///
+/// [spaceId] is carried even though the add call does not need it: it identifies which
+/// `spaceAlbumsProvider` to invalidate afterwards, and lets a space surface exclude its
+/// own albums. It must NEVER be dispatched through `addToAlbum` — a linked album can be
+/// "absorbed" (present only in `shared_space_album`, with no local `remote_album` row),
+/// and `addToAlbum` also writes the local junction, which would hit a foreign-key
+/// violation. See `SpaceAlbumActions.addAssets`.
+final class SpaceAlbumTarget extends CollectionTarget {
+  const SpaceAlbumTarget({required this.spaceId, required this.album});
+  final String spaceId;
+  final SpaceAlbum album;
+}
+```
+
+- [ ] **Step 3: Confirm it analyzes**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+mise exec -- dart analyze --fatal-infos lib/domain/models/collection_target.dart lib/constants/collection.dart
+echo "EXIT=$?"
+```
+
+Expected: `EXIT=0`, "No issues found!". If `RemoteAlbum` or `SpaceAlbum` is not at those import
+paths, grep for `class RemoteAlbum` / `class SpaceAlbum` under `lib/domain/models/` and correct the
+import — do not redefine the types.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux
+git add mobile/lib/domain/models/collection_target.dart mobile/lib/constants/collection.dart
+git commit -m "feat(mobile): add the collection target model"
+```
+
+---
+
+### Task 2: `addToSpace` and `addToSpaceAlbum`
+
+**Files:**
+
+- Modify: `mobile/lib/providers/infrastructure/action.provider.dart`
+- Test: `mobile/test/providers/infrastructure/collection_dispatch_test.dart`
+
+**Interfaces produced** (Slice 7 calls these):
+
+```dart
+Future<ActionResult> addToSpace(ActionSource source, SharedSpaceResponseDto space)
+Future<ActionResult> addToSpaceAlbum(ActionSource source, String spaceId, SpaceAlbum album)
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `mobile/test/providers/infrastructure/collection_dispatch_test.dart`. Model the container
+setup on the existing `test/providers/infrastructure/space_album_actions_test.dart`.
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/constants/enums.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/asset/remote_asset.model.dart';
+import 'package:immich_mobile/domain/models/space_album.model.dart';
+import 'package:immich_mobile/providers/infrastructure/action.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/space_album.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/space_album_actions.dart';
+import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
+import 'package:immich_mobile/repositories/shared_space_api.repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openapi/api.dart';
+
+class MockSharedSpaceApiRepository extends Mock implements SharedSpaceApiRepository {}
+
+class MockSpaceAlbumActions extends Mock implements SpaceAlbumActions {}
+
+void main() {
+  late MockSharedSpaceApiRepository spaceRepo;
+  late MockSpaceAlbumActions albumActions;
+  late ProviderContainer container;
+
+  SharedSpaceResponseDto theSpace() => SharedSpaceResponseDto(
+    id: 'space-1',
+    name: 'Family',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    createdById: 'user-1',
+  );
+
+  SpaceAlbum theAlbum() => SpaceAlbum(
+    id: 'album-1',
+    name: 'Ski trip',
+    showInTimeline: true,
+    linkedAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+  );
+
+  RemoteAsset remote(String id) => RemoteAsset(
+    id: id,
+    name: id,
+    ownerId: 'user-1',
+    checksum: id,
+    type: AssetType.image,
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+    isEdited: false,
+  );
+
+  /// Seeds the timeline multiselect so `_getAssets(timeline)` sees them. The notifier
+  /// only exposes `selectAsset` (one at a time) -- there is no bulk setter.
+  void select(Iterable<BaseAsset> assets) {
+    final notifier = container.read(multiSelectProvider.notifier);
+    for (final asset in assets) {
+      notifier.selectAsset(asset);
+    }
+  }
+
+  setUpAll(() {
+    registerFallbackValue(<String>[]);
+  });
+
+  setUp(() {
+    spaceRepo = MockSharedSpaceApiRepository();
+    albumActions = MockSpaceAlbumActions();
+    when(() => spaceRepo.addAssets(any(), any())).thenAnswer((_) async {});
+    when(() => albumActions.addAssets(any(), any())).thenAnswer((_) async => 2);
+    container = ProviderContainer(
+      overrides: [
+        sharedSpaceApiRepositoryProvider.overrideWithValue(spaceRepo),
+        spaceAlbumActionsProvider.overrideWithValue(albumActions),
+      ],
+    );
+    addTearDown(container.dispose);
+  });
+
+  test('a space pool add sends every id in ONE call', () async {
+    select([remote('a'), remote('b')]);
+
+    final result = await container.read(actionProvider.notifier).addToSpace(ActionSource.timeline, theSpace());
+
+    final captured = verify(() => spaceRepo.addAssets('space-1', captureAny())).captured.single as List<String>;
+    expect(captured..sort(), ['a', 'b']);
+    expect(result.success, isTrue);
+  });
+
+  test('a space pool add reports the REQUEST length, because the endpoint returns no body', () async {
+    select([remote('a'), remote('b'), remote('c')]);
+
+    final result = await container.read(actionProvider.notifier).addToSpace(ActionSource.timeline, theSpace());
+
+    expect(result.count, 3);
+  });
+
+  test('a space album add reports the SERVER count, so duplicates are not over-claimed', () async {
+    when(() => albumActions.addAssets(any(), any())).thenAnswer((_) async => 0);
+    select([remote('a'), remote('b')]);
+
+    final result = await container
+        .read(actionProvider.notifier)
+        .addToSpaceAlbum(ActionSource.timeline, 'space-1', theAlbum());
+
+    expect(result.count, 0, reason: 'all already present -- do not claim "added 2"');
+    expect(result.success, isTrue);
+  });
+
+  test('a space album add never touches the space pool endpoint', () async {
+    select([remote('a')]);
+
+    await container.read(actionProvider.notifier).addToSpaceAlbum(ActionSource.timeline, 'space-1', theAlbum());
+
+    verify(() => albumActions.addAssets('album-1', any())).called(1);
+    verifyNever(() => spaceRepo.addAssets(any(), any()));
+  });
+
+  test('an empty selection makes no call and succeeds with zero', () async {
+    select([]);
+
+    final result = await container.read(actionProvider.notifier).addToSpace(ActionSource.timeline, theSpace());
+
+    expect(result.count, 0);
+    expect(result.success, isTrue);
+    verifyNever(() => spaceRepo.addAssets(any(), any()));
+  });
+
+  test('a failed add returns a failure AND leaves the selection intact for retry', () async {
+    when(() => spaceRepo.addAssets(any(), any())).thenThrow(Exception('403'));
+    select([remote('a')]);
+
+    final result = await container.read(actionProvider.notifier).addToSpace(ActionSource.timeline, theSpace());
+
+    expect(result.success, isFalse);
+    expect(container.read(multiSelectProvider).selectedAssets, isNotEmpty);
+  });
+
+  test('a successful add clears the selection', () async {
+    select([remote('a')]);
+
+    await container.read(actionProvider.notifier).addToSpace(ActionSource.timeline, theSpace());
+
+    expect(container.read(multiSelectProvider).selectedAssets, isEmpty);
+  });
+
+  test('a second add while one is in flight is ignored', () async {
+    final gate = Completer<void>();
+    when(() => spaceRepo.addAssets(any(), any())).thenAnswer((_) => gate.future);
+    select([remote('a')]);
+
+    final notifier = container.read(actionProvider.notifier);
+    final first = notifier.addToSpace(ActionSource.timeline, theSpace());
+    final second = await notifier.addToSpace(ActionSource.timeline, theSpace());
+
+    expect(second.success, isFalse);
+    gate.complete();
+    await first;
+
+    verify(() => spaceRepo.addAssets(any(), any())).called(1);
+  });
+}
+```
+
+Add `import 'dart:async';` for `Completer`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+mise exec -- flutter test test/providers/infrastructure/collection_dispatch_test.dart
+```
+
+Expected: compile error, `The method 'addToSpace' isn't defined for the type 'ActionNotifier'`.
+
+Verified before writing this plan, so do not re-check: the multiselect notifier exposes
+`selectAsset(BaseAsset)` only (no bulk setter); `RemoteAsset` additionally requires `isEdited` and
+lives in `lib/domain/models/asset/remote_asset.model.dart`; `RemoteAlbum` is in
+`lib/domain/models/album/album.model.dart`.
+
+- [ ] **Step 3: Implement**
+
+In `mobile/lib/providers/infrastructure/action.provider.dart`, add a field on `ActionNotifier`
+beside `_logger`:
+
+```dart
+  /// Guards against a second destination being dispatched while one is in flight —
+  /// two taps in a picker would otherwise fire two adds and two sync nudges.
+  bool _spaceAddInFlight = false;
+```
+
+Then add these three members next to `addToAlbum`:
+
+```dart
+  /// Add the selection to a space's own asset pool.
+  ///
+  /// Reports the REQUEST length: `POST /shared-spaces/{id}/assets` is 204 with no body,
+  /// so there is no server-side count to report (web does the same).
+  Future<ActionResult> addToSpace(ActionSource source, SharedSpaceResponseDto space) {
+    return _addToSpaceTarget(source, (ids) async {
+      await ref.read(sharedSpaceApiRepositoryProvider).addAssets(space.id, ids);
+      return ids.length;
+    });
+  }
+
+  /// Add the selection to an album linked to a space.
+  ///
+  /// Routed through [SpaceAlbumActions] rather than [addToAlbum]: a linked album may be
+  /// "absorbed" (no local `remote_album` row) and the album path also writes the local
+  /// junction, which would throw on the foreign key. Returns the server's true count,
+  /// which already excludes assets the album had.
+  Future<ActionResult> addToSpaceAlbum(ActionSource source, String spaceId, SpaceAlbum album) async {
+    final result = await _addToSpaceTarget(
+      source,
+      (ids) => ref.read(spaceAlbumActionsProvider).addAssets(album.id, ids),
+    );
+    if (result.success) {
+      ref.invalidate(spaceAlbumsProvider(spaceId));
+    }
+    return result;
+  }
+
+  /// Shared body for both space destinations.
+  ///
+  /// Local assets are uploaded first and then added in a SINGLE call — one call per
+  /// asset would fire `SpaceAlbumActions`' `syncRemote()` nudge once per photo.
+  /// A partial upload still adds what succeeded: stranding uploaded photos the user
+  /// asked to file would be worse than a partial-success result.
+  Future<ActionResult> _addToSpaceTarget(
+    ActionSource source,
+    Future<int> Function(List<String> remoteIds) add,
+  ) async {
+    if (_spaceAddInFlight) {
+      return const ActionResult(count: 0, success: false);
+    }
+    _spaceAddInFlight = true;
+    try {
+      final selected = _getAssets(source).toList(growable: false);
+      if (selected.isEmpty) {
+        return const ActionResult(count: 0, success: true);
+      }
+
+      final candidates = RemoteAlbumService.categorizeCandidates(selected);
+      final remoteIds = [...candidates.remoteAssetIds];
+      final localAssets = candidates.localAssetsToUpload;
+
+      ActionResult? uploadResult;
+      if (localAssets.isNotEmpty) {
+        final uploaded = <String>[];
+        uploadResult = await upload(
+          source,
+          assets: localAssets,
+          onAssetUploaded: (asset, remoteId) => uploaded.add(remoteId),
+        );
+        remoteIds.addAll(uploaded);
+      }
+
+      if (remoteIds.isEmpty) {
+        // Every asset was local and none uploaded — nothing to add.
+        return ActionResult(count: 0, success: false, error: uploadResult?.error);
+      }
+
+      final int added;
+      try {
+        added = await add(remoteIds);
+      } catch (error, stack) {
+        _logger.severe('Failed to add assets to space target', error, stack);
+        return ActionResult(count: 0, success: false, error: error.toString());
+      }
+
+      // Only a fully successful run clears the selection, so a partial upload leaves
+      // the photos selected for retry. This deliberately differs from addToAlbum,
+      // which resets before its upload and so clears even when the upload fails.
+      final fullSuccess = uploadResult?.success ?? true;
+      if (fullSuccess && source == ActionSource.timeline) {
+        ref.read(multiSelectProvider.notifier).reset();
+      }
+      return ActionResult(count: added, success: fullSuccess, error: uploadResult?.error);
+    } finally {
+      _spaceAddInFlight = false;
+    }
+  }
+```
+
+Add imports as needed: `space_album.model.dart`, `space_album.provider.dart`,
+`space_album_actions.dart`, `shared_space_api.repository.dart`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Expected: `+8: All tests passed!`
+
+- [ ] **Step 5: Slice gates**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+mise exec -- bash -c 'dart format --output=none --set-exit-if-changed $(find lib -name "*.dart" -not \( -name "*.g.dart" -o -name "*.drift.dart" -o -name "*.gr.dart" \))'
+echo "FORMAT_EXIT=$?"
+mise exec -- dart analyze --fatal-infos
+echo "ANALYZE_EXIT=$?"
+mise exec -- flutter test > /tmp/s5.log 2>&1
+echo "TEST_EXIT=$?"; tail -1 /tmp/s5.log
+```
+
+Expected: all `0`, `+2848 ~1 All tests passed!`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux
+git add mobile/lib/providers/infrastructure/action.provider.dart \
+        mobile/test/providers/infrastructure/collection_dispatch_test.dart
+git commit -m "feat(mobile): dispatch selections to spaces and space albums"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage.** Slice 5 lists thirteen behaviours. Covered by tests here: one-call pool add ✓,
+request-length count ✓, server count / duplicates ✓, never-touches-pool (the FK guard) ✓, empty
+selection ✓, failure leaves selection ✓, success resets ✓, in-flight guard ✓.
+
+Covered by implementation but **not** by a test in this slice, deliberately: the local-asset upload
+paths (single add call, 3-of-5 partial, cancelled upload) and `AlbumTarget` routing.
+`ActionNotifier.upload` pulls in `ForegroundUploadService`, `assetUploadProgressProvider` and
+`manualUploadCancelTokenProvider`, so exercising it needs a much heavier harness than a
+`ProviderContainer` with two mocks — the spec's own "tested without any UI" framing does not hold
+for the upload path. `AlbumTarget` simply calls the pre-existing, already-tested `addToAlbum`.
+**Both gaps are recorded in the spec's follow-up section rather than silently dropped**, and the
+upload branch is written to be obviously correct (single `add` after collecting ids).
+
+**2. Placeholder scan.** No TBD/TODO. The two spots where a real name may differ (`setAssets`, the
+model import paths) carry the exact grep and an instruction not to invent replacements.
+
+**3. Type consistency.** `add` is `Future<int> Function(List<String>)` in the helper and both call
+sites; `addToSpace` returns `ids.length`, `addToSpaceAlbum` returns `SpaceAlbumActions.addAssets`'s
+`Future<int>`. `SpaceAlbumTarget.spaceId` is the `String` passed to `addToSpaceAlbum` and to
+`spaceAlbumsProvider(...)`.

--- a/docs/superpowers/plans/2026-07-26-mobile-spaces-ux-slice-6.md
+++ b/docs/superpowers/plans/2026-07-26-mobile-spaces-ux-slice-6.md
@@ -1,0 +1,784 @@
+# Mobile Spaces UX — Slice 6: `SpaceCollectionSection`
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The spaces half of the picker — writable spaces, lazily expandable into their linked
+albums, with six mutually exclusive gating states.
+
+**Architecture:** A plain **box** widget (not a sliver), so it is trivially pumpable in tests; Slice 7
+wraps it in a `SliverToBoxAdapter`. Space rows come from the network `sharedSpacesProvider`; a row's
+linked albums come from the local Drift `spaceAlbumsProvider(spaceId)`, watched only while expanded.
+
+**Tech Stack:** Dart 3.12.1 / Flutter 3.44.1, `hooks_riverpod`, `flutter_test`.
+
+**Spec:** `docs/superpowers/specs/2026-07-26-mobile-spaces-ux-design.md` §3 and Slice 6.
+
+## Global Constraints
+
+- All commands from `mobile/` via `mise exec -- <cmd>` (Flutter 3.44.1 / Dart 3.12.1).
+- Format gate (`lib`-only, generated excluded, **must** use `bash -c`):
+  ```bash
+  cd mobile && mise exec -- bash -c 'dart format --output=none --set-exit-if-changed $(find lib -name "*.dart" -not \( -name "*.g.dart" -o -name "*.drift.dart" -o -name "*.gr.dart" \))'
+  ```
+  Never bare `dart format .`.
+- Analyze gate: `mise exec -- dart analyze --fatal-infos` from `mobile/`.
+- Exit codes on the line _after_ the command.
+- Baseline after Slice 5 is **2848 passing, 1 skipped**.
+- **This slice DOES add one i18n key** (Task 1) — the only slice that touches `i18n/`. It must land in
+  `en.json` **and all nine locale files** in the same commit.
+- After editing `i18n/en.json` you must regenerate the loader or `.t()` will not resolve the new key:
+  ```bash
+  cd mobile && mise exec -- dart run easy_localization:generate -S ../i18n && mise exec -- dart run bin/generate_keys.dart
+  ```
+  Those outputs (`lib/generated/*.g.dart`) are gitignored — regenerate, do not commit them.
+
+## Verified facts (do not re-derive)
+
+- `sharedSpacesProvider` is `FutureProvider<List<SharedSpaceResponseDto>>` (network `getAll`).
+- `spaceAlbumsProvider` is `StreamProvider.family<List<SpaceAlbum>, String>` (local Drift).
+- `SharedSpaceResponseDto.albumCount` is `Optional<num?>` and is populated by `getAll`
+  (`shared-space.service.ts:143,190`). Read it with `.orElse(null) ?? 0`; **never** `.value`.
+- `spaceIsWritable(space, userId)` / `spaceIsOwned` live in `lib/utils/space_permissions.dart`.
+- `kMaxSpaceAssetsPerRequest = 50000` (inclusive) lives in `lib/constants/collection.dart`.
+- `CollectionTarget` / `SpacePoolTarget` / `SpaceAlbumTarget` live in
+  `lib/domain/models/collection_target.dart`.
+- Locked-folder assets are `RemoteAsset` with `visibility == AssetVisibility.locked`.
+  `MultiSelectState.lockedSelectionAssets` is **unrelated** (it means "already in this album").
+- `RemoteAsset` is a `part of base_asset.model.dart` — import `base_asset.model.dart`, never the part.
+- `multiSelectProvider`'s notifier exposes `selectAsset(BaseAsset)` only; no bulk setter.
+
+## File Structure
+
+| File                                                                                       | Responsibility          |
+| ------------------------------------------------------------------------------------------ | ----------------------- |
+| `i18n/en.json` + 9 locale files (modify)                                                   | One new key.            |
+| `mobile/lib/utils/selection_targets.dart` (create)                                         | Pure gating predicates. |
+| `mobile/test/utils/selection_targets_test.dart` (create)                                   | Predicate truth table.  |
+| `mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart` (create) | The section.            |
+| `mobile/test/presentation/widgets/collection/space_collection_section_test.dart` (create)  | Gating + row behaviour. |
+
+---
+
+### Task 1: The new i18n key, in all ten files
+
+**Files:** `i18n/en.json`, and `de`, `fr`, `it`, `es`, `nl`, `pl`, `ru`, `zh_Hans`, `zh_Hant`.
+
+The reused `add_to_collection_restricted_to_space` says "…so only albums in this space can accept
+them", which is web's contribution-mode promise — a destination mobile deliberately does not offer.
+Using it would point the user at something not on screen, so this key is new.
+
+- [ ] **Step 1: Insert `spaces_hidden_non_owned_selection` into all ten files**
+
+Keys in these files are sorted alphabetically and the repo runs prettier with
+`prettier-plugin-sort-json` over `i18n/`, so insert in the correct sorted position (immediately
+after `spaces_hidden_too_many_assets` if present, else in alphabetical order among the `spaces_*`
+keys). Values, verbatim:
+
+| File           | Value                                                                                                             |
+| -------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `en.json`      | `Your selection includes photos owned by other members, so it can't be added to a space.`                         |
+| `de.json`      | `Deine Auswahl enthält Fotos anderer Mitglieder und kann daher nicht zu einem Space hinzugefügt werden.`          |
+| `fr.json`      | `Votre sélection contient des photos appartenant à d'autres membres ; elle ne peut pas être ajoutée à un espace.` |
+| `it.json`      | `La tua selezione include foto di altri membri, quindi non può essere aggiunta a uno Space.`                      |
+| `es.json`      | `Tu selección incluye fotos de otros miembros, por lo que no se puede añadir a un Space.`                         |
+| `nl.json`      | `Je selectie bevat foto's van andere leden en kan daarom niet aan een Space worden toegevoegd.`                   |
+| `pl.json`      | `Twój wybór zawiera zdjęcia należące do innych członków, więc nie można go dodać do Space.`                       |
+| `ru.json`      | `Ваш выбор содержит фотографии других участников, поэтому его нельзя добавить в Space.`                           |
+| `zh_Hans.json` | `您的选择包含其他成员的照片，因此无法添加到 Space。`                                                              |
+| `zh_Hant.json` | `您的選擇包含其他成員的照片，因此無法新增至 Space。`                                                              |
+
+"Space" stays untranslated in every locale except French, which uses "espace" — this matches each
+file's existing `add_to_space` / `spaces_edit` wording.
+
+- [ ] **Step 2: Format the JSON and regenerate the loader**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux
+npx --yes prettier@3 --write "i18n/*.json" > /dev/null
+cd mobile
+mise exec -- dart run easy_localization:generate -S ../i18n
+mise exec -- dart run bin/generate_keys.dart
+echo "EXIT=$?"
+```
+
+- [ ] **Step 3: Verify all ten landed**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux
+for l in en de fr it es nl pl ru zh_Hans zh_Hant; do
+  printf "%-9s " "$l"
+  grep -c '"spaces_hidden_non_owned_selection"' "i18n/$l.json"
+done
+git status --porcelain i18n/ | wc -l
+```
+
+Expected: `1` for each of the ten locales, and `10` changed files.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add i18n/
+git commit -m "i18n: add the non-owned selection notice in all supported locales"
+```
+
+---
+
+### Task 2: The gating predicates
+
+**Files:**
+
+- Create: `mobile/lib/utils/selection_targets.dart`
+- Test: `mobile/test/utils/selection_targets_test.dart`
+
+**Interfaces produced** (Task 3 uses these):
+
+```dart
+bool selectionHasNonOwned(Iterable<BaseAsset> assets, String? currentUserId);
+bool selectionHasLocked(Iterable<BaseAsset> assets);
+bool selectionExceedsSpaceCap(Iterable<BaseAsset> assets);
+```
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/constants/collection.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/utils/selection_targets.dart';
+
+RemoteAsset _remote(String id, {String ownerId = 'me', AssetVisibility visibility = AssetVisibility.timeline}) =>
+    RemoteAsset(
+      id: id,
+      name: id,
+      ownerId: ownerId,
+      checksum: id,
+      type: AssetType.image,
+      createdAt: DateTime(2026, 1, 1),
+      updatedAt: DateTime(2026, 1, 1),
+      isEdited: false,
+      visibility: visibility,
+    );
+
+LocalAsset _local(String id) => LocalAsset(
+  id: id,
+  name: id,
+  checksum: id,
+  type: AssetType.image,
+  createdAt: DateTime(2026, 1, 1),
+  updatedAt: DateTime(2026, 1, 1),
+  isEdited: false,
+);
+
+void main() {
+  group('selectionHasNonOwned', () {
+    test('is false when every remote asset is mine', () {
+      expect(selectionHasNonOwned([_remote('a'), _remote('b')], 'me'), isFalse);
+    });
+
+    test('is true when any remote asset belongs to someone else', () {
+      expect(selectionHasNonOwned([_remote('a'), _remote('b', ownerId: 'other')], 'me'), isTrue);
+    });
+
+    test('treats local-only assets as mine -- they will be uploaded as mine', () {
+      expect(selectionHasNonOwned([_local('l1'), _remote('a')], 'me'), isFalse);
+    });
+
+    test('fails closed when the current user is unknown', () {
+      expect(selectionHasNonOwned([_remote('a')], null), isTrue);
+    });
+
+    test('is false for an empty selection', () {
+      expect(selectionHasNonOwned([], 'me'), isFalse);
+    });
+  });
+
+  group('selectionHasLocked', () {
+    test('is true when any asset is in the locked folder', () {
+      expect(selectionHasLocked([_remote('a'), _remote('b', visibility: AssetVisibility.locked)]), isTrue);
+    });
+
+    test('is false for ordinary timeline assets', () {
+      expect(selectionHasLocked([_remote('a'), _local('l1')]), isFalse);
+    });
+  });
+
+  group('selectionExceedsSpaceCap', () {
+    test('allows exactly the cap', () {
+      final assets = [for (var i = 0; i < kMaxSpaceAssetsPerRequest; i++) _local('l$i')];
+      expect(selectionExceedsSpaceCap(assets), isFalse);
+    });
+
+    test('rejects one over the cap', () {
+      final assets = [for (var i = 0; i < kMaxSpaceAssetsPerRequest + 1; i++) _local('l$i')];
+      expect(selectionExceedsSpaceCap(assets), isTrue);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+mise exec -- flutter test test/utils/selection_targets_test.dart
+```
+
+Expected: compile error about the missing `lib/utils/selection_targets.dart`.
+
+If `LocalAsset`'s constructor differs from the above, read
+`lib/domain/models/asset/local_asset.model.dart` and correct the **test helper** to match the real
+signature — that is fixture scaffolding, not an assertion.
+
+- [ ] **Step 3: Implement**
+
+```dart
+import 'package:immich_mobile/constants/collection.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+
+/// Whether the selection contains an asset the current user does not own.
+///
+/// `POST /shared-spaces/{id}/assets` requires `AssetShare` on **every** id and rejects
+/// the whole request otherwise, so a single non-owned asset makes every space target
+/// unusable. Local-only assets are not "non-owned": they upload as the current user's.
+///
+/// Fails **closed** when [currentUserId] is null — an unknown user gets no space targets
+/// rather than a request certain to 400.
+bool selectionHasNonOwned(Iterable<BaseAsset> assets, String? currentUserId) {
+  if (currentUserId == null) {
+    return assets.isNotEmpty;
+  }
+  return assets.any((asset) => asset is RemoteAsset && asset.ownerId != currentUserId);
+}
+
+/// Whether the selection contains a locked-folder asset.
+///
+/// Defensive: the locked folder is its own surface with its own bottom sheet, so such an
+/// asset should not reach the picker today. If one ever did, pushing it into a shared
+/// space would expose exactly what the user hid.
+bool selectionHasLocked(Iterable<BaseAsset> assets) =>
+    assets.any((asset) => asset is RemoteAsset && asset.visibility == AssetVisibility.locked);
+
+/// Whether the selection is larger than one space-add request allows.
+///
+/// The cap is inclusive, so exactly [kMaxSpaceAssetsPerRequest] is fine.
+bool selectionExceedsSpaceCap(Iterable<BaseAsset> assets) => assets.length > kMaxSpaceAssetsPerRequest;
+```
+
+- [ ] **Step 4: Run to verify it passes** — expected `+9`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux
+git add mobile/lib/utils/selection_targets.dart mobile/test/utils/selection_targets_test.dart
+git commit -m "feat(mobile): add space-target gating predicates"
+```
+
+---
+
+### Task 3: `SpaceCollectionSection`
+
+**Files:**
+
+- Create: `mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart`
+- Test: `mobile/test/presentation/widgets/collection/space_collection_section_test.dart`
+
+**Interfaces produced** (Slice 7 mounts this):
+
+```dart
+class SpaceCollectionSection extends ConsumerStatefulWidget {
+  const SpaceCollectionSection({
+    super.key,
+    required this.onTargetSelected,
+    this.excludeSpaceId,
+    this.isBusy = false,
+  });
+  final void Function(CollectionTarget target) onTargetSelected;
+  final String? excludeSpaceId;
+  final bool isBusy;
+}
+```
+
+It is a **box** widget. Slice 7 wraps it in `SliverToBoxAdapter`.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/collection_target.dart';
+import 'package:immich_mobile/domain/models/space_album.model.dart';
+import 'package:immich_mobile/presentation/widgets/collection/space_collection_section.widget.dart';
+import 'package:immich_mobile/providers/infrastructure/space_album.provider.dart';
+import 'package:immich_mobile/providers/shared_space.provider.dart';
+import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:openapi/api.dart';
+
+import '../../../widget_tester_extensions.dart';
+
+void main() {
+  SharedSpaceMemberResponseDto member(String userId, SharedSpaceRole role) => SharedSpaceMemberResponseDto(
+    userId: userId,
+    name: userId,
+    email: '$userId@e.com',
+    role: role,
+    joinedAt: '2026-01-01T00:00:00Z',
+    sharePersonMetadata: true,
+    showInTimeline: true,
+  );
+
+  SharedSpaceResponseDto space(String id, {SharedSpaceRole role = SharedSpaceRole.owner, int albums = 0}) =>
+      SharedSpaceResponseDto(
+        id: id,
+        name: 'Space $id',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+        createdById: 'someone-else',
+        members: Optional.present([member('user-1', role)]),
+        albumCount: Optional.present(albums),
+      );
+
+  SpaceAlbum album(String id, String name) => SpaceAlbum(
+    id: id,
+    name: name,
+    showInTimeline: true,
+    linkedAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+  );
+
+  RemoteAsset asset(String id, {String ownerId = 'user-1'}) => RemoteAsset(
+    id: id,
+    name: id,
+    ownerId: ownerId,
+    checksum: id,
+    type: AssetType.image,
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+    isEdited: false,
+  );
+
+  Future<List<CollectionTarget>> pump(
+    WidgetTester tester, {
+    required List<SharedSpaceResponseDto> spaces,
+    Map<String, List<SpaceAlbum>> albums = const {},
+    List<RemoteAsset>? selection,
+    String? excludeSpaceId,
+    String? userId = 'user-1',
+    bool raw = false,
+  }) async {
+    final targets = <CollectionTarget>[];
+    final overrides = <Override>[
+      sharedSpacesProvider.overrideWith((ref) async => spaces),
+      currentUserProvider.overrideWith((ref) => userId == null ? null : UserStub.user1),
+      multiSelectProvider.overrideWith(
+        () => MultiSelectNotifier(
+          MultiSelectState(selectedAssets: {...(selection ?? [asset('a')])}, lockedSelectionAssets: const {}),
+        ),
+      ),
+      for (final entry in albums.entries)
+        spaceAlbumsProvider(entry.key).overrideWith((ref) => Stream.value(entry.value)),
+    ];
+    final widget = SpaceCollectionSection(onTargetSelected: targets.add, excludeSpaceId: excludeSpaceId);
+    if (raw) {
+      await tester.pumpConsumerWidgetRaw(widget, overrides: overrides);
+    } else {
+      await tester.pumpConsumerWidget(widget, overrides: overrides);
+    }
+    return targets;
+  }
+
+  testWidgets('renders nothing when there are no writable spaces', (tester) async {
+    await pump(tester, spaces: [space('s1', role: SharedSpaceRole.viewer)]);
+
+    expect(find.byKey(const Key('space-collection-header')), findsNothing);
+    expect(find.byKey(const Key('space-row-s1')), findsNothing);
+  });
+
+  testWidgets('lists only writable spaces, ordered by name', (tester) async {
+    await pump(tester, spaces: [space('s2'), space('s1'), space('s3', role: SharedSpaceRole.viewer)]);
+
+    expect(find.byKey(const Key('space-row-s1')), findsOneWidget);
+    expect(find.byKey(const Key('space-row-s2')), findsOneWidget);
+    expect(find.byKey(const Key('space-row-s3')), findsNothing);
+    final y1 = tester.getTopLeft(find.byKey(const Key('space-row-s1'))).dy;
+    final y2 = tester.getTopLeft(find.byKey(const Key('space-row-s2'))).dy;
+    expect(y1, lessThan(y2));
+  });
+
+  testWidgets('a space with no linked albums adds to the pool on a single tap', (tester) async {
+    final targets = await pump(tester, spaces: [space('s1', albums: 0)]);
+
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+
+    expect(targets, hasLength(1));
+    expect((targets.single as SpacePoolTarget).space.id, 's1');
+  });
+
+  testWidgets('a space with albums expands instead of adding, then collapses', (tester) async {
+    final targets = await pump(
+      tester,
+      spaces: [space('s1', albums: 2)],
+      albums: {'s1': [album('a1', 'Ski trip'), album('a2', 'Christmas')]},
+    );
+
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+
+    expect(targets, isEmpty, reason: 'expanding must not dump photos into the space');
+    expect(find.byKey(const Key('space-pool-child-s1')), findsOneWidget);
+    expect(find.byKey(const Key('space-album-child-a1')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('space-pool-child-s1')), findsNothing);
+  });
+
+  testWidgets('the pool child emits a SpacePoolTarget', (tester) async {
+    final targets = await pump(tester, spaces: [space('s1', albums: 1)], albums: {'s1': [album('a1', 'Ski')]});
+
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('space-pool-child-s1')));
+    await tester.pumpAndSettle();
+
+    expect((targets.single as SpacePoolTarget).space.id, 's1');
+  });
+
+  testWidgets('an album child emits a SpaceAlbumTarget carrying the owning space id', (tester) async {
+    final targets = await pump(tester, spaces: [space('s1', albums: 1)], albums: {'s1': [album('a1', 'Ski')]});
+
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('space-album-child-a1')));
+    await tester.pumpAndSettle();
+
+    final target = targets.single as SpaceAlbumTarget;
+    expect(target.spaceId, 's1');
+    expect(target.album.id, 'a1');
+  });
+
+  testWidgets('expanding a second space collapses the first', (tester) async {
+    await pump(
+      tester,
+      spaces: [space('s1', albums: 1), space('s2', albums: 1)],
+      albums: {'s1': [album('a1', 'One')], 's2': [album('a2', 'Two')]},
+    );
+
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('space-row-s2')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('space-pool-child-s1')), findsNothing);
+    expect(find.byKey(const Key('space-pool-child-s2')), findsOneWidget);
+  });
+
+  testWidgets('albumCount > 0 but an empty stream still offers the pool', (tester) async {
+    final targets = await pump(tester, spaces: [space('s1', albums: 3)], albums: {'s1': const []});
+
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('space-albums-empty-s1')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('space-pool-child-s1')));
+    await tester.pumpAndSettle();
+    expect(targets, hasLength(1));
+  });
+
+  testWidgets('a double-tap on a plain row emits exactly one target', (tester) async {
+    final targets = await pump(tester, spaces: [space('s1', albums: 0)]);
+
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+
+    expect(targets, hasLength(1), reason: 'two adds would fire two activity entries');
+  });
+
+  testWidgets('a non-owned selection hides every row behind a notice', (tester) async {
+    await pump(tester, spaces: [space('s1')], selection: [asset('a'), asset('b', ownerId: 'other')]);
+
+    expect(find.text("Your selection includes photos owned by other members, so it can't be added to a space."), findsOneWidget);
+    expect(find.byKey(const Key('space-row-s1')), findsNothing);
+  });
+
+  testWidgets('an unknown current user hides the rows (fail closed)', (tester) async {
+    await pump(tester, spaces: [space('s1')], userId: null);
+
+    expect(find.byKey(const Key('space-row-s1')), findsNothing);
+  });
+
+  testWidgets('the excluded space is absent from its own list', (tester) async {
+    await pump(tester, spaces: [space('s1'), space('s2')], excludeSpaceId: 's1');
+
+    expect(find.byKey(const Key('space-row-s1')), findsNothing);
+    expect(find.byKey(const Key('space-row-s2')), findsOneWidget);
+  });
+
+  testWidgets('a provider error hides the section rather than surfacing an error', (tester) async {
+    final targets = <CollectionTarget>[];
+    await tester.pumpConsumerWidget(
+      SpaceCollectionSection(onTargetSelected: targets.add),
+      overrides: [
+        sharedSpacesProvider.overrideWith((ref) async => throw Exception('offline')),
+        currentUserProvider.overrideWith((ref) => UserStub.user1),
+      ],
+    );
+
+    expect(find.byKey(const Key('space-collection-header')), findsNothing);
+  });
+}
+```
+
+**Verified fixture:** `test/fixtures/user.stub.dart` exposes `UserStub.user1` (a `UserDto` with
+`id: "user-1"`); there is **no** `UserStub.user(id)` factory. So use `UserStub.user1` and make the
+owner ids in this test `'user-1'` rather than `'me'` (both in `asset()`'s default `ownerId`, in
+`member('me', ...)` -> `member('user-1', ...)`, and in the `userId` parameter). For the
+"unknown current user" test, override `currentUserProvider` to return `null`.
+
+**Note on `multiSelectProvider.overrideWith`:** if `MultiSelectNotifier` cannot be constructed with a
+seed state, instead override with the default and call `selectAsset` for each asset after pumping,
+then `await tester.pump()`. Adapt the harness, not the assertions.
+
+- [ ] **Step 2: Run to verify it fails** — expected: missing-file compile error.
+
+- [ ] **Step 3: Implement**
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/collection_target.dart';
+import 'package:immich_mobile/domain/models/space_album.model.dart';
+import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/extensions/translate_extensions.dart';
+import 'package:immich_mobile/providers/infrastructure/space_album.provider.dart';
+import 'package:immich_mobile/providers/shared_space.provider.dart';
+import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:immich_mobile/utils/selection_targets.dart';
+import 'package:immich_mobile/utils/space_permissions.dart';
+import 'package:immich_mobile/widgets/spaces/space_collage.dart';
+import 'package:openapi/api.dart';
+
+/// The "Spaces" half of the add-to-collection picker.
+///
+/// A plain box widget so it can be pumped directly in tests; the picker wraps it in a
+/// `SliverToBoxAdapter`. Space rows come from the network `sharedSpacesProvider`; a row's
+/// linked albums come from the local Drift `spaceAlbumsProvider`, watched ONLY while that
+/// row is expanded, so collapsed spaces subscribe to nothing.
+class SpaceCollectionSection extends ConsumerStatefulWidget {
+  const SpaceCollectionSection({super.key, required this.onTargetSelected, this.excludeSpaceId, this.isBusy = false});
+
+  final void Function(CollectionTarget target) onTargetSelected;
+
+  /// Set on a space's own surface so it is not offered as a destination for its own assets.
+  final String? excludeSpaceId;
+
+  /// Disables every row while an add is in flight.
+  final bool isBusy;
+
+  @override
+  ConsumerState<SpaceCollectionSection> createState() => _SpaceCollectionSectionState();
+}
+
+class _SpaceCollectionSectionState extends ConsumerState<SpaceCollectionSection> {
+  /// Accordion: at most one expanded space, which bounds live Drift subscriptions to one.
+  String? _expandedSpaceId;
+
+  /// Guards a double-tap on a plain row from emitting two targets.
+  bool _emitted = false;
+
+  void _emit(CollectionTarget target) {
+    if (_emitted || widget.isBusy) return;
+    _emitted = true;
+    widget.onTargetSelected(target);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final spacesAsync = ref.watch(sharedSpacesProvider);
+    final userId = ref.watch(currentUserProvider.select((user) => user?.id));
+    final selection = ref.watch(multiSelectProvider.select((state) => state.selectedAssets));
+
+    final spaces = spacesAsync.valueOrNull;
+    // Offline or still loading: the album half of the picker still works, so stay out of
+    // the way rather than surfacing an error into someone else's sheet.
+    if (spaces == null) return const SizedBox.shrink();
+
+    final writable = spaces
+        .where((space) => spaceIsWritable(space, userId) && space.id != widget.excludeSpaceId)
+        .toList()
+      ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+    if (writable.isEmpty) return const SizedBox.shrink();
+
+    final String? notice;
+    if (selectionHasNonOwned(selection, userId)) {
+      notice = 'spaces_hidden_non_owned_selection'.t(context: context);
+    } else if (selectionHasLocked(selection)) {
+      notice = 'spaces_hidden_non_owned_selection'.t(context: context);
+    } else if (selectionExceedsSpaceCap(selection)) {
+      notice = 'spaces_hidden_too_many_assets'.t(
+        context: context,
+        args: {'count': kMaxSpaceAssetsPerRequest.toString()},
+      );
+    } else {
+      notice = null;
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          key: const Key('space-collection-header'),
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          child: Text('spaces'.t(context: context), style: context.textTheme.labelLarge),
+        ),
+        if (notice != null)
+          Padding(
+            key: const Key('space-collection-notice'),
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Row(
+              children: [
+                const Icon(Icons.info_outline, size: 16),
+                const SizedBox(width: 8),
+                Expanded(child: Text(notice, style: context.textTheme.bodySmall)),
+              ],
+            ),
+          )
+        else
+          for (final space in writable) ..._rowsFor(space),
+      ],
+    );
+  }
+
+  List<Widget> _rowsFor(SharedSpaceResponseDto space) {
+    // albumCount is Optional<num?> and is the ONLY way to know a row is expandable without
+    // subscribing to its Drift stream. An absent count reads as 0 -- a plain row, which
+    // still reaches the pool.
+    final albumCount = (space.albumCount.orElse(null) ?? 0).toInt();
+    final expandable = albumCount > 0;
+    final expanded = _expandedSpaceId == space.id;
+
+    return [
+      ListTile(
+        key: Key('space-row-${space.id}'),
+        enabled: !widget.isBusy,
+        leading: CircleAvatar(backgroundColor: spaceGradientColors(space.color.orElse(null)).first, radius: 16),
+        title: Text(space.name, maxLines: 1, overflow: TextOverflow.ellipsis),
+        trailing: expandable ? Icon(expanded ? Icons.expand_less : Icons.expand_more) : null,
+        onTap: widget.isBusy
+            ? null
+            : () {
+                if (!expandable) {
+                  _emit(SpacePoolTarget(space));
+                  return;
+                }
+                setState(() => _expandedSpaceId = expanded ? null : space.id);
+              },
+      ),
+      if (expanded) ..._childrenFor(space),
+    ];
+  }
+
+  List<Widget> _childrenFor(SharedSpaceResponseDto space) {
+    final albumsAsync = ref.watch(spaceAlbumsProvider(space.id));
+    final albums = albumsAsync.valueOrNull ?? const <SpaceAlbum>[];
+
+    return [
+      ListTile(
+        key: Key('space-pool-child-${space.id}'),
+        contentPadding: const EdgeInsets.only(left: 48, right: 16),
+        leading: const Icon(Icons.workspaces_outline),
+        title: Text('add_to_space'.t(context: context)),
+        enabled: !widget.isBusy,
+        onTap: widget.isBusy ? null : () => _emit(SpacePoolTarget(space)),
+      ),
+      if (albums.isEmpty)
+        Padding(
+          key: Key('space-albums-empty-${space.id}'),
+          padding: const EdgeInsets.only(left: 48, right: 16, bottom: 8),
+          child: Text('no_albums_in_space_yet'.t(context: context), style: context.textTheme.bodySmall),
+        )
+      else
+        for (final album in albums)
+          ListTile(
+            key: Key('space-album-child-${album.id}'),
+            contentPadding: const EdgeInsets.only(left: 48, right: 16),
+            leading: const Icon(Icons.photo_album_outlined),
+            title: Text(album.name, maxLines: 1, overflow: TextOverflow.ellipsis),
+            enabled: !widget.isBusy,
+            onTap: widget.isBusy ? null : () => _emit(SpaceAlbumTarget(spaceId: space.id, album: album)),
+          ),
+    ];
+  }
+}
+```
+
+Add `import 'package:immich_mobile/constants/collection.dart';` for `kMaxSpaceAssetsPerRequest`.
+
+Two existing i18n keys are used here beyond the new one, both already verified present and
+translated — do NOT re-check and do NOT add keys:
+
+- `spaces` = "Spaces" (`i18n/en.json:2714`) for the section header.
+- `no_albums_in_space_yet` = "This space has no albums yet" (`:2061`) for the empty-albums hint.
+  Note this is **not** `no_albums_yet`, which reads "It looks like you do not have any albums yet."
+  and is about the user's personal albums.
+
+- [ ] **Step 4: Run to verify it passes** — expected `+13`.
+
+- [ ] **Step 5: Slice gates**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+mise exec -- bash -c 'dart format --output=none --set-exit-if-changed $(find lib -name "*.dart" -not \( -name "*.g.dart" -o -name "*.drift.dart" -o -name "*.gr.dart" \))'
+echo "FORMAT_EXIT=$?"
+mise exec -- dart analyze --fatal-infos
+echo "ANALYZE_EXIT=$?"
+mise exec -- flutter test > /tmp/s6.log 2>&1
+echo "TEST_EXIT=$?"; tail -1 /tmp/s6.log
+```
+
+Expected: all `0`, `+2870 ~1`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux
+git add mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart \
+        mobile/test/presentation/widgets/collection/space_collection_section_test.dart
+git commit -m "feat(mobile): add the spaces section of the collection picker"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage.** The §3 gating table's six states: loading/error → hidden ✓ (one test; the
+implementation treats both as `valueOrNull == null`), no writable ✓, non-owned notice ✓, locked and
+over-cap ✓ (predicates unit-tested in Task 2; the widget shares one notice branch), normal rows ✓.
+Row behaviour: plain-row single tap ✓, expandable ✓, collapse ✓, accordion ✓, pool child ✓, album
+child with space id ✓, empty stream ✓, double-tap ✓, exclusion ✓, fail-closed ✓, ordering ✓.
+
+**Deliberately not covered here:** the "collapsed row issues no Drift query" assertion (Riverpod
+gives no public subscription-count hook; the accordion structure makes it true by construction —
+`_childrenFor` is the only `ref.watch(spaceAlbumsProvider)` and runs only when expanded), the
+loading-skeleton state (the implementation renders nothing while loading rather than a skeleton — a
+deliberate simplification over the spec, since the section is additive and a skeleton would push the
+album list down then yank it back), semantics/tap-target assertions (`ListTile` already meets both by
+construction), and the "rows disabled while busy" case (`isBusy` is wired but Slice 7 owns its only
+caller). **All are recorded here rather than silently dropped**; the spec's follow-up list should
+gain the skeleton deviation.
+
+**2. Placeholder scan.** No TBD/TODO. The three spots where a real name may differ (`UserStub`,
+`MultiSelectNotifier` seeding, the two extra i18n keys) each carry the exact command or file to check
+and an explicit instruction not to invent replacements.
+
+**3. Type consistency.** `onTargetSelected` is `void Function(CollectionTarget)` in the widget and
+the test's `targets.add`. `SpacePoolTarget(space)` is positional and `SpaceAlbumTarget({spaceId,
+album})` is named — matching Slice 5's definitions exactly. `albumCount.orElse(null) ?? 0` yields
+`num`, hence the `.toInt()`.

--- a/docs/superpowers/plans/2026-07-26-mobile-spaces-ux-slice-7-8.md
+++ b/docs/superpowers/plans/2026-07-26-mobile-spaces-ux-slice-7-8.md
@@ -1,0 +1,505 @@
+# Mobile Spaces UX — Slices 7 & 8: `CollectionPicker`, mounting, toasts and gates
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make everything built in Slices 5–6 actually reachable: compose the picker, mount it in
+both multi-select sheets, and report outcomes truthfully.
+
+**Why 7 and 8 are one plan:** mounting the picker requires wiring its toasts, which was Slice 8's
+main remaining item. Slice 8's other item — keying hardcoded English on the surfaces this work
+touches — was already completed in Slice 4 (the delete confirmation dialog). What is left of Slice 8
+is the toasts and the final gates, so splitting them would create a slice with no independent
+deliverable.
+
+**Tech Stack:** Dart 3.12.1 / Flutter 3.44.1, `hooks_riverpod`, `sliver_tools`, `flutter_test`.
+
+**Spec:** `docs/superpowers/specs/2026-07-26-mobile-spaces-ux-design.md` §1, §9 and Slices 7–8.
+
+## Global Constraints
+
+- All commands from `mobile/` via `mise exec -- <cmd>` (Flutter 3.44.1 / Dart 3.12.1).
+- Format gate (`lib`-only, generated excluded, **must** use `bash -c`):
+  ```bash
+  cd mobile && mise exec -- bash -c 'dart format --output=none --set-exit-if-changed $(find lib -name "*.dart" -not \( -name "*.g.dart" -o -name "*.drift.dart" -o -name "*.gr.dart" \))'
+  ```
+  Never bare `dart format .`.
+- Analyze gate: `mise exec -- dart analyze --fatal-infos` from `mobile/`.
+- Exit codes on the line _after_ the command.
+- Baseline after Slice 6 is **2870 passing, 1 skipped**.
+- **No i18n changes at all.** Every string below already exists.
+- `ImmichToast` schedules a 3s non-frame Timer — any test reaching a toast must pump past it
+  (`settleToast` pattern in `test/presentation/widgets/spaces/space_edit_sheet_test.dart`).
+
+## Ownership rules for the files being edited
+
+- `mobile/lib/presentation/widgets/album/album_selector.widget.dart` — **pure upstream, DO NOT TOUCH.**
+  A `git diff` check in Task 5 enforces this.
+- `mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart` — **pure upstream.**
+  Keep the diff minimal: swap the two picker slivers, delete the now-unused local `addToAlbum`
+  closure and its imports. Nothing else.
+- `mobile/lib/presentation/widgets/bottom_sheet/space_bottom_sheet.widget.dart` — **fork-only**, edit
+  freely.
+
+## Existing strings used (all verified present)
+
+| Key                                        | Used for                                          |
+| ------------------------------------------ | ------------------------------------------------- |
+| `add_to_album_or_space`                    | Picker header                                     |
+| `added_to_space_count`                     | Pool success — takes `{count}`, ICU plural        |
+| `space_album_add_photos_success`           | Space-album success — takes `{count}`, ICU plural |
+| `add_to_album_bottom_sheet_added`          | Album success — takes `{album}`                   |
+| `add_to_album_bottom_sheet_already_exists` | Album no-op — takes `{album}`                     |
+| `scaffold_body_error_occurred`             | Any failure                                       |
+
+---
+
+### Task 1: Fix the `_emitted` latch in `SpaceCollectionSection`
+
+**Files:**
+
+- Modify: `mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart`
+- Modify: `mobile/test/presentation/widgets/collection/space_collection_section_test.dart`
+
+**Why:** Slice 6 added `bool _emitted` as a double-tap guard, set on the first emit and **never
+reset**. On its own that was fine — no caller existed. Now that a caller does, a **failed** add would
+leave the section permanently inert: the sheet stays open and every subsequent tap is swallowed. The
+latch must clear when the parent reports it is no longer busy.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `space_collection_section_test.dart`. Because the harness pumps the widget directly, drive
+`isBusy` through a `StatefulBuilder` so it can be toggled after the first tap.
+
+```dart
+  testWidgets('the double-tap latch clears once the parent is no longer busy', (tester) async {
+    final targets = <CollectionTarget>[];
+    var busy = false;
+    late StateSetter setOuter;
+
+    await tester.pumpConsumerWidget(
+      StatefulBuilder(
+        builder: (context, setState) {
+          setOuter = setState;
+          return SpaceCollectionSection(
+            onTargetSelected: (target) {
+              targets.add(target);
+              setState(() => busy = true);
+            },
+            isBusy: busy,
+          );
+        },
+      ),
+      overrides: [
+        sharedSpacesProvider.overrideWith((ref) async => [space('s1', albums: 0)]),
+        currentUserOverride('user-1'),
+        multiSelectProvider.overrideWith(
+          () => MultiSelectNotifier(
+            MultiSelectState(selectedAssets: {asset('a')}, lockedSelectionAssets: const {}),
+          ),
+        ),
+      ],
+    );
+
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+    expect(targets, hasLength(1));
+
+    // The add failed: the parent clears busy and the sheet stays open.
+    setOuter(() => busy = false);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+
+    expect(targets, hasLength(2), reason: 'a failed add must not leave the section permanently inert');
+  });
+```
+
+- [ ] **Step 2: Run to verify it fails** — expected: `Expected: 2, Actual: 1`.
+
+- [ ] **Step 3: Fix the implementation**
+
+In `_SpaceCollectionSectionState`, clear the latch whenever the parent stops being busy:
+
+```dart
+  @override
+  void didUpdateWidget(covariant SpaceCollectionSection oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // The latch exists to swallow a double-tap while a dispatch is starting. Once the
+    // parent reports it is no longer busy the dispatch has finished -- including when it
+    // FAILED and left the sheet open -- so the section must accept taps again.
+    if (oldWidget.isBusy && !widget.isBusy) {
+      _emitted = false;
+    }
+  }
+```
+
+- [ ] **Step 4: Run to verify it passes** — expected `+14` for this file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux
+git add mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart \
+        mobile/test/presentation/widgets/collection/space_collection_section_test.dart
+git commit -m "fix(mobile): clear the space section tap latch when a dispatch ends"
+```
+
+---
+
+### Task 2: `CollectionPicker`
+
+**Files:**
+
+- Create: `mobile/lib/presentation/widgets/collection/collection_picker.widget.dart`
+- Test: `mobile/test/presentation/widgets/collection/collection_picker_test.dart`
+
+**Interfaces produced:**
+
+```dart
+class CollectionPicker extends ConsumerStatefulWidget {
+  const CollectionPicker({super.key, this.excludeSpaceId, this.onKeyboardExpanded});
+  final String? excludeSpaceId;
+  final Function? onKeyboardExpanded;
+}
+```
+
+Returns a `MultiSliver`, so it drops straight into a `BaseBottomSheet(slivers: [...])`.
+
+- [ ] **Step 1: Write the failing test**
+
+The picker mounts `AlbumSelector`, which pulls in `remoteAlbumProvider`, settings and user providers.
+Rather than fight that, this test asserts **composition and dispatch**, and leaves per-row behaviour
+to the two component suites (which already cover it).
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/presentation/widgets/collection/collection_picker.widget.dart';
+import 'package:immich_mobile/presentation/widgets/collection/space_collection_section.widget.dart';
+import 'package:immich_mobile/presentation/widgets/album/album_selector.widget.dart';
+
+import '../../../widget_tester_extensions.dart';
+
+void main() {
+  testWidgets('composes the header, the album selector and the spaces section, in that order', (tester) async {
+    await tester.pumpConsumerWidgetRaw(
+      const CustomScrollView(slivers: [CollectionPicker()]),
+      overrides: const [],
+    );
+    await tester.pump();
+
+    expect(find.byKey(const Key('collection-picker-header')), findsOneWidget);
+    expect(find.byType(AlbumSelector), findsOneWidget);
+    expect(find.byType(SpaceCollectionSection), findsOneWidget);
+
+    final headerY = tester.getTopLeft(find.byKey(const Key('collection-picker-header'))).dy;
+    final albumsY = tester.getTopLeft(find.byType(AlbumSelector)).dy;
+    expect(headerY, lessThan(albumsY));
+  });
+}
+```
+
+If `AlbumSelector` cannot render in a bare harness (it reads several providers), **do not delete the
+assertions** — add the minimum provider overrides needed, or assert on
+`find.byType(AlbumSelector)` after `pumpConsumerWidgetRaw` + a single `pump()` without settling.
+Report whatever you had to add.
+
+- [ ] **Step 2: Run to verify it fails** — expected: missing-file compile error.
+
+- [ ] **Step 3: Implement**
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/constants/enums.dart';
+import 'package:immich_mobile/domain/models/album/album.model.dart';
+import 'package:immich_mobile/domain/models/collection_target.dart';
+import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/extensions/translate_extensions.dart';
+import 'package:immich_mobile/presentation/widgets/album/album_selector.widget.dart';
+import 'package:immich_mobile/presentation/widgets/collection/space_collection_section.widget.dart';
+import 'package:immich_mobile/providers/infrastructure/action.provider.dart';
+import 'package:immich_mobile/widgets/common/immich_toast.dart';
+import 'package:sliver_tools/sliver_tools.dart';
+
+/// "Add to album or space" — the album selector plus the spaces section.
+///
+/// `AlbumSelector` is upstream and is composed, never modified. Its own
+/// `AddToAlbumHeader` is not reused because it hardcodes the `add_to_album` key; this
+/// picker supplies its own header so the sheet can honestly say "album or space".
+class CollectionPicker extends ConsumerStatefulWidget {
+  const CollectionPicker({super.key, this.excludeSpaceId, this.onKeyboardExpanded});
+
+  /// Set on a space's own surface so that space is not offered as a destination for
+  /// its own assets.
+  final String? excludeSpaceId;
+
+  final Function? onKeyboardExpanded;
+
+  @override
+  ConsumerState<CollectionPicker> createState() => _CollectionPickerState();
+}
+
+class _CollectionPickerState extends ConsumerState<CollectionPicker> {
+  bool _isBusy = false;
+
+  Future<void> _addToAlbum(RemoteAlbum album) async {
+    if (_isBusy) return;
+    setState(() => _isBusy = true);
+    final result = await ref.read(actionProvider.notifier).addToAlbum(ActionSource.timeline, album);
+    if (!mounted) return;
+    setState(() => _isBusy = false);
+
+    if (!result.success) {
+      _toastError();
+      return;
+    }
+    ImmichToast.show(
+      context: context,
+      msg: result.count == 0
+          ? 'add_to_album_bottom_sheet_already_exists'.t(context: context, args: {'album': album.name})
+          : 'add_to_album_bottom_sheet_added'.t(context: context, args: {'album': album.name}),
+    );
+  }
+
+  Future<void> _addToTarget(CollectionTarget target) async {
+    if (_isBusy) return;
+    setState(() => _isBusy = true);
+
+    final notifier = ref.read(actionProvider.notifier);
+    final (result, successMessage) = switch (target) {
+      AlbumTarget(:final album) => (await notifier.addToAlbum(ActionSource.timeline, album), null),
+      SpacePoolTarget(:final space) => (
+        await notifier.addToSpace(ActionSource.timeline, space),
+        // The pool endpoint is 204 with no body, so this count is the request length.
+        'added_to_space_count',
+      ),
+      SpaceAlbumTarget(:final spaceId, :final album) => (
+        await notifier.addToSpaceAlbum(ActionSource.timeline, spaceId, album),
+        // This one IS the server's count, so duplicates are already excluded.
+        'space_album_add_photos_success',
+      ),
+    };
+
+    if (!mounted) return;
+    setState(() => _isBusy = false);
+
+    if (!result.success) {
+      _toastError();
+      return;
+    }
+    if (successMessage != null) {
+      ImmichToast.show(
+        context: context,
+        msg: successMessage.t(context: context, args: {'count': result.count.toString()}),
+        toastType: ToastType.success,
+      );
+    }
+  }
+
+  void _toastError() {
+    ImmichToast.show(
+      context: context,
+      msg: 'scaffold_body_error_occurred'.t(context: context),
+      toastType: ToastType.error,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiSliver(
+      children: [
+        SliverPadding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+          sliver: SliverToBoxAdapter(
+            child: Text(
+              'add_to_album_or_space'.t(context: context),
+              key: const Key('collection-picker-header'),
+              style: context.textTheme.titleSmall,
+            ),
+          ),
+        ),
+        AlbumSelector(onAlbumSelected: _addToAlbum, onKeyboardExpanded: widget.onKeyboardExpanded),
+        SliverToBoxAdapter(
+          child: SpaceCollectionSection(
+            onTargetSelected: _addToTarget,
+            excludeSpaceId: widget.excludeSpaceId,
+            isBusy: _isBusy,
+          ),
+        ),
+      ],
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/presentation/widgets/collection/collection_picker.widget.dart \
+        mobile/test/presentation/widgets/collection/collection_picker_test.dart
+git commit -m "feat(mobile): compose the add-to-album-or-space picker"
+```
+
+---
+
+### Task 3: Mount in the main timeline sheet (upstream file — minimal diff)
+
+**Files:**
+
+- Modify: `mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart`
+
+- [ ] **Step 1: Swap the slivers**
+
+Replace:
+
+```dart
+      slivers: [
+        const AddToAlbumHeader(),
+        AlbumSelector(onAlbumSelected: addToAlbum, onKeyboardExpanded: onKeyboardExpand),
+      ],
+```
+
+with:
+
+```dart
+      slivers: [CollectionPicker(onKeyboardExpanded: onKeyboardExpand)],
+```
+
+Then delete the now-unused local `Future<void> addToAlbum(RemoteAlbum album) async { ... }` closure
+and any imports it alone required (`album.model.dart`, `album_selector.widget.dart`,
+`immich_toast.dart`, `easy_localization` if unused elsewhere in the file). Add the
+`collection_picker.widget.dart` import. `dart analyze --fatal-infos` will name any import that is
+now unused — remove exactly those.
+
+- [ ] **Step 2: Verify**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+mise exec -- flutter test > /tmp/s7t3.log 2>&1
+echo "TEST_EXIT=$?"; tail -1 /tmp/s7t3.log
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart
+git commit -m "feat(mobile): offer spaces in the timeline multiselect sheet"
+```
+
+---
+
+### Task 4: Mount in the space timeline sheet (fork-only file)
+
+**Files:**
+
+- Modify: `mobile/lib/presentation/widgets/bottom_sheet/space_bottom_sheet.widget.dart`
+
+- [ ] **Step 1: Add the picker and raise the sheet's ceiling**
+
+`SpaceBottomSheet` currently passes `initialChildSize: 0.22, minChildSize: 0.22, maxChildSize: 0.55`
+and **no** `slivers:`. At 0.55 the spaces section would sit permanently below the fold, so raise the
+ceiling to 0.85, matching `GeneralBottomSheet`:
+
+```dart
+    return BaseBottomSheet(
+      controller: sheetController,
+      initialChildSize: 0.22,
+      minChildSize: 0.22,
+      // Raised from 0.55: the sheet now hosts the collection picker, which is unreachable
+      // at the old ceiling.
+      maxChildSize: 0.85,
+      shouldCloseOnMinExtent: false,
+      actions: [ ...unchanged... ],
+      slivers: [
+        // A space is not offered as a destination for its own assets.
+        CollectionPicker(excludeSpaceId: widget.spaceId),
+      ],
+    );
+```
+
+Only add `slivers:` and change `maxChildSize`; leave `actions:` exactly as it is.
+
+- [ ] **Step 2: Verify**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+mise exec -- flutter test test/presentation/widgets/bottom_sheet/ > /tmp/s7t4.log 2>&1
+echo "TEST_EXIT=$?"; tail -2 /tmp/s7t4.log
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/lib/presentation/widgets/bottom_sheet/space_bottom_sheet.widget.dart
+git commit -m "feat(mobile): offer collections in the space multiselect sheet"
+```
+
+---
+
+### Task 5: Final gates (Slice 8)
+
+- [ ] **Step 1: Prove the upstream album selector is untouched**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux
+git diff origin/main -- mobile/lib/presentation/widgets/album/album_selector.widget.dart
+echo "ALBUM_SELECTOR_DIFF_LINES=$(git diff origin/main -- mobile/lib/presentation/widgets/album/album_selector.widget.dart | wc -l)"
+```
+
+Expected: **0**. A non-zero result means the composition rule was broken — fix it, do not accept it.
+
+- [ ] **Step 2: Prove no i18n regression**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux
+git diff origin/main --stat -- i18n/ | tail -1
+git diff origin/main -- i18n/ | grep '^+' | grep -v '^+++' | grep -c spaces_hidden_non_owned_selection
+```
+
+Expected: `10 files changed, 10 insertions(+)` and a count of `10` — exactly the one key from
+Slice 6, nothing else.
+
+- [ ] **Step 3: All three CI gates**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/feat+mobile-spaces-ux/mobile
+mise exec -- bash -c 'dart format --output=none --set-exit-if-changed $(find lib -name "*.dart" -not \( -name "*.g.dart" -o -name "*.drift.dart" -o -name "*.gr.dart" \))'
+echo "FORMAT_EXIT=$?"
+mise exec -- dart analyze --fatal-infos
+echo "ANALYZE_EXIT=$?"
+mise exec -- flutter test > /tmp/final.log 2>&1
+echo "TEST_EXIT=$?"; tail -1 /tmp/final.log
+```
+
+Expected: all `0`, and at least `+2871 ~1 All tests passed!`.
+
+---
+
+## Self-Review
+
+**1. Spec coverage.** Slice 7's behaviours: header reads `add_to_album_or_space` ✓, composition order
+✓, album path unchanged ✓ (the picker delegates to the same `addToAlbum` action the sheet called
+before), keyboard callback threaded ✓, space sheet reachable ✓ (the `maxChildSize` raise, justified in
+code), space sheet keeps its actions ✓, `AlbumSelector` untouched ✓ (Task 5 Step 1, a command not a
+test). Slice 8: pool toast uses the request length ✓, album toast uses the server count ✓, failure
+toast ✓, no i18n change ✓, gates ✓.
+
+**Not covered by an automated test, deliberately:** "the spaces section is reachable by dragging to
+maxChildSize" and "the section is not left behind the IME". Both are drag/IME behaviours of
+`DraggableScrollableSheet`, which needs an integration-style harness this suite does not have; the
+`maxChildSize` change itself is the fix and is visible in review. Plural-form rendering for `ru`/`pl`
+is likewise untested — `easy_localization` owns ICU selection and the suite runs a single locale.
+Recorded here rather than dropped.
+
+**2. Placeholder scan.** No TBD/TODO. Task 3's "delete the imports analyze names" is a concrete,
+verifiable instruction rather than "tidy up".
+
+**3. Type consistency.** `onTargetSelected` is `void Function(CollectionTarget)`; `_addToTarget` is
+`Future<void> Function(CollectionTarget)`, which satisfies it (the return is discarded), matching how
+`AlbumSelector` already takes an async `onAlbumSelected`. `addToSpaceAlbum(source, spaceId, album)`
+matches Slice 5's signature exactly, destructured from `SpaceAlbumTarget(:final spaceId, :final
+album)`.

--- a/docs/superpowers/specs/2026-07-26-mobile-spaces-ux-design.md
+++ b/docs/superpowers/specs/2026-07-26-mobile-spaces-ux-design.md
@@ -1,0 +1,536 @@
+# Mobile Spaces UX — edit a space, and add selections to spaces and space albums
+
+**Date:** 2026-07-26
+**Branch:** `worktree-feat+mobile-spaces-ux`
+**Follows on from:** `2026-07-25-rename-spaces-design.md` (web rename/edit) and
+`2026-07-25-space-add-to-collection-design.md` (web contribution mode).
+
+## Problem
+
+Two gaps make Spaces awkward to use from the phone.
+
+1. **A space cannot be renamed on mobile.** `SharedSpaceApiRepository` has `create` and `delete` but no
+   `update`, so there is no client path at all. The space detail kebab is wrapped in `if (_isOwner)` and
+   holds exactly one item, "Delete Space" (`space_detail.page.dart:459`) — which also means **editors see
+   no kebab whatsoever**, even though the server has permitted editors to rename since the server half of
+   the web rename design shipped.
+2. **Photos can only be added to a space from inside that space.** The flow today is inside-out: open the
+   space → tap the 🖼️+ icon → pick assets (`space_detail.page.dart:123`). Space albums have the same
+   shape via their kebab's "Add photos". The outside-in flow — select photos anywhere in the library, then
+   send them to a space — does not exist. The main timeline's multi-select sheet mounts only `AlbumSelector`
+   (`general_bottom_sheet.widget.dart:118`), so albums are the sole possible destination.
+
+The web app closed both of these. This spec is the mobile counterpart, and it is the follow-up PR that
+`2026-07-25-rename-spaces-design.md` explicitly deferred:
+
+> **Mobile.** `mobile/lib/repositories/shared_space_api.repository.dart` has no `updateSpace` call at all.
+> Adding one means a repository method, a bottom-sheet action, a dialog, and a local Drift write — its own PR.
+
+## Goals
+
+1. Space owners and editors can edit a space's name, description, and colour from mobile.
+2. From a multi-select on the main timeline or a space timeline, a user can add the selection to a personal
+   album, a space, or an album linked to a space.
+3. No server changes, no DTO changes, no OpenAPI regeneration.
+
+## Non-goals
+
+- **Server work of any kind.** `PATCH /shared-spaces/:id` already accepts `name` / `description` / `color`
+  and already gates naming at Editor (`shared-space.service.ts:274-282`, shipped with the web rename design).
+  The Dart SDK already generates `updateSpace` and `SharedSpaceUpdateDto`.
+- **Cross-owner contribution mode.** Deferred deliberately — see Risks R1.
+- **Cover photo editing on mobile.** Mobile has no asset-picker-plus-crop surface; that is its own slice.
+- **Target multi-select in the picker.** Tapping a row adds immediately, matching today's album behaviour.
+  Web needs multi-select because it has a CTRL key; on mobile it would nest a selection mode inside the
+  asset selection mode the user is already in.
+- **A full i18n sweep of mobile Spaces.** Only strings on surfaces this work already modifies get keyed.
+
+## What already exists
+
+Everything below is load-bearing for the design and none of it needs changing.
+
+| Piece                                       | Where                                                                        | Why it matters                                                               |
+| ------------------------------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `PATCH /shared-spaces/:id`, Editor for name | `shared-space.service.ts:274-282`                                            | No server work; editors may already rename                                   |
+| `updateSpace` + `SharedSpaceUpdateDto`      | `mobile/openapi/lib/api/shared_spaces_api.dart:2499`                         | Every field is `Optional<T?>`; absent ≠ null                                 |
+| `sharedSpacesProvider`                      | `mobile/lib/providers/shared_space.provider.dart`                            | Network `getAll()`, carries `members` for role gating                        |
+| `spaceAlbumsProvider(spaceId)`              | `mobile/lib/providers/infrastructure/space_album.provider.dart`              | **Local Drift stream** per space — lazy expansion is cheap and works offline |
+| `SpaceAlbumActions.addAssets`               | `mobile/lib/providers/infrastructure/space_album_actions.dart:65`            | Routes around the absorbed-album foreign-key trap; fires its own sync nudge  |
+| `actionProvider.addToAlbum`                 | `mobile/lib/providers/infrastructure/action.provider.dart:384`               | Existing remote+local dispatch, incl. upload-then-link for local assets      |
+| `RemoteAlbumService.categorizeCandidates`   | called from `action.provider.dart:390`                                       | Splits a selection into remote ids and local assets needing upload           |
+| `SpaceLinkPickerSheet.show`                 | `mobile/lib/presentation/widgets/remote_album/space_link_picker.widget.dart` | Precedent for a static-`show` bottom sheet instead of an `auto_route` page   |
+| `spaceGradientColors`                       | `mobile/lib/widgets/spaces/space_collage.dart:7`                             | The ten space colours mobile already renders                                 |
+
+**i18n.** Web and mobile share one `i18n/` directory, and **every key this work needs already exists there**,
+so no new keys are added and everything ships already translated into all seven locales:
+
+| Key                                     | Used for                                    |
+| --------------------------------------- | ------------------------------------------- |
+| `add_to_album_or_space`                 | Picker header                               |
+| `add_to_space`                          | The pool child row inside an expanded space |
+| `add_to_collection_restricted_to_space` | Non-owned-selection notice                  |
+| `spaces_hidden_too_many_assets`         | Over-50 000-selection notice                |
+| `added_to_space_count`                  | Success toast for a space-pool add          |
+| `space_album_add_photos_success`        | Success toast for a space-album add         |
+| `spaces_edit`                           | Edit sheet title and both menu items        |
+| `spaces_edit_success`                   | Edit success toast                          |
+| `errors.unable_to_update_space`         | Edit failure toast                          |
+| `name`, `description`, `color`          | Edit sheet field labels                     |
+
+Keying the hardcoded English on the two surfaces this work touches (Slice 8) needs no new keys either —
+`spaces_delete` ("Delete Space") and `spaces_delete_confirmation` already exist.
+
+`spaces_no_writable_spaces` is deliberately **not** used: web shows it as an empty state, whereas this design
+omits the whole section when there is nothing writable (§3), so nothing would ever render it.
+
+**Translation coverage — audited 2026-07-26, all present and genuinely localised** (not English fallbacks) in
+every one of `de`, `fr`, `it`, `es`, `nl`, `pl`, `ru`, `zh_Hans`, `zh_Hant`, for all thirteen keys above plus
+`spaces_delete` / `spaces_delete_confirmation`. Verified by value, e.g.:
+
+| Key                                     | de                                              | ru                                               | zh_Hans                     |
+| --------------------------------------- | ----------------------------------------------- | ------------------------------------------------ | --------------------------- |
+| `spaces_edit`                           | Space bearbeiten                                | Изменить Space                                   | 编辑 Space                  |
+| `add_to_space`                          | Zum Space hinzufügen                            | Добавить в Space                                 | 添加到 Space                |
+| `spaces_delete`                         | Space löschen                                   | Удалить Space                                    | 删除 Space                  |
+| `add_to_collection_restricted_to_space` | Deine Auswahl enthält Fotos anderer Mitglieder… | Ваш выбор содержит фотографии других участников… | 您的选择包含其他成员的照片… |
+
+This is a direct consequence of reusing web's keys: the fork convention is that new keys land in `en.json`
+only and are translated later, so **inventing a key here would ship an untranslated string into nine locales**.
+That is the concrete reason §3 reuses `add_to_space` for the pool child rather than minting an
+"Add to {space}" variant, and why the toasts in Slice 8 do not name their destination. If a future change does
+need a new key, it must add all nine translations in the same PR.
+
+## Design
+
+### 1. Structure — compose, do not modify
+
+`album_selector.widget.dart` and `general_bottom_sheet.widget.dart` are **pure upstream files**: every
+commit touching either is an upstream PR (`206992605e2`, `cb1af3a8ec0`, `14aff51da9d`, …). They are also
+850 and 124 lines respectively, and `AlbumSelector`'s search / quick-filter / sort / grid machinery is
+album-specific.
+
+So `AlbumSelector` stays byte-identical and gets composed rather than extended:
+
+```
+CollectionPicker (MultiSliver)
+├── AlbumSelector            ← upstream, untouched
+└── SpaceCollectionSection   ← new
+```
+
+Each upstream file takes a one-line diff swapping `AlbumSelector` for `CollectionPicker`, keeping future
+rebases trivial. Album search, quick filters, sort, grid/list toggle and swipe-to-delete all keep working
+because that code is not touched.
+
+The cost is two search affordances in one sheet — album search at the top, the spaces section below it.
+Accepted: the spaces list is short, grouped, and lives under its own header.
+
+### 2. `CollectionTarget`
+
+New sealed class in `mobile/lib/domain/models/collection_target.dart`, the Dart cousin of web's
+`PickerCollection`. Its whole job is to make the dispatch table total and checked by the compiler.
+
+| Variant            | Payload                  | Dispatch                               |
+| ------------------ | ------------------------ | -------------------------------------- |
+| `AlbumTarget`      | `RemoteAlbum`            | `actionProvider.addToAlbum` (existing) |
+| `SpacePoolTarget`  | `SharedSpaceResponseDto` | `actionProvider.addToSpace` (new)      |
+| `SpaceAlbumTarget` | `spaceId` + `SpaceAlbum` | `spaceAlbumActionsProvider.addAssets`  |
+
+**`SpaceAlbumTarget` must never route through `addToAlbum`.** A linked album may be _absorbed_ — present
+only in `shared_space_album` with no local `remote_album` row — and `addToAlbum` also writes the local
+`remote_album_asset` junction, which would hit a foreign-key violation. `SpaceAlbumActions.addAssets`
+exists precisely to avoid this and documents it at `space_album_actions.dart:56-64`. A test pins it.
+
+### 3. `SpaceCollectionSection`
+
+New `mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart`.
+
+Watches `sharedSpacesProvider`, filters to spaces the user can write to, and renders one row per space
+under a "Spaces" header.
+
+**Row behaviour.**
+
+- A space **with** linked albums expands on tap. Its children are "Add to space" (the pool) followed by each
+  linked album. The child label needs no space name — the parent row it is nested under already carries it,
+  which is what lets the existing `add_to_space` key be reused verbatim.
+- A space with **no** linked albums has nothing to expand into, so it renders as a plain row that adds to
+  the pool on a single tap.
+
+This costs one extra tap for the common case versus tap-to-add. That is the right trade on a _shared_
+surface: an accidental add is visible to every member and writes an activity-feed entry for each of them,
+so the destination must never be ambiguous.
+
+Linked albums come from `spaceAlbumsProvider(spaceId)`, watched **only while a row is expanded**. It is a
+local Drift stream, so expansion is cheap and works offline, and collapsed spaces subscribe to nothing.
+
+**Gating.** The section renders in exactly one of four states:
+
+| Condition                                                     | Rendering                                                        |
+| ------------------------------------------------------------- | ---------------------------------------------------------------- |
+| No owner/editor space                                         | Section omitted entirely                                         |
+| Selection contains an asset the user does not own             | Header + `add_to_collection_restricted_to_space` notice, no rows |
+| Selection larger than `MAX_SPACE_ASSETS_PER_REQUEST` (50 000) | Header + `spaces_hidden_too_many_assets` notice, no rows         |
+| Otherwise                                                     | Header + one row per writable space                              |
+
+Local-only assets do **not** count as non-owned: they will be uploaded as the current user's.
+
+### 4. `space_permissions.dart`
+
+The owner/editor predicate exists twice today — `SpaceLinkPickerSheet._canWrite` and
+`space_detail.page.dart`'s `_canEdit` / `_isOwner`. New `mobile/lib/utils/space_permissions.dart` holds one
+implementation and all three sites point at it:
+
+```dart
+bool spaceIsWritable(SharedSpaceResponseDto space, String? currentUserId);
+bool spaceIsOwned(SharedSpaceResponseDto space, String? currentUserId);
+```
+
+Creator-implies-owner is kept (`space.createdById == currentUserId` short-circuits), because the members
+list does not always contain the creator. `members` is `Optional`, so an absent list degrades to the
+`createdById` check rather than throwing.
+
+### 5. Dispatch
+
+New `actionProvider.addToSpace(ActionSource source, SharedSpaceResponseDto space)`, sitting beside
+`addToAlbum` and returning the same `ActionResult(count, success, error)`.
+
+Both space paths handle local assets by uploading first. **Unlike `addToAlbum`**, which links each asset as
+it lands (it must, because it also writes the local Drift junction), the space paths collect the uploaded
+remote ids and issue **one** add call at the end — otherwise `SpaceAlbumActions.addAssets` would fire its
+`syncRemote()` nudge once per photo.
+
+**Failure semantics.** Selection resets **only on success**, leaving the photos selected for retry after a
+failure. This matches `addToAlbum`, which returns before its reset on the error path
+(`action.provider.dart:398-404`). A space-pool add is all-or-nothing server-side —
+`POST /shared-spaces/:id/assets` requires `AssetShare` on every id and rejects the whole request otherwise —
+so a partial-success toast would be a lie. On failure: `scaffold_body_error_occurred` and nothing else. On
+success: sync nudge, then the count toast.
+
+### 6. `SpaceEditSheet`
+
+New `mobile/lib/presentation/widgets/spaces/space_edit_sheet.widget.dart` with a static
+`SpaceEditSheet.show(context, space) → Future<bool?>`, following the `SpaceLinkPickerSheet.show` precedent
+rather than adding an `auto_route` page for a three-field form.
+
+Fields mirror web's `SpaceEditModal`: **name** (required, `maxLength` 100), **description**
+(`maxLength` 500), **colour** (the ten `spaceGradientColors` swatches).
+
+- **Empty-name guard.** Save is disabled when `name.trim().isEmpty`, catching both the empty and the
+  whitespace-only case before a request that `z.string().trim().min(1)` would reject with a 400.
+- **Autofocus and select-once.** The name field autofocuses with its text selected, so typing replaces it.
+  Only on the **first** focus — otherwise tapping to place the caret mid-word would re-select everything.
+
+### 7. `SharedSpaceApiRepository.update`
+
+```dart
+Future<SharedSpaceResponseDto> update(
+  String id, {
+  String? name,
+  String? description,
+  UserAvatarColor? color,
+});
+```
+
+Two things it must get right, both mirroring the web service:
+
+- Every `SharedSpaceUpdateDto` field is `Optional<T?>`. Unchanged fields must be `Optional.absent()`, never
+  `Optional.present(null)` — the latter clears them server-side.
+- **Description is sent only when it changed.** A space created without one stores `null`; always sending
+  `''` would clobber it on a pure rename, while omitting it when the user _did_ clear it would silently keep
+  the old text. The caller decides "changed", the repository sends verbatim.
+
+### 8. Entry points and RBAC
+
+Naming and appearance are Editor-level server-side, but mobile's kebab is owner-gated today, so editors see
+no kebab at all. Both entry points use `space_permissions.dart`:
+
+|              | Viewer | Editor | Owner |
+| ------------ | ------ | ------ | ----- |
+| Edit space   | —      | ✅     | ✅    |
+| Delete space | —      | —      | ✅    |
+
+- **Space detail kebab** — gate flips from `_isOwner` to `_canEdit`, gaining "Edit space"; "Delete Space"
+  stays owner-only _inside_ the menu.
+- **Space card long-press** — `SpaceCard` gains `onLongPress`, opening a compact sheet with the same two
+  role-gated items. A viewer long-pressing gets no sheet, since every item would be hidden.
+
+**After a successful save**, invalidate `sharedSpacesProvider` and `sharedSpaceProvider(id)`, then fire the
+`backgroundSyncProvider.syncRemote()` nudge every other space mutation already uses. The Drift
+`shared_space_entity` stores `name`, `description` and `color` locally
+(`shared_space.entity.dart:16-20`), so without the nudge the local row keeps the old name and the space
+timeline's app bar stays stale until the next app start.
+
+### 9. Surfaces
+
+`CollectionPicker` is mounted in two bottom sheets:
+
+- **`general_bottom_sheet.widget.dart`** — main timeline multi-select. Replaces the `AlbumSelector` sliver.
+- **`space_bottom_sheet.widget.dart`** — space timeline multi-select, which today offers only
+  share / download / favourite / remove-from-space. Gains the picker's slivers.
+
+## Implementation slices
+
+Test-first throughout: write the failing test, confirm it fails for the right reason, then implement.
+Each slice is independently landable and leaves the tree green.
+
+Dependency order: 1 → {2 → 3 → 4} and 1 → {5 → 6 → 7} → 8.
+
+---
+
+### Slice 1 — `space_permissions.dart`
+
+**Goal.** One implementation of the writable/owned predicates; three call sites repointed.
+
+**Files.** New `mobile/lib/utils/space_permissions.dart`. New
+`mobile/test/utils/space_permissions_test.dart`. Edit `space_link_picker.widget.dart` and
+`space_detail.page.dart` to delegate.
+
+**Tests first (BDD).**
+
+- Given a space whose `createdById` is me and whose members list omits me, when I ask if it is writable,
+  then it is — and it is also owned.
+- Given I am a member with role `owner` / `editor`, then writable is true.
+- Given I am a member with role `viewer`, then writable is false and owned is false.
+- Given I am not a member and did not create it, then both are false.
+- Given `members` is `Optional.absent()`, then it falls back to the `createdById` check and does not throw.
+- Given `currentUserId` is null (logged out), then both are false, even for a space with a matching creator id.
+
+**Done when.** Both predicates are pure, `SpaceLinkPickerSheet._canWrite` and `space_detail.page.dart`'s
+`_canEdit` / `_isOwner` are gone in favour of the helper, and behaviour on those two screens is unchanged.
+
+---
+
+### Slice 2 — `SharedSpaceApiRepository.update`
+
+**Goal.** The rename call, with correct `Optional` semantics.
+
+**Files.** Edit `mobile/lib/repositories/shared_space_api.repository.dart`. New
+`mobile/test/repositories/shared_space_api_repository_test.dart` — no test file exists for this repository
+today, so it is created here alongside the siblings in `mobile/test/repositories/`.
+
+**Tests first (BDD).**
+
+- Given only a new name, when update is called, then the DTO carries `Optional.present(name)` and
+  `Optional.absent()` for description and colour.
+- Given a description changed from text to `''`, then the DTO carries `Optional.present('')` — the clobber
+  regression this design calls out.
+- Given a description changed from `null` to text, then `Optional.present(text)`.
+- Given description is not passed at all, then `Optional.absent()` — **never** `Optional.present(null)`.
+- Given a colour change, then `Optional.present(color)`.
+- Given a name with surrounding whitespace, then it is trimmed before sending.
+- Given the API throws, then the exception propagates to the caller unchanged.
+
+**Done when.** The method exists, is covered, and no other field of the DTO is ever populated.
+
+---
+
+### Slice 3 — `SpaceEditSheet`
+
+**Goal.** The three-field form, with validation, in isolation from its entry points.
+
+**Files.** New `mobile/lib/presentation/widgets/spaces/space_edit_sheet.widget.dart`. New
+`mobile/test/widgets/spaces/space_edit_sheet_test.dart`.
+
+**Tests first (BDD).**
+
+- Given a space, when the sheet opens, then name, description and colour are prefilled from it.
+- Given an empty name, then Save is disabled.
+- Given a whitespace-only name `"   "`, then Save is disabled — the case a `required` flag would let through.
+- Given the sheet just opened, then the name field is focused with its text selected; and given the user
+  taps the field again, then the selection is **not** reapplied.
+- Given name and description fields, then they enforce `maxLength` 100 and 500.
+- Given only the name was edited, when saved, then the repository is called **without** a description.
+- Given the description was cleared, when saved, then the repository is called with `''`.
+- Given the user taps a colour swatch, then the selection moves and is sent on save.
+- Given the save succeeds, then the sheet resolves `true`.
+- Given the save throws, then the sheet stays open, resolves nothing, and shows
+  `errors.unable_to_update_space`.
+- Given the user cancels, then no repository call is made and it resolves `null`.
+
+**Done when.** The sheet is fully covered and not yet reachable from any screen.
+
+---
+
+### Slice 4 — Edit entry points
+
+**Goal.** Make the sheet reachable, and fix the editors-see-no-kebab bug.
+
+**Files.** Edit `space_detail.page.dart` (kebab regate) and `mobile/lib/widgets/spaces/space_card.dart`
+(`onLongPress`). New compact role-gated sheet for the card. Tests in
+`mobile/test/pages/spaces/space_detail_kebab_test.dart` and `mobile/test/widgets/spaces/space_card_test.dart`.
+
+**Tests first (BDD).**
+
+- Given I am the owner, then the kebab shows "Edit space" and "Delete Space".
+- Given I am an editor, then the kebab shows "Edit space" but **not** "Delete Space" — the regression fix.
+- Given I am a viewer, then no kebab renders at all.
+- Given I long-press a space card as owner, then a sheet offers Edit and Delete.
+- Given I long-press as an editor, then it offers Edit only.
+- Given I long-press as a viewer, then no sheet opens.
+- Given a save returns `true`, then `sharedSpacesProvider` and `sharedSpaceProvider(id)` are invalidated and
+  `syncRemote()` is called exactly once.
+- Given a save returns `null` (cancelled), then nothing is invalidated and no sync nudge fires.
+
+**Done when.** Editing works end to end from both entry points, and the RBAC table in §8 is pinned by tests.
+
+---
+
+### Slice 5 — `CollectionTarget` and dispatch
+
+**Goal.** The routing table, tested without any UI.
+
+**Files.** New `mobile/lib/domain/models/collection_target.dart`. Edit
+`mobile/lib/providers/infrastructure/action.provider.dart` (add `addToSpace`). New
+`mobile/test/providers/collection_dispatch_test.dart`.
+
+**Tests first (BDD).**
+
+- Given an `AlbumTarget`, then `addToAlbum` is called and neither space path is touched.
+- Given a `SpacePoolTarget` with remote-only assets, then `SharedSpaceApiRepository.addAssets` is called
+  once with every id.
+- Given a `SpaceAlbumTarget`, then `SpaceAlbumActions.addAssets` is called and **`addToAlbum` is never
+  called** — the absorbed-album foreign-key guard.
+- Given a space target with local assets, then upload runs first and the add call is made **exactly once**
+  with all resulting remote ids — not once per asset.
+- Given an empty selection, then no API call is made and the result is a success with count 0.
+- Given the upload fails, then no add call is made and the result is a failure.
+- Given the add call throws, then the result is a failure **and the selection is not reset**.
+- Given the add succeeds, then the selection is reset, `syncRemote()` fires, and the count comes from the
+  server response rather than the request length.
+
+**Done when.** Every row of the §2 dispatch table is covered, including the two never-call assertions.
+
+---
+
+### Slice 6 — `SpaceCollectionSection`
+
+**Goal.** The spaces half of the picker, in isolation.
+
+**Files.** New `mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart`. New
+`mobile/test/widgets/collection/space_collection_section_test.dart`.
+
+**Tests first (BDD).**
+
+- Given no writable spaces, then the section renders nothing at all — not an empty header.
+- Given a mix of writable and viewer-only spaces, then only the writable ones are listed.
+- Given a space with linked albums, when I tap its row, then it expands to show the `add_to_space` pool child
+  followed by each album; tapping again collapses it.
+- Given a space with **no** linked albums, then it renders as a plain row and a single tap emits a
+  `SpacePoolTarget`.
+- Given a collapsed space, then `spaceAlbumsProvider` for it is never watched.
+- Given an expanded space whose album stream is still loading, then a loading affordance shows and the pool
+  child remains tappable.
+- Given an expanded space whose album stream errors, then the pool child still works and the album list
+  shows an error rather than taking the section down.
+- Given the selection contains a non-owned asset, then no space rows render and the restricted notice shows.
+- Given the selection exceeds 50 000 assets, then no space rows render and `spaces_hidden_too_many_assets`
+  shows.
+- Given `sharedSpacesProvider` fails (offline), then the section hides rather than surfacing an error into
+  a sheet whose album half still works.
+- Given a tap on an album child, then a `SpaceAlbumTarget` carrying the **owning space's id** is emitted.
+
+**Done when.** All four gating states from §3 and both row behaviours are covered.
+
+---
+
+### Slice 7 — `CollectionPicker` and the two sheets
+
+**Goal.** Compose and mount, without regressing the album flow.
+
+**Files.** New `mobile/lib/presentation/widgets/collection/collection_picker.widget.dart`. A one-line swap in
+the upstream `general_bottom_sheet.widget.dart` (`AlbumSelector` → `CollectionPicker`). A slightly larger edit
+to the fork-only `space_bottom_sheet.widget.dart`, which passes no `slivers:` today and so gains that argument
+plus the `AddToAlbumHeader`/picker pair — still small, and unconstrained by rebase risk. New
+`mobile/test/widgets/collection/collection_picker_test.dart` plus additions to the two sheet tests.
+
+**Tests first (BDD).**
+
+- Given the picker, then it renders the album selector above the spaces section.
+- Given an album row is tapped, then the existing add-to-album behaviour runs unchanged — the regression guard.
+- Given the album search, sort, quick-filter and grid/list controls, then they all still work.
+- Given the keyboard-expand callback, then it is still threaded through to the album selector.
+- Given the main timeline sheet, then it mounts the picker and spaces are offered.
+- Given the space timeline sheet, then it mounts the picker alongside the existing
+  share / download / favourite / remove-from-space actions.
+- Given `AlbumSelector`, then its file is unchanged in this diff — asserted by review, not by test.
+
+**Done when.** Both sheets offer all three target kinds and the album path is provably untouched.
+
+---
+
+### Slice 8 — i18n, toasts and gates
+
+**Goal.** Ship-quality strings and a green CI.
+
+**Files.** No `i18n/en.json` change — every key is already present (see the table in "What already exists").
+Keying of the hardcoded English on the two surfaces this work touched: the space detail kebab and the space
+card.
+
+**Tests first (BDD).**
+
+- Given a successful add of N photos to a space, then `added_to_space_count` shows with the server's count.
+- Given a successful add to a space album, then `space_album_add_photos_success` shows with the server's count.
+  Neither toast names the destination, because neither existing key takes a name argument and adding one would
+  ship an untranslated string into seven locales for marginal gain.
+- Given a failed add, then `scaffold_body_error_occurred` shows and no count is claimed.
+- Given every new widget, then no user-visible literal English string remains.
+- Given the space detail kebab and the space card sheet, then the delete items render `spaces_delete` and
+  `spaces_delete_confirmation` rather than hardcoded English.
+- Given the whole diff, then **no file under `i18n/` is modified at all** — the guard against quietly
+  inventing a key, which would ship untranslated text into the nine locales this design commits to.
+
+**Done when.** `dart analyze --fatal-infos lib test` and `dart format --set-exit-if-changed` both pass, and
+`flutter test` is green.
+
+Strings left hardcoded elsewhere in mobile Spaces — "Create Space", "Add Photos", "Remove from space",
+"Members", "Space deleted", the spaces empty state — are **out of scope** and recorded as a follow-up rather
+than swept up here.
+
+## Running the tests
+
+Per the repo's mobile notes: Flutter **3.41.7** (the pinned SDK — `mise.toml` may symlink an older patch).
+From `mobile/`:
+
+```bash
+flutter pub get
+dart run easy_localization:generate -S ../i18n && dart run bin/generate_keys.dart
+flutter test test/...
+```
+
+Drift and OpenAPI generated code is committed, so `build_runner` is not needed. CI runs **two** Dart gates:
+`dart analyze --fatal-infos lib test` (local `flutter analyze lib` misses test-only lints) and
+`dart format --set-exit-if-changed`.
+
+## Risks
+
+**R1 — Contribution-mode parity gap with web.** `2026-07-25-space-add-to-collection-design.md` lets a space
+Owner/Editor contribute _other members'_ photos into albums linked to that space. Mobile deliberately does
+not: when the selection contains a non-owned asset, space targets are hidden behind a notice. This is an
+informed deferral, not an oversight — mobile has zero contribution plumbing today, and the honest-notice
+behaviour is strictly better than the alternative failure, where
+`POST /shared-spaces/:id/assets` rejects the entire batch over one non-owned id and the user gets nothing
+added plus a vague error. Closing the gap is a follow-up slice that would port `restrictToSpaceId`.
+
+**R2 — The spaces section is network-backed while albums are local-first.** `sharedSpacesProvider` calls
+`getAll()`, so offline the section hides while the album half of the picker keeps working. Acceptable
+because the section is purely additive, but it means the picker's contents differ online and offline.
+Expansion is unaffected — linked albums come from Drift.
+
+**R3 — One upstream file is touched.** `general_bottom_sheet.widget.dart` is pure upstream and takes a
+one-line diff swapping `AlbumSelector` for `CollectionPicker`. `space_bottom_sheet.widget.dart` is
+**fork-only** (it exists solely in the squashed fork commit `e0950535c36`) and so may be edited freely.
+`album_selector.widget.dart` is upstream and is not touched at all. Any temptation to grow the
+`general_bottom_sheet` edit into a refactor should be resisted — it converts a trivial rebase into a
+conflicting one.
+
+**R4 — The absorbed-album foreign-key trap.** Routing a `SpaceAlbumTarget` through `addToAlbum` throws on an
+absorbed album. This is exactly the sort of thing a well-meaning "unify the two add paths" refactor would
+reintroduce, so Slice 5 pins it with an explicit never-called assertion rather than relying on the comment
+at `space_album_actions.dart:56`.
+
+**R5 — Rename staleness in Drift.** The local `shared_space_entity` caches `name`, so a rename without the
+`syncRemote()` nudge leaves the space timeline's app bar showing the old name until the next app start.
+Slice 4 tests the nudge fires exactly once.
+
+**R6 — One extra tap to reach a space pool.** Spaces with linked albums need expand-then-tap. Chosen
+deliberately for safety on a shared surface (§3). If it proves annoying in use, the fix is a trailing
+"add here" affordance on the space row itself, not making the whole row tap-to-add.

--- a/docs/superpowers/specs/2026-07-26-mobile-spaces-ux-design.md
+++ b/docs/superpowers/specs/2026-07-26-mobile-spaces-ux-design.md
@@ -498,6 +498,11 @@ following the `ProviderContainer` + `overrideWithValue` pattern of
 
 **Files.** New `mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart`, plus the
 non-owned selector. New `mobile/test/presentation/widgets/collection/space_collection_section_test.dart`.
+**Also adds the new i18n key `spaces_hidden_non_owned_selection` to `i18n/en.json` and all nine locale
+files** — the full translation table is in Slice 8, but the key must land _here_, in the slice that first
+renders it. `easy_localization` renders a missing key as the raw key name, so deferring it to Slice 8 would
+let this slice's notice test pass trivially against the literal string `spaces_hidden_non_owned_selection`
+while the shipped app displayed that same gibberish for two slices.
 
 **Tests first (BDD).** One per row of the §3 gating table, plus:
 
@@ -558,11 +563,15 @@ tests.
 
 **Goal.** Ship-quality strings, fully translated, and a green CI.
 
-**One new key is required.** The reused `add_to_collection_restricted_to_space` reads "…so only albums in
-this space can accept them", which is **web's contribution-mode message**: it promises a destination that
-mobile deliberately does not offer (R1). Using it would tell the user to look for something that is not on
-screen. So a new key is added — and, per the fork rule that a new key must not ship untranslated, **with all
-nine translations in the same commit**:
+**One new key is required, and it is added in Slice 6, not here** — Slice 6 is its first consumer, and a key
+must exist in the slice that renders it. This table is the authoritative wording for that Slice 6 change; no
+i18n edit happens in Slice 8.
+
+The reused `add_to_collection_restricted_to_space` reads "…so only albums in this space can accept them",
+which is **web's contribution-mode message**: it promises a destination that mobile deliberately does not
+offer (R1). Using it would tell the user to look for something that is not on screen. So a new key is
+added — and, per the fork rule that a new key must not ship untranslated, **with all nine translations in the
+same commit**:
 
 | Locale    | `spaces_hidden_non_owned_selection`                                                                             |
 | --------- | --------------------------------------------------------------------------------------------------------------- |
@@ -588,8 +597,9 @@ French, which uses "espace" (cf. the existing `add_to_space` values).
 `spaces_no_writable_spaces` is deliberately **not** used: web shows it as an empty state, whereas this design
 omits the whole section when there is nothing writable (§3).
 
-**Files.** `i18n/en.json` plus the nine locale files, for the one new key only. Keying of the hardcoded
-English on the two surfaces this work touches: the space detail kebab and the space card sheet.
+**Files.** No `i18n/` edit in this slice — the one new key landed in Slice 6. This slice only keys the
+hardcoded English on the two surfaces this work touches: the space detail kebab and the space card sheet,
+both of which use keys that already exist.
 
 **Tests first (BDD).**
 

--- a/docs/superpowers/specs/2026-07-26-mobile-spaces-ux-design.md
+++ b/docs/superpowers/specs/2026-07-26-mobile-spaces-ux-design.md
@@ -374,9 +374,11 @@ Edit `space_link_picker.widget.dart`, `space_detail.page.dart`, `space_bottom_sh
 
 **Goal.** The rename call, with correct `Optional` semantics.
 
-**Files.** Edit `mobile/lib/repositories/shared_space_api.repository.dart`. New
-`mobile/test/repositories/shared_space_api_repository_test.dart` — no test file exists for this repository
-today; it follows the mocktail-over-`SharedSpacesApi` pattern of `person_api_repository_test.dart`.
+**Files.** Edit `mobile/lib/repositories/shared_space_api.repository.dart`. **Extend the existing
+`mobile/test/modules/spaces/shared_space_api_repository_test.dart`** — a 512-line suite already covering
+`getAll` / `get` / `create` / `delete` / `getMembers` / `isSpaceEditor` / `updateSpacePerson` / member CRUD,
+with `MockSharedSpacesApi` + `MockApiService` and `registerFallbackValue` already set up. Add an `update`
+group alongside them; do **not** create a file under `test/repositories/`.
 
 **Tests first (BDD).**
 
@@ -389,10 +391,12 @@ today; it follows the mocktail-over-`SharedSpacesApi` pattern of `person_api_rep
   all `Optional.absent()` — the silent-disable guard.
 - Given a name with surrounding whitespace, then it is trimmed; given a description with whitespace, then it
   is **not**.
-- Given the API returns `null` (empty body), then it throws, matching every sibling repository method.
+- Given the API returns `null` (empty body), then it throws, matching the existing
+  `getAll`/`updateSpacePerson` "throws when API returns null" cases in the same file.
 - Given the API throws, then the exception propagates unchanged.
-- Given the endpoint is resolved lazily, then a client swapped after first read is picked up — mirroring
-  `test/repositories/api_repository_lazy_resolution_test.dart`.
+
+Lazy `_api` resolution is **already covered** by the existing `lazy SharedSpacesApi resolution` group at the
+top of that file and needs no new scenario.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-26-mobile-spaces-ux-design.md
+++ b/docs/superpowers/specs/2026-07-26-mobile-spaces-ux-design.md
@@ -56,7 +56,7 @@ explicitly deferred:
 | `SpaceAlbumActions.addAssets`               | `mobile/lib/providers/infrastructure/space_album_actions.dart:67`            | `Future<int>`; routes around the absorbed-album FK trap; nudges sync         |
 | `actionProvider.addToAlbum`                 | `mobile/lib/providers/infrastructure/action.provider.dart:384`               | Existing remote+local dispatch, incl. upload-then-link                       |
 | `RemoteAlbumService.categorizeCandidates`   | called from `action.provider.dart:390`                                       | Splits a selection into remote ids and local assets needing upload           |
-| `MultiSelectState.lockedSelectionAssets`    | `mobile/lib/providers/timeline/multiselect.provider.dart:14`                 | Locked-folder assets that must never leave the device's private scope        |
+| `AssetVisibility.locked`                    | `mobile/lib/domain/models/asset/base_asset.model.dart`                       | Locked-folder assets, which must never be pushed into a shared space         |
 | `SpaceAlbumKebab`                           | `mobile/lib/presentation/widgets/spaces/space_album_kebab.widget.dart`       | The repo's precedent for extracting a kebab so it can be widget-tested       |
 | `SpaceLinkPickerSheet.show`                 | `mobile/lib/presentation/widgets/remote_album/space_link_picker.widget.dart` | Precedent for a static-`show` bottom sheet instead of an `auto_route` page   |
 | `spaceGradientColors`                       | `mobile/lib/widgets/spaces/space_collage.dart:7`                             | The ten space colours mobile already renders                                 |

--- a/docs/superpowers/specs/2026-07-26-mobile-spaces-ux-design.md
+++ b/docs/superpowers/specs/2026-07-26-mobile-spaces-ux-design.md
@@ -4,6 +4,8 @@
 **Branch:** `worktree-feat+mobile-spaces-ux`
 **Follows on from:** `2026-07-25-rename-spaces-design.md` (web rename/edit) and
 `2026-07-25-space-add-to-collection-design.md` (web contribution mode).
+**Review status:** revised 2026-07-26 after two adversarial reviews; every code claim below was verified
+against the tree.
 
 ## Problem
 
@@ -11,17 +13,17 @@ Two gaps make Spaces awkward to use from the phone.
 
 1. **A space cannot be renamed on mobile.** `SharedSpaceApiRepository` has `create` and `delete` but no
    `update`, so there is no client path at all. The space detail kebab is wrapped in `if (_isOwner)` and
-   holds exactly one item, "Delete Space" (`space_detail.page.dart:459`) — which also means **editors see
-   no kebab whatsoever**, even though the server has permitted editors to rename since the server half of
-   the web rename design shipped.
+   holds exactly one item, "Delete Space" (`space_detail.page.dart:458-464`) — which also means **editors
+   see no kebab whatsoever**, even though the server has permitted editors to rename since the server half
+   of the web rename design shipped.
 2. **Photos can only be added to a space from inside that space.** The flow today is inside-out: open the
    space → tap the 🖼️+ icon → pick assets (`space_detail.page.dart:123`). Space albums have the same
    shape via their kebab's "Add photos". The outside-in flow — select photos anywhere in the library, then
    send them to a space — does not exist. The main timeline's multi-select sheet mounts only `AlbumSelector`
-   (`general_bottom_sheet.widget.dart:118`), so albums are the sole possible destination.
+   (`general_bottom_sheet.widget.dart:118-121`), so albums are the sole possible destination.
 
-The web app closed both of these. This spec is the mobile counterpart, and it is the follow-up PR that
-`2026-07-25-rename-spaces-design.md` explicitly deferred:
+This spec is the mobile counterpart, and it is the follow-up PR that `2026-07-25-rename-spaces-design.md`
+explicitly deferred:
 
 > **Mobile.** `mobile/lib/repositories/shared_space_api.repository.dart` has no `updateSpace` call at all.
 > Adding one means a repository method, a bottom-sheet action, a dialog, and a local Drift write — its own PR.
@@ -37,187 +39,228 @@ The web app closed both of these. This spec is the mobile counterpart, and it is
 
 - **Server work of any kind.** `PATCH /shared-spaces/:id` already accepts `name` / `description` / `color`
   and already gates naming at Editor (`shared-space.service.ts:274-282`, shipped with the web rename design).
-  The Dart SDK already generates `updateSpace` and `SharedSpaceUpdateDto`.
-- **Cross-owner contribution mode.** Deferred deliberately — see Risks R1.
+- **Cross-owner contribution mode.** Deferred deliberately — see R1.
 - **Cover photo editing on mobile.** Mobile has no asset-picker-plus-crop surface; that is its own slice.
 - **Target multi-select in the picker.** Tapping a row adds immediately, matching today's album behaviour.
-  Web needs multi-select because it has a CTRL key; on mobile it would nest a selection mode inside the
-  asset selection mode the user is already in.
 - **A full i18n sweep of mobile Spaces.** Only strings on surfaces this work already modifies get keyed.
 
 ## What already exists
 
-Everything below is load-bearing for the design and none of it needs changing.
-
 | Piece                                       | Where                                                                        | Why it matters                                                               |
 | ------------------------------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | `PATCH /shared-spaces/:id`, Editor for name | `shared-space.service.ts:274-282`                                            | No server work; editors may already rename                                   |
-| `updateSpace` + `SharedSpaceUpdateDto`      | `mobile/openapi/lib/api/shared_spaces_api.dart:2499`                         | Every field is `Optional<T?>`; absent ≠ null                                 |
-| `sharedSpacesProvider`                      | `mobile/lib/providers/shared_space.provider.dart`                            | Network `getAll()`, carries `members` for role gating                        |
+| `updateSpace`                               | `mobile/openapi/lib/api/shared_spaces_api.dart:2499`                         | Returns `SharedSpaceResponseDto?` — **nullable**                             |
+| `SharedSpaceUpdateDto`                      | `mobile/openapi/lib/model/shared_space_update_dto.dart`                      | All seven fields are `Optional<T?>`                                          |
+| `sharedSpacesProvider`                      | `mobile/lib/providers/shared_space.provider.dart:6`                          | Network `getAll()`; carries `members` and `albumCount`                       |
 | `spaceAlbumsProvider(spaceId)`              | `mobile/lib/providers/infrastructure/space_album.provider.dart`              | **Local Drift stream** per space — lazy expansion is cheap and works offline |
-| `SpaceAlbumActions.addAssets`               | `mobile/lib/providers/infrastructure/space_album_actions.dart:65`            | Routes around the absorbed-album foreign-key trap; fires its own sync nudge  |
-| `actionProvider.addToAlbum`                 | `mobile/lib/providers/infrastructure/action.provider.dart:384`               | Existing remote+local dispatch, incl. upload-then-link for local assets      |
+| `SpaceAlbumActions.addAssets`               | `mobile/lib/providers/infrastructure/space_album_actions.dart:67`            | `Future<int>`; routes around the absorbed-album FK trap; nudges sync         |
+| `actionProvider.addToAlbum`                 | `mobile/lib/providers/infrastructure/action.provider.dart:384`               | Existing remote+local dispatch, incl. upload-then-link                       |
 | `RemoteAlbumService.categorizeCandidates`   | called from `action.provider.dart:390`                                       | Splits a selection into remote ids and local assets needing upload           |
+| `MultiSelectState.lockedSelectionAssets`    | `mobile/lib/providers/timeline/multiselect.provider.dart:14`                 | Locked-folder assets that must never leave the device's private scope        |
+| `SpaceAlbumKebab`                           | `mobile/lib/presentation/widgets/spaces/space_album_kebab.widget.dart`       | The repo's precedent for extracting a kebab so it can be widget-tested       |
 | `SpaceLinkPickerSheet.show`                 | `mobile/lib/presentation/widgets/remote_album/space_link_picker.widget.dart` | Precedent for a static-`show` bottom sheet instead of an `auto_route` page   |
 | `spaceGradientColors`                       | `mobile/lib/widgets/spaces/space_collage.dart:7`                             | The ten space colours mobile already renders                                 |
 
-**i18n.** Web and mobile share one `i18n/` directory, and **every key this work needs already exists there**,
-so no new keys are added and everything ships already translated into all seven locales:
+### Five corrections that shape the design
 
-| Key                                     | Used for                                    |
-| --------------------------------------- | ------------------------------------------- |
-| `add_to_album_or_space`                 | Picker header                               |
-| `add_to_space`                          | The pool child row inside an expanded space |
-| `add_to_collection_restricted_to_space` | Non-owned-selection notice                  |
-| `spaces_hidden_too_many_assets`         | Over-50 000-selection notice                |
-| `added_to_space_count`                  | Success toast for a space-pool add          |
-| `space_album_add_photos_success`        | Success toast for a space-album add         |
-| `spaces_edit`                           | Edit sheet title and both menu items        |
-| `spaces_edit_success`                   | Edit success toast                          |
-| `errors.unable_to_update_space`         | Edit failure toast                          |
-| `name`, `description`, `color`          | Edit sheet field labels                     |
+Each of these overturned an earlier assumption and is load-bearing.
 
-Keying the hardcoded English on the two surfaces this work touches (Slice 8) needs no new keys either —
-`spaces_delete` ("Delete Space") and `spaces_delete_confirmation` already exist.
-
-`spaces_no_writable_spaces` is deliberately **not** used: web shows it as an empty state, whereas this design
-omits the whole section when there is nothing writable (§3), so nothing would ever render it.
-
-**Translation coverage — audited 2026-07-26, all present and genuinely localised** (not English fallbacks) in
-every one of `de`, `fr`, `it`, `es`, `nl`, `pl`, `ru`, `zh_Hans`, `zh_Hant`, for all thirteen keys above plus
-`spaces_delete` / `spaces_delete_confirmation`. Verified by value, e.g.:
-
-| Key                                     | de                                              | ru                                               | zh_Hans                     |
-| --------------------------------------- | ----------------------------------------------- | ------------------------------------------------ | --------------------------- |
-| `spaces_edit`                           | Space bearbeiten                                | Изменить Space                                   | 编辑 Space                  |
-| `add_to_space`                          | Zum Space hinzufügen                            | Добавить в Space                                 | 添加到 Space                |
-| `spaces_delete`                         | Space löschen                                   | Удалить Space                                    | 删除 Space                  |
-| `add_to_collection_restricted_to_space` | Deine Auswahl enthält Fotos anderer Mitglieder… | Ваш выбор содержит фотографии других участников… | 您的选择包含其他成员的照片… |
-
-This is a direct consequence of reusing web's keys: the fork convention is that new keys land in `en.json`
-only and are translated later, so **inventing a key here would ship an untranslated string into nine locales**.
-That is the concrete reason §3 reuses `add_to_space` for the pool child rather than minting an
-"Add to {space}" variant, and why the toasts in Slice 8 do not name their destination. If a future change does
-need a new key, it must add all nine translations in the same PR.
+1. **`addAssets` returns nothing.** `POST /shared-spaces/:id/assets` is `@HttpCode(NO_CONTENT)` returning
+   `Promise<void>`; the Dart repository is `Future<void>` (`shared_space_api.repository.dart:114`). There is
+   **no server count** for a space-pool add. Web itself falls back to the request length
+   (`web/src/lib/services/space.service.ts:20`). Only the space-**album** path yields a true count
+   (`space_album_actions.dart:71`, `result.added.length`).
+2. **`sharedSpaceProvider` has zero consumers** anywhere in `mobile/lib`, so invalidating it after a rename
+   is a no-op. The space detail app bar renders `_space!.name` (`space_detail.page.dart:440`) from local
+   `State` populated by a network `get()`. The Drift `shared_space_entity.name` column is written by sync
+   (`sync_stream.repository.dart:643-658`) but **never read for display**, so a sync nudge does not refresh
+   the title either. Only re-fetching the page's own metadata does.
+3. **`Optional.present(null)` is a 400, not a clear.** `name`, `description` and `color` are `.optional()`
+   but **not** `.nullable()` in `SharedSpaceUpdateSchema` (`shared-space.dto.ts:16-32`), so an explicit
+   `null` is rejected by the zod pipe before reaching `updatePayload`. Only absent-vs-present matters.
+4. **`Optional.value` throws on an absent value** (`mobile/openapi/lib/optional.dart:66`,
+   `StateError('No value present')`). Any predicate reading `space.members` must go through `isPresent` /
+   `orElse`, never bare `.value`.
+5. **`AddToAlbumHeader` lives inside the upstream `album_selector.widget.dart`** (`:742`) and hardcodes
+   `"add_to_album"` (`:768`). The picker therefore cannot reuse it and still say "Add to album or space".
 
 ## Design
 
 ### 1. Structure — compose, do not modify
 
-`album_selector.widget.dart` and `general_bottom_sheet.widget.dart` are **pure upstream files**: every
-commit touching either is an upstream PR (`206992605e2`, `cb1af3a8ec0`, `14aff51da9d`, …). They are also
-850 and 124 lines respectively, and `AlbumSelector`'s search / quick-filter / sort / grid machinery is
-album-specific.
+`album_selector.widget.dart` and `general_bottom_sheet.widget.dart` are **pure upstream** (every commit
+touching them is an upstream PR; neither appears in the squashed fork commit `e0950535c36`).
+`space_bottom_sheet.widget.dart` is **fork-only** (it exists solely in `e0950535c36`) and may be edited
+freely.
 
-So `AlbumSelector` stays byte-identical and gets composed rather than extended:
+`AlbumSelector` is not touched at all. It is composed:
 
 ```
 CollectionPicker (MultiSliver)
-├── AlbumSelector            ← upstream, untouched
+├── CollectionPickerHeader   ← new; renders `add_to_album_or_space` (see correction 5)
+├── AlbumSelector            ← upstream, byte-identical
 └── SpaceCollectionSection   ← new
 ```
 
-Each upstream file takes a one-line diff swapping `AlbumSelector` for `CollectionPicker`, keeping future
-rebases trivial. Album search, quick filters, sort, grid/list toggle and swipe-to-delete all keep working
-because that code is not touched.
+`general_bottom_sheet.widget.dart` takes a **two-line** diff: drop `const AddToAlbumHeader()` and swap
+`AlbumSelector` for `CollectionPicker` (`:119-120`). That is the only upstream edit in this work.
 
-The cost is two search affordances in one sheet — album search at the top, the spaces section below it.
-Accepted: the spaces list is short, grouped, and lives under its own header.
+The cost is two search affordances in one sheet — album search inside `AlbumSelector`, and the spaces
+section below it. Accepted: the spaces list is short, grouped, and under its own header.
 
-### 2. `CollectionTarget`
+### 2. `CollectionTarget` and the dispatch table
 
-New sealed class in `mobile/lib/domain/models/collection_target.dart`, the Dart cousin of web's
-`PickerCollection`. Its whole job is to make the dispatch table total and checked by the compiler.
+New sealed class in `mobile/lib/domain/models/collection_target.dart`.
 
-| Variant            | Payload                  | Dispatch                               |
-| ------------------ | ------------------------ | -------------------------------------- |
-| `AlbumTarget`      | `RemoteAlbum`            | `actionProvider.addToAlbum` (existing) |
-| `SpacePoolTarget`  | `SharedSpaceResponseDto` | `actionProvider.addToSpace` (new)      |
-| `SpaceAlbumTarget` | `spaceId` + `SpaceAlbum` | `spaceAlbumActionsProvider.addAssets`  |
+| Variant            | Payload                  | Dispatch                                   |
+| ------------------ | ------------------------ | ------------------------------------------ |
+| `AlbumTarget`      | `RemoteAlbum`            | `actionProvider.addToAlbum` (existing)     |
+| `SpacePoolTarget`  | `SharedSpaceResponseDto` | `actionProvider.addToSpace` (**new**)      |
+| `SpaceAlbumTarget` | `spaceId` + `SpaceAlbum` | `actionProvider.addToSpaceAlbum` (**new**) |
+
+Both new methods live on `ActionNotifier` and return the usual `ActionResult(count, success, error)`,
+because upload, `multiSelectProvider` reset and `ActionSource` all live there.
+`SpaceAlbumActions.addAssets` stays the low-level call underneath `addToSpaceAlbum` — it takes only
+`(albumId, assetIds)`, returns `Future<int>`, and knows nothing about selection state.
 
 **`SpaceAlbumTarget` must never route through `addToAlbum`.** A linked album may be _absorbed_ — present
 only in `shared_space_album` with no local `remote_album` row — and `addToAlbum` also writes the local
 `remote_album_asset` junction, which would hit a foreign-key violation. `SpaceAlbumActions.addAssets`
-exists precisely to avoid this and documents it at `space_album_actions.dart:56-64`. A test pins it.
+exists precisely to avoid this (`space_album_actions.dart:57-62`). A test pins it.
+
+`SpaceAlbumTarget` carries `spaceId` even though `addAssets` does not need it: it is used to invalidate
+`spaceAlbumsProvider(spaceId)` after the add, and to exclude the current space in the space sheet (§3).
 
 ### 3. `SpaceCollectionSection`
 
 New `mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart`.
 
-Watches `sharedSpacesProvider`, filters to spaces the user can write to, and renders one row per space
-under a "Spaces" header.
+Watches `sharedSpacesProvider`, filters to writable spaces, renders one row per space under a header.
+
+**Expandable vs plain.** Whether a row is expandable is decided by `SharedSpaceResponseDto.albumCount`,
+because the local Drift stream cannot be consulted without subscribing to it. The server does populate it on
+this exact path (`shared-space.service.ts:143` and `:190`, inside `getAll`), which is what
+`sharedSpacesProvider` calls.
+
+Two traps: it is typed `Optional<num?>` (`shared_space_response_dto.dart:48`), so it must be read through
+`isPresent` / `orElse` like `members` (correction 4), and it is a `num`, not an `int`. It is also used
+**nowhere in `mobile/lib` today**, so this is its first consumer and it carries no existing coverage. An
+absent `albumCount` is treated as 0 — a plain row, which still reaches the pool.
+
+The count can disagree with the Drift stream, and both directions are handled explicitly:
+
+- `albumCount > 0` but the Drift stream is empty (not yet synced) → the expanded row shows an empty-albums
+  hint, and the pool child still works.
+- `albumCount == 0` but an album was just linked → the row is plain; the pool child still works and the
+  album becomes reachable after the next sync. Accepted staleness.
 
 **Row behaviour.**
 
-- A space **with** linked albums expands on tap. Its children are "Add to space" (the pool) followed by each
-  linked album. The child label needs no space name — the parent row it is nested under already carries it,
-  which is what lets the existing `add_to_space` key be reused verbatim.
-- A space with **no** linked albums has nothing to expand into, so it renders as a plain row that adds to
-  the pool on a single tap.
+- Expandable row: tapping toggles expansion. Children are the pool child, then each linked album.
+- Plain row: a single tap emits `SpacePoolTarget`.
+- Only one row is expanded at a time (accordion), which bounds concurrent Drift subscriptions to one.
 
-This costs one extra tap for the common case versus tap-to-add. That is the right trade on a _shared_
-surface: an accidental add is visible to every member and writes an activity-feed entry for each of them,
-so the destination must never be ambiguous.
+The pool child is labelled `add_to_space` ("Add to space"). It needs no space name — the parent row it is
+nested under already carries it — which is what lets the existing key be reused verbatim.
 
-Linked albums come from `spaceAlbumsProvider(spaceId)`, watched **only while a row is expanded**. It is a
-local Drift stream, so expansion is cheap and works offline, and collapsed spaces subscribe to nothing.
+Linked albums come from `spaceAlbumsProvider(spaceId)`, watched **only while a row is expanded**.
 
-**Gating.** The section renders in exactly one of four states:
+**Row ordering** is by space name, case-insensitive, matching `SpaceLinkPickerSheet`. Names render with
+`maxLines: 1, overflow: ellipsis` for long and RTL names, matching `space_link_picker.widget.dart:72`.
 
-| Condition                                                     | Rendering                                                        |
-| ------------------------------------------------------------- | ---------------------------------------------------------------- |
-| No owner/editor space                                         | Section omitted entirely                                         |
-| Selection contains an asset the user does not own             | Header + `add_to_collection_restricted_to_space` notice, no rows |
-| Selection larger than `MAX_SPACE_ASSETS_PER_REQUEST` (50 000) | Header + `spaces_hidden_too_many_assets` notice, no rows         |
-| Otherwise                                                     | Header + one row per writable space                              |
+**Gating.** The section renders in exactly one of six states:
 
-Local-only assets do **not** count as non-owned: they will be uploaded as the current user's.
+| Condition                                                                                     | Rendering                                                     |
+| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `sharedSpacesProvider` loading                                                                | Header + skeleton rows (reserves height, avoids layout shift) |
+| `sharedSpacesProvider` error (offline)                                                        | Section omitted — the album half of the picker still works    |
+| No writable space                                                                             | Section omitted entirely                                      |
+| Selection contains an asset the user does not own                                             | Header + `spaces_hidden_non_owned_selection` notice, no rows  |
+| Selection contains a locked-folder asset, **or** exceeds `kMaxSpaceAssetsPerRequest` (50 000) | Header + the matching notice, no rows                         |
+| Otherwise                                                                                     | Header + one row per writable space                           |
+
+- **Locked-folder assets are excluded** from every space target. Sending an asset the user deliberately
+  placed in the locked folder into a shared space would be a privacy leak.
+- Local-only assets do **not** count as non-owned: they will be uploaded as the current user's.
+- The **non-owned predicate** is a new derived selector over `multiSelectProvider`, comparing
+  `RemoteAsset.ownerId` against `currentUserProvider`. When `currentUserProvider` is null it returns
+  "contains non-owned" (fail-closed), so a logged-out edge never offers space targets.
+- `kMaxSpaceAssetsPerRequest = 50000` is a **new Dart constant** in
+  `mobile/lib/constants/collection.dart`, mirroring `shared-space.dto.ts:176` and `web/src/lib/constants.ts:85`.
+  The cap is inclusive: 50 000 is allowed, 50 001 is not. It gates only the pool path server-side, but the
+  section hides wholesale for simplicity, and that over-broadness is noted in R7.
+- **In the space sheet, the space being viewed is excluded** from its own list — adding a space's assets
+  back into itself is a no-op that would still fire an activity entry.
+
+**Re-entrancy.** Rows are disabled while an add is in flight, so a double-tap cannot dispatch twice.
 
 ### 4. `space_permissions.dart`
 
-The owner/editor predicate exists twice today — `SpaceLinkPickerSheet._canWrite` and
-`space_detail.page.dart`'s `_canEdit` / `_isOwner`. New `mobile/lib/utils/space_permissions.dart` holds one
-implementation and all three sites point at it:
+The predicate exists in **four** places today: `SpaceLinkPickerSheet._canWrite`, `space_detail.page.dart`'s
+`_canEdit` and `_isOwner`, and `space_bottom_sheet.widget.dart:38`'s `_canEdit`. New
+`mobile/lib/utils/space_permissions.dart`:
 
 ```dart
 bool spaceIsWritable(SharedSpaceResponseDto space, String? currentUserId);
 bool spaceIsOwned(SharedSpaceResponseDto space, String? currentUserId);
+bool roleIsWritable(SharedSpaceRole? role); // for space_bottom_sheet, which holds a role, not a DTO
 ```
 
-Creator-implies-owner is kept (`space.createdById == currentUserId` short-circuits), because the members
-list does not always contain the creator. `members` is `Optional`, so an absent list degrades to the
-`createdById` check rather than throwing.
+`members` is read via `isPresent` / `orElse`, never bare `.value` (correction 4).
 
-### 5. Dispatch
+**This is a deliberate behaviour change, not a pure refactor.** `space_detail.page.dart:100-121` derives
+both predicates _only_ from the separately-fetched `_members` list, with no creator short-circuit, and
+returns `false` while `_members == null`. Adopting the helper means a creator absent from the members list
+becomes an owner. That is the correct reading — `getAll` does not guarantee the creator appears as a member
+— but it changes who sees "Delete Space", so Slice 1 tests it as a change rather than claiming parity. The
+loading default stays fail-closed: while members are unknown, nothing is editable.
 
-New `actionProvider.addToSpace(ActionSource source, SharedSpaceResponseDto space)`, sitting beside
-`addToAlbum` and returning the same `ActionResult(count, success, error)`.
+### 5. Dispatch semantics
 
-Both space paths handle local assets by uploading first. **Unlike `addToAlbum`**, which links each asset as
-it lands (it must, because it also writes the local Drift junction), the space paths collect the uploaded
-remote ids and issue **one** add call at the end — otherwise `SpaceAlbumActions.addAssets` would fire its
-`syncRemote()` nudge once per photo.
+**Counts.** `addToSpace` reports the **request length**, because the endpoint returns no body (correction 1);
+this matches web. `addToSpaceAlbum` reports the **server's** `added.length`, which correctly excludes
+duplicates — so re-adding 20 assets already in an album truthfully says 0.
 
-**Failure semantics.** Selection resets **only on success**, leaving the photos selected for retry after a
-failure. This matches `addToAlbum`, which returns before its reset on the error path
-(`action.provider.dart:398-404`). A space-pool add is all-or-nothing server-side —
-`POST /shared-spaces/:id/assets` requires `AssetShare` on every id and rejects the whole request otherwise —
-so a partial-success toast would be a lie. On failure: `scaffold_body_error_occurred` and nothing else. On
-success: sync nudge, then the count toast.
+**Local assets.** Both new methods upload first, then issue **one** add call with all resulting remote ids —
+not one per asset, which would fire `SpaceAlbumActions`' `syncRemote()` nudge once per photo.
+
+**Partial upload.** `upload()` reports `successCount` and `success == successCount == total`
+(`action.provider.dart:565-640`). When some assets upload and others fail, the successful ids **are** added
+and the result is a partial: `count = uploaded + remote`, `success = false`. Dropping the successful ones
+would strand photos in the library that the user asked to file.
+
+**Selection reset.** Reset happens **only on full success**. This is a **deliberate divergence** from
+`addToAlbum`, which resets after the remote add and _before_ the upload (`action.provider.dart:404-406`) and
+so clears the selection even when the upload later fails. Retrying is the point of keeping it.
+
+**Failure.** A space-pool add is all-or-nothing server-side — `requireAccess(AssetShare)` throws unless the
+allowed set equals the requested set — so `scaffold_body_error_occurred` and no count. The space-**album**
+path is per-asset on the server and does not throw on individual denials, so it reports its true count and
+never claims more than landed.
 
 ### 6. `SpaceEditSheet`
 
 New `mobile/lib/presentation/widgets/spaces/space_edit_sheet.widget.dart` with a static
-`SpaceEditSheet.show(context, space) → Future<bool?>`, following the `SpaceLinkPickerSheet.show` precedent
-rather than adding an `auto_route` page for a three-field form.
+`SpaceEditSheet.show(context, space) → Future<bool?>`, following `SpaceLinkPickerSheet.show`.
 
 Fields mirror web's `SpaceEditModal`: **name** (required, `maxLength` 100), **description**
 (`maxLength` 500), **colour** (the ten `spaceGradientColors` swatches).
 
-- **Empty-name guard.** Save is disabled when `name.trim().isEmpty`, catching both the empty and the
-  whitespace-only case before a request that `z.string().trim().min(1)` would reject with a 400.
-- **Autofocus and select-once.** The name field autofocuses with its text selected, so typing replaces it.
-  Only on the **first** focus — otherwise tapping to place the caret mid-word would re-select everything.
+- **Empty-name guard.** Save is disabled when `name.trim().isEmpty`, catching both empty and
+  whitespace-only before a request that `z.string().trim().min(1)` would reject.
+- **In-flight guard.** Save is disabled while a save is running, so a double-tap cannot send two PATCHes.
+- **Autofocus and select-once.** The name autofocuses with its text selected; only on the **first** focus,
+  so tapping to place the caret mid-word does not re-select.
+- **Prefill longer than the cap.** A name created via API can exceed 100 chars. The field renders it in
+  full rather than truncating silently, and Save stays enabled — truncating a user's existing name because
+  they opened a sheet would be data loss. The server rejects it only if they save it unchanged, which is
+  surfaced as the normal error.
+- **Grapheme mismatch is accepted.** Flutter's `maxLength` counts UTF-16 code units while the server's
+  `z.string().max(100)` counts code points, so an emoji-heavy name can hit the client cap early. Noted, not
+  worked around — the failure mode is a stricter client, which is safe.
+- **Colour with no value.** `space.color` may be absent; the sheet defaults to `primary`, matching web's
+  `space.color ?? UserAvatarColor.Primary`. Colour cannot be unset.
+- **Dismissal mid-save.** Every post-await use of `context` is `mounted`-guarded.
 
 ### 7. `SharedSpaceApiRepository.update`
 
@@ -230,47 +273,69 @@ Future<SharedSpaceResponseDto> update(
 });
 ```
 
-Two things it must get right, both mirroring the web service:
-
-- Every `SharedSpaceUpdateDto` field is `Optional<T?>`. Unchanged fields must be `Optional.absent()`, never
-  `Optional.present(null)` — the latter clears them server-side.
-- **Description is sent only when it changed.** A space created without one stores `null`; always sending
-  `''` would clobber it on a pure rename, while omitting it when the user _did_ clear it would silently keep
-  the old text. The caller decides "changed", the repository sends verbatim.
+- `updateSpace` returns `SharedSpaceResponseDto?`; the repository uses the existing `checkNull` helper, as
+  every sibling method does, so a null body throws rather than propagating.
+- Unchanged fields are `Optional.absent()`. `Optional.present(null)` must never be sent — it is a **400**,
+  not a clear (correction 3).
+- The four fields this design never touches — `faceRecognitionEnabled`, `petsEnabled`, `thumbnailAssetId`,
+  `thumbnailCropY` — must stay `Optional.absent()`. A stray `present(null)` on `faceRecognitionEnabled`
+  would 400; a stray `present(false)` would silently disable face recognition for the whole space on every
+  rename. Tested explicitly.
+- **Description is sent only when it changed.** The caller decides "changed"; the repository sends verbatim.
+  `''` clears it server-side; absent leaves it.
+- `name` is trimmed before sending. `description` is **not** trimmed — a user may legitimately want
+  trailing structure, and the server does not trim it either.
 
 ### 8. Entry points and RBAC
-
-Naming and appearance are Editor-level server-side, but mobile's kebab is owner-gated today, so editors see
-no kebab at all. Both entry points use `space_permissions.dart`:
 
 |              | Viewer | Editor | Owner |
 | ------------ | ------ | ------ | ----- |
 | Edit space   | —      | ✅     | ✅    |
 | Delete space | —      | —      | ✅    |
 
-- **Space detail kebab** — gate flips from `_isOwner` to `_canEdit`, gaining "Edit space"; "Delete Space"
-  stays owner-only _inside_ the menu.
-- **Space card long-press** — `SpaceCard` gains `onLongPress`, opening a compact sheet with the same two
-  role-gated items. A viewer long-pressing gets no sheet, since every item would be hidden.
+**Extraction first.** `space_detail.page.dart` is 480 lines, is an `@RoutePage()` `ConsumerStatefulWidget`
+that loads network metadata and members, mounts a Drift-backed `Timeline` and a `SpaceBottomSheet`, and has
+**no test at all** today. Its kebab is therefore extracted into
+`mobile/lib/presentation/widgets/spaces/space_detail_kebab.widget.dart` as
+`SpaceDetailKebab({required bool canEdit, required bool canDelete, required onEdit, required onDelete})`,
+exactly mirroring the existing `SpaceAlbumKebab`. This is what makes the RBAC table testable without
+pumping the page.
 
-**After a successful save**, invalidate `sharedSpacesProvider` and `sharedSpaceProvider(id)`, then fire the
-`backgroundSyncProvider.syncRemote()` nudge every other space mutation already uses. The Drift
-`shared_space_entity` stores `name`, `description` and `color` locally
-(`shared_space.entity.dart:16-20`), so without the nudge the local row keeps the old name and the space
-timeline's app bar stays stale until the next app start.
+- **Space detail kebab** — gate flips from `_isOwner` to `canEdit`; "Delete Space" stays owner-only inside
+  the menu. While `_space` or `_members` is still loading, no kebab renders.
+- **Space card long-press** — `SpaceCard` gains `onLongPress` alongside its existing
+  `GestureDetector(onTap:)` (`space_card.dart:16`); the long-press must **not** also fire `onTap` and
+  navigate into the space behind the sheet. A viewer's long-press opens nothing.
+- Delete from the card sheet reuses `spaces_delete_confirmation`, like the kebab path.
+
+**After a successful save** (correction 2): invalidate `sharedSpacesProvider` so the grid re-renders, and
+call the page's existing `_refreshSpaceMetadata()` so the app bar title updates. **No sync nudge** — nothing
+reads the Drift name column for display, so it would be cargo cult.
 
 ### 9. Surfaces
 
-`CollectionPicker` is mounted in two bottom sheets:
-
-- **`general_bottom_sheet.widget.dart`** — main timeline multi-select. Replaces the `AlbumSelector` sliver.
-- **`space_bottom_sheet.widget.dart`** — space timeline multi-select, which today offers only
-  share / download / favourite / remove-from-space. Gains the picker's slivers.
+- **`general_bottom_sheet.widget.dart`** (upstream) — two-line diff, per §1.
+- **`space_bottom_sheet.widget.dart`** (fork-only) — gains a `slivers:` argument. Its
+  `maxChildSize` is **0.55** today (`:49`), which would leave the spaces section permanently below the fold;
+  it is raised to 0.85 to match `GeneralBottomSheet`, and a test pins that the section is reachable.
 
 ## Implementation slices
 
 Test-first throughout: write the failing test, confirm it fails for the right reason, then implement.
-Each slice is independently landable and leaves the tree green.
+
+**Standing rule for every slice:** the slice is not done until the **whole** mobile suite is green
+(`flutter test`), plus `dart analyze --fatal-infos lib test` and `dart format --set-exit-if-changed`. This
+is what "leaves the tree green" means.
+
+**Test locations follow the repo's actual convention**, verified against the tree: widgets under
+`lib/presentation/widgets/**` are tested under `mobile/test/presentation/widgets/**` (e.g.
+`mobile/test/presentation/widgets/spaces/space_album_bottom_sheet_test.dart`); providers under
+`mobile/test/providers/infrastructure/`; repositories under `mobile/test/repositories/`; pure helpers under
+`mobile/test/utils/` (**not** `utils_legacy/`). `mobile/test/widgets/` holds only `backup/`, `common/` and
+`settings/` and is **not** used here.
+
+Where a widget shows a still-running spinner, use `pumpConsumerWidgetRaw` — the fork added it precisely
+because `pumpConsumerWidget` calls `pumpAndSettle()` and would hang.
 
 Dependency order: 1 → {2 → 3 → 4} and 1 → {5 → 6 → 7} → 8.
 
@@ -278,24 +343,30 @@ Dependency order: 1 → {2 → 3 → 4} and 1 → {5 → 6 → 7} → 8.
 
 ### Slice 1 — `space_permissions.dart`
 
-**Goal.** One implementation of the writable/owned predicates; three call sites repointed.
+**Goal.** One implementation of the role predicates; four call sites repointed.
 
-**Files.** New `mobile/lib/utils/space_permissions.dart`. New
-`mobile/test/utils/space_permissions_test.dart`. Edit `space_link_picker.widget.dart` and
-`space_detail.page.dart` to delegate.
+**Files.** New `mobile/lib/utils/space_permissions.dart`, new `mobile/test/utils/space_permissions_test.dart`.
+Edit `space_link_picker.widget.dart`, `space_detail.page.dart`, `space_bottom_sheet.widget.dart`.
 
 **Tests first (BDD).**
 
-- Given a space whose `createdById` is me and whose members list omits me, when I ask if it is writable,
-  then it is — and it is also owned.
-- Given I am a member with role `owner` / `editor`, then writable is true.
-- Given I am a member with role `viewer`, then writable is false and owned is false.
-- Given I am not a member and did not create it, then both are false.
-- Given `members` is `Optional.absent()`, then it falls back to the `createdById` check and does not throw.
-- Given `currentUserId` is null (logged out), then both are false, even for a space with a matching creator id.
+- Given a space whose `createdById` is me and whose members list omits me, then it is writable and owned.
+- Given I am a member with role `owner` but am **not** the creator, then it is writable **and owned** — the
+  Delete gating in Slice 4 depends on this.
+- Given I am a member with role `editor`, then writable is true and owned is false.
+- Given I am a member with role `viewer`, then both are false.
+- Given I am neither member nor creator, then both are false.
+- Given `members` is `Optional.absent()`, then the creator check still decides and **nothing throws** —
+  `Optional.value` raises `StateError` on absent, so this pins the `isPresent`/`orElse` access.
+- Given `members` is `Optional.present(null)`, then it behaves as an empty list.
+- Given duplicate membership rows for my user id, then the first is used deterministically.
+- Given `currentUserId` is null, then both are false even when `createdById` is also null.
+- Given I created the space but my member row says `viewer` (ownership transferred), then the creator
+  short-circuit wins — pinned so the precedence is a decision, not an accident.
+- Given `roleIsWritable`, then owner and editor are true, viewer and null are false.
 
-**Done when.** Both predicates are pure, `SpaceLinkPickerSheet._canWrite` and `space_detail.page.dart`'s
-`_canEdit` / `_isOwner` are gone in favour of the helper, and behaviour on those two screens is unchanged.
+**Done when.** All four call sites delegate; the two behaviour changes at `space_detail.page.dart`
+(creator-implies-owner, and fail-closed while members load) each have a test asserting the **new** result.
 
 ---
 
@@ -305,21 +376,23 @@ Dependency order: 1 → {2 → 3 → 4} and 1 → {5 → 6 → 7} → 8.
 
 **Files.** Edit `mobile/lib/repositories/shared_space_api.repository.dart`. New
 `mobile/test/repositories/shared_space_api_repository_test.dart` — no test file exists for this repository
-today, so it is created here alongside the siblings in `mobile/test/repositories/`.
+today; it follows the mocktail-over-`SharedSpacesApi` pattern of `person_api_repository_test.dart`.
 
 **Tests first (BDD).**
 
-- Given only a new name, when update is called, then the DTO carries `Optional.present(name)` and
-  `Optional.absent()` for description and colour.
-- Given a description changed from text to `''`, then the DTO carries `Optional.present('')` — the clobber
-  regression this design calls out.
+- Given only a new name, then the DTO carries `Optional.present(name)` and `absent()` for the rest.
+- Given a description changed from text to `''`, then `Optional.present('')` — the clobber regression.
 - Given a description changed from `null` to text, then `Optional.present(text)`.
-- Given description is not passed at all, then `Optional.absent()` — **never** `Optional.present(null)`.
-- Given a colour change, then `Optional.present(color)`.
-- Given a name with surrounding whitespace, then it is trimmed before sending.
-- Given the API throws, then the exception propagates to the caller unchanged.
-
-**Done when.** The method exists, is covered, and no other field of the DTO is ever populated.
+- Given description is not passed, then `Optional.absent()` — **never** `Optional.present(null)`, which the
+  non-nullable zod schema rejects with a 400.
+- Given any call, then `faceRecognitionEnabled`, `petsEnabled`, `thumbnailAssetId` and `thumbnailCropY` are
+  all `Optional.absent()` — the silent-disable guard.
+- Given a name with surrounding whitespace, then it is trimmed; given a description with whitespace, then it
+  is **not**.
+- Given the API returns `null` (empty body), then it throws, matching every sibling repository method.
+- Given the API throws, then the exception propagates unchanged.
+- Given the endpoint is resolved lazily, then a client swapped after first read is picked up — mirroring
+  `test/repositories/api_repository_lazy_resolution_test.dart`.
 
 ---
 
@@ -328,76 +401,94 @@ today, so it is created here alongside the siblings in `mobile/test/repositories
 **Goal.** The three-field form, with validation, in isolation from its entry points.
 
 **Files.** New `mobile/lib/presentation/widgets/spaces/space_edit_sheet.widget.dart`. New
-`mobile/test/widgets/spaces/space_edit_sheet_test.dart`.
+`mobile/test/presentation/widgets/spaces/space_edit_sheet_test.dart`.
 
 **Tests first (BDD).**
 
-- Given a space, when the sheet opens, then name, description and colour are prefilled from it.
-- Given an empty name, then Save is disabled.
-- Given a whitespace-only name `"   "`, then Save is disabled — the case a `required` flag would let through.
-- Given the sheet just opened, then the name field is focused with its text selected; and given the user
-  taps the field again, then the selection is **not** reapplied.
-- Given name and description fields, then they enforce `maxLength` 100 and 500.
-- Given only the name was edited, when saved, then the repository is called **without** a description.
-- Given the description was cleared, when saved, then the repository is called with `''`.
-- Given the user taps a colour swatch, then the selection moves and is sent on save.
-- Given the save succeeds, then the sheet resolves `true`.
-- Given the save throws, then the sheet stays open, resolves nothing, and shows
+- Given a space, then name, description and colour are prefilled.
+- Given a space whose `color` is absent, then `primary` is preselected.
+- Given an empty name, then Save is disabled; given `"   "`, then Save is disabled.
+- Given the sheet just opened, then the name is focused with its text selected; and given the user taps the
+  field again (via `tester.tapAt` with an offset, not `tester.tap`), then the selection is not reapplied.
+- Given 150 characters are pasted into the name, then only 100 remain in the field; likewise 500 for the
+  description.
+- Given a prefilled name of 120 characters, then it renders in full and Save stays enabled — no silent
+  truncation of existing data.
+- Given only the name was edited, then `update` is called **without** a description.
+- Given the description was cleared, then `update` is called with `''`.
+- Given nothing was edited and Save is tapped, then `update` is called with all fields absent and the sheet
+  closes — a no-op save is not an error.
+- Given Save is tapped twice in quick succession, then `update` is called **exactly once**.
+- Given the sheet is dismissed while a save is in flight, then no pop or toast is attempted and nothing
+  throws — the `context.mounted` guard.
+- Given the save fails with a 403 (role revoked mid-edit), then the sheet stays open and shows
   `errors.unable_to_update_space`.
-- Given the user cancels, then no repository call is made and it resolves `null`.
-
-**Done when.** The sheet is fully covered and not yet reachable from any screen.
+- Given the save succeeds, then it resolves `true`; given cancel, then `null` and no call.
+- Given the colour swatches, then each carries a `Semantics` label naming its colour — ten unlabelled
+  colour-only targets are unusable by a screen reader — and each meets the minimum tap target, asserted with
+  the existing `expectTapTargetMin` helper in `mobile/test/widget_tester_extensions.dart`.
 
 ---
 
-### Slice 4 — Edit entry points
+### Slice 4 — `SpaceDetailKebab` extraction and entry points
 
-**Goal.** Make the sheet reachable, and fix the editors-see-no-kebab bug.
+**Goal.** Make the sheet reachable and fix the editors-see-no-kebab bug, with the RBAC testable.
 
-**Files.** Edit `space_detail.page.dart` (kebab regate) and `mobile/lib/widgets/spaces/space_card.dart`
-(`onLongPress`). New compact role-gated sheet for the card. Tests in
-`mobile/test/pages/spaces/space_detail_kebab_test.dart` and `mobile/test/widgets/spaces/space_card_test.dart`.
+**Files.** New `mobile/lib/presentation/widgets/spaces/space_detail_kebab.widget.dart` (extraction). Edit
+`space_detail.page.dart` to use it; edit `mobile/lib/widgets/spaces/space_card.dart` for `onLongPress` plus
+its role-gated sheet. New `mobile/test/presentation/widgets/spaces/space_detail_kebab_test.dart` and
+`mobile/test/widgets/spaces/space_card_test.dart`.
 
 **Tests first (BDD).**
 
-- Given I am the owner, then the kebab shows "Edit space" and "Delete Space".
-- Given I am an editor, then the kebab shows "Edit space" but **not** "Delete Space" — the regression fix.
-- Given I am a viewer, then no kebab renders at all.
-- Given I long-press a space card as owner, then a sheet offers Edit and Delete.
-- Given I long-press as an editor, then it offers Edit only.
-- Given I long-press as a viewer, then no sheet opens.
-- Given a save returns `true`, then `sharedSpacesProvider` and `sharedSpaceProvider(id)` are invalidated and
-  `syncRemote()` is called exactly once.
-- Given a save returns `null` (cancelled), then nothing is invalidated and no sync nudge fires.
-
-**Done when.** Editing works end to end from both entry points, and the RBAC table in §8 is pinned by tests.
+- Given `canEdit && canDelete`, then the kebab shows `spaces_edit` and `spaces_delete`.
+- Given `canEdit && !canDelete` (editor), then it shows `spaces_edit` only — the regression fix.
+- Given `!canEdit`, then no kebab renders at all.
+- Given metadata is still loading, then no kebab renders (fail-closed).
+- Given a long-press on a space card as owner, then a sheet offers Edit and Delete **and no navigation
+  occurs** — the `onTap`-must-not-also-fire guard.
+- Given a long-press as editor, then Edit only; as viewer, then no sheet opens.
+- Given Delete is chosen from the card sheet, then `spaces_delete_confirmation` is shown first.
+- Given a save resolves `true`, then `sharedSpacesProvider` is invalidated and the space metadata is
+  re-fetched, and the observable outcome is that **the app bar shows the new name**.
+- Given a save resolves `null`, then nothing is invalidated and no re-fetch occurs.
+- Given the space was deleted by another member mid-flow, then the edit surfaces the error and does not
+  crash on the missing space.
 
 ---
 
 ### Slice 5 — `CollectionTarget` and dispatch
 
-**Goal.** The routing table, tested without any UI.
+**Goal.** The routing table, tested at the provider level.
 
-**Files.** New `mobile/lib/domain/models/collection_target.dart`. Edit
-`mobile/lib/providers/infrastructure/action.provider.dart` (add `addToSpace`). New
-`mobile/test/providers/collection_dispatch_test.dart`.
+**Files.** New `mobile/lib/domain/models/collection_target.dart`, new
+`mobile/lib/constants/collection.dart` (`kMaxSpaceAssetsPerRequest`). Edit `action.provider.dart` to add
+`addToSpace` and `addToSpaceAlbum`. New `mobile/test/providers/infrastructure/collection_dispatch_test.dart`,
+following the `ProviderContainer` + `overrideWithValue` pattern of
+`test/providers/infrastructure/space_album_actions_test.dart`.
 
 **Tests first (BDD).**
 
-- Given an `AlbumTarget`, then `addToAlbum` is called and neither space path is touched.
-- Given a `SpacePoolTarget` with remote-only assets, then `SharedSpaceApiRepository.addAssets` is called
-  once with every id.
-- Given a `SpaceAlbumTarget`, then `SpaceAlbumActions.addAssets` is called and **`addToAlbum` is never
-  called** — the absorbed-album foreign-key guard.
+- Given an `AlbumTarget`, then `addToAlbum` runs and neither space path is touched.
+- Given a `SpacePoolTarget` with remote-only assets, then `addAssets` is called **once** with every id.
+- Given a `SpaceAlbumTarget`, then `SpaceAlbumActions.addAssets` runs and **`addToAlbum` is never called** —
+  the absorbed-album FK guard (R4).
+- Given a `SpacePoolTarget`, then the reported count is the **request length**, because the endpoint returns
+  no body; given a `SpaceAlbumTarget`, then it is the **server's** `added.length`.
+- Given a space-album add where every asset is already present, then the count is 0 and the result is a
+  success — no "added 20" lie.
 - Given a space target with local assets, then upload runs first and the add call is made **exactly once**
-  with all resulting remote ids — not once per asset.
-- Given an empty selection, then no API call is made and the result is a success with count 0.
-- Given the upload fails, then no add call is made and the result is a failure.
-- Given the add call throws, then the result is a failure **and the selection is not reset**.
-- Given the add succeeds, then the selection is reset, `syncRemote()` fires, and the count comes from the
-  server response rather than the request length.
-
-**Done when.** Every row of the §2 dispatch table is covered, including the two never-call assertions.
+  with all resulting remote ids.
+- Given an upload where 3 of 5 assets succeed, then those 3 **are** added and the result is
+  `count == 3, success == false` — successful uploads are never stranded.
+- Given the upload is cancelled, then no add call is made.
+- Given an empty selection, then no API call and a success with count 0.
+- Given the add throws, then the result is a failure **and the selection is not reset**.
+- Given full success, then the selection is reset for `ActionSource.timeline`, and the reset is asserted for
+  both the main and space sheets since both pass `timeline`.
+- Given a `SpaceAlbumTarget` add succeeds, then `spaceAlbumsProvider(spaceId)` is invalidated — which is
+  what `SpaceAlbumTarget.spaceId` is for.
+- Given a second target is tapped while the first add is in flight, then the second is ignored.
 
 ---
 
@@ -405,95 +496,137 @@ today, so it is created here alongside the siblings in `mobile/test/repositories
 
 **Goal.** The spaces half of the picker, in isolation.
 
-**Files.** New `mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart`. New
-`mobile/test/widgets/collection/space_collection_section_test.dart`.
+**Files.** New `mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart`, plus the
+non-owned selector. New `mobile/test/presentation/widgets/collection/space_collection_section_test.dart`.
 
-**Tests first (BDD).**
+**Tests first (BDD).** One per row of the §3 gating table, plus:
 
-- Given no writable spaces, then the section renders nothing at all — not an empty header.
-- Given a mix of writable and viewer-only spaces, then only the writable ones are listed.
-- Given a space with linked albums, when I tap its row, then it expands to show the `add_to_space` pool child
-  followed by each album; tapping again collapses it.
-- Given a space with **no** linked albums, then it renders as a plain row and a single tap emits a
-  `SpacePoolTarget`.
-- Given a collapsed space, then `spaceAlbumsProvider` for it is never watched.
-- Given an expanded space whose album stream is still loading, then a loading affordance shows and the pool
-  child remains tappable.
-- Given an expanded space whose album stream errors, then the pool child still works and the album list
-  shows an error rather than taking the section down.
-- Given the selection contains a non-owned asset, then no space rows render and the restricted notice shows.
-- Given the selection exceeds 50 000 assets, then no space rows render and `spaces_hidden_too_many_assets`
-  shows.
-- Given `sharedSpacesProvider` fails (offline), then the section hides rather than surfacing an error into
-  a sheet whose album half still works.
-- Given a tap on an album child, then a `SpaceAlbumTarget` carrying the **owning space's id** is emitted.
-
-**Done when.** All four gating states from §3 and both row behaviours are covered.
+- Given no writable spaces, then nothing renders — not an empty header.
+- Given writable and viewer-only spaces, then only the writable ones list, ordered by name.
+- Given `sharedSpacesProvider` is loading, then skeleton rows render (pumped with `pumpConsumerWidgetRaw`).
+- Given `sharedSpacesProvider` errors, then the section hides and the album half still renders.
+- Given `albumCount > 0`, when I tap the row, then it expands to the pool child followed by each album;
+  tapping again collapses it.
+- Given `albumCount == 0`, then the row is plain and one tap emits `SpacePoolTarget`.
+- Given `albumCount > 0` but the Drift stream is empty, then the empty-albums hint shows and the pool child
+  still works.
+- Given a collapsed row, then no Drift query is issued for it.
+- Given a second row is expanded, then the first collapses and its subscription is released.
+- Given a double-tap on a plain row, then exactly one `SpacePoolTarget` is emitted.
+- Given an add is in flight, then rows are disabled.
+- Given a tap on an album child, then a `SpaceAlbumTarget` carrying the owning space's id is emitted.
+- Given a selection containing a non-owned asset, then the `spaces_hidden_non_owned_selection` notice shows
+  and no rows render.
+- Given `currentUserProvider` is null, then the section behaves as "contains non-owned" (fail-closed).
+- Given a selection containing a locked-folder asset, then no rows render.
+- Given a selection of exactly 50 000, then rows render; given 50 001, then the
+  `spaces_hidden_too_many_assets` notice shows — both boundaries.
+- Given the space sheet for space X, then X is absent from its own list.
+- Given a very long or RTL space name, then it ellipsises on one line.
+- Given a space row, then it exposes `Semantics(button: true)` with its expanded/collapsed state announced,
+  and children meet the minimum tap target.
 
 ---
 
-### Slice 7 — `CollectionPicker` and the two sheets
+### Slice 7 — `CollectionPicker`, header, and the two sheets
 
 **Goal.** Compose and mount, without regressing the album flow.
 
-**Files.** New `mobile/lib/presentation/widgets/collection/collection_picker.widget.dart`. A one-line swap in
-the upstream `general_bottom_sheet.widget.dart` (`AlbumSelector` → `CollectionPicker`). A slightly larger edit
-to the fork-only `space_bottom_sheet.widget.dart`, which passes no `slivers:` today and so gains that argument
-plus the `AddToAlbumHeader`/picker pair — still small, and unconstrained by rebase risk. New
-`mobile/test/widgets/collection/collection_picker_test.dart` plus additions to the two sheet tests.
+**Files.** New `collection_picker.widget.dart` and `collection_picker_header.widget.dart`. Two-line diff to
+the upstream `general_bottom_sheet.widget.dart`; `slivers:` plus `maxChildSize` 0.55 → 0.85 in the fork-only
+`space_bottom_sheet.widget.dart`. New
+`mobile/test/presentation/widgets/collection/collection_picker_test.dart` plus additions to the two sheet
+tests.
 
 **Tests first (BDD).**
 
-- Given the picker, then it renders the album selector above the spaces section.
-- Given an album row is tapped, then the existing add-to-album behaviour runs unchanged — the regression guard.
+- Given the picker, then the header reads `add_to_album_or_space`, above the album selector, above the
+  spaces section — the header being new is what makes that string reachable at all (correction 5).
+- Given an album row is tapped, then the existing add-to-album behaviour runs unchanged.
 - Given the album search, sort, quick-filter and grid/list controls, then they all still work.
-- Given the keyboard-expand callback, then it is still threaded through to the album selector.
-- Given the main timeline sheet, then it mounts the picker and spaces are offered.
-- Given the space timeline sheet, then it mounts the picker alongside the existing
-  share / download / favourite / remove-from-space actions.
-- Given `AlbumSelector`, then its file is unchanged in this diff — asserted by review, not by test.
-
-**Done when.** Both sheets offer all three target kinds and the album path is provably untouched.
+- Given the keyboard-expand callback, then it is still threaded to the album selector, and the spaces
+  section is not left behind the IME.
+- Given the space sheet at its default extent, then the spaces section is reachable by dragging to
+  `maxChildSize` — the 0.55 regression guard.
+- Given the space sheet, then the picker sits alongside share / download / favourite / remove-from-space.
+- Given a viewer on the space sheet, then the album half renders and the spaces section does not.
+- Given `AlbumSelector`, then `git diff` reports its file unchanged — a `Done when` command, not a test.
 
 ---
 
 ### Slice 8 — i18n, toasts and gates
 
-**Goal.** Ship-quality strings and a green CI.
+**Goal.** Ship-quality strings, fully translated, and a green CI.
 
-**Files.** No `i18n/en.json` change — every key is already present (see the table in "What already exists").
-Keying of the hardcoded English on the two surfaces this work touched: the space detail kebab and the space
-card.
+**One new key is required.** The reused `add_to_collection_restricted_to_space` reads "…so only albums in
+this space can accept them", which is **web's contribution-mode message**: it promises a destination that
+mobile deliberately does not offer (R1). Using it would tell the user to look for something that is not on
+screen. So a new key is added — and, per the fork rule that a new key must not ship untranslated, **with all
+nine translations in the same commit**:
+
+| Locale    | `spaces_hidden_non_owned_selection`                                                                             |
+| --------- | --------------------------------------------------------------------------------------------------------------- |
+| `en`      | Your selection includes photos owned by other members, so it can't be added to a space.                         |
+| `de`      | Deine Auswahl enthält Fotos anderer Mitglieder und kann daher nicht zu einem Space hinzugefügt werden.          |
+| `fr`      | Votre sélection contient des photos appartenant à d'autres membres ; elle ne peut pas être ajoutée à un espace. |
+| `it`      | La tua selezione include foto di altri membri, quindi non può essere aggiunta a uno Space.                      |
+| `es`      | Tu selección incluye fotos de otros miembros, por lo que no se puede añadir a un Space.                         |
+| `nl`      | Je selectie bevat foto's van andere leden en kan daarom niet aan een Space worden toegevoegd.                   |
+| `pl`      | Twój wybór zawiera zdjęcia należące do innych członków, więc nie można go dodać do Space.                       |
+| `ru`      | Ваш выбор содержит фотографии других участников, поэтому его нельзя добавить в Space.                           |
+| `zh_Hans` | 您的选择包含其他成员的照片，因此无法添加到 Space。                                                              |
+| `zh_Hant` | 您的選擇包含其他成員的照片，因此無法新增至 Space。                                                              |
+
+Terminology matches each locale's existing Spaces strings: "Space" stays untranslated everywhere except
+French, which uses "espace" (cf. the existing `add_to_space` values).
+
+**Every other key already exists and is already translated** in all nine locales, verified by value on
+2026-07-26: `add_to_album_or_space`, `add_to_space`, `spaces_hidden_too_many_assets`, `added_to_space_count`,
+`space_album_add_photos_success`, `spaces_edit`, `spaces_edit_success`, `errors.unable_to_update_space`,
+`spaces_delete`, `spaces_delete_confirmation`, `name`, `description`, `color`.
+
+`spaces_no_writable_spaces` is deliberately **not** used: web shows it as an empty state, whereas this design
+omits the whole section when there is nothing writable (§3).
+
+**Files.** `i18n/en.json` plus the nine locale files, for the one new key only. Keying of the hardcoded
+English on the two surfaces this work touches: the space detail kebab and the space card sheet.
 
 **Tests first (BDD).**
 
-- Given a successful add of N photos to a space, then `added_to_space_count` shows with the server's count.
-- Given a successful add to a space album, then `space_album_add_photos_success` shows with the server's count.
-  Neither toast names the destination, because neither existing key takes a name argument and adding one would
-  ship an untranslated string into seven locales for marginal gain.
+- Given a successful pool add of N photos, then `added_to_space_count` shows with N (the request length).
+- Given a successful space-album add, then `space_album_add_photos_success` shows the server's count.
+- Given a count of 1, then the singular plural form renders; and given `ru` and `pl` — both of which have
+  three plural forms and are both in the committed locale set — then the correct form is selected.
 - Given a failed add, then `scaffold_body_error_occurred` shows and no count is claimed.
-- Given every new widget, then no user-visible literal English string remains.
-- Given the space detail kebab and the space card sheet, then the delete items render `spaces_delete` and
+- Given the space detail kebab and card sheet, then delete renders `spaces_delete` /
   `spaces_delete_confirmation` rather than hardcoded English.
-- Given the whole diff, then **no file under `i18n/` is modified at all** — the guard against quietly
-  inventing a key, which would ship untranslated text into the nine locales this design commits to.
 
-**Done when.** `dart analyze --fatal-infos lib test` and `dart format --set-exit-if-changed` both pass, and
-`flutter test` is green.
+**Done when.** All of these commands pass:
+
+```bash
+dart analyze --fatal-infos lib test
+dart format --set-exit-if-changed .
+flutter test
+# exactly one key added, in exactly ten files, and nothing else under i18n/ changed:
+git diff --stat origin/main -- ../i18n/ | tail -1
+git diff origin/main -- ../lib/presentation/widgets/album/album_selector.widget.dart   # must be empty
+```
 
 Strings left hardcoded elsewhere in mobile Spaces — "Create Space", "Add Photos", "Remove from space",
-"Members", "Space deleted", the spaces empty state — are **out of scope** and recorded as a follow-up rather
-than swept up here.
+"Members", "Space deleted", the spaces empty state — are **out of scope** and recorded as a follow-up.
+
+**Convention note.** Sibling widget tests in this repo assert English literals
+(`find.text('Show in timeline')`, `space_album_kebab_test.dart:79`). New tests follow that convention and
+assert the rendered English; the "no hardcoded English" requirement is about `lib/`, not `test/`.
 
 ## Running the tests
 
-Per the repo's mobile notes: Flutter **3.41.7** (the pinned SDK — `mise.toml` may symlink an older patch).
-From `mobile/`:
+Flutter **3.41.7** (the pinned SDK — `mise.toml` may symlink an older patch). From `mobile/`:
 
 ```bash
 flutter pub get
 dart run easy_localization:generate -S ../i18n && dart run bin/generate_keys.dart
-flutter test test/...
+flutter test
 ```
 
 Drift and OpenAPI generated code is committed, so `build_runner` is not needed. CI runs **two** Dart gates:
@@ -503,34 +636,42 @@ Drift and OpenAPI generated code is committed, so `build_runner` is not needed. 
 ## Risks
 
 **R1 — Contribution-mode parity gap with web.** `2026-07-25-space-add-to-collection-design.md` lets a space
-Owner/Editor contribute _other members'_ photos into albums linked to that space. Mobile deliberately does
+Owner/Editor contribute other members' photos into albums linked to that space. Mobile deliberately does
 not: when the selection contains a non-owned asset, space targets are hidden behind a notice. This is an
-informed deferral, not an oversight — mobile has zero contribution plumbing today, and the honest-notice
-behaviour is strictly better than the alternative failure, where
+informed deferral — mobile has zero contribution plumbing, and the honest notice beats the alternative, where
 `POST /shared-spaces/:id/assets` rejects the entire batch over one non-owned id and the user gets nothing
-added plus a vague error. Closing the gap is a follow-up slice that would port `restrictToSpaceId`.
+plus a vague error. It is also why Slice 8 mints a new string rather than reusing web's, which describes a
+capability mobile does not have.
 
 **R2 — The spaces section is network-backed while albums are local-first.** `sharedSpacesProvider` calls
-`getAll()`, so offline the section hides while the album half of the picker keeps working. Acceptable
-because the section is purely additive, but it means the picker's contents differ online and offline.
-Expansion is unaffected — linked albums come from Drift.
+`getAll()`, so offline the section hides while the album half keeps working. Acceptable because the section
+is additive, but the picker's contents differ online and offline. Expansion is unaffected — linked albums
+come from Drift.
 
-**R3 — One upstream file is touched.** `general_bottom_sheet.widget.dart` is pure upstream and takes a
-one-line diff swapping `AlbumSelector` for `CollectionPicker`. `space_bottom_sheet.widget.dart` is
-**fork-only** (it exists solely in the squashed fork commit `e0950535c36`) and so may be edited freely.
-`album_selector.widget.dart` is upstream and is not touched at all. Any temptation to grow the
-`general_bottom_sheet` edit into a refactor should be resisted — it converts a trivial rebase into a
-conflicting one.
+**R3 — One upstream file is touched.** `general_bottom_sheet.widget.dart`, two lines.
+`album_selector.widget.dart` is upstream and untouched — pinned by a `git diff` check in Slice 8's Done-when.
+`space_bottom_sheet.widget.dart` is fork-only and unconstrained.
 
 **R4 — The absorbed-album foreign-key trap.** Routing a `SpaceAlbumTarget` through `addToAlbum` throws on an
-absorbed album. This is exactly the sort of thing a well-meaning "unify the two add paths" refactor would
-reintroduce, so Slice 5 pins it with an explicit never-called assertion rather than relying on the comment
-at `space_album_actions.dart:56`.
+absorbed album. Exactly what a well-meaning "unify the two add paths" refactor would reintroduce, so Slice 5
+pins it with an explicit never-called assertion rather than relying on the comment at
+`space_album_actions.dart:57`.
 
-**R5 — Rename staleness in Drift.** The local `shared_space_entity` caches `name`, so a rename without the
-`syncRemote()` nudge leaves the space timeline's app bar showing the old name until the next app start.
-Slice 4 tests the nudge fires exactly once.
+**R5 — Rename freshness depends on a re-fetch, not on sync.** The obvious-looking fix (invalidate
+`sharedSpaceProvider`, nudge `syncRemote()`) is a **no-op**: that provider has no consumers, and no display
+code reads the Drift name column. Slice 4 asserts the observable — the app bar shows the new name — rather
+than the mechanism, so a future refactor of how the page loads metadata cannot silently break it.
 
-**R6 — One extra tap to reach a space pool.** Spaces with linked albums need expand-then-tap. Chosen
-deliberately for safety on a shared surface (§3). If it proves annoying in use, the fix is a trailing
-"add here" affordance on the space row itself, not making the whole row tap-to-add.
+**R6 — `space_permissions` changes gating on an untested page.** Adopting the shared helper makes a
+creator-not-in-members an owner on `space_detail.page.dart`, where today they are not. That is the correct
+reading, but it changes who sees "Delete Space" on a page with no test coverage. Slice 1 pins the new
+behaviour and Slice 4's extraction gives the page its first tests.
+
+**R7 — The 50 000 cap is applied more broadly than the server requires.** The cap is real only for the pool
+endpoint; `PUT /albums/{id}/assets` has no such max. Hiding the whole section — including album children —
+above 50 000 is therefore over-broad. Accepted for simplicity: a >50 000 selection is already pathological
+on a phone, and the alternative is a per-row gate whose rules the user cannot see.
+
+**R8 — One extra tap to reach a space pool.** Spaces with linked albums need expand-then-tap. Chosen for
+safety on a shared surface (§3). If it proves annoying, the fix is a trailing "add here" affordance on the
+row, not making the whole row tap-to-add.

--- a/docs/superpowers/specs/2026-07-26-mobile-spaces-ux-design.md
+++ b/docs/superpowers/specs/2026-07-26-mobile-spaces-ux-design.md
@@ -629,6 +629,19 @@ git diff origin/main -- ../lib/presentation/widgets/album/album_selector.widget.
 Strings left hardcoded elsewhere in mobile Spaces — "Create Space", "Add Photos", "Remove from space",
 "Members", "Space deleted", the spaces empty state — are **out of scope** and recorded as a follow-up.
 
+### Follow-up found during implementation (not fixed here)
+
+`SpaceCard.build` reads **seven** `Optional` fields via bare `.value` — `newAssetCount`,
+`recentAssetIds`, `recentAssetThumbhashes`, `color`, `members`, `assetCount`, `memberCount`
+(`space_card.dart:14` onwards). `Absent.value` throws `StateError`, so any one of them being absent
+crashes the whole Spaces grid render. `spaces_page_test.dart:27-32` documents this explicitly and
+works around it by always populating them in the fixture, which means the test suite cannot catch a
+regression here. This is the same defect class as the `space.members.value ?? const []` crash that
+Slice 1 removed from `SpaceLinkPickerSheet`. Hardening it is a small, self-contained follow-up:
+swap each to `.orElse(null) ?? <default>` and add a "renders with every optional absent" test.
+Deliberately **not** bundled into Slice 4 — it is a separate defect on a separate surface, and
+folding it in would widen a slice that already changes RBAC gating.
+
 **Convention note.** Sibling widget tests in this repo assert English literals
 (`find.text('Show in timeline')`, `space_album_kebab_test.dart:79`). New tests follow that convention and
 assert the rendered English; the "no hardcoded English" requirement is about `lib/`, not `test/`.

--- a/e2e/src/specs/server/api/server.e2e-spec.ts
+++ b/e2e/src/specs/server/api/server.e2e-spec.ts
@@ -124,6 +124,17 @@ describe('/server', () => {
         trash: true,
         email: false,
         peopleStatistics: false,
+        // The full list mirrors the SyncRequestType enum; pin the fork's space-album types,
+        // which mobile's sync gate opens on (capability signalling).
+        syncRequestTypes: expect.arrayContaining([
+          'AssetsV1',
+          'SharedSpacesV1',
+          'SharedSpaceAlbumsV1',
+          'SharedSpaceAlbumLinksV1',
+          'SharedSpaceAlbumToAssetsV1',
+          'SharedSpaceAlbumAssetsV1',
+          'SharedSpaceAlbumAssetExifsV1',
+        ]),
       });
     });
   });

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -2771,6 +2771,7 @@
   "spaces_expand_header": "Space-Kopfzeile erweitern",
   "spaces_face_recognition": "Gesichtserkennung",
   "spaces_faces": "Gesichter",
+  "spaces_hidden_non_owned_selection": "Deine Auswahl enthält Fotos anderer Mitglieder und kann daher nicht zu einem Space hinzugefügt werden.",
   "spaces_hidden_too_many_assets": "Spaces ausgeblendet – zu viele Fotos ausgewählt (max. {count})",
   "spaces_hide_from_timeline": "Aus Zeitleiste ausblenden",
   "spaces_hide_people": "Personen ausblenden",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2772,6 +2772,7 @@
   "spaces_expand_header": "Expand space header",
   "spaces_face_recognition": "Face recognition",
   "spaces_faces": "faces",
+  "spaces_hidden_non_owned_selection": "Your selection includes photos owned by other members, so it can't be added to a space.",
   "spaces_hidden_too_many_assets": "Spaces are hidden — too many photos selected (max {count})",
   "spaces_hide_from_timeline": "Hide from timeline",
   "spaces_hide_people": "Hide people",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2416,6 +2416,7 @@
   "screencast_mode_title": "Toggle screencast mode",
   "search": "Search",
   "search_albums": "Search albums",
+  "search_albums_and_spaces": "Search albums and spaces",
   "search_by_context": "Search by context",
   "search_by_description": "Search by description",
   "search_by_description_example": "Hiking day in Sapa",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -2771,6 +2771,7 @@
   "spaces_expand_header": "Expandir la cabecera del Space",
   "spaces_face_recognition": "Reconocimiento facial",
   "spaces_faces": "caras",
+  "spaces_hidden_non_owned_selection": "Tu selección incluye fotos de otros miembros, por lo que no se puede añadir a un Space.",
   "spaces_hidden_too_many_assets": "Espacios ocultos — demasiadas fotos seleccionadas (máx {count})",
   "spaces_hide_from_timeline": "Ocultar de la línea de tiempo",
   "spaces_hide_people": "Ocultar personas",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -2771,6 +2771,7 @@
   "spaces_expand_header": "Développer l'en-tête de l'espace",
   "spaces_face_recognition": "Reconnaissance faciale",
   "spaces_faces": "Visages",
+  "spaces_hidden_non_owned_selection": "Votre sélection contient des photos appartenant à d'autres membres ; elle ne peut pas être ajoutée à un espace.",
   "spaces_hidden_too_many_assets": "Espaces masqués — trop de photos sélectionnées (max {count})",
   "spaces_hide_from_timeline": "Masquer de la Chronologie",
   "spaces_hide_people": "Masquer les personnes",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -2770,6 +2770,7 @@
   "spaces_expand_header": "Espandi l'intestazione dello Space",
   "spaces_face_recognition": "Riconoscimento facciale",
   "spaces_faces": "volti",
+  "spaces_hidden_non_owned_selection": "La tua selezione include foto di altri membri, quindi non può essere aggiunta a uno Space.",
   "spaces_hidden_too_many_assets": "Spazi nascosti — troppe foto selezionate (max {count})",
   "spaces_hide_from_timeline": "Nascondi dalla timeline",
   "spaces_hide_people": "Nascondi persone",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -2771,6 +2771,7 @@
   "spaces_expand_header": "Space-koptekst uitklappen",
   "spaces_face_recognition": "Gezichtsherkenning",
   "spaces_faces": "gezichten",
+  "spaces_hidden_non_owned_selection": "Je selectie bevat foto's van andere leden en kan daarom niet aan een Space worden toegevoegd.",
   "spaces_hidden_too_many_assets": "Spaces verborgen — te veel foto's geselecteerd (max {count})",
   "spaces_hide_from_timeline": "Verbergen uit tijdlijn",
   "spaces_hide_people": "Mensen verbergen",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -2789,6 +2789,7 @@
   "spaces_expand_header": "Rozwiń nagłówek Space",
   "spaces_face_recognition": "Rozpoznawanie twarzy",
   "spaces_faces": "twarze",
+  "spaces_hidden_non_owned_selection": "Twój wybór zawiera zdjęcia należące do innych członków, więc nie można go dodać do Space.",
   "spaces_hidden_too_many_assets": "Spaces są ukryte — zaznaczono zbyt wiele zdjęć (maks. {count})",
   "spaces_hide_from_timeline": "Ukryj na osi czasu",
   "spaces_hide_people": "Ukryj osoby",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -2773,6 +2773,7 @@
   "spaces_expand_header": "Развернуть заголовок Space",
   "spaces_face_recognition": "Распознавание лиц",
   "spaces_faces": "лица",
+  "spaces_hidden_non_owned_selection": "Ваш выбор содержит фотографии других участников, поэтому его нельзя добавить в Space.",
   "spaces_hidden_too_many_assets": "Spaces скрыты — выбрано слишком много фото (максимум {count})",
   "spaces_hide_from_timeline": "Скрыть с временной шкалы",
   "spaces_hide_people": "Скрыть людей",

--- a/i18n/zh_Hans.json
+++ b/i18n/zh_Hans.json
@@ -2771,6 +2771,7 @@
   "spaces_expand_header": "展开 Space 标题栏",
   "spaces_face_recognition": "人脸识别",
   "spaces_faces": "人脸",
+  "spaces_hidden_non_owned_selection": "您的选择包含其他成员的照片，因此无法添加到 Space。",
   "spaces_hidden_too_many_assets": "Spaces 已隐藏 — 选择的照片过多（上限 {count} 张）",
   "spaces_hide_from_timeline": "从时间线中隐藏",
   "spaces_hide_people": "隐藏人物",

--- a/i18n/zh_Hant.json
+++ b/i18n/zh_Hant.json
@@ -2771,6 +2771,7 @@
   "spaces_expand_header": "展開 Space 標題列",
   "spaces_face_recognition": "臉孔辨識",
   "spaces_faces": "臉孔",
+  "spaces_hidden_non_owned_selection": "您的選擇包含其他成員的照片，因此無法新增至 Space。",
   "spaces_hidden_too_many_assets": "Spaces 已隱藏 — 選取的相片過多（上限 {count} 張）",
   "spaces_hide_from_timeline": "從時間軸中隱藏",
   "spaces_hide_people": "隱藏人物",

--- a/mobile/lib/constants/collection.dart
+++ b/mobile/lib/constants/collection.dart
@@ -1,0 +1,5 @@
+/// Maximum asset ids accepted by `POST /shared-spaces/{id}/assets` in one request.
+///
+/// Mirrors `SharedSpaceAssetAddSchema` (`server/src/dtos/shared-space.dto.ts`) and
+/// web's `MAX_SPACE_ASSETS_PER_REQUEST`. Inclusive: 50000 is allowed, 50001 is not.
+const int kMaxSpaceAssetsPerRequest = 50000;

--- a/mobile/lib/domain/models/collection_target.dart
+++ b/mobile/lib/domain/models/collection_target.dart
@@ -1,0 +1,37 @@
+import 'package:immich_mobile/domain/models/album/album.model.dart';
+import 'package:immich_mobile/domain/models/space_album.model.dart';
+import 'package:openapi/api.dart';
+
+/// Where a multi-selection can be sent.
+///
+/// Sealed so the dispatch table in `ActionNotifier` is exhaustive and checked by the
+/// compiler: adding a destination without wiring it up becomes a build error.
+sealed class CollectionTarget {
+  const CollectionTarget();
+}
+
+/// A personal or shared album. Dispatches through the existing `addToAlbum`.
+final class AlbumTarget extends CollectionTarget {
+  const AlbumTarget(this.album);
+  final RemoteAlbum album;
+}
+
+/// A space's own asset pool.
+final class SpacePoolTarget extends CollectionTarget {
+  const SpacePoolTarget(this.space);
+  final SharedSpaceResponseDto space;
+}
+
+/// An album linked to a space.
+///
+/// [spaceId] is carried even though the add call does not need it: it identifies which
+/// `spaceAlbumsProvider` to invalidate afterwards, and lets a space surface exclude its
+/// own albums. It must NEVER be dispatched through `addToAlbum` — a linked album can be
+/// "absorbed" (present only in `shared_space_album`, with no local `remote_album` row),
+/// and `addToAlbum` also writes the local junction, which would hit a foreign-key
+/// violation. See `SpaceAlbumActions.addAssets`.
+final class SpaceAlbumTarget extends CollectionTarget {
+  const SpaceAlbumTarget({required this.spaceId, required this.album});
+  final String spaceId;
+  final SpaceAlbum album;
+}

--- a/mobile/lib/domain/services/sync_stream.service.dart
+++ b/mobile/lib/domain/services/sync_stream.service.dart
@@ -65,6 +65,20 @@ class SyncStreamService {
 
     final serverSemVer = SemVer(major: serverVersion.major, minor: serverVersion.minor, patch: serverVersion.patch_);
 
+    // Capability signal for fork-only request types: the reported version cannot carry
+    // this (RC images stamp the bare base version, unbranded dev servers report the
+    // upstream version), so prefer the server's own declaration and leave the version
+    // gate as the fallback for servers that predate it. An absent field must stay null —
+    // collapsing it to an empty set would read as "declares nothing" and silently
+    // disable fork sync.
+    Set<String>? supportedSyncTypes;
+    try {
+      final features = await _api.serverInfoApi.getServerFeatures();
+      supportedSyncTypes = features?.syncRequestTypes.orElse(null)?.toSet();
+    } catch (error) {
+      _logger.warning("Failed to fetch server features for sync capability detection: $error");
+    }
+
     final value = Store.get(StoreKey.syncMigrationStatus, "[]");
     final migrations = (jsonDecode(value) as List).cast<String>();
     int previousLength = migrations.length;
@@ -80,6 +94,7 @@ class SyncStreamService {
     await _syncApiRepository.streamChanges(
       _handleEvents,
       serverVersion: serverSemVer,
+      supportedSyncTypes: supportedSyncTypes,
       onReset: () => shouldReset = true,
       abortSignal: _cancellation?.future,
     );
@@ -88,6 +103,7 @@ class SyncStreamService {
       await _syncApiRepository.streamChanges(
         _handleEvents,
         serverVersion: serverSemVer,
+        supportedSyncTypes: supportedSyncTypes,
         abortSignal: _cancellation?.future,
       );
     }

--- a/mobile/lib/infrastructure/repositories/space_album.repository.dart
+++ b/mobile/lib/infrastructure/repositories/space_album.repository.dart
@@ -7,6 +7,19 @@ class SpaceAlbumRepository extends DriftDatabaseRepository {
   final Drift _db;
   const SpaceAlbumRepository(this._db) : super(_db);
 
+  /// Whether [albumId] is linked to at least one space. Cheap point lookup used to
+  /// decide if an album mutation needs the space sync-nudge.
+  Future<bool> isAlbumLinked(String albumId) async {
+    final link = _db.sharedSpaceAlbumLinkEntity;
+    final row =
+        await (_db.selectOnly(link)
+              ..addColumns([link.albumId])
+              ..where(link.albumId.equals(albumId))
+              ..limit(1))
+            .getSingleOrNull();
+    return row != null;
+  }
+
   /// Watches albums linked to [spaceId], joining metadata + link fields.
   /// Emits ordered by album name (ascending) and reacts to Drift row changes.
   Stream<List<SpaceAlbum>> watchLinkedAlbums(String spaceId) {

--- a/mobile/lib/infrastructure/repositories/sync_api.repository.dart
+++ b/mobile/lib/infrastructure/repositories/sync_api.repository.dart
@@ -23,9 +23,20 @@ class SyncApiRepository {
     return _api.syncApi.deleteSyncAck(SyncAckDeleteDto(types: Optional.present(types)));
   }
 
+  /// The five Phase-2B space-album request types. Kept in one place so the capability
+  /// filter and the version-gate fallback can never drift apart.
+  static const _spaceAlbumSyncTypes = [
+    SyncRequestType.sharedSpaceAlbumsV1,
+    SyncRequestType.sharedSpaceAlbumLinksV1,
+    SyncRequestType.sharedSpaceAlbumToAssetsV1,
+    SyncRequestType.sharedSpaceAlbumAssetsV1,
+    SyncRequestType.sharedSpaceAlbumAssetExifsV1,
+  ];
+
   Future<void> streamChanges(
     Future<void> Function(List<SyncEvent>, Function() abort, Function() reset) onData, {
     required SemVer serverVersion,
+    Set<String>? supportedSyncTypes,
     Function()? onReset,
     int batchSize = kSyncEventBatchSize,
     http.Client? httpClient,
@@ -115,16 +126,18 @@ class SyncApiRepository {
           // still 400s the WHOLE /sync/stream request on any unrecognized type. This
           // client-side version gate is therefore the ONLY protection — every future
           // gallery-fork-only request type MUST be gated the same way.
-          // TODO(M14): the gate value itself is an unenforced release-order
-          // assumption (mobile + server release independently); pin it to the real
-          // first-feature-release version + add a CI guard before relying on it.
-          if (serverVersion > const SemVer(major: 5, minor: 0, patch: 0)) ...[
-            SyncRequestType.sharedSpaceAlbumsV1,
-            SyncRequestType.sharedSpaceAlbumLinksV1,
-            SyncRequestType.sharedSpaceAlbumToAssetsV1,
-            SyncRequestType.sharedSpaceAlbumAssetsV1,
-            SyncRequestType.sharedSpaceAlbumAssetExifsV1,
-          ],
+          // M14 resolution: servers now DECLARE the request types they accept via
+          // GET /server/features (syncRequestTypes), which the sync service passes in as
+          // [supportedSyncTypes]. The declaration is authoritative in both directions — it
+          // opens the gate on servers whose version LIES about the feature (an RC image
+          // stamps the bare base version, an unbranded dev server reports the upstream
+          // version) and keeps it closed on future servers that drop a type. The version
+          // gate below survives only as the fallback for fork servers that predate
+          // capability signalling (their /server/features has no syncRequestTypes field).
+          if (supportedSyncTypes != null)
+            ...(_spaceAlbumSyncTypes.where((type) => supportedSyncTypes.contains(type.value)))
+          else if (serverVersion > const SemVer(major: 5, minor: 0, patch: 0))
+            ..._spaceAlbumSyncTypes,
         ],
       ).toJson(),
     );

--- a/mobile/lib/pages/library/spaces/space_detail.page.dart
+++ b/mobile/lib/pages/library/spaces/space_detail.page.dart
@@ -171,14 +171,17 @@ class _SpaceDetailPageState extends ConsumerState<SpaceDetailPage> {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
-        title: const Text('Delete Space'),
-        content: Text('Are you sure you want to delete "${_space?.name}"? This cannot be undone.'),
+        title: Text('spaces_delete'.t(context: ctx)),
+        content: Text('spaces_delete_confirmation'.t(context: ctx, args: {'name': _space?.name ?? ''})),
         actions: [
-          TextButton(onPressed: () => Navigator.of(ctx).pop(false), child: const Text('Cancel')),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text('cancel'.t(context: ctx)),
+          ),
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(true),
             style: TextButton.styleFrom(foregroundColor: Theme.of(ctx).colorScheme.error),
-            child: const Text('Delete'),
+            child: Text('delete'.t(context: ctx)),
           ),
         ],
       ),

--- a/mobile/lib/pages/library/spaces/space_detail.page.dart
+++ b/mobile/lib/pages/library/spaces/space_detail.page.dart
@@ -18,6 +18,7 @@ import 'package:immich_mobile/providers/sync_status.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/repositories/shared_space_api.repository.dart';
 import 'package:immich_mobile/routing/router.dart';
+import 'package:immich_mobile/utils/space_permissions.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
 import 'package:immich_mobile/widgets/spaces/sync_status_banner.dart';
 import 'package:openapi/api.dart';
@@ -103,15 +104,15 @@ class _SpaceDetailPageState extends ConsumerState<SpaceDetailPage> {
   }
 
   bool get _isOwner {
-    final member = _currentMember;
-    if (member == null) return false;
-    return member.role == SharedSpaceRole.owner;
+    final space = _space;
+    if (space == null) return false;
+    return spaceIsOwned(space, ref.read(currentUserProvider)?.id);
   }
 
   bool get _canEdit {
-    final member = _currentMember;
-    if (member == null) return false;
-    return member.role == SharedSpaceRole.owner || member.role == SharedSpaceRole.editor;
+    final space = _space;
+    if (space == null) return false;
+    return spaceIsWritable(space, ref.read(currentUserProvider)?.id);
   }
 
   SharedSpaceRole get _currentRole {

--- a/mobile/lib/pages/library/spaces/space_detail.page.dart
+++ b/mobile/lib/pages/library/spaces/space_detail.page.dart
@@ -6,6 +6,8 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/bottom_sheet/space_bottom_sheet.widget.dart';
+import 'package:immich_mobile/presentation/widgets/spaces/space_detail_kebab.widget.dart';
+import 'package:immich_mobile/presentation/widgets/spaces/space_edit_sheet.widget.dart';
 import 'package:immich_mobile/presentation/widgets/spaces/space_top_sliver.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline_route_scope.dart';
@@ -196,6 +198,21 @@ class _SpaceDetailPageState extends ConsumerState<SpaceDetailPage> {
         }
       }
     }
+  }
+
+  Future<void> _editSpace() async {
+    final space = _space;
+    if (space == null) return;
+
+    final saved = await SpaceEditSheet.show(context, space);
+    if (saved != true) return;
+
+    // The grid reads sharedSpacesProvider; the app bar reads this page's own
+    // `_space`, which is network-loaded rather than Drift-backed. A sync nudge would
+    // NOT refresh the title -- nothing reads the local shared_space name column for
+    // display -- so re-fetch the metadata explicitly.
+    ref.invalidate(sharedSpacesProvider);
+    await _refreshSpaceMetadata();
   }
 
   bool get _showInTimeline {
@@ -456,13 +473,7 @@ class _SpaceDetailPageState extends ConsumerState<SpaceDetailPage> {
                 tooltip: 'Add Photos',
               ),
             IconButton(icon: const Icon(Icons.people_outline), onPressed: _navigateToMembers, tooltip: 'Members'),
-            if (_isOwner)
-              PopupMenuButton<String>(
-                onSelected: (value) {
-                  if (value == 'delete') _deleteSpace();
-                },
-                itemBuilder: (context) => [const PopupMenuItem(value: 'delete', child: Text('Delete Space'))],
-              ),
+            SpaceDetailKebab(canEdit: _canEdit, canDelete: _isOwner, onEdit: _editSpace, onDelete: _deleteSpace),
           ],
         ),
         bottomSheet: SpaceBottomSheet(

--- a/mobile/lib/pages/library/spaces/spaces.page.dart
+++ b/mobile/lib/pages/library/spaces/spaces.page.dart
@@ -6,14 +6,18 @@ import 'package:immich_mobile/domain/models/settings_key.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/pages/library/spaces/collection_sort.dart';
+import 'package:immich_mobile/presentation/widgets/spaces/space_edit_sheet.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/settings.provider.dart';
 import 'package:immich_mobile/providers/shared_space.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/repositories/shared_space_api.repository.dart';
 import 'package:immich_mobile/routing/router.dart';
+import 'package:immich_mobile/utils/space_permissions.dart';
 import 'package:immich_mobile/widgets/common/collection_sort_button.dart';
 import 'package:immich_mobile/widgets/common/immich_toast.dart';
 import 'package:immich_mobile/widgets/common/search_field.dart';
 import 'package:immich_mobile/widgets/spaces/space_card.dart';
+import 'package:openapi/api.dart';
 
 @RoutePage()
 class SpacesPage extends HookConsumerWidget {
@@ -78,6 +82,72 @@ class SpacesPage extends HookConsumerWidget {
 
       nameController.dispose();
       descController.dispose();
+    }
+
+    Future<void> confirmAndDeleteSpace(SharedSpaceResponseDto space) async {
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: Text('spaces_delete'.t(context: ctx)),
+          content: Text('spaces_delete_confirmation'.t(context: ctx, args: {'name': space.name})),
+          actions: [
+            TextButton(onPressed: () => Navigator.of(ctx).pop(false), child: Text('cancel'.t(context: ctx))),
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(true),
+              style: TextButton.styleFrom(foregroundColor: Theme.of(ctx).colorScheme.error),
+              child: Text('delete'.t(context: ctx)),
+            ),
+          ],
+        ),
+      );
+      if (confirmed != true) return;
+
+      try {
+        await ref.read(sharedSpaceApiRepositoryProvider).delete(space.id);
+        ref.invalidate(sharedSpacesProvider);
+      } catch (e) {
+        if (context.mounted) {
+          ImmichToast.show(context: context, msg: 'Failed to delete space', toastType: ToastType.error);
+        }
+      }
+    }
+
+    Future<void> showSpaceActions(SharedSpaceResponseDto space) async {
+      final userId = ref.read(currentUserProvider)?.id;
+      // A viewer has no actions at all, so opening an empty sheet would be worse
+      // than not reacting.
+      if (!spaceIsWritable(space, userId)) return;
+
+      await showModalBottomSheet<void>(
+        context: context,
+        builder: (sheetContext) => SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                key: const Key('space-card-action-edit'),
+                leading: const Icon(Icons.edit_outlined),
+                title: Text('spaces_edit'.t(context: sheetContext)),
+                onTap: () async {
+                  Navigator.of(sheetContext).pop();
+                  final saved = await SpaceEditSheet.show(context, space);
+                  if (saved == true) ref.invalidate(sharedSpacesProvider);
+                },
+              ),
+              if (spaceIsOwned(space, userId))
+                ListTile(
+                  key: const Key('space-card-action-delete'),
+                  leading: const Icon(Icons.delete_outline),
+                  title: Text('spaces_delete'.t(context: sheetContext)),
+                  onTap: () async {
+                    Navigator.of(sheetContext).pop();
+                    await confirmAndDeleteSpace(space);
+                  },
+                ),
+            ],
+          ),
+        ),
+      );
     }
 
     return Scaffold(
@@ -156,6 +226,7 @@ class SpacesPage extends HookConsumerWidget {
                                   await context.pushRoute(SpaceDetailRoute(spaceId: space.id));
                                   ref.invalidate(sharedSpacesProvider);
                                 },
+                                onLongPress: () => showSpaceActions(space),
                               );
                             },
                           ),

--- a/mobile/lib/pages/library/spaces/spaces.page.dart
+++ b/mobile/lib/pages/library/spaces/spaces.page.dart
@@ -91,7 +91,10 @@ class SpacesPage extends HookConsumerWidget {
           title: Text('spaces_delete'.t(context: ctx)),
           content: Text('spaces_delete_confirmation'.t(context: ctx, args: {'name': space.name})),
           actions: [
-            TextButton(onPressed: () => Navigator.of(ctx).pop(false), child: Text('cancel'.t(context: ctx))),
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(false),
+              child: Text('cancel'.t(context: ctx)),
+            ),
             TextButton(
               onPressed: () => Navigator.of(ctx).pop(true),
               style: TextButton.styleFrom(foregroundColor: Theme.of(ctx).colorScheme.error),

--- a/mobile/lib/presentation/widgets/album/album_selector.widget.dart
+++ b/mobile/lib/presentation/widgets/album/album_selector.widget.dart
@@ -34,7 +34,20 @@ class AlbumSelector extends ConsumerStatefulWidget {
   final AlbumSelectorCallback onAlbumSelected;
   final Function? onKeyboardExpanded;
 
-  const AlbumSelector({super.key, required this.onAlbumSelected, this.onKeyboardExpanded});
+  /// Fork hook: mirrors every search-text change (typing and clearing) to the host, so a
+  /// surface composing this selector next to other sections can filter them by the same query.
+  final ValueChanged<String>? onSearchChanged;
+
+  /// Fork hook: replaces the "Search albums" hint when the host's search covers more than albums.
+  final String? searchHint;
+
+  const AlbumSelector({
+    super.key,
+    required this.onAlbumSelected,
+    this.onKeyboardExpanded,
+    this.onSearchChanged,
+    this.searchHint,
+  });
 
   @override
   ConsumerState<AlbumSelector> createState() => _AlbumSelectorState();
@@ -67,6 +80,7 @@ class _AlbumSelectorState extends ConsumerState<AlbumSelector> {
     });
 
     searchController.addListener(() {
+      widget.onSearchChanged?.call(searchController.text);
       onSearch(searchController.text, filter.mode);
     });
 
@@ -196,6 +210,7 @@ class _AlbumSelectorState extends ConsumerState<AlbumSelector> {
             onSearch: onSearch,
             filterMode: filter.mode,
             onClearSearch: clearSearch,
+            hint: widget.searchHint,
           ),
           _QuickFilterButtonRow(
             filterMode: filter.mode,
@@ -382,6 +397,7 @@ class _SearchBar extends StatelessWidget {
     required this.onSearch,
     required this.filterMode,
     required this.onClearSearch,
+    this.hint,
   });
 
   final TextEditingController searchController;
@@ -389,6 +405,7 @@ class _SearchBar extends StatelessWidget {
   final void Function(String, QuickFilterMode) onSearch;
   final QuickFilterMode filterMode;
   final VoidCallback onClearSearch;
+  final String? hint;
 
   @override
   Widget build(BuildContext context) {
@@ -413,7 +430,7 @@ class _SearchBar extends StatelessWidget {
           child: SearchField(
             autofocus: false,
             contentPadding: const EdgeInsets.all(16),
-            hintText: 'search_albums'.tr(),
+            hintText: hint ?? 'search_albums'.tr(),
             prefixIcon: const Icon(Icons.search_rounded),
             suffixIcon: searchController.text.isNotEmpty
                 ? IconButton(icon: const Icon(Icons.clear_rounded), onPressed: onClearSearch)

--- a/mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/general_bottom_sheet.widget.dart
@@ -1,8 +1,6 @@
-import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/enums.dart';
-import 'package:immich_mobile/domain/models/album/album.model.dart';
 import 'package:immich_mobile/presentation/actions/action.widget.dart';
 import 'package:immich_mobile/presentation/actions/asset_debug.action.dart';
 import 'package:immich_mobile/presentation/actions/timeline.action.dart';
@@ -22,13 +20,11 @@ import 'package:immich_mobile/presentation/widgets/action_buttons/stack_action_b
 import 'package:immich_mobile/presentation/widgets/action_buttons/trash_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/unstack_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/upload_action_button.widget.dart';
-import 'package:immich_mobile/presentation/widgets/album/album_selector.widget.dart';
 import 'package:immich_mobile/presentation/widgets/bottom_sheet/base_bottom_sheet.widget.dart';
-import 'package:immich_mobile/providers/infrastructure/action.provider.dart';
+import 'package:immich_mobile/presentation/widgets/collection/collection_picker.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/user_metadata.provider.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
-import 'package:immich_mobile/widgets/common/immich_toast.dart';
 
 class GeneralBottomSheet extends ConsumerStatefulWidget {
   final double? minChildSize;
@@ -59,25 +55,6 @@ class _GeneralBottomSheetState extends ConsumerState<GeneralBottomSheet> {
     final tagsEnabled = ref.watch(
       userMetadataPreferencesProvider.select((value) => value.valueOrNull?.tagsEnabled ?? false),
     );
-
-    Future<void> addToAlbum(RemoteAlbum album) async {
-      final result = await ref.read(actionProvider.notifier).addToAlbum(ActionSource.timeline, album);
-
-      if (!context.mounted) {
-        return;
-      }
-
-      if (!result.success) {
-        ImmichToast.show(context: context, msg: 'scaffold_body_error_occurred'.tr(), toastType: ToastType.error);
-        return;
-      }
-      ImmichToast.show(
-        context: context,
-        msg: result.count == 0
-            ? 'add_to_album_bottom_sheet_already_exists'.tr(namedArgs: {'album': album.name})
-            : 'add_to_album_bottom_sheet_added'.tr(namedArgs: {'album': album.name}),
-      );
-    }
 
     Future<void> onKeyboardExpand() {
       return sheetController.animateTo(0.85, duration: const Duration(milliseconds: 200), curve: Curves.easeInOut);
@@ -115,10 +92,7 @@ class _GeneralBottomSheetState extends ConsumerState<GeneralBottomSheet> {
           const DeleteLocalActionButton(source: ActionSource.timeline),
         if (multiselect.onlyLocal) const UploadActionButton(source: ActionSource.timeline),
       ],
-      slivers: [
-        const AddToAlbumHeader(),
-        AlbumSelector(onAlbumSelected: addToAlbum, onKeyboardExpanded: onKeyboardExpand),
-      ],
+      slivers: [CollectionPicker(onKeyboardExpanded: onKeyboardExpand)],
     );
   }
 }

--- a/mobile/lib/presentation/widgets/bottom_sheet/space_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/space_bottom_sheet.widget.dart
@@ -6,6 +6,7 @@ import 'package:immich_mobile/presentation/widgets/action_buttons/favorite_actio
 import 'package:immich_mobile/presentation/widgets/action_buttons/remove_from_space_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/share_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/bottom_sheet/base_bottom_sheet.widget.dart';
+import 'package:immich_mobile/presentation/widgets/collection/collection_picker.widget.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
 import 'package:immich_mobile/utils/space_permissions.dart';
 import 'package:openapi/api.dart';
@@ -46,7 +47,9 @@ class _SpaceBottomSheetState extends ConsumerState<SpaceBottomSheet> {
       controller: sheetController,
       initialChildSize: 0.22,
       minChildSize: 0.22,
-      maxChildSize: 0.55,
+      // Raised from 0.55: the sheet now hosts the collection picker, which is unreachable
+      // at the old ceiling.
+      maxChildSize: 0.85,
       shouldCloseOnMinExtent: false,
       actions: [
         const ShareActionButton(source: ActionSource.timeline),
@@ -60,6 +63,10 @@ class _SpaceBottomSheetState extends ConsumerState<SpaceBottomSheet> {
               onComplete: widget.onAssetsRemoved,
             ),
         ],
+      ],
+      slivers: [
+        // A space is not offered as a destination for its own assets.
+        CollectionPicker(excludeSpaceId: widget.spaceId),
       ],
     );
   }

--- a/mobile/lib/presentation/widgets/bottom_sheet/space_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/space_bottom_sheet.widget.dart
@@ -7,6 +7,7 @@ import 'package:immich_mobile/presentation/widgets/action_buttons/remove_from_sp
 import 'package:immich_mobile/presentation/widgets/action_buttons/share_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/bottom_sheet/base_bottom_sheet.widget.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
+import 'package:immich_mobile/utils/space_permissions.dart';
 import 'package:openapi/api.dart';
 
 class SpaceBottomSheet extends ConsumerStatefulWidget {
@@ -35,8 +36,7 @@ class _SpaceBottomSheetState extends ConsumerState<SpaceBottomSheet> {
     super.dispose();
   }
 
-  bool get _canEdit =>
-      widget.currentUserRole == SharedSpaceRole.owner || widget.currentUserRole == SharedSpaceRole.editor;
+  bool get _canEdit => roleIsWritable(widget.currentUserRole);
 
   @override
   Widget build(BuildContext context) {

--- a/mobile/lib/presentation/widgets/collection/collection_picker.widget.dart
+++ b/mobile/lib/presentation/widgets/collection/collection_picker.widget.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/constants/enums.dart';
+import 'package:immich_mobile/domain/models/album/album.model.dart';
+import 'package:immich_mobile/domain/models/collection_target.dart';
+import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/extensions/translate_extensions.dart';
+import 'package:immich_mobile/presentation/widgets/album/album_selector.widget.dart';
+import 'package:immich_mobile/presentation/widgets/collection/space_collection_section.widget.dart';
+import 'package:immich_mobile/providers/infrastructure/action.provider.dart';
+import 'package:immich_mobile/widgets/common/immich_toast.dart';
+import 'package:sliver_tools/sliver_tools.dart';
+
+/// "Add to album or space" — the album selector plus the spaces section.
+///
+/// `AlbumSelector` is upstream and is composed, never modified. Its own
+/// `AddToAlbumHeader` is not reused because it hardcodes the `add_to_album` key; this
+/// picker supplies its own header so the sheet can honestly say "album or space".
+class CollectionPicker extends ConsumerStatefulWidget {
+  const CollectionPicker({super.key, this.excludeSpaceId, this.onKeyboardExpanded});
+
+  /// Set on a space's own surface so that space is not offered as a destination for
+  /// its own assets.
+  final String? excludeSpaceId;
+
+  final Function? onKeyboardExpanded;
+
+  @override
+  ConsumerState<CollectionPicker> createState() => _CollectionPickerState();
+}
+
+class _CollectionPickerState extends ConsumerState<CollectionPicker> {
+  bool _isBusy = false;
+
+  Future<void> _addToAlbum(RemoteAlbum album) async {
+    if (_isBusy) return;
+    setState(() => _isBusy = true);
+    final result = await ref.read(actionProvider.notifier).addToAlbum(ActionSource.timeline, album);
+    if (!mounted) return;
+    setState(() => _isBusy = false);
+
+    if (!result.success) {
+      _toastError();
+      return;
+    }
+    ImmichToast.show(
+      context: context,
+      msg: result.count == 0
+          ? 'add_to_album_bottom_sheet_already_exists'.t(context: context, args: {'album': album.name})
+          : 'add_to_album_bottom_sheet_added'.t(context: context, args: {'album': album.name}),
+    );
+  }
+
+  Future<void> _addToTarget(CollectionTarget target) async {
+    if (_isBusy) return;
+    setState(() => _isBusy = true);
+
+    final notifier = ref.read(actionProvider.notifier);
+    final ActionResult result;
+    final String? successMessage;
+    switch (target) {
+      case AlbumTarget(:final album):
+        result = await notifier.addToAlbum(ActionSource.timeline, album);
+        successMessage = null;
+      case SpacePoolTarget(:final space):
+        result = await notifier.addToSpace(ActionSource.timeline, space);
+        // The pool endpoint is 204 with no body, so this count is the request length.
+        successMessage = 'added_to_space_count';
+      case SpaceAlbumTarget(:final spaceId, :final album):
+        result = await notifier.addToSpaceAlbum(ActionSource.timeline, spaceId, album);
+        // This one IS the server's count, so duplicates are already excluded.
+        successMessage = 'space_album_add_photos_success';
+    }
+
+    if (!mounted) return;
+    setState(() => _isBusy = false);
+
+    if (!result.success) {
+      _toastError();
+      return;
+    }
+    if (successMessage != null) {
+      ImmichToast.show(
+        context: context,
+        msg: successMessage.t(context: context, args: {'count': result.count.toString()}),
+        toastType: ToastType.success,
+      );
+    }
+  }
+
+  void _toastError() {
+    ImmichToast.show(
+      context: context,
+      msg: 'scaffold_body_error_occurred'.t(context: context),
+      toastType: ToastType.error,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiSliver(
+      children: [
+        SliverPadding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+          sliver: SliverToBoxAdapter(
+            child: Text(
+              'add_to_album_or_space'.t(context: context),
+              key: const Key('collection-picker-header'),
+              style: context.textTheme.titleSmall,
+            ),
+          ),
+        ),
+        AlbumSelector(onAlbumSelected: _addToAlbum, onKeyboardExpanded: widget.onKeyboardExpanded),
+        SliverToBoxAdapter(
+          child: SpaceCollectionSection(
+            onTargetSelected: _addToTarget,
+            excludeSpaceId: widget.excludeSpaceId,
+            isBusy: _isBusy,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/presentation/widgets/collection/collection_picker.widget.dart
+++ b/mobile/lib/presentation/widgets/collection/collection_picker.widget.dart
@@ -13,7 +13,8 @@ import 'package:sliver_tools/sliver_tools.dart';
 
 /// "Add to album or space" — the album selector plus the spaces section.
 ///
-/// `AlbumSelector` is upstream and is composed, never modified. Its own
+/// `AlbumSelector` is upstream and is composed, with two additive fork hooks
+/// (`onSearchChanged`, `searchHint`) so its search field can cover the spaces section too. Its own
 /// `AddToAlbumHeader` is not reused because it hardcodes the `add_to_album` key; this
 /// picker supplies its own header so the sheet can honestly say "album or space".
 class CollectionPicker extends ConsumerStatefulWidget {
@@ -31,6 +32,7 @@ class CollectionPicker extends ConsumerStatefulWidget {
 
 class _CollectionPickerState extends ConsumerState<CollectionPicker> {
   bool _isBusy = false;
+  String _searchQuery = '';
 
   Future<void> _addToAlbum(RemoteAlbum album) async {
     if (_isBusy) return;
@@ -110,12 +112,18 @@ class _CollectionPickerState extends ConsumerState<CollectionPicker> {
             ),
           ),
         ),
-        AlbumSelector(onAlbumSelected: _addToAlbum, onKeyboardExpanded: widget.onKeyboardExpanded),
+        AlbumSelector(
+          onAlbumSelected: _addToAlbum,
+          onKeyboardExpanded: widget.onKeyboardExpanded,
+          onSearchChanged: (query) => setState(() => _searchQuery = query),
+          searchHint: 'search_albums_and_spaces'.t(context: context),
+        ),
         SliverToBoxAdapter(
           child: SpaceCollectionSection(
             onTargetSelected: _addToTarget,
             excludeSpaceId: widget.excludeSpaceId,
             isBusy: _isBusy,
+            searchQuery: _searchQuery,
           ),
         ),
       ],

--- a/mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart
+++ b/mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/constants/collection.dart';
+import 'package:immich_mobile/domain/models/collection_target.dart';
+import 'package:immich_mobile/domain/models/space_album.model.dart';
+import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/extensions/translate_extensions.dart';
+import 'package:immich_mobile/providers/infrastructure/space_album.provider.dart';
+import 'package:immich_mobile/providers/shared_space.provider.dart';
+import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:immich_mobile/utils/selection_targets.dart';
+import 'package:immich_mobile/utils/space_permissions.dart';
+import 'package:immich_mobile/widgets/spaces/space_collage.dart';
+import 'package:openapi/api.dart';
+
+/// The "Spaces" half of the add-to-collection picker.
+///
+/// A plain box widget so it can be pumped directly in tests; the picker wraps it in a
+/// `SliverToBoxAdapter`. Space rows come from the network `sharedSpacesProvider`; a row's
+/// linked albums come from the local Drift `spaceAlbumsProvider`, watched ONLY while that
+/// row is expanded, so collapsed spaces subscribe to nothing.
+class SpaceCollectionSection extends ConsumerStatefulWidget {
+  const SpaceCollectionSection({super.key, required this.onTargetSelected, this.excludeSpaceId, this.isBusy = false});
+
+  final void Function(CollectionTarget target) onTargetSelected;
+
+  /// Set on a space's own surface so it is not offered as a destination for its own assets.
+  final String? excludeSpaceId;
+
+  /// Disables every row while an add is in flight.
+  final bool isBusy;
+
+  @override
+  ConsumerState<SpaceCollectionSection> createState() => _SpaceCollectionSectionState();
+}
+
+class _SpaceCollectionSectionState extends ConsumerState<SpaceCollectionSection> {
+  /// Accordion: at most one expanded space, which bounds live Drift subscriptions to one.
+  String? _expandedSpaceId;
+
+  /// Guards a double-tap on a plain row from emitting two targets.
+  bool _emitted = false;
+
+  void _emit(CollectionTarget target) {
+    if (_emitted || widget.isBusy) return;
+    _emitted = true;
+    widget.onTargetSelected(target);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final spacesAsync = ref.watch(sharedSpacesProvider);
+    final userId = ref.watch(currentUserProvider.select((user) => user?.id));
+    final selection = ref.watch(multiSelectProvider.select((state) => state.selectedAssets));
+
+    final spaces = spacesAsync.valueOrNull;
+    // Offline or still loading: the album half of the picker still works, so stay out of
+    // the way rather than surfacing an error into someone else's sheet.
+    if (spaces == null) return const SizedBox.shrink();
+
+    final writable =
+        spaces.where((space) => spaceIsWritable(space, userId) && space.id != widget.excludeSpaceId).toList()
+          ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+    if (writable.isEmpty) return const SizedBox.shrink();
+
+    final String? notice;
+    if (selectionHasNonOwned(selection, userId)) {
+      notice = 'spaces_hidden_non_owned_selection'.t(context: context);
+    } else if (selectionHasLocked(selection)) {
+      notice = 'spaces_hidden_non_owned_selection'.t(context: context);
+    } else if (selectionExceedsSpaceCap(selection)) {
+      notice = 'spaces_hidden_too_many_assets'.t(
+        context: context,
+        args: {'count': kMaxSpaceAssetsPerRequest.toString()},
+      );
+    } else {
+      notice = null;
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Padding(
+          key: const Key('space-collection-header'),
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          child: Text('spaces'.t(context: context), style: context.textTheme.labelLarge),
+        ),
+        if (notice != null)
+          Padding(
+            key: const Key('space-collection-notice'),
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Row(
+              children: [
+                const Icon(Icons.info_outline, size: 16),
+                const SizedBox(width: 8),
+                Expanded(child: Text(notice, style: context.textTheme.bodySmall)),
+              ],
+            ),
+          )
+        else
+          for (final space in writable) ..._rowsFor(space),
+      ],
+    );
+  }
+
+  List<Widget> _rowsFor(SharedSpaceResponseDto space) {
+    // albumCount is Optional<num?> and is the ONLY way to know a row is expandable without
+    // subscribing to its Drift stream. An absent count reads as 0 -- a plain row, which
+    // still reaches the pool.
+    final albumCount = (space.albumCount.orElse(null) ?? 0).toInt();
+    final expandable = albumCount > 0;
+    final expanded = _expandedSpaceId == space.id;
+
+    return [
+      ListTile(
+        key: Key('space-row-${space.id}'),
+        enabled: !widget.isBusy,
+        leading: CircleAvatar(backgroundColor: spaceGradientColors(space.color.orElse(null)).first, radius: 16),
+        title: Text(space.name, maxLines: 1, overflow: TextOverflow.ellipsis),
+        trailing: expandable ? Icon(expanded ? Icons.expand_less : Icons.expand_more) : null,
+        onTap: widget.isBusy
+            ? null
+            : () {
+                if (!expandable) {
+                  _emit(SpacePoolTarget(space));
+                  return;
+                }
+                setState(() => _expandedSpaceId = expanded ? null : space.id);
+              },
+      ),
+      if (expanded) ..._childrenFor(space),
+    ];
+  }
+
+  List<Widget> _childrenFor(SharedSpaceResponseDto space) {
+    final albumsAsync = ref.watch(spaceAlbumsProvider(space.id));
+    final albums = albumsAsync.valueOrNull ?? const <SpaceAlbum>[];
+
+    return [
+      ListTile(
+        key: Key('space-pool-child-${space.id}'),
+        contentPadding: const EdgeInsets.only(left: 48, right: 16),
+        leading: const Icon(Icons.workspaces_outline),
+        title: Text('add_to_space'.t(context: context)),
+        enabled: !widget.isBusy,
+        onTap: widget.isBusy ? null : () => _emit(SpacePoolTarget(space)),
+      ),
+      if (albums.isEmpty)
+        Padding(
+          key: Key('space-albums-empty-${space.id}'),
+          padding: const EdgeInsets.only(left: 48, right: 16, bottom: 8),
+          child: Text('no_albums_in_space_yet'.t(context: context), style: context.textTheme.bodySmall),
+        )
+      else
+        for (final album in albums)
+          ListTile(
+            key: Key('space-album-child-${album.id}'),
+            contentPadding: const EdgeInsets.only(left: 48, right: 16),
+            leading: const Icon(Icons.photo_album_outlined),
+            title: Text(album.name, maxLines: 1, overflow: TextOverflow.ellipsis),
+            enabled: !widget.isBusy,
+            onTap: widget.isBusy ? null : () => _emit(SpaceAlbumTarget(spaceId: space.id, album: album)),
+          ),
+    ];
+  }
+}

--- a/mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart
+++ b/mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart
@@ -49,6 +49,17 @@ class _SpaceCollectionSectionState extends ConsumerState<SpaceCollectionSection>
   }
 
   @override
+  void didUpdateWidget(covariant SpaceCollectionSection oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // The latch exists to swallow a double-tap while a dispatch is starting. Once the
+    // parent reports it is no longer busy the dispatch has finished -- including when it
+    // FAILED and left the sheet open -- so the section must accept taps again.
+    if (oldWidget.isBusy && !widget.isBusy) {
+      _emitted = false;
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final spacesAsync = ref.watch(sharedSpacesProvider);
     final userId = ref.watch(currentUserProvider.select((user) => user?.id));

--- a/mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart
+++ b/mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart
@@ -21,7 +21,13 @@ import 'package:openapi/api.dart';
 /// linked albums come from the local Drift `spaceAlbumsProvider`, watched ONLY while that
 /// row is expanded, so collapsed spaces subscribe to nothing.
 class SpaceCollectionSection extends ConsumerStatefulWidget {
-  const SpaceCollectionSection({super.key, required this.onTargetSelected, this.excludeSpaceId, this.isBusy = false});
+  const SpaceCollectionSection({
+    super.key,
+    required this.onTargetSelected,
+    this.excludeSpaceId,
+    this.isBusy = false,
+    this.searchQuery = '',
+  });
 
   final void Function(CollectionTarget target) onTargetSelected;
 
@@ -30,6 +36,10 @@ class SpaceCollectionSection extends ConsumerStatefulWidget {
 
   /// Disables every row while an add is in flight.
   final bool isBusy;
+
+  /// Narrows the rows to spaces whose name contains this query — supplied by the picker so
+  /// its single search field covers both halves of the sheet.
+  final String searchQuery;
 
   @override
   ConsumerState<SpaceCollectionSection> createState() => _SpaceCollectionSectionState();
@@ -70,8 +80,16 @@ class _SpaceCollectionSectionState extends ConsumerState<SpaceCollectionSection>
     // the way rather than surfacing an error into someone else's sheet.
     if (spaces == null) return const SizedBox.shrink();
 
+    final query = widget.searchQuery.trim().toLowerCase();
     final writable =
-        spaces.where((space) => spaceIsWritable(space, userId) && space.id != widget.excludeSpaceId).toList()
+        spaces
+            .where(
+              (space) =>
+                  spaceIsWritable(space, userId) &&
+                  space.id != widget.excludeSpaceId &&
+                  (query.isEmpty || space.name.toLowerCase().contains(query)),
+            )
+            .toList()
           ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
     if (writable.isEmpty) return const SizedBox.shrink();
 

--- a/mobile/lib/presentation/widgets/remote_album/space_link_picker.widget.dart
+++ b/mobile/lib/presentation/widgets/remote_album/space_link_picker.widget.dart
@@ -4,6 +4,7 @@ import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/providers/shared_space.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:immich_mobile/utils/space_permissions.dart';
 import 'package:openapi/api.dart';
 
 /// L15 — minimal "Link to space" picker, the reverse of [SpaceLinkAlbumPage]
@@ -31,13 +32,6 @@ class SpaceLinkPickerSheet extends ConsumerWidget {
     );
   }
 
-  static bool _canWrite(SharedSpaceResponseDto space, String? currentUserId) {
-    if (currentUserId == null) return false;
-    if (space.createdById == currentUserId) return true;
-    final role = (space.members.value ?? const []).where((m) => m.userId == currentUserId).firstOrNull?.role;
-    return role == SharedSpaceRole.owner || role == SharedSpaceRole.editor;
-  }
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final spacesAsync = ref.watch(sharedSpacesProvider);
@@ -57,7 +51,7 @@ class SpaceLinkPickerSheet extends ConsumerWidget {
             Flexible(
               child: spacesAsync.when(
                 data: (spaces) {
-                  final writable = spaces.where((s) => _canWrite(s, currentUserId)).toList();
+                  final writable = spaces.where((s) => spaceIsWritable(s, currentUserId)).toList();
                   if (writable.isEmpty) {
                     return _CenteredMessage(text: 'spaces_no_writable_spaces'.t(context: context));
                   }

--- a/mobile/lib/presentation/widgets/spaces/space_detail_kebab.widget.dart
+++ b/mobile/lib/presentation/widgets/spaces/space_detail_kebab.widget.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:immich_mobile/extensions/translate_extensions.dart';
+
+/// Role-gated overflow menu for the space detail page.
+///
+/// Extracted from [SpaceDetailPage] so the RBAC table can be widget-tested without
+/// pumping a routed page that loads network metadata, members and a Drift timeline.
+/// Mirrors the existing [SpaceAlbumKebab].
+///
+/// Naming and appearance are editor-level server-side, so the menu itself is shown
+/// for [canEdit]; only deletion is restricted further, via [canDelete].
+class SpaceDetailKebab extends StatelessWidget {
+  const SpaceDetailKebab({
+    super.key,
+    required this.canEdit,
+    required this.canDelete,
+    required this.onEdit,
+    required this.onDelete,
+  });
+
+  final bool canEdit;
+  final bool canDelete;
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!canEdit) return const SizedBox.shrink();
+
+    return PopupMenuButton<_KebabAction>(
+      key: const Key('space-detail-kebab'),
+      onSelected: (action) => switch (action) {
+        _KebabAction.edit => onEdit(),
+        _KebabAction.delete => onDelete(),
+      },
+      itemBuilder: (context) => [
+        PopupMenuItem<_KebabAction>(
+          key: const Key('space-detail-kebab-edit'),
+          value: _KebabAction.edit,
+          child: Text('spaces_edit'.t(context: context)),
+        ),
+        if (canDelete)
+          PopupMenuItem<_KebabAction>(
+            key: const Key('space-detail-kebab-delete'),
+            value: _KebabAction.delete,
+            child: Text('spaces_delete'.t(context: context)),
+          ),
+      ],
+    );
+  }
+}
+
+enum _KebabAction { edit, delete }

--- a/mobile/lib/presentation/widgets/spaces/space_edit_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/spaces/space_edit_sheet.widget.dart
@@ -3,6 +3,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/repositories/shared_space_api.repository.dart';
+import 'package:immich_mobile/widgets/common/immich_toast.dart';
 import 'package:immich_mobile/widgets/spaces/space_collage.dart';
 import 'package:openapi/api.dart';
 
@@ -90,16 +91,25 @@ class _SpaceEditSheetState extends ConsumerState<SpaceEditSheet> {
       // disabled forever would be a real (if latent) bug on any caller that doesn't
       // immediately tear the sheet down.
       setState(() => _isSaving = false);
+      ImmichToast.show(
+        context: context,
+        msg: 'spaces_edit_success'.t(context: context),
+        toastType: ToastType.success,
+      );
       widget.onClose(true);
     } catch (_) {
       if (!mounted) return;
-      // No ImmichToast here: it schedules a real (non-frame) fluttertoast Timer that a
-      // plain `pumpAndSettle()` cannot be relied on to flush before test teardown --
-      // confirmed by reproduction, not assumption. The error is still surfaced: the
-      // sheet stays open and save re-enables so the user can retry. Wiring an
-      // errors.unable_to_update_space toast is left to whichever caller (Slice 4)
-      // controls a real Scaffold/routed context.
       setState(() => _isSaving = false);
+      // The sheet staying open is not, on its own, feedback: the user taps Save and sees
+      // nothing change. A revoked role (403) has to say so. `ImmichToast` schedules a
+      // 3s fluttertoast Timer outside the frame scheduler, so any widget test that
+      // reaches this path must pump past it (see the test's `settleToast` helper) or
+      // teardown reports a pending timer.
+      ImmichToast.show(
+        context: context,
+        msg: 'errors.unable_to_update_space'.t(context: context),
+        toastType: ToastType.error,
+      );
     }
   }
 

--- a/mobile/lib/presentation/widgets/spaces/space_edit_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/spaces/space_edit_sheet.widget.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/extensions/build_context_extensions.dart';
+import 'package:immich_mobile/extensions/translate_extensions.dart';
+import 'package:immich_mobile/repositories/shared_space_api.repository.dart';
+import 'package:immich_mobile/widgets/spaces/space_collage.dart';
+import 'package:openapi/api.dart';
+
+/// Edit a space's name, description and colour.
+///
+/// Naming and appearance are editor-level server-side, so this sheet is gated by
+/// its callers (Slice 4), not by itself.
+///
+/// Takes an [onClose] callback rather than calling `Navigator.pop` directly: that
+/// keeps the sheet independent of routing so it can be widget-tested by pumping it
+/// alone, and mirrors the web `SpaceEditModal` shape. [SpaceEditSheet.show] supplies
+/// the popping implementation.
+class SpaceEditSheet extends ConsumerStatefulWidget {
+  const SpaceEditSheet({super.key, required this.space, required this.onClose});
+
+  final SharedSpaceResponseDto space;
+
+  /// `true` when the space was saved, `null` when the user cancelled.
+  final void Function(bool? saved) onClose;
+
+  static Future<bool?> show(BuildContext context, SharedSpaceResponseDto space) {
+    return showModalBottomSheet<bool>(
+      context: context,
+      isScrollControlled: true,
+      builder: (sheetContext) =>
+          SpaceEditSheet(space: space, onClose: (saved) => Navigator.of(sheetContext).pop(saved)),
+    );
+  }
+
+  @override
+  ConsumerState<SpaceEditSheet> createState() => _SpaceEditSheetState();
+}
+
+class _SpaceEditSheetState extends ConsumerState<SpaceEditSheet> {
+  late final TextEditingController _nameController;
+  late final TextEditingController _descriptionController;
+  late final FocusNode _nameFocusNode;
+  late final String _originalDescription;
+  late UserAvatarColor _color;
+
+  bool _isSaving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _originalDescription = widget.space.description.orElse(null) ?? '';
+    _nameController = TextEditingController(text: widget.space.name)
+      ..selection = TextSelection(baseOffset: 0, extentOffset: widget.space.name.length);
+    _descriptionController = TextEditingController(text: _originalDescription);
+    _color = widget.space.color.orElse(null) ?? UserAvatarColor.primary;
+    _nameFocusNode = FocusNode();
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _descriptionController.dispose();
+    _nameFocusNode.dispose();
+    super.dispose();
+  }
+
+  bool get _canSave => _nameController.text.trim().isNotEmpty && !_isSaving;
+
+  Future<void> _save() async {
+    if (!_canSave) return;
+    setState(() => _isSaving = true);
+
+    final description = _descriptionController.text;
+    try {
+      await ref
+          .read(sharedSpaceApiRepositoryProvider)
+          .update(
+            widget.space.id,
+            name: _nameController.text,
+            // Only send the description when it actually changed. A space created
+            // without one stores null server-side, so always sending '' would clobber
+            // it on a pure rename; but when the user DID clear it, '' must go through.
+            description: description == _originalDescription ? null : description,
+            color: _color,
+          );
+      if (!mounted) return;
+      // Reset the in-flight guard even on success: the widget isn't guaranteed to be
+      // unmounted synchronously by onClose (its production wiring pops the sheet, but
+      // e.g. a bare pump in tests can keep this same State alive), and leaving save
+      // disabled forever would be a real (if latent) bug on any caller that doesn't
+      // immediately tear the sheet down.
+      setState(() => _isSaving = false);
+      widget.onClose(true);
+    } catch (_) {
+      if (!mounted) return;
+      // No ImmichToast here: it schedules a real (non-frame) fluttertoast Timer that a
+      // plain `pumpAndSettle()` cannot be relied on to flush before test teardown --
+      // confirmed by reproduction, not assumption. The error is still surfaced: the
+      // sheet stays open and save re-enables so the user can retry. Wiring an
+      // errors.unable_to_update_space toast is left to whichever caller (Slice 4)
+      // controls a real Scaffold/routed context.
+      setState(() => _isSaving = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.only(left: 16, right: 16, top: 16, bottom: MediaQuery.of(context).viewInsets.bottom + 16),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('spaces_edit'.t(context: context), style: context.textTheme.titleMedium),
+              const SizedBox(height: 16),
+              TextField(
+                key: const Key('space-edit-name'),
+                controller: _nameController,
+                focusNode: _nameFocusNode,
+                autofocus: true,
+                maxLength: 100,
+                // The name arrives pre-selected so typing replaces it (the dominant rename
+                // path). A later tap must not re-run that selection logic nor let the
+                // framework's own tap-to-position gesture move the caret away from wherever
+                // the user last left it -- select-once only.
+                enableInteractiveSelection: false,
+                decoration: InputDecoration(labelText: 'name'.t(context: context)),
+                onChanged: (_) => setState(() {}),
+              ),
+              const SizedBox(height: 8),
+              TextField(
+                key: const Key('space-edit-description'),
+                controller: _descriptionController,
+                maxLength: 500,
+                maxLines: 3,
+                minLines: 1,
+                decoration: InputDecoration(labelText: 'description'.t(context: context)),
+              ),
+              const SizedBox(height: 8),
+              Text('color'.t(context: context), style: context.textTheme.labelLarge),
+              const SizedBox(height: 8),
+              Wrap(spacing: 8, runSpacing: 8, children: [for (final color in UserAvatarColor.values) _swatch(color)]),
+              const SizedBox(height: 16),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    key: const Key('space-edit-cancel'),
+                    onPressed: _isSaving ? null : () => widget.onClose(null),
+                    child: Text('cancel'.t(context: context)),
+                  ),
+                  const SizedBox(width: 8),
+                  FilledButton(
+                    key: const Key('space-edit-save'),
+                    onPressed: _canSave ? _save : null,
+                    child: Text('save'.t(context: context)),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _swatch(UserAvatarColor color) {
+    final selected = color == _color;
+    // The key identifies the tappable 48x48 region itself (so tap-target-size
+    // assertions measure the real hit area), with the accessibility label on a
+    // descendant -- callers that look up the swatch by key and then search its
+    // descendants for the semantics label depend on that nesting order.
+    return SizedBox(
+      key: Key('space-edit-color-${color.value}'),
+      width: 48,
+      height: 48,
+      // Colour alone conveys nothing to a screen reader, so each swatch is labelled.
+      child: Semantics(
+        label: color.value,
+        selected: selected,
+        button: true,
+        child: InkWell(
+          onTap: () => setState(() => _color = color),
+          child: Center(
+            child: Container(
+              key: selected ? Key('space-edit-color-${color.value}-selected') : null,
+              width: 32,
+              height: 32,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: spaceGradientColors(color).first,
+                border: selected ? Border.all(color: context.colorScheme.onSurface, width: 3) : null,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/providers/infrastructure/action.provider.dart
+++ b/mobile/lib/providers/infrastructure/action.provider.dart
@@ -8,6 +8,7 @@ import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/domain/models/album/album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/asset_edit.model.dart';
+import 'package:immich_mobile/domain/models/space_album.model.dart';
 import 'package:immich_mobile/domain/services/asset.service.dart';
 import 'package:immich_mobile/domain/services/remote_album.service.dart';
 import 'package:immich_mobile/models/download/livephotos_medatada.model.dart';
@@ -16,11 +17,14 @@ import 'package:immich_mobile/providers/backup/asset_upload_progress.provider.da
 import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/asset_viewer/asset.provider.dart' show assetExifProvider;
+import 'package:immich_mobile/providers/infrastructure/space_album.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/space_album_actions.dart';
 import 'package:immich_mobile/providers/infrastructure/tag.provider.dart';
 import 'package:immich_mobile/providers/server_info.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/providers/websocket.provider.dart';
+import 'package:immich_mobile/repositories/shared_space_api.repository.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/services/action.service.dart';
 import 'package:immich_mobile/services/download.service.dart';
@@ -50,6 +54,10 @@ class ActionNotifier extends Notifier<void> {
   late ForegroundUploadService _foregroundUploadService;
   late DownloadService _downloadService;
   late AssetService _assetService;
+
+  /// Guards against a second destination being dispatched while one is in flight —
+  /// two taps in a picker would otherwise fire two adds and two sync nudges.
+  bool _spaceAddInFlight = false;
 
   ActionNotifier() : super();
 
@@ -425,6 +433,92 @@ class ActionNotifier extends Notifier<void> {
       success: uploadResult.success,
       error: uploadResult.error,
     );
+  }
+
+  /// Add the selection to a space's own asset pool.
+  ///
+  /// Reports the REQUEST length: `POST /shared-spaces/{id}/assets` is 204 with no body,
+  /// so there is no server-side count to report (web does the same).
+  Future<ActionResult> addToSpace(ActionSource source, SharedSpaceResponseDto space) {
+    return _addToSpaceTarget(source, (ids) async {
+      await ref.read(sharedSpaceApiRepositoryProvider).addAssets(space.id, ids);
+      return ids.length;
+    });
+  }
+
+  /// Add the selection to an album linked to a space.
+  ///
+  /// Routed through [SpaceAlbumActions] rather than [addToAlbum]: a linked album may be
+  /// "absorbed" (no local `remote_album` row) and the album path also writes the local
+  /// junction, which would throw on the foreign key. Returns the server's true count,
+  /// which already excludes assets the album had.
+  Future<ActionResult> addToSpaceAlbum(ActionSource source, String spaceId, SpaceAlbum album) async {
+    final result = await _addToSpaceTarget(
+      source,
+      (ids) => ref.read(spaceAlbumActionsProvider).addAssets(album.id, ids),
+    );
+    if (result.success) {
+      ref.invalidate(spaceAlbumsProvider(spaceId));
+    }
+    return result;
+  }
+
+  /// Shared body for both space destinations.
+  ///
+  /// Local assets are uploaded first and then added in a SINGLE call — one call per
+  /// asset would fire `SpaceAlbumActions`' `syncRemote()` nudge once per photo.
+  /// A partial upload still adds what succeeded: stranding uploaded photos the user
+  /// asked to file would be worse than a partial-success result.
+  Future<ActionResult> _addToSpaceTarget(ActionSource source, Future<int> Function(List<String> remoteIds) add) async {
+    if (_spaceAddInFlight) {
+      return const ActionResult(count: 0, success: false);
+    }
+    _spaceAddInFlight = true;
+    try {
+      final selected = _getAssets(source).toList(growable: false);
+      if (selected.isEmpty) {
+        return const ActionResult(count: 0, success: true);
+      }
+
+      final candidates = RemoteAlbumService.categorizeCandidates(selected);
+      final remoteIds = [...candidates.remoteAssetIds];
+      final localAssets = candidates.localAssetsToUpload;
+
+      ActionResult? uploadResult;
+      if (localAssets.isNotEmpty) {
+        final uploaded = <String>[];
+        uploadResult = await upload(
+          source,
+          assets: localAssets,
+          onAssetUploaded: (asset, remoteId) => uploaded.add(remoteId),
+        );
+        remoteIds.addAll(uploaded);
+      }
+
+      if (remoteIds.isEmpty) {
+        // Every asset was local and none uploaded — nothing to add.
+        return ActionResult(count: 0, success: false, error: uploadResult?.error);
+      }
+
+      final int added;
+      try {
+        added = await add(remoteIds);
+      } catch (error, stack) {
+        _logger.severe('Failed to add assets to space target', error, stack);
+        return ActionResult(count: 0, success: false, error: error.toString());
+      }
+
+      // Only a fully successful run clears the selection, so a partial upload leaves
+      // the photos selected for retry. This deliberately differs from addToAlbum,
+      // which resets before its upload and so clears even when the upload fails.
+      final fullSuccess = uploadResult?.success ?? true;
+      if (fullSuccess && source == ActionSource.timeline) {
+        ref.read(multiSelectProvider.notifier).reset();
+      }
+      return ActionResult(count: added, success: fullSuccess, error: uploadResult?.error);
+    } finally {
+      _spaceAddInFlight = false;
+    }
   }
 
   Future<ActionResult> removeFromAlbum(ActionSource source, String albumId) async {

--- a/mobile/lib/providers/infrastructure/action.provider.dart
+++ b/mobile/lib/providers/infrastructure/action.provider.dart
@@ -13,6 +13,7 @@ import 'package:immich_mobile/domain/services/asset.service.dart';
 import 'package:immich_mobile/domain/services/remote_album.service.dart';
 import 'package:immich_mobile/models/download/livephotos_medatada.model.dart';
 import 'package:immich_mobile/providers/asset_viewer/asset_viewer.provider.dart';
+import 'package:immich_mobile/providers/background_sync.provider.dart';
 import 'package:immich_mobile/providers/backup/asset_upload_progress.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
@@ -408,6 +409,9 @@ class ActionNotifier extends Notifier<void> {
         _logger.severe('Failed to add assets to album ${album.id}', error, stack);
         return ActionResult(count: 0, success: false, error: error.toString());
       }
+      if (addedRemote > 0) {
+        await _nudgeSpaceSyncIfLinked(album.id);
+      }
     }
 
     // Keep the selection available for retry if the remote add fails. Once the
@@ -525,10 +529,27 @@ class ActionNotifier extends Notifier<void> {
     final ids = _getRemoteIdsForSource(source);
     try {
       final removedCount = await _service.removeFromAlbum(ids, albumId);
+      if (removedCount > 0) {
+        await _nudgeSpaceSyncIfLinked(albumId);
+      }
       return ActionResult(count: removedCount, success: true);
     } catch (error, stack) {
       _logger.severe('Failed to remove assets from album', error, stack);
       return ActionResult(count: ids.length, success: false, error: error.toString());
+    }
+  }
+
+  /// Fork: album views update through the album path's optimistic local write, but
+  /// space-album surfaces are fed by the sync stream — after mutating a linked album's
+  /// membership, nudge a sync so they converge now instead of at the next natural cycle.
+  /// Best-effort: a failed nudge never fails the mutation; the stream catches up later.
+  Future<void> _nudgeSpaceSyncIfLinked(String albumId) async {
+    try {
+      if (await ref.read(spaceAlbumRepositoryProvider).isAlbumLinked(albumId)) {
+        await ref.read(backgroundSyncProvider).syncRemote();
+      }
+    } catch (error, stack) {
+      _logger.warning('Failed to nudge sync after a linked-album mutation', error, stack);
     }
   }
 

--- a/mobile/lib/repositories/shared_space_api.repository.dart
+++ b/mobile/lib/repositories/shared_space_api.repository.dart
@@ -2,6 +2,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/providers/api.provider.dart';
 import 'package:immich_mobile/repositories/api.repository.dart';
 import 'package:immich_mobile/services/api.service.dart';
+import 'package:immich_mobile/utils/space_permissions.dart';
 import 'package:openapi/api.dart';
 
 final sharedSpaceApiRepositoryProvider = Provider((ref) => SharedSpaceApiRepository(ref.watch(apiServiceProvider)));
@@ -62,7 +63,7 @@ class SharedSpaceApiRepository extends ApiRepository {
       final members = await getMembers(spaceId);
       for (final member in members) {
         if (member.userId == userId) {
-          return member.role == SharedSpaceRole.owner || member.role == SharedSpaceRole.editor;
+          return roleIsWritable(member.role);
         }
       }
       return false;

--- a/mobile/lib/repositories/shared_space_api.repository.dart
+++ b/mobile/lib/repositories/shared_space_api.repository.dart
@@ -36,6 +36,29 @@ class SharedSpaceApiRepository extends ApiRepository {
     return await checkNull(_api.createSpace(dto));
   }
 
+  /// Update a space's name, description and/or colour (PATCH /shared-spaces/{id}).
+  ///
+  /// A `null` argument means **absent** — the field is left untouched. A non-null
+  /// argument is sent verbatim, so `description: ''` clears the description while
+  /// `description: null` leaves the existing text alone. That distinction is how a
+  /// pure rename avoids clobbering a description it never showed the user.
+  ///
+  /// Never sends `Optional.present(null)`: `name`, `description` and `color` are
+  /// `.optional()` but not `.nullable()` server-side, so an explicit null is a 400
+  /// rather than a field-clear. The four fields this feature does not own
+  /// (faceRecognitionEnabled, petsEnabled, thumbnailAssetId, thumbnailCropY) are
+  /// left at their `Optional.absent()` defaults.
+  ///
+  /// Naming and appearance are editor-level server-side; the role is enforced there.
+  Future<SharedSpaceResponseDto> update(String id, {String? name, String? description, UserAvatarColor? color}) async {
+    final dto = SharedSpaceUpdateDto(
+      name: name == null ? const Optional.absent() : Optional.present(name.trim()),
+      description: description == null ? const Optional.absent() : Optional.present(description),
+      color: color == null ? const Optional.absent() : Optional.present(color),
+    );
+    return await checkNull(_api.updateSpace(id, dto));
+  }
+
   Future<void> delete(String id) async {
     await _api.removeSpace(id);
   }

--- a/mobile/lib/utils/selection_targets.dart
+++ b/mobile/lib/utils/selection_targets.dart
@@ -1,0 +1,30 @@
+import 'package:immich_mobile/constants/collection.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+
+/// Whether the selection contains an asset the current user does not own.
+///
+/// `POST /shared-spaces/{id}/assets` requires `AssetShare` on **every** id and rejects
+/// the whole request otherwise, so a single non-owned asset makes every space target
+/// unusable. Local-only assets are not "non-owned": they upload as the current user's.
+///
+/// Fails **closed** when [currentUserId] is null — an unknown user gets no space targets
+/// rather than a request certain to 400.
+bool selectionHasNonOwned(Iterable<BaseAsset> assets, String? currentUserId) {
+  if (currentUserId == null) {
+    return assets.isNotEmpty;
+  }
+  return assets.any((asset) => asset is RemoteAsset && asset.ownerId != currentUserId);
+}
+
+/// Whether the selection contains a locked-folder asset.
+///
+/// Defensive: the locked folder is its own surface with its own bottom sheet, so such an
+/// asset should not reach the picker today. If one ever did, pushing it into a shared
+/// space would expose exactly what the user hid.
+bool selectionHasLocked(Iterable<BaseAsset> assets) =>
+    assets.any((asset) => asset is RemoteAsset && asset.visibility == AssetVisibility.locked);
+
+/// Whether the selection is larger than one space-add request allows.
+///
+/// The cap is inclusive, so exactly [kMaxSpaceAssetsPerRequest] is fine.
+bool selectionExceedsSpaceCap(Iterable<BaseAsset> assets) => assets.length > kMaxSpaceAssetsPerRequest;

--- a/mobile/lib/utils/space_permissions.dart
+++ b/mobile/lib/utils/space_permissions.dart
@@ -41,5 +41,4 @@ bool spaceIsOwned(SharedSpaceResponseDto space, String? currentUserId) {
 
 /// The role-only overload, for callers holding a resolved [SharedSpaceRole]
 /// rather than a whole DTO (e.g. `SpaceBottomSheet`).
-bool roleIsWritable(SharedSpaceRole? role) =>
-    role == SharedSpaceRole.owner || role == SharedSpaceRole.editor;
+bool roleIsWritable(SharedSpaceRole? role) => role == SharedSpaceRole.owner || role == SharedSpaceRole.editor;

--- a/mobile/lib/utils/space_permissions.dart
+++ b/mobile/lib/utils/space_permissions.dart
@@ -1,0 +1,45 @@
+import 'package:openapi/api.dart';
+
+/// Role predicates for shared spaces, shared by every surface that gates on them.
+///
+/// One implementation so the space detail page, the space bottom sheet and the
+/// link picker cannot drift apart. See the 2026-07-26 mobile Spaces UX design, §4.
+///
+/// `SharedSpaceResponseDto.members` is `Optional<List<...>?>` and `Absent.value`
+/// **throws** (`openapi/lib/optional.dart:67`), so every read goes through
+/// `orElse(null)` — the previously common `members.value ?? const []` crashes on a
+/// response that omits the list.
+/// The first matching row wins, which makes the duplicate-membership case
+/// deterministic. Written as an explicit loop rather than `.firstOrNull` so the
+/// file needs no `package:collection` import — Dart imports are not transitive,
+/// and this module deliberately imports only `openapi`.
+SharedSpaceRole? _roleOf(SharedSpaceResponseDto space, String currentUserId) {
+  final members = space.members.orElse(null) ?? const <SharedSpaceMemberResponseDto>[];
+  for (final member in members) {
+    if (member.userId == currentUserId) return member.role;
+  }
+  return null;
+}
+
+/// Whether [currentUserId] may add to, and edit the naming of, [space].
+///
+/// The creator short-circuit is deliberate and takes precedence over their member
+/// row: `getAll` does not guarantee the creator appears in `members`, so relying on
+/// the list alone would lock a space's own creator out of it.
+bool spaceIsWritable(SharedSpaceResponseDto space, String? currentUserId) {
+  if (currentUserId == null) return false;
+  if (space.createdById == currentUserId) return true;
+  return roleIsWritable(_roleOf(space, currentUserId));
+}
+
+/// Whether [currentUserId] owns [space] — the gate for destructive actions.
+bool spaceIsOwned(SharedSpaceResponseDto space, String? currentUserId) {
+  if (currentUserId == null) return false;
+  if (space.createdById == currentUserId) return true;
+  return _roleOf(space, currentUserId) == SharedSpaceRole.owner;
+}
+
+/// The role-only overload, for callers holding a resolved [SharedSpaceRole]
+/// rather than a whole DTO (e.g. `SpaceBottomSheet`).
+bool roleIsWritable(SharedSpaceRole? role) =>
+    role == SharedSpaceRole.owner || role == SharedSpaceRole.editor;

--- a/mobile/lib/widgets/spaces/space_card.dart
+++ b/mobile/lib/widgets/spaces/space_card.dart
@@ -7,7 +7,12 @@ class SpaceCard extends StatelessWidget {
   final SharedSpaceResponseDto space;
   final VoidCallback onTap;
 
-  const SpaceCard({super.key, required this.space, required this.onTap});
+  /// Optional so existing call sites keep working. `GestureDetector` fires either
+  /// `onTap` or `onLongPress` for a given gesture, never both, which is what keeps a
+  /// long-press from also navigating into the space behind the sheet.
+  final VoidCallback? onLongPress;
+
+  const SpaceCard({super.key, required this.space, required this.onTap, this.onLongPress});
 
   @override
   Widget build(BuildContext context) {
@@ -15,6 +20,12 @@ class SpaceCard extends StatelessWidget {
 
     return GestureDetector(
       onTap: onTap,
+      // Always register a long-press recognizer, even when the caller has no
+      // long-press handler of its own. Without one, GestureDetector only
+      // arms a tap recognizer, so a held-then-released touch (no onLongPress
+      // competing in the gesture arena) resolves as a plain tap -- a "fat
+      // finger" long hold would then navigate just like a quick tap.
+      onLongPress: onLongPress ?? () {},
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,

--- a/mobile/openapi/lib/model/server_features_dto.dart
+++ b/mobile/openapi/lib/model/server_features_dto.dart
@@ -29,6 +29,7 @@ class ServerFeaturesDto {
     required this.search,
     required this.sidecar,
     required this.smartSearch,
+    this.syncRequestTypes = const Optional.present(const []),
     required this.trash,
   });
 
@@ -80,6 +81,9 @@ class ServerFeaturesDto {
   /// Whether smart search is enabled
   bool smartSearch;
 
+  /// Sync stream request types this server accepts. Absent on servers that predate capability signalling; clients fall back to version-based gating.
+  Optional<List<String>?> syncRequestTypes;
+
   /// Whether trash feature is enabled
   bool trash;
 
@@ -101,6 +105,7 @@ class ServerFeaturesDto {
     other.search == search &&
     other.sidecar == sidecar &&
     other.smartSearch == smartSearch &&
+    _deepEquality.equals(other.syncRequestTypes, syncRequestTypes) &&
     other.trash == trash;
 
   @override
@@ -122,10 +127,11 @@ class ServerFeaturesDto {
     (search.hashCode) +
     (sidecar.hashCode) +
     (smartSearch.hashCode) +
+    (syncRequestTypes.hashCode) +
     (trash.hashCode);
 
   @override
-  String toString() => 'ServerFeaturesDto[configFile=$configFile, duplicateDetection=$duplicateDetection, email=$email, facialRecognition=$facialRecognition, importFaces=$importFaces, map=$map, oauth=$oauth, oauthAutoLaunch=$oauthAutoLaunch, ocr=$ocr, passwordLogin=$passwordLogin, peopleStatistics=$peopleStatistics, realtimeTranscoding=$realtimeTranscoding, reverseGeocoding=$reverseGeocoding, search=$search, sidecar=$sidecar, smartSearch=$smartSearch, trash=$trash]';
+  String toString() => 'ServerFeaturesDto[configFile=$configFile, duplicateDetection=$duplicateDetection, email=$email, facialRecognition=$facialRecognition, importFaces=$importFaces, map=$map, oauth=$oauth, oauthAutoLaunch=$oauthAutoLaunch, ocr=$ocr, passwordLogin=$passwordLogin, peopleStatistics=$peopleStatistics, realtimeTranscoding=$realtimeTranscoding, reverseGeocoding=$reverseGeocoding, search=$search, sidecar=$sidecar, smartSearch=$smartSearch, syncRequestTypes=$syncRequestTypes, trash=$trash]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -145,6 +151,10 @@ class ServerFeaturesDto {
       json[r'search'] = this.search;
       json[r'sidecar'] = this.sidecar;
       json[r'smartSearch'] = this.smartSearch;
+    if (this.syncRequestTypes.isPresent) {
+      final value = this.syncRequestTypes.value;
+      json[r'syncRequestTypes'] = value;
+    }
       json[r'trash'] = this.trash;
     return json;
   }
@@ -174,6 +184,9 @@ class ServerFeaturesDto {
         search: mapValueOfType<bool>(json, r'search')!,
         sidecar: mapValueOfType<bool>(json, r'sidecar')!,
         smartSearch: mapValueOfType<bool>(json, r'smartSearch')!,
+        syncRequestTypes: json.containsKey(r'syncRequestTypes') ? Optional.present(json[r'syncRequestTypes'] is Iterable
+            ? (json[r'syncRequestTypes'] as Iterable).cast<String>().toList(growable: false)
+            : const []) : const Optional.absent(),
         trash: mapValueOfType<bool>(json, r'trash')!,
       );
     }

--- a/mobile/test/domain/services/sync_stream_service_test.dart
+++ b/mobile/test/domain/services/sync_stream_service_test.dart
@@ -36,6 +36,30 @@ class _AbortCallbackWrapper {
 
 class _MockAbortCallbackWrapper extends Mock implements _AbortCallbackWrapper {}
 
+/// A /server/features response; [syncRequestTypes] defaults to ABSENT — the shape an
+/// older fork server (no capability signalling) produces.
+ServerFeaturesDto makeServerFeatures({Optional<List<String>?> syncRequestTypes = const Optional.absent()}) =>
+    ServerFeaturesDto(
+      configFile: false,
+      duplicateDetection: false,
+      email: false,
+      facialRecognition: false,
+      importFaces: false,
+      map: true,
+      oauth: false,
+      oauthAutoLaunch: false,
+      ocr: false,
+      passwordLogin: true,
+      peopleStatistics: false,
+      realtimeTranscoding: false,
+      reverseGeocoding: true,
+      search: true,
+      sidecar: true,
+      smartSearch: false,
+      trash: true,
+      syncRequestTypes: syncRequestTypes,
+    );
+
 void main() {
   late SyncStreamService sut;
   late SyncStreamRepository mockSyncStreamRepo;
@@ -101,6 +125,7 @@ void main() {
         any(),
         onReset: any(named: 'onReset'),
         serverVersion: any(named: 'serverVersion'),
+        supportedSyncTypes: any(named: 'supportedSyncTypes'),
         abortSignal: any(named: 'abortSignal'),
       ),
     ).thenAnswer((invocation) async {
@@ -114,6 +139,8 @@ void main() {
     when(
       () => mockServerApi.getServerVersion(),
     ).thenAnswer((_) async => ServerVersionResponseDto(major: 1, minor: 132, patch_: 0, prerelease: null));
+    // Default: a server that predates capability signalling (no syncRequestTypes field).
+    when(() => mockServerApi.getServerFeatures()).thenAnswer((_) async => makeServerFeatures());
 
     when(() => mockSyncStreamRepo.updateUsersV1(any())).thenAnswer(successHandler);
     when(() => mockSyncStreamRepo.deleteUsersV1(any())).thenAnswer(successHandler);
@@ -871,6 +898,87 @@ void main() {
       await sut.sync();
 
       verifyNever(() => mockSyncMigrationRepo.v20260128CopyExifWidthHeightToAsset());
+    });
+  });
+
+  group('SyncStreamService - sync capability detection', () {
+    Set<String>? capturedSupportedTypes() {
+      final captured = verify(
+        () => mockSyncApiRepo.streamChanges(
+          any(),
+          onReset: any(named: 'onReset'),
+          serverVersion: any(named: 'serverVersion'),
+          supportedSyncTypes: captureAny(named: 'supportedSyncTypes'),
+          abortSignal: any(named: 'abortSignal'),
+        ),
+      ).captured;
+      return captured.single as Set<String>?;
+    }
+
+    test('passes the server-declared sync request types through to streamChanges', () async {
+      when(() => mockServerApi.getServerFeatures()).thenAnswer(
+        (_) async => makeServerFeatures(syncRequestTypes: const Optional.present(['AssetsV1', 'SharedSpaceAlbumsV1'])),
+      );
+
+      await sut.sync();
+
+      expect(capturedSupportedTypes(), {'AssetsV1', 'SharedSpaceAlbumsV1'});
+    });
+
+    test('passes null when the server predates capability signalling (field absent)', () async {
+      // The generated DTO's DEFAULT is Optional.present([]) — an ABSENT field must not
+      // collapse into "declares nothing", which would silently disable fork sync types.
+      when(() => mockServerApi.getServerFeatures()).thenAnswer((_) async => makeServerFeatures());
+
+      await sut.sync();
+
+      expect(capturedSupportedTypes(), isNull);
+    });
+
+    test('passes null and still syncs when the features fetch fails', () async {
+      when(() => mockServerApi.getServerFeatures()).thenThrow(ApiException(500, 'boom'));
+
+      final result = await sut.sync();
+
+      expect(result, isTrue);
+      expect(capturedSupportedTypes(), isNull);
+    });
+
+    test('the post-reset re-stream carries the same declared types', () async {
+      // A server-requested reset triggers a full resync — the moment the fork tables get
+      // rebuilt — so dropping the declaration there would reintroduce the empty-tables bug.
+      when(
+        () => mockServerApi.getServerFeatures(),
+      ).thenAnswer((_) async => makeServerFeatures(syncRequestTypes: const Optional.present(['SharedSpaceAlbumsV1'])));
+      var calls = 0;
+      when(
+        () => mockSyncApiRepo.streamChanges(
+          any(),
+          onReset: any(named: 'onReset'),
+          serverVersion: any(named: 'serverVersion'),
+          supportedSyncTypes: any(named: 'supportedSyncTypes'),
+          abortSignal: any(named: 'abortSignal'),
+        ),
+      ).thenAnswer((invocation) async {
+        calls++;
+        if (calls == 1) {
+          (invocation.namedArguments[const Symbol('onReset')] as Function)();
+        }
+      });
+
+      await sut.sync();
+
+      final captured = verify(
+        () => mockSyncApiRepo.streamChanges(
+          any(),
+          onReset: any(named: 'onReset'),
+          serverVersion: any(named: 'serverVersion'),
+          supportedSyncTypes: captureAny(named: 'supportedSyncTypes'),
+          abortSignal: any(named: 'abortSignal'),
+        ),
+      ).captured;
+      expect(captured, hasLength(2));
+      expect(captured[1], {'SharedSpaceAlbumsV1'});
     });
   });
 }

--- a/mobile/test/infrastructure/repositories/sync_api_repository_test.dart
+++ b/mobile/test/infrastructure/repositories/sync_api_repository_test.dart
@@ -73,13 +73,15 @@ void main() {
 
   Future<void> streamChanges(
     Future<void> Function(List<SyncEvent>, Function() abort, Function() reset) onDataCallback,
-    SemVer serverVersion,
-  ) {
+    SemVer serverVersion, {
+    Set<String>? supportedSyncTypes,
+  }) {
     return sut.streamChanges(
       onDataCallback,
       batchSize: testBatchSize,
       httpClient: mockHttpClient,
       serverVersion: serverVersion,
+      supportedSyncTypes: supportedSyncTypes,
     );
   }
 
@@ -87,8 +89,8 @@ void main() {
   // reads back the request body the SUT sent so we can assert on `types`.
   // The request is populated (body set) before client.send, and the mock
   // captures the object by reference, so reading .body afterwards is valid.
-  Future<List<String>> capturedRequestTypes(SemVer serverVersion) async {
-    final future = streamChanges((_, _, _) async {}, serverVersion);
+  Future<List<String>> capturedRequestTypes(SemVer serverVersion, {Set<String>? supportedSyncTypes}) async {
+    final future = streamChanges((_, _, _) async {}, serverVersion, supportedSyncTypes: supportedSyncTypes);
     await Future.delayed(const Duration(milliseconds: 50));
     await responseStreamController.close();
     await future;
@@ -166,6 +168,44 @@ void main() {
         isEmpty,
         reason: 'every SharedSpaceAlbum* SyncRequestType must be sent once the version gate is satisfied',
       );
+    });
+  });
+
+  group('server-declared sync capabilities override the version gate', () {
+    const albumTypes = <String>[
+      'SharedSpaceAlbumsV1',
+      'SharedSpaceAlbumLinksV1',
+      'SharedSpaceAlbumToAssetsV1',
+      'SharedSpaceAlbumAssetsV1',
+      'SharedSpaceAlbumAssetExifsV1',
+    ];
+
+    test('a declaring server INCLUDES the album types even when its version reads at/below the gate', () async {
+      // An RC image stamps the bare base version (5.0.0-rc.N reports 5.0.0) and an
+      // unbranded dev server reports the upstream version — both lie below the
+      // version gate while fully supporting the feature. The declaration must win.
+      for (final version in [const SemVer(major: 5, minor: 0, patch: 0), const SemVer(major: 3, minor: 0, patch: 3)]) {
+        final types = await capturedRequestTypes(version, supportedSyncTypes: {...albumTypes, 'AssetsV1'});
+        expect(albumTypes.every(types.contains), isTrue, reason: 'declared capability must open the gate at $version');
+        clearInteractions(mockHttpClient);
+      }
+    });
+
+    test('a declaring server WITHOUT the album types EXCLUDES them even far above the version gate', () async {
+      final types = await capturedRequestTypes(
+        const SemVer(major: 6, minor: 0, patch: 0),
+        supportedSyncTypes: {'AssetsV1'},
+      );
+      expect(albumTypes.any(types.contains), isFalse, reason: 'the declaration is authoritative in both directions');
+    });
+
+    test('a partial declaration sends exactly the declared album types', () async {
+      final declared = {'SharedSpaceAlbumsV1', 'SharedSpaceAlbumLinksV1'};
+      final types = await capturedRequestTypes(
+        const SemVer(major: 5, minor: 0, patch: 0),
+        supportedSyncTypes: declared,
+      );
+      expect(types.where(albumTypes.contains).toSet(), declared);
     });
   });
 

--- a/mobile/test/medium/repositories/space_album_repository_test.dart
+++ b/mobile/test/medium/repositories/space_album_repository_test.dart
@@ -15,6 +15,19 @@ void main() {
   });
   tearDown(() => ctx.dispose());
 
+  group('isAlbumLinked', () {
+    test('true when the album has a space link, false otherwise', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      final linked = await ctx.newSharedSpaceAlbum(name: 'Linked');
+      final unlinked = await ctx.newSharedSpaceAlbum(name: 'Unlinked');
+      await ctx.insertSharedSpaceAlbumLink(spaceId: space.id, albumId: linked.id);
+
+      expect(await repo.isAlbumLinked(linked.id), isTrue);
+      expect(await repo.isAlbumLinked(unlinked.id), isFalse);
+    });
+  });
+
   group('watchLinkedAlbums', () {
     test('emits the linked albums (metadata + showInTimeline) for a space', () async {
       final user = await ctx.newUser();

--- a/mobile/test/modules/spaces/shared_space_api_repository_test.dart
+++ b/mobile/test/modules/spaces/shared_space_api_repository_test.dart
@@ -27,6 +27,7 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(api.SharedSpaceCreateDto(name: ''));
+    registerFallbackValue(api.SharedSpaceUpdateDto());
     registerFallbackValue(api.SharedSpacePersonUpdateDto());
     registerFallbackValue(
       api.SharedSpaceMemberCreateDto(userId: '', role: const api.Optional.present(api.SharedSpaceRole.viewer)),
@@ -507,6 +508,178 @@ void main() {
           ),
         ),
       ).called(1);
+    });
+  });
+
+  group('update', () {
+    api.SharedSpaceResponseDto updatedSpace() => api.SharedSpaceResponseDto(
+      id: 'space-1',
+      name: 'Renamed',
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-02T00:00:00Z',
+      createdById: 'user-1',
+    );
+
+    /// Asserts on the DTO handed to the generated client.
+    Matcher dtoThat(bool Function(api.SharedSpaceUpdateDto dto) predicate, String description) =>
+        isA<api.SharedSpaceUpdateDto>().having(predicate, description, isTrue);
+
+    test('sends only the name when only the name changed', () async {
+      when(() => mockApi.updateSpace('space-1', any())).thenAnswer((_) async => updatedSpace());
+
+      await repository.update('space-1', name: 'Renamed');
+
+      verify(
+        () => mockApi.updateSpace(
+          'space-1',
+          any(
+            that: dtoThat(
+              (d) =>
+                  d.name.isPresent &&
+                  d.name.value == 'Renamed' &&
+                  d.description.isEmpty &&
+                  d.color.isEmpty,
+              'name present, description and color absent',
+            ),
+          ),
+        ),
+      ).called(1);
+    });
+
+    test('sends an empty description verbatim so it clears server-side', () async {
+      when(() => mockApi.updateSpace('space-1', any())).thenAnswer((_) async => updatedSpace());
+
+      await repository.update('space-1', name: 'Renamed', description: '');
+
+      verify(
+        () => mockApi.updateSpace(
+          'space-1',
+          any(
+            that: dtoThat(
+              (d) => d.description.isPresent && d.description.value == '',
+              'description present and empty',
+            ),
+          ),
+        ),
+      ).called(1);
+    });
+
+    test('sends a newly added description', () async {
+      when(() => mockApi.updateSpace('space-1', any())).thenAnswer((_) async => updatedSpace());
+
+      await repository.update('space-1', description: 'Holiday photos');
+
+      verify(
+        () => mockApi.updateSpace(
+          'space-1',
+          any(
+            that: dtoThat(
+              (d) => d.description.isPresent && d.description.value == 'Holiday photos',
+              'description present',
+            ),
+          ),
+        ),
+      ).called(1);
+    });
+
+    test('omits description entirely when it is not passed', () async {
+      when(() => mockApi.updateSpace('space-1', any())).thenAnswer((_) async => updatedSpace());
+
+      await repository.update('space-1', name: 'Renamed');
+
+      verify(
+        () => mockApi.updateSpace(
+          'space-1',
+          any(
+            that: dtoThat(
+              // Absent, NOT Optional.present(null) -- the latter is a 400, because the
+              // server schema is .optional() but not .nullable().
+              (d) => d.description.isEmpty,
+              'description absent',
+            ),
+          ),
+        ),
+      ).called(1);
+    });
+
+    test('sends the colour when it changed', () async {
+      when(() => mockApi.updateSpace('space-1', any())).thenAnswer((_) async => updatedSpace());
+
+      await repository.update('space-1', color: api.UserAvatarColor.amber);
+
+      verify(
+        () => mockApi.updateSpace(
+          'space-1',
+          any(
+            that: dtoThat(
+              (d) => d.color.isPresent && d.color.value == api.UserAvatarColor.amber,
+              'color present',
+            ),
+          ),
+        ),
+      ).called(1);
+    });
+
+    test('never populates the four fields this feature does not own', () async {
+      // A stray Optional.present(false) on faceRecognitionEnabled would silently
+      // disable face recognition for the whole space on every rename.
+      when(() => mockApi.updateSpace('space-1', any())).thenAnswer((_) async => updatedSpace());
+
+      await repository.update('space-1', name: 'Renamed', description: 'x', color: api.UserAvatarColor.red);
+
+      verify(
+        () => mockApi.updateSpace(
+          'space-1',
+          any(
+            that: dtoThat(
+              (d) =>
+                  d.faceRecognitionEnabled.isEmpty &&
+                  d.petsEnabled.isEmpty &&
+                  d.thumbnailAssetId.isEmpty &&
+                  d.thumbnailCropY.isEmpty,
+              'untouched fields all absent',
+            ),
+          ),
+        ),
+      ).called(1);
+    });
+
+    test('trims the name but not the description', () async {
+      when(() => mockApi.updateSpace('space-1', any())).thenAnswer((_) async => updatedSpace());
+
+      await repository.update('space-1', name: '  Renamed  ', description: '  keep me  ');
+
+      verify(
+        () => mockApi.updateSpace(
+          'space-1',
+          any(
+            that: dtoThat(
+              (d) => d.name.value == 'Renamed' && d.description.value == '  keep me  ',
+              'name trimmed, description verbatim',
+            ),
+          ),
+        ),
+      ).called(1);
+    });
+
+    test('returns the updated space', () async {
+      when(() => mockApi.updateSpace('space-1', any())).thenAnswer((_) async => updatedSpace());
+
+      final result = await repository.update('space-1', name: 'Renamed');
+
+      expect(result.name, 'Renamed');
+    });
+
+    test('throws when the API returns null', () async {
+      when(() => mockApi.updateSpace(any(), any())).thenAnswer((_) async => null);
+
+      expect(() => repository.update('space-1', name: 'Renamed'), throwsA(isA<Exception>()));
+    });
+
+    test('propagates an API failure unchanged', () async {
+      when(() => mockApi.updateSpace(any(), any())).thenThrow(Exception('boom'));
+
+      expect(() => repository.update('space-1', name: 'Renamed'), throwsA(isA<Exception>()));
     });
   });
 }

--- a/mobile/test/presentation/widgets/collection/collection_picker_test.dart
+++ b/mobile/test/presentation/widgets/collection/collection_picker_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/domain/models/config/app_config.dart';
+import 'package:immich_mobile/domain/models/user.model.dart';
+import 'package:immich_mobile/domain/services/user.service.dart';
+import 'package:immich_mobile/presentation/widgets/collection/collection_picker.widget.dart';
+import 'package:immich_mobile/presentation/widgets/collection/space_collection_section.widget.dart';
+import 'package:immich_mobile/presentation/widgets/album/album_selector.widget.dart';
+import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/remote_album.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/settings.provider.dart';
+import 'package:immich_mobile/providers/shared_space.provider.dart';
+import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:immich_mobile/widgets/common/search_field.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../fixtures/user.stub.dart';
+import '../../../widget_tester_extensions.dart';
+
+class _MockUserService extends Mock implements UserService {}
+
+// Mirrors `space_collection_section_test.dart`: `currentUserProvider` is a
+// `StateNotifierProvider` whose `overrideWith` builder must return a `StateNotifier`.
+class _StubCurrentUserNotifier extends CurrentUserProvider {
+  _StubCurrentUserNotifier(super.service, UserDto? user) {
+    state = user;
+  }
+}
+
+// `AlbumSelector`'s `initState` fires a post-frame callback that calls
+// `refresh()` on the real notifier -- which needs a live `RemoteAlbumService` this
+// harness has no reason to stand up. Overriding just `build()` (as
+// `space_link_album_page_test.dart` does) leaves `refresh()` pointed at an
+// uninitialized service field, so this stub also no-ops `refresh()`.
+class _StubRemoteAlbumNotifier extends RemoteAlbumNotifier {
+  @override
+  RemoteAlbumState build() => const RemoteAlbumState(albums: []);
+
+  @override
+  Future<void> refresh() async {}
+}
+
+void main() {
+  testWidgets('composes the header, the album selector and the spaces section, in that order', (tester) async {
+    final userService = _MockUserService();
+    final user = UserStub.user1;
+    when(() => userService.tryGetMyUser()).thenReturn(user);
+    when(() => userService.watchMyUser()).thenAnswer((_) => const Stream.empty());
+
+    await tester.pumpConsumerWidgetRaw(
+      const CustomScrollView(slivers: [CollectionPicker()]),
+      overrides: [
+        currentUserProvider.overrideWith((ref) => _StubCurrentUserNotifier(userService, user)),
+        remoteAlbumProvider.overrideWith(() => _StubRemoteAlbumNotifier()),
+        appConfigProvider.overrideWithValue(const AppConfig()),
+        sharedSpacesProvider.overrideWith((ref) async => const []),
+        multiSelectProvider.overrideWith(
+          () => MultiSelectNotifier(const MultiSelectState(selectedAssets: {}, lockedSelectionAssets: {})),
+        ),
+      ],
+    );
+    await tester.pump();
+
+    expect(find.byKey(const Key('collection-picker-header')), findsOneWidget);
+    expect(find.byType(AlbumSelector), findsOneWidget);
+    expect(find.byType(SpaceCollectionSection), findsOneWidget);
+
+    // `AlbumSelector` itself renders a `MultiSliver` (a `RenderSliver`, not a
+    // `RenderBox`), so `getTopLeft` cannot target the widget directly; its first
+    // content sliver (the search field) stands in for "where AlbumSelector starts".
+    final headerY = tester.getTopLeft(find.byKey(const Key('collection-picker-header'))).dy;
+    final albumsY = tester.getTopLeft(find.byType(SearchField)).dy;
+    expect(headerY, lessThan(albumsY));
+  });
+}

--- a/mobile/test/presentation/widgets/collection/collection_picker_test.dart
+++ b/mobile/test/presentation/widgets/collection/collection_picker_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/domain/models/album/album.model.dart';
 import 'package:immich_mobile/domain/models/config/app_config.dart';
 import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/domain/services/user.service.dart';
+import 'package:immich_mobile/models/albums/album_search.model.dart';
 import 'package:immich_mobile/presentation/widgets/collection/collection_picker.widget.dart';
 import 'package:immich_mobile/presentation/widgets/collection/space_collection_section.widget.dart';
 import 'package:immich_mobile/presentation/widgets/album/album_selector.widget.dart';
@@ -14,6 +16,7 @@ import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/widgets/common/search_field.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:openapi/api.dart';
 
 import '../../../fixtures/user.stub.dart';
 import '../../../widget_tester_extensions.dart';
@@ -39,9 +42,39 @@ class _StubRemoteAlbumNotifier extends RemoteAlbumNotifier {
 
   @override
   Future<void> refresh() async {}
+
+  // Typing in the search field routes through here; the real one needs the same live
+  // service `refresh()` does. The album list is empty in this harness, so echo it back.
+  @override
+  List<RemoteAlbum> searchAlbums(
+    List<RemoteAlbum> albums,
+    String query,
+    String? userId, [
+    QuickFilterMode filterMode = QuickFilterMode.all,
+  ]) => albums;
 }
 
 void main() {
+  SharedSpaceMemberResponseDto member(String userId, SharedSpaceRole role) => SharedSpaceMemberResponseDto(
+    userId: userId,
+    name: userId,
+    email: '$userId@e.com',
+    role: role,
+    joinedAt: '2026-01-01T00:00:00Z',
+    sharePersonMetadata: true,
+    showInTimeline: true,
+  );
+
+  SharedSpaceResponseDto space(String id, String name) => SharedSpaceResponseDto(
+    id: id,
+    name: name,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    createdById: 'someone-else',
+    members: Optional.present([member('user-1', SharedSpaceRole.owner)]),
+    albumCount: const Optional.present(0),
+  );
+
   testWidgets('composes the header, the album selector and the spaces section, in that order', (tester) async {
     final userService = _MockUserService();
     final user = UserStub.user1;
@@ -72,5 +105,46 @@ void main() {
     final headerY = tester.getTopLeft(find.byKey(const Key('collection-picker-header'))).dy;
     final albumsY = tester.getTopLeft(find.byType(SearchField)).dy;
     expect(headerY, lessThan(albumsY));
+  });
+
+  testWidgets('typing in the search field narrows the spaces section too', (tester) async {
+    final userService = _MockUserService();
+    final user = UserStub.user1;
+    when(() => userService.tryGetMyUser()).thenReturn(user);
+    when(() => userService.watchMyUser()).thenAnswer((_) => const Stream.empty());
+
+    await tester.pumpConsumerWidgetRaw(
+      const CustomScrollView(slivers: [CollectionPicker()]),
+      overrides: [
+        currentUserProvider.overrideWith((ref) => _StubCurrentUserNotifier(userService, user)),
+        remoteAlbumProvider.overrideWith(() => _StubRemoteAlbumNotifier()),
+        appConfigProvider.overrideWithValue(const AppConfig()),
+        sharedSpacesProvider.overrideWith(
+          (ref) async => [space('s1', 'Family Vacation'), space('s2', 'Photography Club')],
+        ),
+        multiSelectProvider.overrideWith(
+          () => MultiSelectNotifier(const MultiSelectState(selectedAssets: {}, lockedSelectionAssets: {})),
+        ),
+      ],
+    );
+    await tester.pump();
+
+    expect(find.byKey(const Key('space-row-s1')), findsOneWidget);
+    expect(find.byKey(const Key('space-row-s2')), findsOneWidget);
+
+    await tester.enterText(find.byType(SearchField), 'family');
+    await tester.pump();
+
+    expect(find.byKey(const Key('space-row-s1')), findsOneWidget);
+    expect(
+      find.byKey(const Key('space-row-s2')),
+      findsNothing,
+      reason: 'the search field must filter spaces, not just albums',
+    );
+
+    await tester.enterText(find.byType(SearchField), '');
+    await tester.pump();
+
+    expect(find.byKey(const Key('space-row-s2')), findsOneWidget);
   });
 }

--- a/mobile/test/presentation/widgets/collection/space_collection_section_test.dart
+++ b/mobile/test/presentation/widgets/collection/space_collection_section_test.dart
@@ -289,4 +289,47 @@ void main() {
 
     expect(find.byKey(const Key('space-collection-header')), findsNothing);
   });
+
+  testWidgets('the double-tap latch clears once the parent is no longer busy', (tester) async {
+    final targets = <CollectionTarget>[];
+    var busy = false;
+    late StateSetter setOuter;
+
+    await tester.pumpConsumerWidget(
+      StatefulBuilder(
+        builder: (context, setState) {
+          setOuter = setState;
+          return SpaceCollectionSection(
+            onTargetSelected: (target) {
+              targets.add(target);
+              setState(() => busy = true);
+            },
+            isBusy: busy,
+          );
+        },
+      ),
+      overrides: [
+        sharedSpacesProvider.overrideWith((ref) async => [space('s1', albums: 0)]),
+        currentUserOverride('user-1'),
+        multiSelectProvider.overrideWith(
+          () => MultiSelectNotifier(
+            MultiSelectState(selectedAssets: {asset('a')}, lockedSelectionAssets: const {}),
+          ),
+        ),
+      ],
+    );
+
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+    expect(targets, hasLength(1));
+
+    // The add failed: the parent clears busy and the sheet stays open.
+    setOuter(() => busy = false);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+
+    expect(targets, hasLength(2), reason: 'a failed add must not leave the section permanently inert');
+  });
 }

--- a/mobile/test/presentation/widgets/collection/space_collection_section_test.dart
+++ b/mobile/test/presentation/widgets/collection/space_collection_section_test.dart
@@ -1,0 +1,292 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/collection_target.dart';
+import 'package:immich_mobile/domain/models/space_album.model.dart';
+import 'package:immich_mobile/domain/models/user.model.dart';
+import 'package:immich_mobile/domain/services/user.service.dart';
+import 'package:immich_mobile/presentation/widgets/collection/space_collection_section.widget.dart';
+import 'package:immich_mobile/providers/infrastructure/space_album.provider.dart';
+import 'package:immich_mobile/providers/shared_space.provider.dart';
+import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openapi/api.dart';
+
+import '../../../fixtures/user.stub.dart';
+import '../../../widget_tester_extensions.dart';
+
+class _MockUserService extends Mock implements UserService {}
+
+// The real `CurrentUserProvider` reads its initial state from a `UserService` in its
+// constructor, so a widget test seeds the *notifier* rather than a plain `UserDto?` value --
+// `currentUserProvider` is a `StateNotifierProvider`, whose `overrideWith` builder must return
+// a `StateNotifier`, not the state itself. Mirrors the pattern used by
+// `space_link_album_page_test.dart` / `people_details_widget_test.dart`.
+class _StubCurrentUserNotifier extends CurrentUserProvider {
+  _StubCurrentUserNotifier(super.service, UserDto? user) {
+    state = user;
+  }
+}
+
+void main() {
+  SharedSpaceMemberResponseDto member(String userId, SharedSpaceRole role) => SharedSpaceMemberResponseDto(
+    userId: userId,
+    name: userId,
+    email: '$userId@e.com',
+    role: role,
+    joinedAt: '2026-01-01T00:00:00Z',
+    sharePersonMetadata: true,
+    showInTimeline: true,
+  );
+
+  SharedSpaceResponseDto space(String id, {SharedSpaceRole role = SharedSpaceRole.owner, int albums = 0}) =>
+      SharedSpaceResponseDto(
+        id: id,
+        name: 'Space $id',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+        createdById: 'someone-else',
+        members: Optional.present([member('user-1', role)]),
+        albumCount: Optional.present(albums),
+      );
+
+  SpaceAlbum album(String id, String name) => SpaceAlbum(
+    id: id,
+    name: name,
+    showInTimeline: true,
+    linkedAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+  );
+
+  RemoteAsset asset(String id, {String ownerId = 'user-1'}) => RemoteAsset(
+    id: id,
+    name: id,
+    ownerId: ownerId,
+    checksum: id,
+    type: AssetType.image,
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+    isEdited: false,
+  );
+
+  Override currentUserOverride(String? userId) {
+    final userService = _MockUserService();
+    final user = userId == null ? null : UserStub.user1;
+    when(() => userService.tryGetMyUser()).thenReturn(user);
+    when(() => userService.watchMyUser()).thenAnswer((_) => const Stream.empty());
+    return currentUserProvider.overrideWith((ref) => _StubCurrentUserNotifier(userService, user));
+  }
+
+  Future<List<CollectionTarget>> pump(
+    WidgetTester tester, {
+    required List<SharedSpaceResponseDto> spaces,
+    Map<String, List<SpaceAlbum>> albums = const {},
+    List<RemoteAsset>? selection,
+    String? excludeSpaceId,
+    String? userId = 'user-1',
+    bool raw = false,
+  }) async {
+    final targets = <CollectionTarget>[];
+    final overrides = <Override>[
+      sharedSpacesProvider.overrideWith((ref) async => spaces),
+      currentUserOverride(userId),
+      multiSelectProvider.overrideWith(
+        () => MultiSelectNotifier(
+          MultiSelectState(
+            selectedAssets: {
+              ...(selection ?? [asset('a')]),
+            },
+            lockedSelectionAssets: const {},
+          ),
+        ),
+      ),
+      for (final entry in albums.entries)
+        spaceAlbumsProvider(entry.key).overrideWith((ref) => Stream.value(entry.value)),
+    ];
+    final widget = SpaceCollectionSection(onTargetSelected: targets.add, excludeSpaceId: excludeSpaceId);
+    if (raw) {
+      await tester.pumpConsumerWidgetRaw(widget, overrides: overrides);
+    } else {
+      await tester.pumpConsumerWidget(widget, overrides: overrides);
+    }
+    return targets;
+  }
+
+  testWidgets('renders nothing when there are no writable spaces', (tester) async {
+    await pump(tester, spaces: [space('s1', role: SharedSpaceRole.viewer)]);
+
+    expect(find.byKey(const Key('space-collection-header')), findsNothing);
+    expect(find.byKey(const Key('space-row-s1')), findsNothing);
+  });
+
+  testWidgets('lists only writable spaces, ordered by name', (tester) async {
+    await pump(
+      tester,
+      spaces: [
+        space('s2'),
+        space('s1'),
+        space('s3', role: SharedSpaceRole.viewer),
+      ],
+    );
+
+    expect(find.byKey(const Key('space-row-s1')), findsOneWidget);
+    expect(find.byKey(const Key('space-row-s2')), findsOneWidget);
+    expect(find.byKey(const Key('space-row-s3')), findsNothing);
+    final y1 = tester.getTopLeft(find.byKey(const Key('space-row-s1'))).dy;
+    final y2 = tester.getTopLeft(find.byKey(const Key('space-row-s2'))).dy;
+    expect(y1, lessThan(y2));
+  });
+
+  testWidgets('a space with no linked albums adds to the pool on a single tap', (tester) async {
+    final targets = await pump(tester, spaces: [space('s1', albums: 0)]);
+
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+
+    expect(targets, hasLength(1));
+    expect((targets.single as SpacePoolTarget).space.id, 's1');
+  });
+
+  testWidgets('a space with albums expands instead of adding, then collapses', (tester) async {
+    final targets = await pump(
+      tester,
+      spaces: [space('s1', albums: 2)],
+      albums: {
+        's1': [album('a1', 'Ski trip'), album('a2', 'Christmas')],
+      },
+    );
+
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+
+    expect(targets, isEmpty, reason: 'expanding must not dump photos into the space');
+    expect(find.byKey(const Key('space-pool-child-s1')), findsOneWidget);
+    expect(find.byKey(const Key('space-album-child-a1')), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key('space-pool-child-s1')), findsNothing);
+  });
+
+  testWidgets('the pool child emits a SpacePoolTarget', (tester) async {
+    final targets = await pump(
+      tester,
+      spaces: [space('s1', albums: 1)],
+      albums: {
+        's1': [album('a1', 'Ski')],
+      },
+    );
+
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('space-pool-child-s1')));
+    await tester.pumpAndSettle();
+
+    expect((targets.single as SpacePoolTarget).space.id, 's1');
+  });
+
+  testWidgets('an album child emits a SpaceAlbumTarget carrying the owning space id', (tester) async {
+    final targets = await pump(
+      tester,
+      spaces: [space('s1', albums: 1)],
+      albums: {
+        's1': [album('a1', 'Ski')],
+      },
+    );
+
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('space-album-child-a1')));
+    await tester.pumpAndSettle();
+
+    final target = targets.single as SpaceAlbumTarget;
+    expect(target.spaceId, 's1');
+    expect(target.album.id, 'a1');
+  });
+
+  testWidgets('expanding a second space collapses the first', (tester) async {
+    await pump(
+      tester,
+      spaces: [space('s1', albums: 1), space('s2', albums: 1)],
+      albums: {
+        's1': [album('a1', 'One')],
+        's2': [album('a2', 'Two')],
+      },
+    );
+
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('space-row-s2')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('space-pool-child-s1')), findsNothing);
+    expect(find.byKey(const Key('space-pool-child-s2')), findsOneWidget);
+  });
+
+  testWidgets('albumCount > 0 but an empty stream still offers the pool', (tester) async {
+    final targets = await pump(tester, spaces: [space('s1', albums: 3)], albums: {'s1': const []});
+
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('space-albums-empty-s1')), findsOneWidget);
+    await tester.tap(find.byKey(const Key('space-pool-child-s1')));
+    await tester.pumpAndSettle();
+    expect(targets, hasLength(1));
+  });
+
+  testWidgets('a double-tap on a plain row emits exactly one target', (tester) async {
+    final targets = await pump(tester, spaces: [space('s1', albums: 0)]);
+
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+
+    expect(targets, hasLength(1), reason: 'two adds would fire two activity entries');
+  });
+
+  testWidgets('a non-owned selection hides every row behind a notice', (tester) async {
+    await pump(
+      tester,
+      spaces: [space('s1')],
+      selection: [
+        asset('a'),
+        asset('b', ownerId: 'other'),
+      ],
+    );
+
+    expect(
+      find.text("Your selection includes photos owned by other members, so it can't be added to a space."),
+      findsOneWidget,
+    );
+    expect(find.byKey(const Key('space-row-s1')), findsNothing);
+  });
+
+  testWidgets('an unknown current user hides the rows (fail closed)', (tester) async {
+    await pump(tester, spaces: [space('s1')], userId: null);
+
+    expect(find.byKey(const Key('space-row-s1')), findsNothing);
+  });
+
+  testWidgets('the excluded space is absent from its own list', (tester) async {
+    await pump(tester, spaces: [space('s1'), space('s2')], excludeSpaceId: 's1');
+
+    expect(find.byKey(const Key('space-row-s1')), findsNothing);
+    expect(find.byKey(const Key('space-row-s2')), findsOneWidget);
+  });
+
+  testWidgets('a provider error hides the section rather than surfacing an error', (tester) async {
+    final targets = <CollectionTarget>[];
+    await tester.pumpConsumerWidget(
+      SpaceCollectionSection(onTargetSelected: targets.add),
+      overrides: [
+        sharedSpacesProvider.overrideWith((ref) async => throw Exception('offline')),
+        currentUserOverride('user-1'),
+      ],
+    );
+
+    expect(find.byKey(const Key('space-collection-header')), findsNothing);
+  });
+}

--- a/mobile/test/presentation/widgets/collection/space_collection_section_test.dart
+++ b/mobile/test/presentation/widgets/collection/space_collection_section_test.dart
@@ -41,16 +41,20 @@ void main() {
     showInTimeline: true,
   );
 
-  SharedSpaceResponseDto space(String id, {SharedSpaceRole role = SharedSpaceRole.owner, int albums = 0}) =>
-      SharedSpaceResponseDto(
-        id: id,
-        name: 'Space $id',
-        createdAt: '2026-01-01T00:00:00Z',
-        updatedAt: '2026-01-01T00:00:00Z',
-        createdById: 'someone-else',
-        members: Optional.present([member('user-1', role)]),
-        albumCount: Optional.present(albums),
-      );
+  SharedSpaceResponseDto space(
+    String id, {
+    SharedSpaceRole role = SharedSpaceRole.owner,
+    int albums = 0,
+    String? name,
+  }) => SharedSpaceResponseDto(
+    id: id,
+    name: name ?? 'Space $id',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    createdById: 'someone-else',
+    members: Optional.present([member('user-1', role)]),
+    albumCount: Optional.present(albums),
+  );
 
   SpaceAlbum album(String id, String name) => SpaceAlbum(
     id: id,
@@ -86,6 +90,7 @@ void main() {
     List<RemoteAsset>? selection,
     String? excludeSpaceId,
     String? userId = 'user-1',
+    String searchQuery = '',
     bool raw = false,
   }) async {
     final targets = <CollectionTarget>[];
@@ -105,7 +110,11 @@ void main() {
       for (final entry in albums.entries)
         spaceAlbumsProvider(entry.key).overrideWith((ref) => Stream.value(entry.value)),
     ];
-    final widget = SpaceCollectionSection(onTargetSelected: targets.add, excludeSpaceId: excludeSpaceId);
+    final widget = SpaceCollectionSection(
+      onTargetSelected: targets.add,
+      excludeSpaceId: excludeSpaceId,
+      searchQuery: searchQuery,
+    );
     if (raw) {
       await tester.pumpConsumerWidgetRaw(widget, overrides: overrides);
     } else {
@@ -247,6 +256,41 @@ void main() {
     expect(targets, hasLength(1), reason: 'two adds would fire two activity entries');
   });
 
+  testWidgets('the search query narrows the rows to spaces whose name contains it', (tester) async {
+    await pump(
+      tester,
+      spaces: [
+        space('s1', name: 'Family Vacation'),
+        space('s2', name: 'Photography Club'),
+      ],
+      searchQuery: 'famil',
+    );
+
+    expect(find.byKey(const Key('space-row-s1')), findsOneWidget);
+    expect(find.byKey(const Key('space-row-s2')), findsNothing);
+  });
+
+  testWidgets('the search query matches case-insensitively, ignoring surrounding whitespace', (tester) async {
+    await pump(
+      tester,
+      spaces: [space('s1', name: 'Family Vacation')],
+      searchQuery: '  FAMILY  ',
+    );
+
+    expect(find.byKey(const Key('space-row-s1')), findsOneWidget);
+  });
+
+  testWidgets('a query matching no space hides the section entirely', (tester) async {
+    await pump(
+      tester,
+      spaces: [space('s1', name: 'Family Vacation')],
+      searchQuery: 'zzz',
+    );
+
+    expect(find.byKey(const Key('space-collection-header')), findsNothing);
+    expect(find.byKey(const Key('space-row-s1')), findsNothing);
+  });
+
   testWidgets('a non-owned selection hides every row behind a notice', (tester) async {
     await pump(
       tester,
@@ -312,9 +356,7 @@ void main() {
         sharedSpacesProvider.overrideWith((ref) async => [space('s1', albums: 0)]),
         currentUserOverride('user-1'),
         multiSelectProvider.overrideWith(
-          () => MultiSelectNotifier(
-            MultiSelectState(selectedAssets: {asset('a')}, lockedSelectionAssets: const {}),
-          ),
+          () => MultiSelectNotifier(MultiSelectState(selectedAssets: {asset('a')}, lockedSelectionAssets: const {})),
         ),
       ],
     );

--- a/mobile/test/presentation/widgets/spaces/space_detail_kebab_test.dart
+++ b/mobile/test/presentation/widgets/spaces/space_detail_kebab_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/presentation/widgets/spaces/space_detail_kebab.widget.dart';
+
+import '../../../widget_tester_extensions.dart';
+
+void main() {
+  Future<({List<String> events})> pumpKebab(
+    WidgetTester tester, {
+    required bool canEdit,
+    required bool canDelete,
+  }) async {
+    final events = <String>[];
+    await tester.pumpConsumerWidget(
+      SpaceDetailKebab(
+        canEdit: canEdit,
+        canDelete: canDelete,
+        onEdit: () => events.add('edit'),
+        onDelete: () => events.add('delete'),
+      ),
+    );
+    return (events: events);
+  }
+
+  Future<void> openMenu(WidgetTester tester) async {
+    await tester.tap(find.byKey(const Key('space-detail-kebab')));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('an owner sees both Edit Space and Delete Space', (tester) async {
+    await pumpKebab(tester, canEdit: true, canDelete: true);
+    await openMenu(tester);
+
+    expect(find.text('Edit Space'), findsOneWidget);
+    expect(find.text('Delete Space'), findsOneWidget);
+  });
+
+  testWidgets('an editor sees Edit Space but not Delete Space', (tester) async {
+    // The regression this slice fixes: editors previously saw no kebab at all.
+    await pumpKebab(tester, canEdit: true, canDelete: false);
+    await openMenu(tester);
+
+    expect(find.text('Edit Space'), findsOneWidget);
+    expect(find.text('Delete Space'), findsNothing);
+  });
+
+  testWidgets('a viewer sees no kebab at all', (tester) async {
+    await pumpKebab(tester, canEdit: false, canDelete: false);
+
+    expect(find.byKey(const Key('space-detail-kebab')), findsNothing);
+  });
+
+  testWidgets('selecting Edit Space invokes onEdit only', (tester) async {
+    final result = await pumpKebab(tester, canEdit: true, canDelete: true);
+    await openMenu(tester);
+
+    await tester.tap(find.text('Edit Space'));
+    await tester.pumpAndSettle();
+
+    expect(result.events, ['edit']);
+  });
+
+  testWidgets('selecting Delete Space invokes onDelete only', (tester) async {
+    final result = await pumpKebab(tester, canEdit: true, canDelete: true);
+    await openMenu(tester);
+
+    await tester.tap(find.text('Delete Space'));
+    await tester.pumpAndSettle();
+
+    expect(result.events, ['delete']);
+  });
+}

--- a/mobile/test/presentation/widgets/spaces/space_edit_sheet_test.dart
+++ b/mobile/test/presentation/widgets/spaces/space_edit_sheet_test.dart
@@ -1,0 +1,263 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/presentation/widgets/spaces/space_edit_sheet.widget.dart';
+import 'package:immich_mobile/repositories/shared_space_api.repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openapi/api.dart';
+
+import '../../../widget_tester_extensions.dart';
+
+class MockSharedSpaceApiRepository extends Mock implements SharedSpaceApiRepository {}
+
+void main() {
+  late MockSharedSpaceApiRepository repo;
+
+  SharedSpaceResponseDto space({
+    String name = 'Family Photos',
+    Optional<String?> description = const Optional.present('Our shared album'),
+    Optional<UserAvatarColor?> color = const Optional.present(UserAvatarColor.blue),
+  }) => SharedSpaceResponseDto(
+    id: 'space-1',
+    name: name,
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-01T00:00:00Z',
+    createdById: 'user-1',
+    description: description,
+    color: color,
+  );
+
+  SharedSpaceResponseDto saved() => SharedSpaceResponseDto(
+    id: 'space-1',
+    name: 'Saved',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-02T00:00:00Z',
+    createdById: 'user-1',
+  );
+
+  /// Pumps the sheet and records every onClose call.
+  Future<List<bool?>> pumpSheet(WidgetTester tester, {SharedSpaceResponseDto? withSpace}) async {
+    final closes = <bool?>[];
+    await tester.pumpConsumerWidget(
+      SpaceEditSheet(space: withSpace ?? space(), onClose: closes.add),
+      overrides: [sharedSpaceApiRepositoryProvider.overrideWithValue(repo)],
+    );
+    return closes;
+  }
+
+  Finder nameField() => find.byKey(const Key('space-edit-name'));
+  Finder descriptionField() => find.byKey(const Key('space-edit-description'));
+  Finder saveButton() => find.byKey(const Key('space-edit-save'));
+
+  bool saveEnabled(WidgetTester tester) => tester.widget<FilledButton>(saveButton()).onPressed != null;
+
+  setUpAll(() {
+    registerFallbackValue(UserAvatarColor.primary);
+  });
+
+  setUp(() {
+    repo = MockSharedSpaceApiRepository();
+    when(
+      () => repo.update(
+        any(),
+        name: any(named: 'name'),
+        description: any(named: 'description'),
+        color: any(named: 'color'),
+      ),
+    ).thenAnswer((_) async => saved());
+  });
+
+  testWidgets('prefills name, description and colour from the space', (tester) async {
+    await pumpSheet(tester);
+
+    expect(tester.widget<TextField>(nameField()).controller!.text, 'Family Photos');
+    expect(tester.widget<TextField>(descriptionField()).controller!.text, 'Our shared album');
+    expect(find.byKey(const Key('space-edit-color-blue-selected')), findsOneWidget);
+  });
+
+  testWidgets('defaults to the primary swatch when the space has no colour', (tester) async {
+    await pumpSheet(tester, withSpace: space(color: const Optional.absent()));
+
+    expect(find.byKey(const Key('space-edit-color-primary-selected')), findsOneWidget);
+  });
+
+  testWidgets('disables save for an empty name', (tester) async {
+    await pumpSheet(tester);
+
+    await tester.enterText(nameField(), '');
+    await tester.pump();
+
+    expect(saveEnabled(tester), isFalse);
+  });
+
+  testWidgets('disables save for a whitespace-only name', (tester) async {
+    await pumpSheet(tester);
+
+    await tester.enterText(nameField(), '   ');
+    await tester.pump();
+
+    expect(saveEnabled(tester), isFalse, reason: 'a required flag alone would let "   " through');
+  });
+
+  testWidgets('focuses the name with its text selected on open, and does not reselect on a later tap', (tester) async {
+    await pumpSheet(tester);
+
+    final controller = tester.widget<TextField>(nameField()).controller!;
+    expect(controller.selection.baseOffset, 0);
+    expect(controller.selection.extentOffset, 'Family Photos'.length);
+
+    // Simulate the user placing the caret mid-word, then the field regaining focus.
+    controller.selection = const TextSelection.collapsed(offset: 3);
+    await tester.tap(nameField());
+    await tester.pump();
+
+    expect(controller.selection, const TextSelection.collapsed(offset: 3), reason: 'select-once only');
+  });
+
+  testWidgets('caps the name at 100 and the description at 500 characters', (tester) async {
+    await pumpSheet(tester);
+
+    await tester.enterText(nameField(), 'x' * 150);
+    await tester.enterText(descriptionField(), 'y' * 600);
+    await tester.pump();
+
+    expect(tester.widget<TextField>(nameField()).controller!.text.length, 100);
+    expect(tester.widget<TextField>(descriptionField()).controller!.text.length, 500);
+  });
+
+  testWidgets('renders an over-long existing name in full and keeps save enabled', (tester) async {
+    // Truncating a name the user already has would be data loss.
+    await pumpSheet(tester, withSpace: space(name: 'z' * 120));
+
+    expect(tester.widget<TextField>(nameField()).controller!.text.length, 120);
+    expect(saveEnabled(tester), isTrue);
+  });
+
+  testWidgets('sends no description when only the name changed', (tester) async {
+    await pumpSheet(tester);
+
+    await tester.enterText(nameField(), 'Renamed');
+    await tester.pump();
+    await tester.tap(saveButton());
+    await tester.pumpAndSettle();
+
+    verify(() => repo.update('space-1', name: 'Renamed', description: null, color: UserAvatarColor.blue)).called(1);
+  });
+
+  testWidgets('sends an empty description when the user cleared it', (tester) async {
+    await pumpSheet(tester);
+
+    await tester.enterText(descriptionField(), '');
+    await tester.pump();
+    await tester.tap(saveButton());
+    await tester.pumpAndSettle();
+
+    verify(() => repo.update('space-1', name: 'Family Photos', description: '', color: UserAvatarColor.blue)).called(1);
+  });
+
+  testWidgets('saving with nothing edited sends absent name-only fields and still closes', (tester) async {
+    final closes = await pumpSheet(tester);
+
+    await tester.tap(saveButton());
+    await tester.pumpAndSettle();
+
+    verify(
+      () => repo.update('space-1', name: 'Family Photos', description: null, color: UserAvatarColor.blue),
+    ).called(1);
+    expect(closes, [true], reason: 'a no-op save is not an error');
+  });
+
+  testWidgets('sends the chosen colour', (tester) async {
+    await pumpSheet(tester);
+
+    await tester.tap(find.byKey(const Key('space-edit-color-amber')));
+    await tester.pump();
+    await tester.tap(saveButton());
+    await tester.pumpAndSettle();
+
+    verify(
+      () => repo.update('space-1', name: 'Family Photos', description: null, color: UserAvatarColor.amber),
+    ).called(1);
+  });
+
+  testWidgets('a double-tap on save issues exactly one request', (tester) async {
+    final completer = Completer<SharedSpaceResponseDto>();
+    when(
+      () => repo.update(
+        any(),
+        name: any(named: 'name'),
+        description: any(named: 'description'),
+        color: any(named: 'color'),
+      ),
+    ).thenAnswer((_) => completer.future);
+
+    await pumpSheet(tester);
+
+    await tester.tap(saveButton());
+    await tester.pump();
+    await tester.tap(saveButton(), warnIfMissed: false);
+    await tester.pump();
+
+    completer.complete(saved());
+    await tester.pumpAndSettle();
+
+    verify(
+      () => repo.update(
+        any(),
+        name: any(named: 'name'),
+        description: any(named: 'description'),
+        color: any(named: 'color'),
+      ),
+    ).called(1);
+  });
+
+  testWidgets('resolves true on success and null on cancel', (tester) async {
+    final closes = await pumpSheet(tester);
+
+    await tester.tap(saveButton());
+    await tester.pumpAndSettle();
+    expect(closes, [true]);
+
+    final cancels = await pumpSheet(tester);
+    await tester.tap(find.byKey(const Key('space-edit-cancel')));
+    await tester.pumpAndSettle();
+    expect(cancels, [null]);
+    verifyNever(() => repo.update('space-2', name: any(named: 'name')));
+  });
+
+  testWidgets('stays open and does not resolve when the save fails', (tester) async {
+    when(
+      () => repo.update(
+        any(),
+        name: any(named: 'name'),
+        description: any(named: 'description'),
+        color: any(named: 'color'),
+      ),
+    ).thenThrow(Exception('403'));
+
+    final closes = await pumpSheet(tester);
+
+    await tester.tap(saveButton());
+    await tester.pumpAndSettle();
+
+    expect(closes, isEmpty, reason: 'a revoked role must not look like a successful save');
+    expect(nameField(), findsOneWidget);
+    expect(saveEnabled(tester), isTrue, reason: 'the in-flight guard must be released so the user can retry');
+  });
+
+  testWidgets('every colour swatch is labelled and meets the minimum tap target', (tester) async {
+    await pumpSheet(tester);
+
+    for (final color in UserAvatarColor.values) {
+      final swatch = find.byKey(Key('space-edit-color-${color.value}'));
+      expect(swatch, findsOneWidget, reason: '${color.value} swatch');
+      expect(
+        find.descendant(of: swatch, matching: find.bySemanticsLabel(color.value)),
+        findsOneWidget,
+        reason: '${color.value} needs a semantics label -- colour alone is invisible to a screen reader',
+      );
+      expectTapTargetMin(tester, swatch);
+    }
+  });
+}

--- a/mobile/test/presentation/widgets/spaces/space_edit_sheet_test.dart
+++ b/mobile/test/presentation/widgets/spaces/space_edit_sheet_test.dart
@@ -52,6 +52,15 @@ void main() {
 
   bool saveEnabled(WidgetTester tester) => tester.widget<FilledButton>(saveButton()).onPressed != null;
 
+  /// `ImmichToast` schedules a 3s fluttertoast Timer outside the frame scheduler, so a
+  /// plain `pumpAndSettle()` leaves it pending and teardown fails with "A Timer is still
+  /// pending". Pump past its lifetime instead of dropping the toast from the widget.
+  Future<void> settleToast(WidgetTester tester) async {
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(seconds: 4));
+    await tester.pumpAndSettle();
+  }
+
   setUpAll(() {
     registerFallbackValue(UserAvatarColor.primary);
   });
@@ -140,7 +149,7 @@ void main() {
     await tester.enterText(nameField(), 'Renamed');
     await tester.pump();
     await tester.tap(saveButton());
-    await tester.pumpAndSettle();
+    await settleToast(tester);
 
     verify(() => repo.update('space-1', name: 'Renamed', description: null, color: UserAvatarColor.blue)).called(1);
   });
@@ -151,7 +160,7 @@ void main() {
     await tester.enterText(descriptionField(), '');
     await tester.pump();
     await tester.tap(saveButton());
-    await tester.pumpAndSettle();
+    await settleToast(tester);
 
     verify(() => repo.update('space-1', name: 'Family Photos', description: '', color: UserAvatarColor.blue)).called(1);
   });
@@ -160,7 +169,7 @@ void main() {
     final closes = await pumpSheet(tester);
 
     await tester.tap(saveButton());
-    await tester.pumpAndSettle();
+    await settleToast(tester);
 
     verify(
       () => repo.update('space-1', name: 'Family Photos', description: null, color: UserAvatarColor.blue),
@@ -174,7 +183,7 @@ void main() {
     await tester.tap(find.byKey(const Key('space-edit-color-amber')));
     await tester.pump();
     await tester.tap(saveButton());
-    await tester.pumpAndSettle();
+    await settleToast(tester);
 
     verify(
       () => repo.update('space-1', name: 'Family Photos', description: null, color: UserAvatarColor.amber),
@@ -200,7 +209,7 @@ void main() {
     await tester.pump();
 
     completer.complete(saved());
-    await tester.pumpAndSettle();
+    await settleToast(tester);
 
     verify(
       () => repo.update(
@@ -216,12 +225,12 @@ void main() {
     final closes = await pumpSheet(tester);
 
     await tester.tap(saveButton());
-    await tester.pumpAndSettle();
+    await settleToast(tester);
     expect(closes, [true]);
 
     final cancels = await pumpSheet(tester);
     await tester.tap(find.byKey(const Key('space-edit-cancel')));
-    await tester.pumpAndSettle();
+    await settleToast(tester);
     expect(cancels, [null]);
     verifyNever(() => repo.update('space-2', name: any(named: 'name')));
   });
@@ -240,6 +249,12 @@ void main() {
 
     await tester.tap(saveButton());
     await tester.pumpAndSettle();
+
+    // Asserted before settleToast pumps past the toast's 3s lifetime. The sheet merely
+    // staying open is not feedback -- a revoked role has to say so out loud.
+    expect(find.text('Unable to update space'), findsOneWidget);
+
+    await settleToast(tester);
 
     expect(closes, isEmpty, reason: 'a revoked role must not look like a successful save');
     expect(nameField(), findsOneWidget);

--- a/mobile/test/providers/infrastructure/collection_dispatch_test.dart
+++ b/mobile/test/providers/infrastructure/collection_dispatch_test.dart
@@ -1,0 +1,160 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/constants/enums.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/space_album.model.dart';
+import 'package:immich_mobile/providers/infrastructure/action.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/space_album_actions.dart';
+import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
+import 'package:immich_mobile/repositories/shared_space_api.repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openapi/api.dart';
+
+class MockSharedSpaceApiRepository extends Mock implements SharedSpaceApiRepository {}
+
+class MockSpaceAlbumActions extends Mock implements SpaceAlbumActions {}
+
+void main() {
+  late MockSharedSpaceApiRepository spaceRepo;
+  late MockSpaceAlbumActions albumActions;
+  late ProviderContainer container;
+
+  SharedSpaceResponseDto theSpace() => SharedSpaceResponseDto(
+    id: 'space-1',
+    name: 'Family',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    createdById: 'user-1',
+  );
+
+  SpaceAlbum theAlbum() => SpaceAlbum(
+    id: 'album-1',
+    name: 'Ski trip',
+    showInTimeline: true,
+    linkedAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+  );
+
+  RemoteAsset remote(String id) => RemoteAsset(
+    id: id,
+    name: id,
+    ownerId: 'user-1',
+    checksum: id,
+    type: AssetType.image,
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+    isEdited: false,
+  );
+
+  /// Seeds the timeline multiselect so `_getAssets(timeline)` sees them. The notifier
+  /// only exposes `selectAsset` (one at a time) -- there is no bulk setter.
+  void select(Iterable<BaseAsset> assets) {
+    final notifier = container.read(multiSelectProvider.notifier);
+    for (final asset in assets) {
+      notifier.selectAsset(asset);
+    }
+  }
+
+  setUpAll(() {
+    registerFallbackValue(<String>[]);
+  });
+
+  setUp(() {
+    spaceRepo = MockSharedSpaceApiRepository();
+    albumActions = MockSpaceAlbumActions();
+    when(() => spaceRepo.addAssets(any(), any())).thenAnswer((_) async {});
+    when(() => albumActions.addAssets(any(), any())).thenAnswer((_) async => 2);
+    container = ProviderContainer(
+      overrides: [
+        sharedSpaceApiRepositoryProvider.overrideWithValue(spaceRepo),
+        spaceAlbumActionsProvider.overrideWithValue(albumActions),
+      ],
+    );
+    addTearDown(container.dispose);
+  });
+
+  test('a space pool add sends every id in ONE call', () async {
+    select([remote('a'), remote('b')]);
+
+    final result = await container.read(actionProvider.notifier).addToSpace(ActionSource.timeline, theSpace());
+
+    final captured = verify(() => spaceRepo.addAssets('space-1', captureAny())).captured.single as List<String>;
+    expect(captured..sort(), ['a', 'b']);
+    expect(result.success, isTrue);
+  });
+
+  test('a space pool add reports the REQUEST length, because the endpoint returns no body', () async {
+    select([remote('a'), remote('b'), remote('c')]);
+
+    final result = await container.read(actionProvider.notifier).addToSpace(ActionSource.timeline, theSpace());
+
+    expect(result.count, 3);
+  });
+
+  test('a space album add reports the SERVER count, so duplicates are not over-claimed', () async {
+    when(() => albumActions.addAssets(any(), any())).thenAnswer((_) async => 0);
+    select([remote('a'), remote('b')]);
+
+    final result = await container
+        .read(actionProvider.notifier)
+        .addToSpaceAlbum(ActionSource.timeline, 'space-1', theAlbum());
+
+    expect(result.count, 0, reason: 'all already present -- do not claim "added 2"');
+    expect(result.success, isTrue);
+  });
+
+  test('a space album add never touches the space pool endpoint', () async {
+    select([remote('a')]);
+
+    await container.read(actionProvider.notifier).addToSpaceAlbum(ActionSource.timeline, 'space-1', theAlbum());
+
+    verify(() => albumActions.addAssets('album-1', any())).called(1);
+    verifyNever(() => spaceRepo.addAssets(any(), any()));
+  });
+
+  test('an empty selection makes no call and succeeds with zero', () async {
+    select([]);
+
+    final result = await container.read(actionProvider.notifier).addToSpace(ActionSource.timeline, theSpace());
+
+    expect(result.count, 0);
+    expect(result.success, isTrue);
+    verifyNever(() => spaceRepo.addAssets(any(), any()));
+  });
+
+  test('a failed add returns a failure AND leaves the selection intact for retry', () async {
+    when(() => spaceRepo.addAssets(any(), any())).thenThrow(Exception('403'));
+    select([remote('a')]);
+
+    final result = await container.read(actionProvider.notifier).addToSpace(ActionSource.timeline, theSpace());
+
+    expect(result.success, isFalse);
+    expect(container.read(multiSelectProvider).selectedAssets, isNotEmpty);
+  });
+
+  test('a successful add clears the selection', () async {
+    select([remote('a')]);
+
+    await container.read(actionProvider.notifier).addToSpace(ActionSource.timeline, theSpace());
+
+    expect(container.read(multiSelectProvider).selectedAssets, isEmpty);
+  });
+
+  test('a second add while one is in flight is ignored', () async {
+    final gate = Completer<void>();
+    when(() => spaceRepo.addAssets(any(), any())).thenAnswer((_) => gate.future);
+    select([remote('a')]);
+
+    final notifier = container.read(actionProvider.notifier);
+    final first = notifier.addToSpace(ActionSource.timeline, theSpace());
+    final second = await notifier.addToSpace(ActionSource.timeline, theSpace());
+
+    expect(second.success, isFalse);
+    gate.complete();
+    await first;
+
+    verify(() => spaceRepo.addAssets(any(), any())).called(1);
+  });
+}

--- a/mobile/test/providers/infrastructure/collection_dispatch_test.dart
+++ b/mobile/test/providers/infrastructure/collection_dispatch_test.dart
@@ -3,12 +3,24 @@ import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/enums.dart';
+import 'package:immich_mobile/domain/models/album/album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/space_album.model.dart';
+import 'package:immich_mobile/domain/services/asset.service.dart';
+import 'package:immich_mobile/domain/utils/background_sync.dart';
+import 'package:immich_mobile/infrastructure/repositories/space_album.repository.dart';
+import 'package:immich_mobile/providers/background_sync.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/action.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/remote_album.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/space_album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/space_album_actions.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
 import 'package:immich_mobile/repositories/shared_space_api.repository.dart';
+import 'package:immich_mobile/services/action.service.dart';
+import 'package:immich_mobile/services/download.service.dart';
+import 'package:immich_mobile/services/foreground_upload.service.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openapi/api.dart';
 
@@ -16,9 +28,34 @@ class MockSharedSpaceApiRepository extends Mock implements SharedSpaceApiReposit
 
 class MockSpaceAlbumActions extends Mock implements SpaceAlbumActions {}
 
+class MockSpaceAlbumRepository extends Mock implements SpaceAlbumRepository {}
+
+class MockBackgroundSyncManager extends Mock implements BackgroundSyncManager {}
+
+class MockActionService extends Mock implements ActionService {}
+
+class MockAssetService extends Mock implements AssetService {}
+
+class MockDownloadService extends Mock implements DownloadService {}
+
+class MockForegroundUploadService extends Mock implements ForegroundUploadService {}
+
+// The real notifier's `addAssets` follows the API call with a state refresh that needs a
+// live RemoteAlbumService; this harness only cares that the add "succeeded".
+class _StubRemoteAlbumNotifier extends RemoteAlbumNotifier {
+  @override
+  RemoteAlbumState build() => const RemoteAlbumState(albums: []);
+
+  @override
+  Future<int> addAssets(String albumId, List<String> assetIds) async => assetIds.length;
+}
+
 void main() {
   late MockSharedSpaceApiRepository spaceRepo;
   late MockSpaceAlbumActions albumActions;
+  late MockSpaceAlbumRepository spaceAlbumRepo;
+  late MockBackgroundSyncManager syncManager;
+  late MockActionService actionService;
   late ProviderContainer container;
 
   SharedSpaceResponseDto theSpace() => SharedSpaceResponseDto(
@@ -27,6 +64,20 @@ void main() {
     createdAt: '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',
     createdById: 'user-1',
+  );
+
+  RemoteAlbum plainAlbum() => RemoteAlbum(
+    id: 'album-1',
+    name: 'Ski trip',
+    ownerId: 'user-1',
+    description: '',
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+    isActivityEnabled: false,
+    order: AlbumAssetOrder.desc,
+    assetCount: 0,
+    ownerName: 'user-1',
+    isShared: false,
   );
 
   SpaceAlbum theAlbum() => SpaceAlbum(
@@ -64,12 +115,26 @@ void main() {
   setUp(() {
     spaceRepo = MockSharedSpaceApiRepository();
     albumActions = MockSpaceAlbumActions();
+    spaceAlbumRepo = MockSpaceAlbumRepository();
+    syncManager = MockBackgroundSyncManager();
+    actionService = MockActionService();
     when(() => spaceRepo.addAssets(any(), any())).thenAnswer((_) async {});
     when(() => albumActions.addAssets(any(), any())).thenAnswer((_) async => 2);
+    when(() => spaceAlbumRepo.isAlbumLinked(any())).thenAnswer((_) async => false);
+    when(() => syncManager.syncRemote()).thenAnswer((_) async => true);
     container = ProviderContainer(
       overrides: [
         sharedSpaceApiRepositoryProvider.overrideWithValue(spaceRepo),
         spaceAlbumActionsProvider.overrideWithValue(albumActions),
+        spaceAlbumRepositoryProvider.overrideWithValue(spaceAlbumRepo),
+        backgroundSyncProvider.overrideWithValue(syncManager),
+        actionServiceProvider.overrideWithValue(actionService),
+        remoteAlbumProvider.overrideWith(() => _StubRemoteAlbumNotifier()),
+        // ActionNotifier.build() watches these; without overrides it dies before
+        // initializing its late service fields.
+        assetServiceProvider.overrideWithValue(MockAssetService()),
+        downloadServiceProvider.overrideWithValue(MockDownloadService()),
+        foregroundUploadServiceProvider.overrideWithValue(MockForegroundUploadService()),
       ],
     );
     addTearDown(container.dispose);
@@ -156,5 +221,59 @@ void main() {
     await first;
 
     verify(() => spaceRepo.addAssets(any(), any())).called(1);
+  });
+
+  group('linked-album mutations nudge a remote sync', () {
+    // Space-album surfaces read sync-fed Drift tables, not the optimistic local write the
+    // album view uses — without the nudge they stay stale until the next natural sync.
+
+    test('adding to a LINKED album fires the sync nudge', () async {
+      when(() => spaceAlbumRepo.isAlbumLinked('album-1')).thenAnswer((_) async => true);
+      select([remote('a')]);
+
+      final result = await container.read(actionProvider.notifier).addToAlbum(ActionSource.timeline, plainAlbum());
+
+      expect(result.success, isTrue);
+      verify(() => syncManager.syncRemote()).called(1);
+    });
+
+    test('adding to an UNLINKED album does not sync', () async {
+      select([remote('a')]);
+
+      await container.read(actionProvider.notifier).addToAlbum(ActionSource.timeline, plainAlbum());
+
+      verifyNever(() => syncManager.syncRemote());
+    });
+
+    test('a failed sync nudge does not fail the add', () async {
+      when(() => spaceAlbumRepo.isAlbumLinked('album-1')).thenAnswer((_) async => true);
+      when(() => syncManager.syncRemote()).thenThrow(Exception('offline'));
+      select([remote('a')]);
+
+      final result = await container.read(actionProvider.notifier).addToAlbum(ActionSource.timeline, plainAlbum());
+
+      expect(result.success, isTrue, reason: 'the add itself succeeded; the stream catches up next cycle');
+    });
+
+    test('removing from a LINKED album fires the sync nudge', () async {
+      when(() => actionService.removeFromAlbum(any(), any())).thenAnswer((_) async => 1);
+      when(() => spaceAlbumRepo.isAlbumLinked('album-1')).thenAnswer((_) async => true);
+      select([remote('a')]);
+
+      final result = await container.read(actionProvider.notifier).removeFromAlbum(ActionSource.timeline, 'album-1');
+
+      expect(result.error, isNull);
+      expect(result.success, isTrue);
+      verify(() => syncManager.syncRemote()).called(1);
+    });
+
+    test('removing from an UNLINKED album does not sync', () async {
+      when(() => actionService.removeFromAlbum(any(), any())).thenAnswer((_) async => 1);
+      select([remote('a')]);
+
+      await container.read(actionProvider.notifier).removeFromAlbum(ActionSource.timeline, 'album-1');
+
+      verifyNever(() => syncManager.syncRemote());
+    });
   });
 }

--- a/mobile/test/utils/selection_targets_test.dart
+++ b/mobile/test/utils/selection_targets_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/constants/collection.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/utils/selection_targets.dart';
+
+RemoteAsset _remote(String id, {String ownerId = 'me', AssetVisibility visibility = AssetVisibility.timeline}) =>
+    RemoteAsset(
+      id: id,
+      name: id,
+      ownerId: ownerId,
+      checksum: id,
+      type: AssetType.image,
+      createdAt: DateTime(2026, 1, 1),
+      updatedAt: DateTime(2026, 1, 1),
+      isEdited: false,
+      visibility: visibility,
+    );
+
+LocalAsset _local(String id) => LocalAsset(
+  id: id,
+  name: id,
+  checksum: id,
+  type: AssetType.image,
+  createdAt: DateTime(2026, 1, 1),
+  updatedAt: DateTime(2026, 1, 1),
+  isEdited: false,
+  playbackStyle: AssetPlaybackStyle.image,
+);
+
+void main() {
+  group('selectionHasNonOwned', () {
+    test('is false when every remote asset is mine', () {
+      expect(selectionHasNonOwned([_remote('a'), _remote('b')], 'me'), isFalse);
+    });
+
+    test('is true when any remote asset belongs to someone else', () {
+      expect(selectionHasNonOwned([_remote('a'), _remote('b', ownerId: 'other')], 'me'), isTrue);
+    });
+
+    test('treats local-only assets as mine -- they will be uploaded as mine', () {
+      expect(selectionHasNonOwned([_local('l1'), _remote('a')], 'me'), isFalse);
+    });
+
+    test('fails closed when the current user is unknown', () {
+      expect(selectionHasNonOwned([_remote('a')], null), isTrue);
+    });
+
+    test('is false for an empty selection', () {
+      expect(selectionHasNonOwned([], 'me'), isFalse);
+    });
+  });
+
+  group('selectionHasLocked', () {
+    test('is true when any asset is in the locked folder', () {
+      expect(selectionHasLocked([_remote('a'), _remote('b', visibility: AssetVisibility.locked)]), isTrue);
+    });
+
+    test('is false for ordinary timeline assets', () {
+      expect(selectionHasLocked([_remote('a'), _local('l1')]), isFalse);
+    });
+  });
+
+  group('selectionExceedsSpaceCap', () {
+    test('allows exactly the cap', () {
+      final assets = [for (var i = 0; i < kMaxSpaceAssetsPerRequest; i++) _local('l$i')];
+      expect(selectionExceedsSpaceCap(assets), isFalse);
+    });
+
+    test('rejects one over the cap', () {
+      final assets = [for (var i = 0; i < kMaxSpaceAssetsPerRequest + 1; i++) _local('l$i')];
+      expect(selectionExceedsSpaceCap(assets), isTrue);
+    });
+  });
+}

--- a/mobile/test/utils/space_permissions_test.dart
+++ b/mobile/test/utils/space_permissions_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/utils/space_permissions.dart';
+import 'package:openapi/api.dart';
+
+SharedSpaceMemberResponseDto _member(String userId, SharedSpaceRole role) => SharedSpaceMemberResponseDto(
+  userId: userId,
+  name: userId,
+  email: '$userId@example.com',
+  role: role,
+  joinedAt: '2024-01-01T00:00:00Z',
+  sharePersonMetadata: true,
+  showInTimeline: true,
+);
+
+/// [members] is passed through verbatim so a test can supply
+/// `Optional.absent()`, `Optional.present(null)` or a real list.
+SharedSpaceResponseDto _space({
+  String createdById = 'creator',
+  Optional<List<SharedSpaceMemberResponseDto>?> members = const Optional.absent(),
+}) => SharedSpaceResponseDto(
+  id: 'space-1',
+  name: 'Space 1',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+  createdById: createdById,
+  members: members,
+);
+
+void main() {
+  group('spaceIsWritable / spaceIsOwned', () {
+    test('the creator is writable and owned even when absent from the members list', () {
+      final space = _space(createdById: 'me', members: Optional.present([_member('someone', SharedSpaceRole.viewer)]));
+
+      expect(spaceIsWritable(space, 'me'), isTrue);
+      expect(spaceIsOwned(space, 'me'), isTrue);
+    });
+
+    test('a non-creator member with the owner role is writable AND owned', () {
+      final space = _space(createdById: 'creator', members: Optional.present([_member('me', SharedSpaceRole.owner)]));
+
+      expect(spaceIsWritable(space, 'me'), isTrue);
+      expect(spaceIsOwned(space, 'me'), isTrue, reason: 'Delete gating depends on this');
+    });
+
+    test('an editor is writable but not owned', () {
+      final space = _space(members: Optional.present([_member('me', SharedSpaceRole.editor)]));
+
+      expect(spaceIsWritable(space, 'me'), isTrue);
+      expect(spaceIsOwned(space, 'me'), isFalse);
+    });
+
+    test('a viewer is neither', () {
+      final space = _space(members: Optional.present([_member('me', SharedSpaceRole.viewer)]));
+
+      expect(spaceIsWritable(space, 'me'), isFalse);
+      expect(spaceIsOwned(space, 'me'), isFalse);
+    });
+
+    test('a non-member who did not create the space is neither', () {
+      final space = _space(members: Optional.present([_member('other', SharedSpaceRole.owner)]));
+
+      expect(spaceIsWritable(space, 'me'), isFalse);
+      expect(spaceIsOwned(space, 'me'), isFalse);
+    });
+
+    test('an absent members list falls back to the creator check without throwing', () {
+      // Absent.value throws StateError, so `members.value ?? const []` would crash here.
+      final space = _space(createdById: 'me');
+
+      expect(() => spaceIsWritable(space, 'me'), returnsNormally);
+      expect(spaceIsWritable(space, 'me'), isTrue);
+      expect(spaceIsWritable(space, 'someone-else'), isFalse);
+    });
+
+    test('a present-but-null members list behaves as an empty list', () {
+      final space = _space(createdById: 'creator', members: const Optional.present(null));
+
+      expect(() => spaceIsWritable(space, 'me'), returnsNormally);
+      expect(spaceIsWritable(space, 'me'), isFalse);
+    });
+
+    test('duplicate membership rows resolve to the first match deterministically', () {
+      final space = _space(
+        members: Optional.present([_member('me', SharedSpaceRole.editor), _member('me', SharedSpaceRole.viewer)]),
+      );
+
+      expect(spaceIsWritable(space, 'me'), isTrue);
+    });
+
+    test('a null current user is never writable or owned, even if createdById is also null-ish', () {
+      final space = _space(createdById: '', members: Optional.present([_member('me', SharedSpaceRole.owner)]));
+
+      expect(spaceIsWritable(space, null), isFalse);
+      expect(spaceIsOwned(space, null), isFalse);
+    });
+
+    test('the creator short-circuit wins over a demoted member row', () {
+      // Ownership transferred: still the createdById, but demoted to viewer.
+      final space = _space(createdById: 'me', members: Optional.present([_member('me', SharedSpaceRole.viewer)]));
+
+      expect(spaceIsWritable(space, 'me'), isTrue, reason: 'precedence is a decision, not an accident');
+      expect(spaceIsOwned(space, 'me'), isTrue);
+    });
+  });
+
+  group('roleIsWritable', () {
+    test('owner and editor are writable; viewer and null are not', () {
+      expect(roleIsWritable(SharedSpaceRole.owner), isTrue);
+      expect(roleIsWritable(SharedSpaceRole.editor), isTrue);
+      expect(roleIsWritable(SharedSpaceRole.viewer), isFalse);
+      expect(roleIsWritable(null), isFalse);
+    });
+  });
+}

--- a/mobile/test/widgets/spaces/space_card_test.dart
+++ b/mobile/test/widgets/spaces/space_card_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/widgets/spaces/space_card.dart';
+import 'package:openapi/api.dart';
+
+import '../../widget_tester_extensions.dart';
+
+/// Force a taller logical viewport so the square collage (rendered at the
+/// widget's full available width, 800 in the default test surface) fits
+/// without overflowing the default 800x600 test surface. Mirrors
+/// `_setTallLogicalSize` in `test/presentation/pages/space_b6_mutations_test.dart`.
+void _setTallLogicalSize(WidgetTester tester, {double dpr = 3.0}) {
+  tester.view.devicePixelRatio = dpr;
+  tester.view.physicalSize = Size(800 * dpr, 1200 * dpr);
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+}
+
+void main() {
+  SharedSpaceResponseDto fullSpace() => SharedSpaceResponseDto(
+    id: 's1',
+    name: 'Family Photos',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    createdById: 'user-1',
+    newAssetCount: const Optional.present(0),
+    recentAssetIds: const Optional.present([]),
+    recentAssetThumbhashes: const Optional.present([]),
+    color: const Optional.present(UserAvatarColor.blue),
+    members: const Optional.present([]),
+    assetCount: const Optional.present(3),
+    memberCount: const Optional.present(2),
+  );
+
+  testWidgets('a long-press fires onLongPress and does NOT also fire onTap', (tester) async {
+    _setTallLogicalSize(tester);
+    final events = <String>[];
+    await tester.pumpConsumerWidget(
+      SpaceCard(
+        space: fullSpace(),
+        onTap: () => events.add('tap'),
+        onLongPress: () => events.add('longPress'),
+      ),
+    );
+
+    await tester.longPress(find.byType(SpaceCard));
+    await tester.pumpAndSettle();
+
+    expect(events, ['longPress'], reason: 'a long-press must not navigate into the space behind the sheet');
+  });
+
+  testWidgets('a tap still fires onTap only', (tester) async {
+    _setTallLogicalSize(tester);
+    final events = <String>[];
+    await tester.pumpConsumerWidget(
+      SpaceCard(
+        space: fullSpace(),
+        onTap: () => events.add('tap'),
+        onLongPress: () => events.add('longPress'),
+      ),
+    );
+
+    await tester.tap(find.byType(SpaceCard));
+    await tester.pumpAndSettle();
+
+    expect(events, ['tap']);
+  });
+
+  testWidgets('omitting onLongPress leaves tap behaviour unchanged', (tester) async {
+    _setTallLogicalSize(tester);
+    final events = <String>[];
+    await tester.pumpConsumerWidget(
+      SpaceCard(space: fullSpace(), onTap: () => events.add('tap')),
+    );
+
+    await tester.longPress(find.byType(SpaceCard));
+    await tester.pumpAndSettle();
+
+    expect(events, isEmpty);
+  });
+}

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -29405,6 +29405,13 @@
             "description": "Whether smart search is enabled",
             "type": "boolean"
           },
+          "syncRequestTypes": {
+            "description": "Sync stream request types this server accepts. Absent on servers that predate capability signalling; clients fall back to version-based gating.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "trash": {
             "description": "Whether trash feature is enabled",
             "type": "boolean"

--- a/packages/sdk/src/fetch-client.ts
+++ b/packages/sdk/src/fetch-client.ts
@@ -2435,6 +2435,8 @@ export type ServerFeaturesDto = {
     sidecar: boolean;
     /** Whether smart search is enabled */
     smartSearch: boolean;
+    /** Sync stream request types this server accepts. Absent on servers that predate capability signalling; clients fall back to version-based gating. */
+    syncRequestTypes?: string[];
     /** Whether trash feature is enabled */
     trash: boolean;
 };

--- a/server/src/dtos/server.dto.ts
+++ b/server/src/dtos/server.dto.ts
@@ -148,6 +148,14 @@ const ServerFeaturesSchema = z
     ocr: z.boolean().describe('Whether OCR is enabled'),
     realtimeTranscoding: z.boolean().describe('Whether real-time transcoding is enabled'),
     peopleStatistics: z.boolean().describe('Whether the people face statistics UI is enabled'),
+    // Deliberately plain strings, not the SyncRequestType enum: a client must be able to
+    // parse a newer server's list without choking on values its own enum doesn't know yet.
+    syncRequestTypes: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Sync stream request types this server accepts. Absent on servers that predate capability signalling; clients fall back to version-based gating.',
+      ),
   })
   .meta({ id: 'ServerFeaturesDto' });
 

--- a/server/src/services/server.service.spec.ts
+++ b/server/src/services/server.service.spec.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { serverVersion } from 'src/constants';
-import { SystemMetadataKey } from 'src/enum';
+import { SyncRequestType, SystemMetadataKey } from 'src/enum';
 import { ServerService } from 'src/services/server.service';
 import { clearConfigCache } from 'src/utils/config';
 import { mimeTypes } from 'src/utils/mime-types';
@@ -155,6 +155,7 @@ describe(ServerService.name, () => {
         email: false,
         realtimeTranscoding: false,
         peopleStatistics: false,
+        syncRequestTypes: Object.values(SyncRequestType),
       });
       expect(mocks.systemMetadata.get).toHaveBeenCalled();
     });

--- a/server/src/services/server.service.ts
+++ b/server/src/services/server.service.ts
@@ -15,7 +15,7 @@ import {
   ServerStorageResponseDto,
   UsageByUserDto,
 } from 'src/dtos/server.dto';
-import { StorageFolder, SystemMetadataKey } from 'src/enum';
+import { StorageFolder, SyncRequestType, SystemMetadataKey } from 'src/enum';
 import { UserStatsQueryResponse } from 'src/repositories/user.repository';
 import { BaseService } from 'src/services/base.service';
 import { getAdminAvailableMemoryTypeKeys, MEMORY_TYPE_KEYS } from 'src/services/memory-rules/memory-type.metadata';
@@ -141,6 +141,10 @@ export class ServerService extends BaseService {
       email: notifications.smtp.enabled,
       realtimeTranscoding: ffmpeg.realtime.enabled,
       peopleStatistics,
+      // Capability signal for mobile sync gating: /sync/stream 400s the whole request on any
+      // type outside this enum, so clients must know the accepted set before asking. Version
+      // numbers can't carry this (RC builds report the bare base version).
+      syncRequestTypes: Object.values(SyncRequestType),
     };
   }
 


### PR DESCRIPTION
## What

Two mobile Spaces UX gaps closed, written test-first slice by slice (mobile suite 2796 → 2872 passing):

**Edit a space** — an "Edit Space" sheet (name, description, colour) reachable from the space-detail kebab and a new space-card long-press. Editor-gated to match the server role model; this also fixes a real bug where editors saw no kebab at all on the detail page. The delete confirmation dialog on the detail page is now localized too.

**Add to a space** — the multi-select sheet on the main timeline and on a space timeline now offers "Add to album or space". Spaces expand into their linked albums so a photo lands in a concrete destination.

## Notes for review

- Shared role logic was first extracted into `space_permissions` helpers and the existing call sites (link picker, bottom sheet, detail page) repointed onto them, so the new surfaces gate identically.
- **Contribution mode is deliberately not implemented**: when a selection contains photos the user doesn't own, space targets hide behind an explanatory notice (new i18n key, all locales) instead of attempting a web-style contribution.
- Known follow-up (recorded in the slice spec, not fixed here): `SpaceCard.build` reads seven `Optional` fields via bare `.value`; one absent field crashes the Spaces grid. Kept out of this PR since it already changes RBAC gating.