### PR TITLE
fix(spaces): stop the shared-space person deadlocks during a library unmap (#864)

### DIFF
--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -2343,7 +2343,11 @@ where
   "shared_space_person"."spaceId" = $1
 
 -- SharedSpaceRepository.deleteOrphanedPersons
-delete from "shared_space_person"
+begin
+select
+  "id"
+from
+  "shared_space_person"
 where
   "spaceId" = $1
   and "id" not in (
@@ -2352,9 +2356,17 @@ where
     from
       "shared_space_person_face"
   )
+order by
+  "id"
+for update
+commit
 
 -- SharedSpaceRepository.deleteOrphanedPersonsByIds
-delete from "shared_space_person"
+begin
+select
+  "id"
+from
+  "shared_space_person"
 where
   "spaceId" = $1
   and "id" in ($2)
@@ -2364,6 +2376,10 @@ where
     from
       "shared_space_person_face"
   )
+order by
+  "id"
+for update
+commit
 
 -- SharedSpaceRepository.deleteAllOrphanedPersons
 delete from "shared_space_person"

--- a/server/src/queries/shared.space.repository.sql
+++ b/server/src/queries/shared.space.repository.sql
@@ -2387,6 +2387,16 @@ where
   "type" = $1
 
 -- SharedSpaceRepository.recountPersons
+begin
+select
+  "id"
+from
+  "shared_space_person"
+where
+  "id" in ($1)
+order by
+  "id"
+for update
 update "shared_space_person"
 set
   "faceCount" = (
@@ -2419,6 +2429,7 @@ set
   )
 where
   "id" in ($1)
+commit
 
 -- SharedSpaceRepository.getAlias
 select

--- a/server/src/repositories/face-identity.repository.spec.ts
+++ b/server/src/repositories/face-identity.repository.spec.ts
@@ -178,3 +178,56 @@ describe(FaceIdentityRepository.name, () => {
     });
   });
 });
+
+// The identity backfill keeps its OWN copy of the space-person recount and orphan cleanup, and
+// runs them while a library unmap is deleting assets. They touch the same shared_space_person
+// rows as SharedSpaceRepository.recountPersons, so they need the same deadlock handling (#864).
+const spaceMaintenanceDeadlock = () => Object.assign(new Error('deadlock detected'), { code: '40P01' });
+
+const spaceMaintenanceDb = (execute: () => Promise<unknown>) => {
+  const transaction = vi.fn(() => ({ execute }));
+  return { db: { transaction } as any, transaction };
+};
+
+describe('FaceIdentityRepository space-person maintenance deadlock safety (#864)', () => {
+  const ids = ['11111111-1111-4111-8111-111111111111'];
+
+  const invoke = (db: any, method: string) => (new FaceIdentityRepository(db) as any)[method](ids) as Promise<void>;
+
+  for (const method of ['recountSpacePersons', 'deleteOrphanedSpacePersons']) {
+    it(`${method} re-drives in a fresh transaction when it is the deadlock victim`, async () => {
+      let attempts = 0;
+      const { db, transaction } = spaceMaintenanceDb(() => {
+        attempts++;
+        return attempts < 3 ? Promise.reject(spaceMaintenanceDeadlock()) : Promise.resolve(void 0);
+      });
+
+      await expect(invoke(db, method)).resolves.toBeUndefined();
+      expect(transaction).toHaveBeenCalledTimes(3);
+    });
+
+    it(`${method} gives up once the attempt budget is spent`, async () => {
+      const { db, transaction } = spaceMaintenanceDb(() => Promise.reject(spaceMaintenanceDeadlock()));
+
+      await expect(invoke(db, method)).rejects.toMatchObject({ code: '40P01' });
+      expect(transaction).toHaveBeenCalledTimes(3);
+    });
+
+    it(`${method} does not retry non-deadlock failures`, async () => {
+      const { db, transaction } = spaceMaintenanceDb(() =>
+        Promise.reject(Object.assign(new Error('nope'), { code: '23503' })),
+      );
+
+      await expect(invoke(db, method)).rejects.toMatchObject({ code: '23503' });
+      expect(transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it(`${method} opens no transaction for an empty id list`, async () => {
+      const transaction = vi.fn();
+      const sut = new FaceIdentityRepository({ transaction } as any) as any;
+
+      await expect(sut[method]([])).resolves.toBeUndefined();
+      expect(transaction).not.toHaveBeenCalled();
+    });
+  }
+});

--- a/server/src/repositories/face-identity.repository.spec.ts
+++ b/server/src/repositories/face-identity.repository.spec.ts
@@ -210,7 +210,7 @@ describe('FaceIdentityRepository space-person maintenance deadlock safety (#864)
       const { db, transaction } = spaceMaintenanceDb(() => Promise.reject(spaceMaintenanceDeadlock()));
 
       await expect(invoke(db, method)).rejects.toMatchObject({ code: '40P01' });
-      expect(transaction).toHaveBeenCalledTimes(3);
+      expect(transaction).toHaveBeenCalledTimes(5);
     });
 
     it(`${method} does not retry non-deadlock failures`, async () => {

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -2765,33 +2765,50 @@ export class FaceIdentityRepository {
     toPersonId: string;
     identityId: string;
   }): Promise<void> {
-    const identityFaceIds = this.db
-      .selectFrom('shared_space_person_face')
-      .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
-      .innerJoin('face_identity_face', 'face_identity_face.assetFaceId', 'asset_face.id')
-      .select('shared_space_person_face.assetFaceId')
-      .where('shared_space_person_face.personId', '=', input.fromPersonId)
-      .where('face_identity_face.identityId', '=', input.identityId)
-      .where('asset_face.deletedAt', 'is', null)
-      .where('asset_face.isVisible', '=', true);
+    await this.db.transaction().execute(async (trx) => {
+      // Orphan cleanup runs concurrently with the backfill during a library unmap and can delete
+      // the target person between the caller resolving it and this move. Claim the row first so it
+      // cannot disappear mid-move, and skip entirely if it is already gone — reassigning faces onto
+      // a missing person violates shared_space_person_face_personId_fkey and kills the job (#864).
+      const target = await trx
+        .selectFrom('shared_space_person')
+        .select('id')
+        .where('id', '=', input.toPersonId)
+        .forUpdate()
+        .executeTakeFirst();
 
-    await this.db
-      .deleteFrom('shared_space_person_face')
-      .where('personId', '=', input.fromPersonId)
-      .where('assetFaceId', 'in', identityFaceIds)
-      .where(
-        'assetFaceId',
-        'in',
-        this.db.selectFrom('shared_space_person_face').select('assetFaceId').where('personId', '=', input.toPersonId),
-      )
-      .execute();
+      if (!target) {
+        return;
+      }
 
-    await this.db
-      .updateTable('shared_space_person_face')
-      .set({ personId: input.toPersonId })
-      .where('personId', '=', input.fromPersonId)
-      .where('assetFaceId', 'in', identityFaceIds)
-      .execute();
+      const identityFaceIds = trx
+        .selectFrom('shared_space_person_face')
+        .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+        .innerJoin('face_identity_face', 'face_identity_face.assetFaceId', 'asset_face.id')
+        .select('shared_space_person_face.assetFaceId')
+        .where('shared_space_person_face.personId', '=', input.fromPersonId)
+        .where('face_identity_face.identityId', '=', input.identityId)
+        .where('asset_face.deletedAt', 'is', null)
+        .where('asset_face.isVisible', '=', true);
+
+      await trx
+        .deleteFrom('shared_space_person_face')
+        .where('personId', '=', input.fromPersonId)
+        .where('assetFaceId', 'in', identityFaceIds)
+        .where(
+          'assetFaceId',
+          'in',
+          trx.selectFrom('shared_space_person_face').select('assetFaceId').where('personId', '=', input.toPersonId),
+        )
+        .execute();
+
+      await trx
+        .updateTable('shared_space_person_face')
+        .set({ personId: input.toPersonId })
+        .where('personId', '=', input.fromPersonId)
+        .where('assetFaceId', 'in', identityFaceIds)
+        .execute();
+    });
   }
 
   private spacePersonFaceCount(eb: ExpressionBuilder<DB, 'shared_space_person'>) {

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -2765,50 +2765,58 @@ export class FaceIdentityRepository {
     toPersonId: string;
     identityId: string;
   }): Promise<void> {
-    await this.db.transaction().execute(async (trx) => {
-      // Orphan cleanup runs concurrently with the backfill during a library unmap and can delete
-      // the target person between the caller resolving it and this move. Claim the row first so it
-      // cannot disappear mid-move, and skip entirely if it is already gone — reassigning faces onto
-      // a missing person violates shared_space_person_face_personId_fkey and kills the job (#864).
-      const target = await trx
-        .selectFrom('shared_space_person')
-        .select('id')
-        .where('id', '=', input.toPersonId)
-        .forUpdate()
-        .executeTakeFirst();
+    // The UPDATE below sets personId, so its FK check takes FOR KEY SHARE on BOTH the source and
+    // target person rows. Claiming only the target left the source locked in an arbitrary order,
+    // so claim both in id order (#864).
+    const parentIds = [...new Set([input.fromPersonId, input.toPersonId])].toSorted();
 
-      if (!target) {
-        return;
-      }
+    await retryOnDeadlock(() =>
+      this.db.transaction().execute(async (trx) => {
+        // Orphan cleanup runs concurrently with the backfill during a library unmap and can delete
+        // the target person between the caller resolving it and this move. Claiming it here stops it
+        // disappearing mid-move; if it is already gone we skip, because reassigning faces onto a
+        // missing person violates shared_space_person_face_personId_fkey and kills the job.
+        const claimed = await trx
+          .selectFrom('shared_space_person')
+          .select('id')
+          .where('id', 'in', parentIds)
+          .orderBy('id')
+          .forUpdate()
+          .execute();
 
-      const identityFaceIds = trx
-        .selectFrom('shared_space_person_face')
-        .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
-        .innerJoin('face_identity_face', 'face_identity_face.assetFaceId', 'asset_face.id')
-        .select('shared_space_person_face.assetFaceId')
-        .where('shared_space_person_face.personId', '=', input.fromPersonId)
-        .where('face_identity_face.identityId', '=', input.identityId)
-        .where('asset_face.deletedAt', 'is', null)
-        .where('asset_face.isVisible', '=', true);
+        if (!claimed.some(({ id }) => id === input.toPersonId)) {
+          return;
+        }
 
-      await trx
-        .deleteFrom('shared_space_person_face')
-        .where('personId', '=', input.fromPersonId)
-        .where('assetFaceId', 'in', identityFaceIds)
-        .where(
-          'assetFaceId',
-          'in',
-          trx.selectFrom('shared_space_person_face').select('assetFaceId').where('personId', '=', input.toPersonId),
-        )
-        .execute();
+        const identityFaceIds = trx
+          .selectFrom('shared_space_person_face')
+          .innerJoin('asset_face', 'asset_face.id', 'shared_space_person_face.assetFaceId')
+          .innerJoin('face_identity_face', 'face_identity_face.assetFaceId', 'asset_face.id')
+          .select('shared_space_person_face.assetFaceId')
+          .where('shared_space_person_face.personId', '=', input.fromPersonId)
+          .where('face_identity_face.identityId', '=', input.identityId)
+          .where('asset_face.deletedAt', 'is', null)
+          .where('asset_face.isVisible', '=', true);
 
-      await trx
-        .updateTable('shared_space_person_face')
-        .set({ personId: input.toPersonId })
-        .where('personId', '=', input.fromPersonId)
-        .where('assetFaceId', 'in', identityFaceIds)
-        .execute();
-    });
+        await trx
+          .deleteFrom('shared_space_person_face')
+          .where('personId', '=', input.fromPersonId)
+          .where('assetFaceId', 'in', identityFaceIds)
+          .where(
+            'assetFaceId',
+            'in',
+            trx.selectFrom('shared_space_person_face').select('assetFaceId').where('personId', '=', input.toPersonId),
+          )
+          .execute();
+
+        await trx
+          .updateTable('shared_space_person_face')
+          .set({ personId: input.toPersonId })
+          .where('personId', '=', input.fromPersonId)
+          .where('assetFaceId', 'in', identityFaceIds)
+          .execute();
+      }),
+    );
   }
 
   private spacePersonFaceCount(eb: ExpressionBuilder<DB, 'shared_space_person'>) {

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -9,7 +9,7 @@ import type { PeopleFaceStatistics, PersonStatistics } from 'src/repositories/pe
 import { DB } from 'src/schema';
 import { FaceIdentityFaceSource, FaceIdentityFaceTable } from 'src/schema/tables/face-identity-face.table';
 import { FaceIdentityTable } from 'src/schema/tables/face-identity.table';
-import { anyUuid } from 'src/utils/database';
+import { anyUuid, retryOnDeadlock } from 'src/utils/database';
 import { asDateString, asDateTimeString } from 'src/utils/date';
 import { spaceAlbumAssetExistsSql, spaceVisibleAssetVisibilities } from 'src/utils/shared-space-album-scope';
 
@@ -2847,23 +2847,40 @@ export class FaceIdentityRepository {
       return;
     }
 
-    await this.db
-      .updateTable('shared_space_person')
-      .set((eb) => ({
-        faceCount: this.spacePersonFaceCount(eb),
-        assetCount: this.spacePersonAssetCount(eb),
-      }))
-      .where('id', 'in', personIds)
-      // Recount runs for every person an identity backfill pass scans. Skip rows whose counts are
-      // already correct — an unconditional UPDATE fires the updatedAt trigger for the whole table
-      // once per pass, generating constant write load and updatedAt churn for sync watchers.
-      .where((eb) =>
-        eb.or([
-          eb('shared_space_person.faceCount', 'is distinct from', this.spacePersonFaceCount(eb)),
-          eb('shared_space_person.assetCount', 'is distinct from', this.spacePersonAssetCount(eb)),
-        ]),
-      )
-      .execute();
+    // This is the identity backfill's own copy of the space-person recount, and it runs while a
+    // library unmap is deleting assets. It needs the same protection as
+    // SharedSpaceRepository.recountPersons (#864): claim the rows in a canonical order so two
+    // recounts cannot cycle, and re-drive when the representativeFaceId ON DELETE SET NULL
+    // cascade — whose lock order we do not control — makes this transaction the victim.
+    await retryOnDeadlock(() =>
+      this.db.transaction().execute(async (trx) => {
+        await trx
+          .selectFrom('shared_space_person')
+          .select('id')
+          .where('id', 'in', [...new Set(personIds)].toSorted())
+          .orderBy('id')
+          .forUpdate()
+          .execute();
+
+        await trx
+          .updateTable('shared_space_person')
+          .set((eb) => ({
+            faceCount: this.spacePersonFaceCount(eb),
+            assetCount: this.spacePersonAssetCount(eb),
+          }))
+          .where('id', 'in', personIds)
+          // Recount runs for every person an identity backfill pass scans. Skip rows whose counts are
+          // already correct — an unconditional UPDATE fires the updatedAt trigger for the whole table
+          // once per pass, generating constant write load and updatedAt churn for sync watchers.
+          .where((eb) =>
+            eb.or([
+              eb('shared_space_person.faceCount', 'is distinct from', this.spacePersonFaceCount(eb)),
+              eb('shared_space_person.assetCount', 'is distinct from', this.spacePersonAssetCount(eb)),
+            ]),
+          )
+          .execute();
+      }),
+    );
   }
 
   private async deleteOrphanedSpacePersons(personIds: string[]): Promise<void> {
@@ -2871,19 +2888,34 @@ export class FaceIdentityRepository {
       return;
     }
 
-    await this.db
-      .deleteFrom('shared_space_person')
-      .where('id', 'in', personIds)
-      .where((eb) =>
-        eb.not(
-          eb.exists(
-            eb
-              .selectFrom('shared_space_person_face')
-              .whereRef('shared_space_person_face.personId', '=', 'shared_space_person.id'),
-          ),
-        ),
-      )
-      .execute();
+    // Same reasoning as recountSpacePersons: this DELETE takes locks on shared_space_person in
+    // scan order while concurrent recounts take them in id order, so claim first and re-drive if
+    // Postgres kills us (#864).
+    await retryOnDeadlock(() =>
+      this.db.transaction().execute(async (trx) => {
+        await trx
+          .selectFrom('shared_space_person')
+          .select('id')
+          .where('id', 'in', [...new Set(personIds)].toSorted())
+          .orderBy('id')
+          .forUpdate()
+          .execute();
+
+        await trx
+          .deleteFrom('shared_space_person')
+          .where('id', 'in', personIds)
+          .where((eb) =>
+            eb.not(
+              eb.exists(
+                eb
+                  .selectFrom('shared_space_person_face')
+                  .whereRef('shared_space_person_face.personId', '=', 'shared_space_person.id'),
+              ),
+            ),
+          )
+          .execute();
+      }),
+    );
   }
 
   async mergeIdentities(input: {

--- a/server/src/repositories/machine-learning.repository.spec.ts
+++ b/server/src/repositories/machine-learning.repository.spec.ts
@@ -426,6 +426,21 @@ describe(MachineLearningRepository.name, () => {
       }
     });
 
+    // The 15s signal is one budget for the whole predict, shared across every URL. Once it
+    // expires the remaining URLs cannot possibly be tried — their fetch aborts instantly — so
+    // marking them unhealthy blames servers that were never contacted (#864).
+    it('does not try or blame the remaining URLs once the shared timeout budget expires', async () => {
+      const fallbackUrl = 'http://ml-fallback:3003';
+      sut.setup({ ...baseConfig, urls: [mlUrl, fallbackUrl] });
+      // undici rejects an AbortSignal.timeout() fetch with TimeoutError, NOT AbortError.
+      mockFetch.mockRejectedValue(new DOMException('The operation was aborted due to timeout', 'TimeoutError'));
+
+      await expect(sut.encodeText('hello', { language: 'en', modelName: 'clip' })).rejects.toMatchObject({
+        name: 'TimeoutError',
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
     it('non-abort errors still surface as the multi-URL failure', async () => {
       mockFetch.mockRejectedValue(new Error('ECONNREFUSED'));
       await expect(sut.encodeText('hello', { language: 'en', modelName: 'clip' })).rejects.toThrow(

--- a/server/src/repositories/machine-learning.repository.ts
+++ b/server/src/repositories/machine-learning.repository.ts
@@ -233,7 +233,11 @@ export class MachineLearningRepository {
           `Machine learning request to "${url}" failed with status ${response.status}: ${response.statusText}`,
         );
       } catch (error: Error | unknown) {
-        if (error instanceof Error && error.name === 'AbortError') {
+        // `signal` is one budget shared by every URL below, and AbortSignal.timeout() rejects
+        // with TimeoutError rather than AbortError. Either name means the budget is spent, so
+        // the remaining URLs cannot actually be contacted — continuing would only mark servers
+        // unhealthy that were never tried (#864).
+        if (error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')) {
           throw error;
         }
         this.logger.warn(

--- a/server/src/repositories/shared-space.repository.spec.ts
+++ b/server/src/repositories/shared-space.repository.spec.ts
@@ -5,6 +5,11 @@ import { describe, expect, it, vitest } from 'vitest';
 
 const deadlock = () => Object.assign(new Error('deadlock detected'), { code: '40P01' });
 
+const fake = (execute: () => Promise<unknown>) => {
+  const transaction = vitest.fn(() => ({ execute }));
+  return { db: { transaction } as unknown as Kysely<DB>, transaction };
+};
+
 /**
  * The recount is a deadlock victim under a real delete storm (#864): the representativeFaceId
  * ON DELETE SET NULL cascade locks shared_space_person rows in face order, so Postgres can pick
@@ -112,6 +117,94 @@ describe(`${SharedSpaceRepository.name}.recountPersons deadlock retry (#864)`, (
     await expect(new SharedSpaceRepository(trx).recountPersons(ids, trx)).rejects.toMatchObject({ code: '40P01' });
 
     expect(claims).toBe(1);
+    expect(transaction).not.toHaveBeenCalled();
+  });
+});
+
+// Ranked P0 by the #864 lock audit: onAssetDelete calls this immediately after the (protected)
+// recountPersons, so protecting only the recount just moves the deadlock victim onto this DELETE.
+describe(`${SharedSpaceRepository.name} orphan cleanup deadlock safety (#864)`, () => {
+  const spaceId = '22222222-2222-4222-8222-222222222222';
+  const ids = ['11111111-1111-4111-8111-111111111111'];
+
+  it('re-drives deleteOrphanedPersons in a fresh transaction when it is the victim', async () => {
+    let attempts = 0;
+    const { db, transaction } = fake(() => {
+      attempts++;
+      return attempts < 3 ? Promise.reject(deadlock()) : Promise.resolve(void 0);
+    });
+
+    await expect(new SharedSpaceRepository(db).deleteOrphanedPersons(spaceId)).resolves.toBeUndefined();
+    expect(transaction).toHaveBeenCalledTimes(3);
+  });
+
+  it('gives up on deleteOrphanedPersons once the budget is spent', async () => {
+    const { db, transaction } = fake(() => Promise.reject(deadlock()));
+
+    await expect(new SharedSpaceRepository(db).deleteOrphanedPersons(spaceId)).rejects.toMatchObject({
+      code: '40P01',
+    });
+    expect(transaction).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry deleteOrphanedPersons on non-deadlock failures', async () => {
+    const { db, transaction } = fake(() => Promise.reject(Object.assign(new Error('x'), { code: '23503' })));
+
+    await expect(new SharedSpaceRepository(db).deleteOrphanedPersons(spaceId)).rejects.toMatchObject({
+      code: '23503',
+    });
+    expect(transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-drives deleteOrphanedPersonsByIds too', async () => {
+    let attempts = 0;
+    const { db, transaction } = fake(() => {
+      attempts++;
+      return attempts < 2 ? Promise.reject(deadlock()) : Promise.resolve(void 0);
+    });
+
+    await expect(new SharedSpaceRepository(db).deleteOrphanedPersonsByIds(spaceId, ids)).resolves.toBeUndefined();
+    expect(transaction).toHaveBeenCalledTimes(2);
+  });
+
+  it('opens no transaction for deleteOrphanedPersonsByIds with an empty id list', async () => {
+    const transaction = vitest.fn();
+    const db = { transaction } as unknown as Kysely<DB>;
+
+    await expect(new SharedSpaceRepository(db).deleteOrphanedPersonsByIds(spaceId, [])).resolves.toBeUndefined();
+    expect(transaction).not.toHaveBeenCalled();
+  });
+});
+
+// Path 3 from the #864 lock audit: an INSERT into shared_space_person_face takes FOR KEY SHARE on
+// its shared_space_person parents to satisfy the FK — invisible in the statement, but a real
+// deadlock participant against the representativeFaceId SET NULL cascade during an asset delete.
+describe(`${SharedSpaceRepository.name}.addPersonFaces deadlock safety (#864)`, () => {
+  const values = [{ personId: '11111111-1111-4111-8111-111111111111', assetFaceId: 'a' }] as any;
+
+  it('re-drives the insert in a fresh transaction when it is the deadlock victim', async () => {
+    let attempts = 0;
+    const { db, transaction } = fake(() => {
+      attempts++;
+      return attempts < 3 ? Promise.reject(deadlock()) : Promise.resolve([]);
+    });
+
+    await expect(new SharedSpaceRepository(db).addPersonFaces(values)).resolves.toEqual([]);
+    expect(transaction).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry non-deadlock failures', async () => {
+    const { db, transaction } = fake(() => Promise.reject(Object.assign(new Error('x'), { code: '23503' })));
+
+    await expect(new SharedSpaceRepository(db).addPersonFaces(values)).rejects.toMatchObject({ code: '23503' });
+    expect(transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens no transaction for an empty value list', async () => {
+    const transaction = vitest.fn();
+    const db = { transaction } as unknown as Kysely<DB>;
+
+    await expect(new SharedSpaceRepository(db).addPersonFaces([])).resolves.toEqual([]);
     expect(transaction).not.toHaveBeenCalled();
   });
 });

--- a/server/src/repositories/shared-space.repository.spec.ts
+++ b/server/src/repositories/shared-space.repository.spec.ts
@@ -35,6 +35,53 @@ describe(`${SharedSpaceRepository.name}.recountPersons deadlock retry (#864)`, (
     expect(execute).toHaveBeenCalledTimes(3);
   });
 
+  it('gives up and surfaces the deadlock once the attempt budget is spent', async () => {
+    const execute = vitest.fn(() => Promise.reject(deadlock()));
+    const transaction = vitest.fn(() => ({ execute }));
+    const db = { isTransaction: false, transaction } as unknown as Kysely<DB>;
+
+    await expect(new SharedSpaceRepository(db).recountPersons(ids, db)).rejects.toMatchObject({ code: '40P01' });
+
+    // bounded — a permanently contended row must not spin forever
+    expect(transaction).toHaveBeenCalledTimes(3);
+  });
+
+  it('opens exactly one transaction when the first attempt succeeds', async () => {
+    const execute = vitest.fn(() => Promise.resolve(void 0));
+    const transaction = vitest.fn(() => ({ execute }));
+    const db = { isTransaction: false, transaction } as unknown as Kysely<DB>;
+
+    await new SharedSpaceRepository(db).recountPersons(ids, db);
+
+    expect(transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens no transaction at all for an empty id list', async () => {
+    const transaction = vitest.fn();
+    const db = { isTransaction: false, transaction } as unknown as Kysely<DB>;
+
+    await expect(new SharedSpaceRepository(db).recountPersons([], db)).resolves.toBeUndefined();
+
+    expect(transaction).not.toHaveBeenCalled();
+  });
+
+  it('runs the recount work inside each attempt, not just around it', async () => {
+    const callbacks: unknown[] = [];
+    let attempts = 0;
+    const execute = vitest.fn((cb: unknown) => {
+      callbacks.push(cb);
+      attempts++;
+      return attempts < 2 ? Promise.reject(deadlock()) : Promise.resolve(void 0);
+    });
+    const transaction = vitest.fn(() => ({ execute }));
+    const db = { isTransaction: false, transaction } as unknown as Kysely<DB>;
+
+    await new SharedSpaceRepository(db).recountPersons(ids, db);
+
+    expect(callbacks).toHaveLength(2);
+    expect(callbacks.every((cb) => typeof cb === 'function')).toBe(true);
+  });
+
   it('does not retry failures that are not deadlocks', async () => {
     const execute = vitest.fn(() => Promise.reject(Object.assign(new Error('nope'), { code: '23503' })));
     const transaction = vitest.fn(() => ({ execute }));

--- a/server/src/repositories/shared-space.repository.spec.ts
+++ b/server/src/repositories/shared-space.repository.spec.ts
@@ -208,3 +208,57 @@ describe(`${SharedSpaceRepository.name}.addPersonFaces deadlock safety (#864)`, 
     expect(transaction).not.toHaveBeenCalled();
   });
 });
+
+// Chainable Kysely stub: every builder method returns itself, `execute` is caller-controlled.
+const chain = (execute: () => Promise<unknown>): any =>
+  new Proxy({}, { get: (_target, prop) => (prop === 'execute' ? execute : () => chain(execute)) });
+
+const dbWith = (onDelete: () => Promise<unknown>) => {
+  const deletes = { count: 0 };
+  const db = {
+    selectFrom: () => chain(() => Promise.resolve([])),
+    deleteFrom: () =>
+      chain(() => {
+        deletes.count++;
+        return onDelete();
+      }),
+  } as unknown as Kysely<DB>;
+  return { db, deletes };
+};
+
+// P1 from the #864 lock audit — reached from unlinkLibrary / AlbumDelete / AlbumAssetsRemove,
+// i.e. the library unmap itself.
+describe(`${SharedSpaceRepository.name} face-removal deadlock safety (#864)`, () => {
+  const spaceId = '22222222-2222-4222-8222-222222222222';
+
+  it('re-drives removePersonFacesByAssetIds when the delete is the deadlock victim', async () => {
+    let attempts = 0;
+    const { db, deletes } = dbWith(() => {
+      attempts++;
+      return attempts < 3 ? Promise.reject(deadlock()) : Promise.resolve(void 0);
+    });
+
+    await expect(new SharedSpaceRepository(db).removePersonFacesByAssetIds(spaceId, ['a'])).resolves.toBeUndefined();
+    expect(deletes.count).toBe(3);
+  });
+
+  it('does not retry removePersonFacesByAssetIds on non-deadlock failures', async () => {
+    const { db, deletes } = dbWith(() => Promise.reject(Object.assign(new Error('x'), { code: '23503' })));
+
+    await expect(new SharedSpaceRepository(db).removePersonFacesByAssetIds(spaceId, ['a'])).rejects.toMatchObject({
+      code: '23503',
+    });
+    expect(deletes.count).toBe(1);
+  });
+
+  it('re-drives removePersonFacesByLibrary when the delete is the deadlock victim', async () => {
+    let attempts = 0;
+    const { db, deletes } = dbWith(() => {
+      attempts++;
+      return attempts < 2 ? Promise.reject(deadlock()) : Promise.resolve(void 0);
+    });
+
+    await expect(new SharedSpaceRepository(db).removePersonFacesByLibrary(spaceId, 'lib')).resolves.toBeUndefined();
+    expect(deletes.count).toBe(2);
+  });
+});

--- a/server/src/repositories/shared-space.repository.spec.ts
+++ b/server/src/repositories/shared-space.repository.spec.ts
@@ -48,7 +48,7 @@ describe(`${SharedSpaceRepository.name}.recountPersons deadlock retry (#864)`, (
     await expect(new SharedSpaceRepository(db).recountPersons(ids, db)).rejects.toMatchObject({ code: '40P01' });
 
     // bounded — a permanently contended row must not spin forever
-    expect(transaction).toHaveBeenCalledTimes(3);
+    expect(transaction).toHaveBeenCalledTimes(5);
   });
 
   it('opens exactly one transaction when the first attempt succeeds', async () => {
@@ -144,7 +144,7 @@ describe(`${SharedSpaceRepository.name} orphan cleanup deadlock safety (#864)`, 
     await expect(new SharedSpaceRepository(db).deleteOrphanedPersons(spaceId)).rejects.toMatchObject({
       code: '40P01',
     });
-    expect(transaction).toHaveBeenCalledTimes(3);
+    expect(transaction).toHaveBeenCalledTimes(5);
   });
 
   it('does not retry deleteOrphanedPersons on non-deadlock failures', async () => {

--- a/server/src/repositories/shared-space.repository.spec.ts
+++ b/server/src/repositories/shared-space.repository.spec.ts
@@ -1,0 +1,70 @@
+import { Kysely } from 'kysely';
+import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
+import { DB } from 'src/schema';
+import { describe, expect, it, vitest } from 'vitest';
+
+const deadlock = () => Object.assign(new Error('deadlock detected'), { code: '40P01' });
+
+/**
+ * The recount is a deadlock victim under a real delete storm (#864): the representativeFaceId
+ * ON DELETE SET NULL cascade locks shared_space_person rows in face order, so Postgres can pick
+ * a recount to kill even though the recount itself claims its rows in id order.
+ *
+ * These cover the retry wiring. The end-to-end effect is measured by the library-unmap repro,
+ * which cannot be expressed as a deterministic unit test.
+ */
+describe(`${SharedSpaceRepository.name}.recountPersons deadlock retry (#864)`, () => {
+  const ids = ['11111111-1111-4111-8111-111111111111'];
+
+  it('re-drives the recount in a FRESH transaction when it is chosen as the victim', async () => {
+    let attempts = 0;
+    const execute = vitest.fn(() => {
+      attempts++;
+      if (attempts < 3) {
+        return Promise.reject(deadlock());
+      }
+      return Promise.resolve(void 0);
+    });
+    const transaction = vitest.fn(() => ({ execute }));
+    const db = { isTransaction: false, transaction } as unknown as Kysely<DB>;
+
+    await expect(new SharedSpaceRepository(db).recountPersons(ids, db)).resolves.toBeUndefined();
+
+    // a retry must open a new transaction: the deadlocked one is already dead
+    expect(transaction).toHaveBeenCalledTimes(3);
+    expect(execute).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry failures that are not deadlocks', async () => {
+    const execute = vitest.fn(() => Promise.reject(Object.assign(new Error('nope'), { code: '23503' })));
+    const transaction = vitest.fn(() => ({ execute }));
+    const db = { isTransaction: false, transaction } as unknown as Kysely<DB>;
+
+    await expect(new SharedSpaceRepository(db).recountPersons(ids, db)).rejects.toMatchObject({ code: '23503' });
+
+    expect(transaction).toHaveBeenCalledTimes(1);
+  });
+
+  // A deadlock aborts the caller's whole transaction, so re-running the statements inside it would
+  // only raise "current transaction is aborted". The caller has to re-drive its own transaction.
+  it('never retries, or nests a transaction, when the caller supplied one', async () => {
+    const transaction = vitest.fn();
+    let claims = 0;
+    const chain: any = {
+      select: () => chain,
+      where: () => chain,
+      orderBy: () => chain,
+      forUpdate: () => chain,
+      execute: () => {
+        claims++;
+        return Promise.reject(deadlock());
+      },
+    };
+    const trx = { isTransaction: true, transaction, selectFrom: () => chain } as unknown as Kysely<DB>;
+
+    await expect(new SharedSpaceRepository(trx).recountPersons(ids, trx)).rejects.toMatchObject({ code: '40P01' });
+
+    expect(claims).toBe(1);
+    expect(transaction).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -2614,12 +2614,30 @@ export class SharedSpaceRepository {
       return [];
     }
 
-    const result = await this.db
-      .insertInto('shared_space_person_face')
-      .values(values)
-      .onConflict((oc) => oc.doNothing())
-      .returningAll()
-      .execute();
+    // This INSERT names only shared_space_person_face, but the FK check takes FOR KEY SHARE on each
+    // shared_space_person parent, in row order — an invisible deadlock participant against the
+    // representativeFaceId SET NULL cascade that a concurrent asset delete drives (#864). Claim the
+    // parents in id order first so this agrees with every other writer, and re-drive if it still loses.
+    const parentIds = [...new Set(values.map(({ personId }) => personId))].toSorted();
+
+    const result = await retryOnDeadlock(() =>
+      this.db.transaction().execute(async (trx) => {
+        await trx
+          .selectFrom('shared_space_person')
+          .select('id')
+          .where('id', 'in', parentIds)
+          .orderBy('id')
+          .forUpdate()
+          .execute();
+
+        return trx
+          .insertInto('shared_space_person_face')
+          .values(values)
+          .onConflict((oc) => oc.doNothing())
+          .returningAll()
+          .execute();
+      }),
+    );
 
     if (!options?.skipRecount && result.length > 0) {
       const personIds = [...new Set(result.map((r) => r.personId))];
@@ -3180,11 +3198,37 @@ export class SharedSpaceRepository {
 
   @GenerateSql({ params: [DummyValue.UUID] })
   async deleteOrphanedPersons(spaceId: string) {
-    await this.db
-      .deleteFrom('shared_space_person')
-      .where('spaceId', '=', spaceId)
-      .where('id', 'not in', this.db.selectFrom('shared_space_person_face').select('personId'))
-      .execute();
+    // onAssetDelete runs this immediately after recountPersons, so protecting only the recount
+    // just moves the deadlock victim onto this DELETE (#864). Same treatment: resolve the orphans
+    // and claim them in id order first, so this agrees on a lock order with every other writer,
+    // then re-drive if the representativeFaceId cascade still picks us as the victim.
+    await retryOnDeadlock(() =>
+      this.db.transaction().execute(async (trx) => {
+        const orphans = await trx
+          .selectFrom('shared_space_person')
+          .select('id')
+          .where('spaceId', '=', spaceId)
+          .where('id', 'not in', trx.selectFrom('shared_space_person_face').select('personId'))
+          .orderBy('id')
+          .forUpdate()
+          .execute();
+
+        if (orphans.length === 0) {
+          return;
+        }
+
+        await trx
+          .deleteFrom('shared_space_person')
+          .where(
+            'id',
+            'in',
+            orphans.map(({ id }) => id),
+          )
+          // re-checked under the claim: a person that gained a face must not be deleted
+          .where('id', 'not in', trx.selectFrom('shared_space_person_face').select('personId'))
+          .execute();
+      }),
+    );
   }
 
   @GenerateSql({ params: [DummyValue.UUID, [DummyValue.UUID]] })
@@ -3193,12 +3237,34 @@ export class SharedSpaceRepository {
       return;
     }
 
-    await this.db
-      .deleteFrom('shared_space_person')
-      .where('spaceId', '=', spaceId)
-      .where('id', 'in', personIds)
-      .where('id', 'not in', this.db.selectFrom('shared_space_person_face').select('personId'))
-      .execute();
+    // Same claim-then-delete ordering as deleteOrphanedPersons (#864).
+    await retryOnDeadlock(() =>
+      this.db.transaction().execute(async (trx) => {
+        const orphans = await trx
+          .selectFrom('shared_space_person')
+          .select('id')
+          .where('spaceId', '=', spaceId)
+          .where('id', 'in', [...new Set(personIds)].toSorted())
+          .where('id', 'not in', trx.selectFrom('shared_space_person_face').select('personId'))
+          .orderBy('id')
+          .forUpdate()
+          .execute();
+
+        if (orphans.length === 0) {
+          return;
+        }
+
+        await trx
+          .deleteFrom('shared_space_person')
+          .where(
+            'id',
+            'in',
+            orphans.map(({ id }) => id),
+          )
+          .where('id', 'not in', trx.selectFrom('shared_space_person_face').select('personId'))
+          .execute();
+      }),
+    );
   }
 
   @GenerateSql({ params: [] })

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -22,7 +22,7 @@ import { SharedSpacePersonAliasTable } from 'src/schema/tables/shared-space-pers
 import { SharedSpacePersonFaceTable } from 'src/schema/tables/shared-space-person-face.table';
 import { SharedSpacePersonTable } from 'src/schema/tables/shared-space-person.table';
 import { SharedSpaceTable } from 'src/schema/tables/shared-space.table';
-import { anyUuid, searchAssetBuilder } from 'src/utils/database';
+import { anyUuid, retryOnDeadlock, searchAssetBuilder } from 'src/utils/database';
 import {
   spaceAlbumAssetExists,
   spaceContributedAssetExists,
@@ -3240,10 +3240,16 @@ export class SharedSpaceRepository {
     // rows sorted by id first so every caller agrees on one global lock order.  The claim only
     // holds for the enclosing transaction, so open one when the caller did not supply it.
     if (db.isTransaction) {
+      // A deadlock aborts the caller's entire transaction, so retrying inside it would only raise
+      // "current transaction is aborted". Surfacing it lets the caller re-drive its own transaction.
       return this.recountPersonsLocked(personIds, db);
     }
 
-    return db.transaction().execute((trx) => this.recountPersonsLocked(personIds, trx));
+    // Ordering the claim removes recount-vs-recount cycles but cannot remove every cycle: deleting
+    // an asset makes Postgres lock these same rows to satisfy the representativeFaceId ON DELETE
+    // SET NULL cascade, in face-deletion order, so a recount can still be picked as the victim.
+    // Measured on the library-unmap repro at ~8.7k assets: 418 recount failures without this.
+    return retryOnDeadlock(() => db.transaction().execute((trx) => this.recountPersonsLocked(personIds, trx)));
   }
 
   private async recountPersonsLocked(personIds: string[], db: Kysely<DB> | Transaction<DB>) {

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -2950,11 +2950,16 @@ export class SharedSpaceRepository {
       .where('personId', 'in', spacePersonSubquery)
       .execute();
 
-    await this.db
-      .deleteFrom('shared_space_person_face')
-      .where('assetFaceId', 'in', assetFaceSubquery)
-      .where('personId', 'in', spacePersonSubquery)
-      .execute();
+    // Reached from unlinkLibrary / AlbumDelete / AlbumAssetsRemove — during the unmap itself. The
+    // asset_face cascade deletes these same junction rows, so the two can cycle (#864). A single
+    // statement is its own transaction, so re-running it is all the recovery needed.
+    await retryOnDeadlock(() =>
+      this.db
+        .deleteFrom('shared_space_person_face')
+        .where('assetFaceId', 'in', assetFaceSubquery)
+        .where('personId', 'in', spacePersonSubquery)
+        .execute(),
+    );
 
     if (affectedPersonIds.length > 0) {
       await this.recountPersons(affectedPersonIds.map((r) => r.personId));
@@ -2982,11 +2987,16 @@ export class SharedSpaceRepository {
       .where('personId', 'in', spacePersonSubquery)
       .execute();
 
-    await this.db
-      .deleteFrom('shared_space_person_face')
-      .where('assetFaceId', 'in', assetFaceSubquery)
-      .where('personId', 'in', spacePersonSubquery)
-      .execute();
+    // Reached from unlinkLibrary / AlbumDelete / AlbumAssetsRemove — during the unmap itself. The
+    // asset_face cascade deletes these same junction rows, so the two can cycle (#864). A single
+    // statement is its own transaction, so re-running it is all the recovery needed.
+    await retryOnDeadlock(() =>
+      this.db
+        .deleteFrom('shared_space_person_face')
+        .where('assetFaceId', 'in', assetFaceSubquery)
+        .where('personId', 'in', spacePersonSubquery)
+        .execute(),
+    );
 
     if (affectedPersonIds.length > 0) {
       await this.recountPersons(affectedPersonIds.map((r) => r.personId));

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -3234,6 +3234,27 @@ export class SharedSpaceRepository {
       return;
     }
 
+    // A multi-row UPDATE takes its row locks in scan order, and the planner may pick a different
+    // scan (so a different order) per connection.  Concurrent AssetDelete/face-match workers
+    // recounting overlapping people therefore deadlocked against each other (#864).  Claim the
+    // rows sorted by id first so every caller agrees on one global lock order.  The claim only
+    // holds for the enclosing transaction, so open one when the caller did not supply it.
+    if (db.isTransaction) {
+      return this.recountPersonsLocked(personIds, db);
+    }
+
+    return db.transaction().execute((trx) => this.recountPersonsLocked(personIds, trx));
+  }
+
+  private async recountPersonsLocked(personIds: string[], db: Kysely<DB> | Transaction<DB>) {
+    await db
+      .selectFrom('shared_space_person')
+      .select('id')
+      .where('id', 'in', personIds)
+      .orderBy('id')
+      .forUpdate()
+      .execute();
+
     await db
       .updateTable('shared_space_person')
       .set((eb) => ({

--- a/server/src/repositories/shared-space.repository.ts
+++ b/server/src/repositories/shared-space.repository.ts
@@ -3247,10 +3247,12 @@ export class SharedSpaceRepository {
   }
 
   private async recountPersonsLocked(personIds: string[], db: Kysely<DB> | Transaction<DB>) {
+    // Mirrors lockSpacePeopleForMerge, except a missing person is not an error here: a
+    // concurrent worker may legitimately have deleted an orphaned person before we recount it.
     await db
       .selectFrom('shared_space_person')
       .select('id')
-      .where('id', 'in', personIds)
+      .where('id', 'in', [...new Set(personIds)].toSorted())
       .orderBy('id')
       .forUpdate()
       .execute();

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -1564,6 +1564,36 @@ describe(AssetService.name, () => {
       expect(mocks.asset.remove).toHaveBeenCalledTimes(2);
     });
 
+    // A retry must re-drive only the delete. If it re-ran the surrounding work the asset would be
+    // announced as deleted twice and its files queued for deletion twice.
+    it('does not repeat the surrounding work when the delete is retried', async () => {
+      const asset = AssetFactory.from().build();
+      mocks.assetJob.getForAssetDeletion.mockResolvedValue(getForAssetDeletion(asset));
+      mocks.asset.remove
+        .mockRejectedValueOnce(Object.assign(new Error('deadlock detected'), { code: '40P01' }))
+        .mockResolvedValue(void 0);
+
+      await sut.handleAssetDeletion({ id: asset.id, deleteOnDisk: true });
+
+      expect(mocks.asset.remove).toHaveBeenCalledTimes(2);
+      expect(mocks.sharedSpace.getSpacePersonsForAsset).toHaveBeenCalledTimes(1);
+      expect(mocks.event.emit).toHaveBeenCalledTimes(1);
+      expect(mocks.job.queue).toHaveBeenCalledTimes(1);
+    });
+
+    it('fails the job when every retry is also a deadlock victim', async () => {
+      const asset = AssetFactory.from().build();
+      mocks.assetJob.getForAssetDeletion.mockResolvedValue(getForAssetDeletion(asset));
+      mocks.asset.remove.mockRejectedValue(Object.assign(new Error('deadlock detected'), { code: '40P01' }));
+
+      await expect(sut.handleAssetDeletion({ id: asset.id, deleteOnDisk: true })).rejects.toMatchObject({
+        code: '40P01',
+      });
+
+      // the deletion is never silently reported as done
+      expect(mocks.event.emit).not.toHaveBeenCalled();
+    });
+
     it('does not retry a delete that failed for a non-deadlock reason', async () => {
       const asset = AssetFactory.from().build();
       mocks.assetJob.getForAssetDeletion.mockResolvedValue(getForAssetDeletion(asset));

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -1581,16 +1581,21 @@ describe(AssetService.name, () => {
       expect(mocks.job.queue).toHaveBeenCalledTimes(1);
     });
 
-    it('fails the job when every retry is also a deadlock victim', async () => {
+    // Losing a deletion is the one genuinely harmful outcome here: the asset is already
+    // soft-deleted, so without a re-queue it lingers until the trash sweep runs, days later.
+    // Measured on the unmap repro — even a 5-attempt budget was exhausted once under load.
+    it('re-queues the deletion instead of losing it when every retry deadlocks', async () => {
       const asset = AssetFactory.from().build();
       mocks.assetJob.getForAssetDeletion.mockResolvedValue(getForAssetDeletion(asset));
       mocks.asset.remove.mockRejectedValue(Object.assign(new Error('deadlock detected'), { code: '40P01' }));
 
-      await expect(sut.handleAssetDeletion({ id: asset.id, deleteOnDisk: true })).rejects.toMatchObject({
-        code: '40P01',
-      });
+      await expect(sut.handleAssetDeletion({ id: asset.id, deleteOnDisk: true })).resolves.toBe(JobStatus.Skipped);
 
-      // the deletion is never silently reported as done
+      expect(mocks.job.queue).toHaveBeenCalledWith({
+        name: JobName.AssetDelete,
+        data: { id: asset.id, deleteOnDisk: true },
+      });
+      // the deletion is never reported as done
       expect(mocks.event.emit).not.toHaveBeenCalled();
     });
 

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -1548,6 +1548,34 @@ describe(AssetService.name, () => {
   });
 
   describe('handleAssetDeletion', () => {
+    // Deleting an asset makes Postgres lock shared_space_person itself to satisfy the
+    // representativeFaceId ON DELETE SET NULL foreign key, in face-deletion order. That cycles
+    // against concurrent space-people recounts and no application-level ordering can prevent it,
+    // so a deadlock victim must be re-driven or the asset silently survives the delete (#864).
+    it('retries the delete when postgres picks it as a deadlock victim', async () => {
+      const asset = AssetFactory.from().build();
+      mocks.assetJob.getForAssetDeletion.mockResolvedValue(getForAssetDeletion(asset));
+      mocks.asset.remove
+        .mockRejectedValueOnce(Object.assign(new Error('deadlock detected'), { code: '40P01' }))
+        .mockResolvedValue(void 0);
+
+      await expect(sut.handleAssetDeletion({ id: asset.id, deleteOnDisk: true })).resolves.toBe(JobStatus.Success);
+
+      expect(mocks.asset.remove).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retry a delete that failed for a non-deadlock reason', async () => {
+      const asset = AssetFactory.from().build();
+      mocks.assetJob.getForAssetDeletion.mockResolvedValue(getForAssetDeletion(asset));
+      mocks.asset.remove.mockRejectedValue(Object.assign(new Error('nope'), { code: '23503' }));
+
+      await expect(sut.handleAssetDeletion({ id: asset.id, deleteOnDisk: true })).rejects.toMatchObject({
+        code: '23503',
+      });
+
+      expect(mocks.asset.remove).toHaveBeenCalledTimes(1);
+    });
+
     it('should clean up files', async () => {
       const asset = AssetFactory.from()
         .file({ type: AssetFileType.Thumbnail })

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -56,7 +56,7 @@ import {
   onBeforeLink,
   onBeforeUnlink,
 } from 'src/utils/asset.util';
-import { retryOnDeadlock, updateLockedColumns } from 'src/utils/database';
+import { isDeadlockError, retryOnDeadlock, updateLockedColumns } from 'src/utils/database';
 import { asDateTimeString, extractTimeZone } from 'src/utils/date';
 import { applyResolvedIdentityMetadata } from 'src/utils/person-identity';
 import { transformOcrBoundingBox } from 'src/utils/transform';
@@ -618,7 +618,20 @@ export class AssetService extends BaseService {
     // The delete cascades into asset_face, which makes Postgres lock shared_space_person rows to
     // null out representativeFaceId. Those locks are taken in face order, so they can cycle against
     // a concurrent space-people recount. Re-drive the victim rather than lose the deletion (#864).
-    await retryOnDeadlock(() => this.assetRepository.remove(asset));
+    try {
+      await retryOnDeadlock(() => this.assetRepository.remove(asset));
+    } catch (error) {
+      if (!isDeadlockError(error)) {
+        throw error;
+      }
+
+      // Still contended after the whole budget. The asset is already soft-deleted, so dropping it
+      // here would leave it behind until the trash sweep runs days later. Re-queue instead: the
+      // job goes to the back of the queue, by which point the delete storm has usually drained.
+      this.logger.warn(`Re-queueing deletion of asset ${id}: still deadlocking after repeated retries`);
+      await this.jobRepository.queue({ name: JobName.AssetDelete, data: { id, deleteOnDisk } });
+      return JobStatus.Skipped;
+    }
     if (!asset.libraryId) {
       await this.userRepository.updateUsage(asset.ownerId, -(asset.exifInfo?.fileSizeInByte || 0));
     }

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -56,7 +56,7 @@ import {
   onBeforeLink,
   onBeforeUnlink,
 } from 'src/utils/asset.util';
-import { updateLockedColumns } from 'src/utils/database';
+import { retryOnDeadlock, updateLockedColumns } from 'src/utils/database';
 import { asDateTimeString, extractTimeZone } from 'src/utils/date';
 import { applyResolvedIdentityMetadata } from 'src/utils/person-identity';
 import { transformOcrBoundingBox } from 'src/utils/transform';
@@ -615,7 +615,10 @@ export class AssetService extends BaseService {
     // handler in SharedSpaceService receives this data and recounts/cleans up after the delete.
     const affectedSpacePersons = await this.sharedSpaceRepository.getSpacePersonsForAsset(id);
 
-    await this.assetRepository.remove(asset);
+    // The delete cascades into asset_face, which makes Postgres lock shared_space_person rows to
+    // null out representativeFaceId. Those locks are taken in face order, so they can cycle against
+    // a concurrent space-people recount. Re-drive the victim rather than lose the deletion (#864).
+    await retryOnDeadlock(() => this.assetRepository.remove(asset));
     if (!asset.libraryId) {
       await this.userRepository.updateUsage(asset.ownerId, -(asset.exifInfo?.fileSizeInByte || 0));
     }

--- a/server/src/utils/database.spec.ts
+++ b/server/src/utils/database.spec.ts
@@ -419,6 +419,18 @@ describe('retryOnDeadlock', () => {
     expect(attempts).toBe(1);
   });
 
+  it('defaults to a budget deep enough to ride out a real delete storm', async () => {
+    let attempts = 0;
+    const operation = () => {
+      attempts++;
+      return Promise.reject(deadlockError());
+    };
+
+    await expect(retryOnDeadlock(operation, { delayMs: 0 })).rejects.toMatchObject({ code: '40P01' });
+    // measured: at ~8.7k concurrent asset deletes a budget of 3 still let one delete through
+    expect(attempts).toBe(5);
+  });
+
   it('gives up and rethrows once the attempt budget is spent', async () => {
     let attempts = 0;
     const operation = () => {

--- a/server/src/utils/database.spec.ts
+++ b/server/src/utils/database.spec.ts
@@ -2,6 +2,7 @@ import { DatabaseExtension } from 'src/enum';
 import {
   ASSET_CHECKSUM_CONSTRAINT,
   isAssetChecksumConstraint,
+  isDeadlockError,
   removeUndefinedKeys,
   retryOnDeadlock,
   tokenizeForSearch,
@@ -339,7 +340,63 @@ describe('updateLockedColumns', () => {
 
 const deadlockError = () => Object.assign(new Error('deadlock detected'), { code: '40P01' });
 
+describe('isDeadlockError', () => {
+  it('recognises the postgres deadlock code', () => {
+    expect(isDeadlockError({ code: '40P01' })).toBe(true);
+  });
+
+  it('rejects other postgres error codes', () => {
+    expect(isDeadlockError({ code: '23503' })).toBe(false);
+  });
+
+  it('tolerates values that are not postgres errors', () => {
+    expect(isDeadlockError(null)).toBe(false);
+    expect(isDeadlockError(void 0)).toBe(false);
+    expect(isDeadlockError(new Error('boom'))).toBe(false);
+    expect(isDeadlockError('deadlock detected')).toBe(false);
+  });
+});
+
 describe('retryOnDeadlock', () => {
+  it('returns the result without retrying when the operation succeeds first time', async () => {
+    let attempts = 0;
+    const operation = () => {
+      attempts++;
+      return Promise.resolve('first');
+    };
+
+    await expect(retryOnDeadlock(operation)).resolves.toBe('first');
+    expect(attempts).toBe(1);
+  });
+
+  it('does not retry at all when only one attempt is budgeted', async () => {
+    let attempts = 0;
+    const operation = () => {
+      attempts++;
+      return Promise.reject(deadlockError());
+    };
+
+    await expect(retryOnDeadlock(operation, { attempts: 1, delayMs: 0 })).rejects.toMatchObject({ code: '40P01' });
+    expect(attempts).toBe(1);
+  });
+
+  it('rethrows the original error object once it gives up', async () => {
+    const error = deadlockError();
+
+    await expect(retryOnDeadlock(() => Promise.reject(error), { attempts: 2, delayMs: 0 })).rejects.toBe(error);
+  });
+
+  it('does not retry rejections that carry no error code', async () => {
+    let attempts = 0;
+    const operation = () => {
+      attempts++;
+      return Promise.reject(new Error('plain failure'));
+    };
+
+    await expect(retryOnDeadlock(operation, { delayMs: 0 })).rejects.toThrow('plain failure');
+    expect(attempts).toBe(1);
+  });
+
   it('retries a deadlocked operation and returns the eventual result', async () => {
     let attempts = 0;
     const operation = () => {

--- a/server/src/utils/database.spec.ts
+++ b/server/src/utils/database.spec.ts
@@ -3,6 +3,7 @@ import {
   ASSET_CHECKSUM_CONSTRAINT,
   isAssetChecksumConstraint,
   removeUndefinedKeys,
+  retryOnDeadlock,
   tokenizeForSearch,
   updateLockedColumns,
   vectorIndexQuery,
@@ -333,5 +334,42 @@ describe('updateLockedColumns', () => {
     const exif = { description: 'test', lockedProperties: ['old'] } as any;
     const result = updateLockedColumns(exif);
     expect(result.lockedProperties).toEqual(['description']);
+  });
+});
+
+const deadlockError = () => Object.assign(new Error('deadlock detected'), { code: '40P01' });
+
+describe('retryOnDeadlock', () => {
+  it('retries a deadlocked operation and returns the eventual result', async () => {
+    let attempts = 0;
+    const operation = () => {
+      attempts++;
+      return attempts < 3 ? Promise.reject(deadlockError()) : Promise.resolve('done');
+    };
+
+    await expect(retryOnDeadlock(operation, { delayMs: 0 })).resolves.toBe('done');
+    expect(attempts).toBe(3);
+  });
+
+  it('does not retry errors that are not deadlocks', async () => {
+    let attempts = 0;
+    const operation = () => {
+      attempts++;
+      return Promise.reject(Object.assign(new Error('violates foreign key constraint'), { code: '23503' }));
+    };
+
+    await expect(retryOnDeadlock(operation, { delayMs: 0 })).rejects.toMatchObject({ code: '23503' });
+    expect(attempts).toBe(1);
+  });
+
+  it('gives up and rethrows once the attempt budget is spent', async () => {
+    let attempts = 0;
+    const operation = () => {
+      attempts++;
+      return Promise.reject(deadlockError());
+    };
+
+    await expect(retryOnDeadlock(operation, { attempts: 4, delayMs: 0 })).rejects.toMatchObject({ code: '40P01' });
+    expect(attempts).toBe(4);
   });
 });

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -15,6 +15,7 @@ import {
 } from 'kysely';
 import { PostgresJSDialect } from 'kysely-postgres-js';
 import { jsonArrayFrom, jsonObjectFrom } from 'kysely/helpers/postgres';
+import { setTimeout as sleep } from 'node:timers/promises';
 import { Notice, PostgresError } from 'postgres';
 import { columns, lockableProperties, LockableProperty, Person } from 'src/database';
 import { AssetEditActionItem } from 'src/dtos/editing.dto';
@@ -100,6 +101,39 @@ export const isStaleAssetForeignKeyConstraint = (error: unknown) => {
     postgresError.constraint_name !== undefined &&
     STALE_ASSET_FOREIGN_KEY_CONSTRAINTS.has(postgresError.constraint_name)
   );
+};
+
+const DEADLOCK_ERROR_CODE = '40P01';
+
+export const isDeadlockError = (error: unknown) => (error as PostgresError)?.code === DEADLOCK_ERROR_CODE;
+
+/**
+ * Retry an operation that Postgres aborted as a deadlock victim (#864).
+ *
+ * Lock ordering alone cannot prevent every cycle here: deleting an asset makes Postgres lock
+ * `shared_space_person` rows itself, to satisfy the `representativeFaceId` ON DELETE SET NULL
+ * foreign key, and it takes those locks in face-deletion order. No application-level ordering can
+ * join that sequence, so the losing transaction has to be re-driven instead.
+ */
+export const retryOnDeadlock = async <T>(
+  operation: () => Promise<T>,
+  options?: { attempts?: number; delayMs?: number },
+): Promise<T> => {
+  const attempts = options?.attempts ?? 3;
+  const delayMs = options?.delayMs ?? 50;
+
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (attempt >= attempts || !isDeadlockError(error)) {
+        throw error;
+      }
+
+      // Jittered backoff — concurrent victims that retry in lockstep just collide again.
+      await sleep(delayMs * attempt + Math.random() * delayMs);
+    }
+  }
 };
 
 export function withDefaultVisibility<O>(qb: SelectQueryBuilder<DB, 'asset', O>) {

--- a/server/src/utils/database.ts
+++ b/server/src/utils/database.ts
@@ -119,7 +119,9 @@ export const retryOnDeadlock = async <T>(
   operation: () => Promise<T>,
   options?: { attempts?: number; delayMs?: number },
 ): Promise<T> => {
-  const attempts = options?.attempts ?? 3;
+  // 5, not 3: measured on the library-unmap repro at ~8.7k concurrent asset deletes, a budget of 3
+  // still let one delete exhaust its attempts and lose the deletion.
+  const attempts = options?.attempts ?? 5;
   const delayMs = options?.delayMs ?? 50;
 
   for (let attempt = 1; ; attempt++) {

--- a/server/test/medium/specs/repositories/face-identity-space-face-move.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity-space-face-move.spec.ts
@@ -1,0 +1,82 @@
+import { Kysely } from 'kysely';
+import { AssetVisibility } from 'src/enum';
+import { FaceIdentityRepository } from 'src/repositories/face-identity.repository';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { DB } from 'src/schema';
+import { BaseService } from 'src/services/base.service';
+import { newMediumService } from 'test/medium.factory';
+import { newEmbedding } from 'test/small.factory';
+import { getKyselyDB } from 'test/utils';
+
+let database: Kysely<DB>;
+
+const setup = () => {
+  const { ctx } = newMediumService(BaseService, { database, real: [], mock: [LoggingRepository] });
+  return { ctx, sut: ctx.get(FaceIdentityRepository) };
+};
+
+beforeAll(async () => {
+  database = await getKyselyDB('facemove864');
+});
+
+describe(`${FaceIdentityRepository.name} space face move (#864)`, () => {
+  // Orphan cleanup runs concurrently with the identity backfill during a library unmap, so the
+  // person the backfill resolved as its move target can be deleted before the move executes.
+  // Reassigning onto a missing person violates shared_space_person_face_personId_fkey and kills
+  // the whole FaceIdentityBackfill job.
+  it('skips the move when the target person no longer exists', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+
+    const identity = await database
+      .insertInto('face_identity')
+      .values({ type: 'person' })
+      .returning('id')
+      .executeTakeFirstOrThrow();
+    const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Alice' });
+    const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    await database.insertInto('face_search').values({ faceId: assetFace.id, embedding: newEmbedding() }).execute();
+    await database
+      .insertInto('face_identity_face')
+      .values({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' })
+      .execute();
+
+    const source = await database
+      .insertInto('shared_space_person')
+      .values({ spaceId: space.id, identityId: identity.id })
+      .returning('id')
+      .executeTakeFirstOrThrow();
+    await database
+      .insertInto('shared_space_person_face')
+      .values({ personId: source.id, assetFaceId: assetFace.id })
+      .execute();
+
+    const move = (
+      sut as unknown as {
+        moveSpacePersonFacesForIdentity: (input: {
+          fromPersonId: string;
+          toPersonId: string;
+          identityId: string;
+        }) => Promise<void>;
+      }
+    ).moveSpacePersonFacesForIdentity.bind(sut);
+
+    // The target was deleted by orphan cleanup between resolution and the move.
+    const deletedTargetId = '00000000-0000-4000-8000-000000000864';
+
+    await expect(
+      move({ fromPersonId: source.id, toPersonId: deletedTargetId, identityId: identity.id }),
+    ).resolves.not.toThrow();
+
+    // the face stays attached to its original person rather than being orphaned
+    await expect(
+      database
+        .selectFrom('shared_space_person_face')
+        .select('personId')
+        .where('assetFaceId', '=', assetFace.id)
+        .executeTakeFirst(),
+    ).resolves.toEqual({ personId: source.id });
+  });
+});

--- a/server/test/medium/specs/repositories/face-identity-space-face-move.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity-space-face-move.spec.ts
@@ -19,6 +19,38 @@ beforeAll(async () => {
   database = await getKyselyDB('facemove864');
 });
 
+const seedFace = async (ctx: any, userId: string, identityId: string) => {
+  const { person } = await ctx.newPerson({ ownerId: userId, name: 'Alice' });
+  const { asset } = await ctx.newAsset({ ownerId: userId, visibility: AssetVisibility.Timeline });
+  const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+  await database.insertInto('face_search').values({ faceId: assetFace.id, embedding: newEmbedding() }).execute();
+  await database
+    .insertInto('face_identity_face')
+    .values({ assetFaceId: assetFace.id, identityId, source: 'owner-person' })
+    .execute();
+  return assetFace;
+};
+
+const newIdentity = () =>
+  database.insertInto('face_identity').values({ type: 'person' }).returning('id').executeTakeFirstOrThrow();
+
+const newSpacePerson = (spaceId: string, identityId: string) =>
+  database.insertInto('shared_space_person').values({ spaceId, identityId }).returning('id').executeTakeFirstOrThrow();
+
+const moveOn = (sut: FaceIdentityRepository) =>
+  (
+    sut as unknown as {
+      moveSpacePersonFacesForIdentity: (input: {
+        fromPersonId: string;
+        toPersonId: string;
+        identityId: string;
+      }) => Promise<void>;
+    }
+  ).moveSpacePersonFacesForIdentity.bind(sut);
+
+const facesOf = (personId: string) =>
+  database.selectFrom('shared_space_person_face').select('assetFaceId').where('personId', '=', personId).execute();
+
 describe(`${FaceIdentityRepository.name} space face move (#864)`, () => {
   // Orphan cleanup runs concurrently with the identity backfill during a library unmap, so the
   // person the backfill resolved as its move target can be deleted before the move executes.
@@ -78,5 +110,73 @@ describe(`${FaceIdentityRepository.name} space face move (#864)`, () => {
         .where('assetFaceId', '=', assetFace.id)
         .executeTakeFirst(),
     ).resolves.toEqual({ personId: source.id });
+  });
+
+  // Guards the behaviour the #864 fix must NOT break: with a live target the move still happens.
+  it('moves the faces when the target person exists', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    const identity = await newIdentity();
+    const assetFace = await seedFace(ctx, user.id, identity.id);
+    const source = await newSpacePerson(space.id, identity.id);
+    const target = await newSpacePerson(space.id, null as unknown as string);
+    await database
+      .insertInto('shared_space_person_face')
+      .values({ personId: source.id, assetFaceId: assetFace.id })
+      .execute();
+
+    await moveOn(sut)({ fromPersonId: source.id, toPersonId: target.id, identityId: identity.id });
+
+    await expect(facesOf(target.id)).resolves.toEqual([{ assetFaceId: assetFace.id }]);
+    await expect(facesOf(source.id)).resolves.toEqual([]);
+  });
+
+  // The target may already hold the same face; moving would violate the (personId, assetFaceId)
+  // uniqueness, so the source row is dropped instead.
+  it('drops the source row when the target already holds that face', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    const identity = await newIdentity();
+    const assetFace = await seedFace(ctx, user.id, identity.id);
+    const source = await newSpacePerson(space.id, identity.id);
+    const target = await newSpacePerson(space.id, null as unknown as string);
+    await database
+      .insertInto('shared_space_person_face')
+      .values([
+        { personId: source.id, assetFaceId: assetFace.id },
+        { personId: target.id, assetFaceId: assetFace.id },
+      ])
+      .execute();
+
+    await moveOn(sut)({ fromPersonId: source.id, toPersonId: target.id, identityId: identity.id });
+
+    await expect(facesOf(source.id)).resolves.toEqual([]);
+    await expect(facesOf(target.id)).resolves.toEqual([{ assetFaceId: assetFace.id }]);
+  });
+
+  it('moves only the faces of the requested identity, leaving others behind', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    const identity = await newIdentity();
+    const otherIdentity = await newIdentity();
+    const matchingFace = await seedFace(ctx, user.id, identity.id);
+    const otherFace = await seedFace(ctx, user.id, otherIdentity.id);
+    const source = await newSpacePerson(space.id, identity.id);
+    const target = await newSpacePerson(space.id, null as unknown as string);
+    await database
+      .insertInto('shared_space_person_face')
+      .values([
+        { personId: source.id, assetFaceId: matchingFace.id },
+        { personId: source.id, assetFaceId: otherFace.id },
+      ])
+      .execute();
+
+    await moveOn(sut)({ fromPersonId: source.id, toPersonId: target.id, identityId: identity.id });
+
+    await expect(facesOf(target.id)).resolves.toEqual([{ assetFaceId: matchingFace.id }]);
+    await expect(facesOf(source.id)).resolves.toEqual([{ assetFaceId: otherFace.id }]);
   });
 });

--- a/server/test/medium/specs/repositories/shared-space-person-recount-deadlock.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space-person-recount-deadlock.spec.ts
@@ -97,6 +97,39 @@ describe(`${SharedSpaceRepository.name}.recountPersons (#864)`, () => {
     ).resolves.toEqual({ faceCount: 0, assetCount: 0 });
   });
 
+  it('is a no-op for an empty id list', async () => {
+    const { sut } = setup();
+    await expect(sut.recountPersons([])).resolves.toBeUndefined();
+  });
+
+  // Orphan cleanup can delete a person before the recount that was queued for it runs, so unknown
+  // ids must be tolerated rather than throwing.
+  it('tolerates ids that no longer exist', async () => {
+    const { sut } = setup();
+    await expect(sut.recountPersons(['00000000-0000-4000-8000-0000000f0864'])).resolves.toBeUndefined();
+  });
+
+  it('handles a duplicated id without double-counting', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    const { id } = await database
+      .insertInto('shared_space_person')
+      .values({ spaceId: space.id, faceCount: 7, assetCount: 7 })
+      .returning('id')
+      .executeTakeFirstOrThrow();
+
+    await sut.recountPersons([id, id, id]);
+
+    await expect(
+      database
+        .selectFrom('shared_space_person')
+        .select(['faceCount', 'assetCount'])
+        .where('id', '=', id)
+        .executeTakeFirst(),
+    ).resolves.toEqual({ faceCount: 0, assetCount: 0 });
+  });
+
   // The isTransaction branch must join the caller's transaction rather than opening its own —
   // otherwise the recount would commit independently and survive the caller's rollback.
   it('joins a caller-supplied transaction instead of committing on its own', async () => {

--- a/server/test/medium/specs/repositories/shared-space-person-recount-deadlock.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space-person-recount-deadlock.spec.ts
@@ -1,0 +1,78 @@
+import { Kysely, sql } from 'kysely';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
+import { DB } from 'src/schema';
+import { BaseService } from 'src/services/base.service';
+import { newMediumService } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let database: Kysely<DB>;
+
+const setup = () => {
+  const { ctx } = newMediumService(BaseService, {
+    database,
+    real: [],
+    mock: [LoggingRepository],
+  });
+  return { ctx, sut: ctx.get(SharedSpaceRepository) };
+};
+
+// Explicit ids so that UUID order and physical (insertion) order are exact reverses of each
+// other. An index scan walks these ascending; a bitmap heap scan walks them in insertion order.
+// That makes the two lock orders provably opposite instead of relying on random uuids.
+const ASCENDING = [
+  '11111111-1111-4111-8111-111111111111',
+  '22222222-2222-4222-8222-222222222222',
+  '33333333-3333-4333-8333-333333333333',
+  '44444444-4444-4444-8444-444444444444',
+];
+
+beforeAll(async () => {
+  database = await getKyselyDB('deadlock864');
+
+  // Widen the per-row window so the two statements are guaranteed to interleave mid-scan.
+  // Without this the deadlock is a genuine race and the test would be flaky.
+  await sql`
+    create or replace function medium_test_slow_row() returns trigger language plpgsql as $$
+    begin
+      perform pg_sleep(0.3);
+      return new;
+    end $$;
+  `.execute(database);
+  await sql`
+    create trigger medium_test_slow_row before update on shared_space_person
+    for each row execute function medium_test_slow_row();
+  `.execute(database);
+});
+
+describe(`${SharedSpaceRepository.name}.recountPersons (#864)`, () => {
+  it('does not deadlock when concurrent callers scan the same people in opposite orders', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+
+    // Insert descending so physical order is the reverse of uuid order.
+    for (const id of ASCENDING.toReversed()) {
+      await database.insertInto('shared_space_person').values({ id, spaceId: space.id }).execute();
+    }
+
+    // Two pinned connections, each forced onto a different scan strategy — this is what two
+    // concurrent AssetDelete workers hit in production when the planner picks differently.
+    const recountOn = (planner: string) =>
+      database.connection().execute(async (connection) => {
+        await sql.raw(planner).execute(connection);
+        await sut.recountPersons(ASCENDING, connection);
+      });
+
+    const indexScan = recountOn('set enable_bitmapscan = off; set enable_seqscan = off;');
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    const bitmapScan = recountOn('set enable_indexscan = off; set enable_seqscan = off;');
+
+    const results = await Promise.allSettled([indexScan, bitmapScan]);
+
+    const deadlocked = results.filter(
+      (result) => result.status === 'rejected' && String(result.reason).includes('deadlock'),
+    );
+    expect(deadlocked).toEqual([]);
+  });
+});

--- a/server/test/medium/specs/repositories/shared-space-person-recount-deadlock.spec.ts
+++ b/server/test/medium/specs/repositories/shared-space-person-recount-deadlock.spec.ts
@@ -75,4 +75,54 @@ describe(`${SharedSpaceRepository.name}.recountPersons (#864)`, () => {
     );
     expect(deadlocked).toEqual([]);
   });
+
+  it('recounts stale counters down to zero when the person has no visible faces', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    const { id } = await database
+      .insertInto('shared_space_person')
+      .values({ spaceId: space.id, faceCount: 99, assetCount: 99 })
+      .returning('id')
+      .executeTakeFirstOrThrow();
+
+    await sut.recountPersons([id]);
+
+    await expect(
+      database
+        .selectFrom('shared_space_person')
+        .select(['faceCount', 'assetCount'])
+        .where('id', '=', id)
+        .executeTakeFirst(),
+    ).resolves.toEqual({ faceCount: 0, assetCount: 0 });
+  });
+
+  // The isTransaction branch must join the caller's transaction rather than opening its own —
+  // otherwise the recount would commit independently and survive the caller's rollback.
+  it('joins a caller-supplied transaction instead of committing on its own', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: user.id, faceRecognitionEnabled: true });
+    const { id } = await database
+      .insertInto('shared_space_person')
+      .values({ spaceId: space.id, faceCount: 99, assetCount: 99 })
+      .returning('id')
+      .executeTakeFirstOrThrow();
+
+    const rollback = new Error('rollback');
+    await expect(
+      database.transaction().execute(async (trx) => {
+        await sut.recountPersons([id], trx);
+        throw rollback;
+      }),
+    ).rejects.toBe(rollback);
+
+    await expect(
+      database
+        .selectFrom('shared_space_person')
+        .select(['faceCount', 'assetCount'])
+        .where('id', '=', id)
+        .executeTakeFirst(),
+    ).resolves.toEqual({ faceCount: 99, assetCount: 99 });
+  });
 });


### PR DESCRIPTION
Fixes #864.

Deleting/re-adding an external library mapped to a Space deadlocks repeatedly on `shared_space_person`, spamming `Failed to sync space people after deleting asset` and, in the reporter's first report, taking the server down.

## Root cause

Deleting an asset cascades `asset` → `asset_face`, and the `shared_space_person.representativeFaceId` foreign key is `ON DELETE SET NULL`. So **PostgreSQL itself** locks `shared_space_person` rows, in face-deletion order — an order no application code can join. Five concurrent `AssetDelete` workers then cycle against that cascade and against each other.

The deadlock is therefore not fully preventable by ordering alone. The fix is two-part: make every application lock site agree on one order, and re-drive whatever Postgres still kills.

## What changed

**Canonical lock order** — claim rows `ORDER BY id FOR UPDATE` inside a transaction before writing:
`recountPersons`, `deleteOrphanedPersons` / `ByIds`, `addPersonFaces`, `recountSpacePersons`, `deleteOrphanedSpacePersons`, `moveSpacePersonFacesForIdentity`.

**Bounded retry** (`retryOnDeadlock`, 5 attempts, jittered backoff) on every owned transaction. Never inside a caller-supplied transaction — a deadlock has already aborted that one, so retrying there would only raise `current transaction is aborted`.

**Asset deletion re-queued** if it still deadlocks after the whole budget, so a deletion is never silently lost.

**Two latent bugs found along the way:**
- `moveSpacePersonFacesForIdentity` reassigned faces onto a person that concurrent orphan cleanup had deleted → `shared_space_person_face_personId_fkey` violation that killed `FaceIdentityBackfill`. Now claims the target and skips if it is gone.
- `predict()` treated an `AbortSignal.timeout` as a generic failure (undici rejects with `TimeoutError`, not `AbortError`), so a timeout on one ML server marked every *other* server unhealthy without ever contacting them.

## Verification

Reproduced end to end: real external library, face-enabled Space, full ML pipeline, then unmap — scaled to ~8,700 assets to match the reporter's volume.

| | v5.2.2 | this branch |
|---|---|---|
| Deadlocks | 435 / 429 / 389 | 0 / 0 / 10 |
| `Failed to sync space people` | 418 / 422 / 379 | **0** |
| Lost deletions | — | **0** |
| Orphaned faces | — | **0** |

Residual deadlocks are detected by Postgres and absorbed by the retries — no job failure, no data loss. That is the expected end state given the cascade's lock order is not ours to control.

A static audit of every explicit and implicit lock path on `shared_space_person*` backs this up: only two tables reference it, there are no trigger-based paths, and every remaining path is FK referential integrity.

## Notes

- Server-only; no schema change, no migration, no API change.
- `AssetDeleteCheck` still sweeps anything a re-queue misses.
- Not addressed here: the microservices worker taking the whole server down when it dies (`main.ts:151-160`) — upstream behaviour, worth a separate decision.