### PR TITLE
fix(web): keep locked-folder photos out of palette results and recents (#869)

### DIFF
--- a/web/src/lib/components/global-search/__tests__/global-search.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search.spec.ts
@@ -98,6 +98,9 @@ vi.mock('@immich/sdk', async () => {
       hasUnnamedPeople: false,
     }),
     getMlHealth: vi.fn().mockResolvedValue({ smartSearchHealthy: true }),
+    // open() revalidates photo recents (#869). Stub it so specs that seed a photo row
+    // resolve it locally instead of firing an unmocked request at the dev server.
+    getAssetInfo: vi.fn().mockResolvedValue({ id: 'stub' }),
   };
 });
 

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -5,6 +5,7 @@ import {
   getAllPeople,
   getAllSpaces,
   getAllTags,
+  getAssetInfo,
   getMlHealth,
   getSpace,
   searchAssets,
@@ -131,6 +132,7 @@ vi.mock('@immich/sdk', async () => ({
   getAlbumNames: vi.fn(),
   getAllSpaces: vi.fn(),
   getAlbumInfo: vi.fn(),
+  getAssetInfo: vi.fn(),
   getSpace: vi.fn(),
   // Default bare-@ tests in prior suites rely on an empty-people baseline so the
   // people section lands at `empty` (not `ok`) when a test doesn't set its own mock.
@@ -626,6 +628,35 @@ describe('real providers', () => {
     expect(searchAssets).toHaveBeenCalledWith(
       expect.objectContaining({
         metadataSearchDto: expect.objectContaining({ ocr: 'ACME' }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  // #869: the palette omitted `visibility`, so the server default applied — and for an
+  // elevated session that default is "no filter", which pulled locked-folder assets into
+  // ordinary palette results. Pin Timeline the way the main search page already does
+  // (search/+page.svelte), so palette results never depend on the PIN state.
+  it('photos pins visibility to timeline in smart mode', async () => {
+    const m = new GlobalSearchManager();
+    m.setQuery('beach');
+    await vi.advanceTimersByTimeAsync(200);
+    expect(searchSmart).toHaveBeenCalledWith(
+      expect.objectContaining({
+        smartSearchDto: expect.objectContaining({ visibility: AssetVisibility.Timeline }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('photos pins visibility to timeline in metadata mode', async () => {
+    localStorage.setItem('searchQueryType', 'metadata');
+    const m = new GlobalSearchManager();
+    m.setQuery('IMG_0042');
+    await vi.advanceTimersByTimeAsync(200);
+    expect(searchAssets).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadataSearchDto: expect.objectContaining({ visibility: AssetVisibility.Timeline }),
       }),
       expect.anything(),
     );
@@ -2876,6 +2907,86 @@ describe('topSearchMatch', () => {
 
     m.query = '@alice';
     expect(m.topSearchMatch).toBeNull();
+  });
+});
+
+// #869: a photo recent is written to localStorage with its filename and nothing ever
+// re-checked it. Moving that photo into the locked folder left the filename sitting in
+// RECENT — visible without the PIN — until the user removed the row by hand. Re-check
+// photo entries when the palette opens and drop the ones the server no longer returns.
+describe('photo recents revalidation', () => {
+  const photoEntry = { kind: 'photo' as const, id: 'photo:a1', assetId: 'a1', label: 'private.jpg', lastUsed: 1 };
+  const httpError = (status: number) => Object.assign(new Error(`HTTP ${status}`), { status });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    localStorage.clear();
+    resetRecentStore();
+  });
+
+  // 400 sits alongside 403/404 because Gallery's requireAccess middleware answers
+  // BadRequestException for both "row missing" and "no access" — same reasoning as
+  // activateAlbum's stale-entry branch.
+  it.each([400, 403, 404])('drops a photo recent the server refuses with %i', async (status) => {
+    addEntry(photoEntry);
+    vi.mocked(getAssetInfo).mockRejectedValue(httpError(status));
+
+    const m = new GlobalSearchManager();
+    await m.validatePhotoRecents();
+
+    expect(getEntries()).toEqual([]);
+  });
+
+  it('keeps a photo recent the user can still open', async () => {
+    addEntry(photoEntry);
+    vi.mocked(getAssetInfo).mockResolvedValue({ id: 'a1' } as unknown as Awaited<ReturnType<typeof getAssetInfo>>);
+
+    const m = new GlobalSearchManager();
+    await m.validatePhotoRecents();
+
+    expect(getEntries().map((entry) => entry.id)).toEqual(['photo:a1']);
+  });
+
+  // A dropped connection must not erase history — only an explicit refusal does.
+  it('keeps a photo recent when the request fails without a status', async () => {
+    addEntry(photoEntry);
+    vi.mocked(getAssetInfo).mockRejectedValue(new Error('network down'));
+
+    const m = new GlobalSearchManager();
+    await m.validatePhotoRecents();
+
+    expect(getEntries().map((entry) => entry.id)).toEqual(['photo:a1']);
+  });
+
+  it('leaves non-photo recents alone', async () => {
+    addEntry({ kind: 'query', id: 'query:beach', text: 'beach', lastUsed: 1 });
+
+    const m = new GlobalSearchManager();
+    await m.validatePhotoRecents();
+
+    expect(getAssetInfo).not.toHaveBeenCalled();
+    expect(getEntries().map((entry) => entry.id)).toEqual(['query:beach']);
+  });
+
+  it('bumps recentsRevision so an open palette re-renders without the dropped row', async () => {
+    addEntry(photoEntry);
+    vi.mocked(getAssetInfo).mockRejectedValue(httpError(400));
+
+    const m = new GlobalSearchManager();
+    const before = m.recentsRevision;
+    await m.validatePhotoRecents();
+
+    expect(m.recentsRevision).toBeGreaterThan(before);
+  });
+
+  it('revalidates when the palette opens', async () => {
+    addEntry(photoEntry);
+    vi.mocked(getAssetInfo).mockRejectedValue(httpError(400));
+
+    const m = new GlobalSearchManager();
+    m.open();
+
+    await vi.waitFor(() => expect(getEntries()).toEqual([]));
   });
 });
 

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -2939,12 +2939,33 @@ describe('photo recents revalidation', () => {
 
   it('keeps a photo recent the user can still open', async () => {
     addEntry(photoEntry);
-    vi.mocked(getAssetInfo).mockResolvedValue({ id: 'a1' } as unknown as Awaited<ReturnType<typeof getAssetInfo>>);
+    vi.mocked(getAssetInfo).mockResolvedValue({
+      id: 'a1',
+      visibility: AssetVisibility.Timeline,
+    } as unknown as Awaited<ReturnType<typeof getAssetInfo>>);
 
     const m = new GlobalSearchManager();
     await m.validatePhotoRecents();
 
     expect(getEntries().map((entry) => entry.id)).toEqual(['photo:a1']);
+  });
+
+  // Moving a photo into the locked folder requires an elevated session
+  // (asset.service.ts requireElevatedPermission), so right after the move the caller can
+  // still resolve it — a refusal-only check would keep the row until the PIN window
+  // lapsed. Drop it on the visibility itself, which also matches the palette's searches:
+  // they pin Timeline, so a locked photo is not reachable from the palette either way.
+  it('drops a photo recent that has moved into the locked folder even while unlocked', async () => {
+    addEntry(photoEntry);
+    vi.mocked(getAssetInfo).mockResolvedValue({
+      id: 'a1',
+      visibility: AssetVisibility.Locked,
+    } as unknown as Awaited<ReturnType<typeof getAssetInfo>>);
+
+    const m = new GlobalSearchManager();
+    await m.validatePhotoRecents();
+
+    expect(getEntries()).toEqual([]);
   });
 
   // A dropped connection must not erase history — only an explicit refusal does.

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -1,9 +1,11 @@
 import {
+  AssetVisibility,
   getAlbumInfo,
   getAlbumNames,
   getAllPeople,
   getAllSpaces,
   getAllTags,
+  getAssetInfo,
   getMlHealth,
   getSpace,
   searchAssets,
@@ -697,6 +699,49 @@ export class GlobalSearchManager {
       this.mlProbed = true;
       void this.probeMlHealth();
     }
+    void this.validatePhotoRecents();
+  }
+
+  /**
+   * Re-check the photo rows in RECENT against the server and drop the ones it no longer
+   * hands back. Recents live in localStorage and carry the filename, so without this a
+   * photo that has since moved into the locked folder (or been deleted) keeps its
+   * filename on the palette's cold surface until the user removes the row by hand
+   * (#869). The thumbnail already 400s, so the row rendered as a blank tile with a
+   * readable name.
+   *
+   * Only an explicit refusal purges. 400/403/404 mirror `activateAlbum`'s stale-entry
+   * branch — Gallery's `requireAccess` answers 400 (BadRequestException) for both "row
+   * missing" and "no access", so it sits alongside the canonical 404/403. A network
+   * failure leaves history intact rather than erasing it on a dropped connection, and an
+   * abort (palette closed mid-flight) is a no-op because the next open re-runs the check.
+   *
+   * An elevated session resolves its own locked assets just fine, so entries survive
+   * while the folder is unlocked and are dropped on the first open after it re-locks.
+   */
+  async validatePhotoRecents() {
+    const photos = getEntries().filter(
+      (entry): entry is Extract<RecentEntry, { kind: 'photo' }> => entry.kind === 'photo',
+    );
+    if (photos.length === 0) {
+      return;
+    }
+    await Promise.all(
+      photos.map(async (entry) => {
+        try {
+          await getAssetInfo({ id: entry.assetId }, { signal: this.closeSignal });
+        } catch (error: unknown) {
+          if (error instanceof Error && error.name === 'AbortError') {
+            return;
+          }
+          const status = (error as { status?: number } | null)?.status;
+          if (status === 400 || status === 403 || status === 404) {
+            removeEntry(entry.id);
+            this.recentsRevision++;
+          }
+        }
+      }),
+    );
   }
 
   private async probeMlHealth() {
@@ -2611,8 +2656,13 @@ export class GlobalSearchManager {
           if (mode === 'smart') {
             // withSharedSpaces:true mirrors Gallery's main search page so palette
             // results include shared-space content the user can access.
+            // visibility:Timeline also mirrors that page (search/+page.svelte). Omitting it
+            // hands the decision to the server default, which is "no visibility filter" while
+            // the session is elevated — that pulled locked-folder assets into palette results
+            // for the whole PIN window (#869). Pin it so palette results never vary with the
+            // PIN state; the locked folder has its own dedicated view.
             const response = await searchSmart(
-              { smartSearchDto: { query, size: 5, withSharedSpaces: true } },
+              { smartSearchDto: { query, size: 5, withSharedSpaces: true, visibility: AssetVisibility.Timeline } },
               { signal },
             );
             const items = response.assets.items;
@@ -2623,6 +2673,7 @@ export class GlobalSearchManager {
           // have in the palette. Only smart search includes shared-space content in v1.
           const metadataSearchDto: MetadataSearchDto = {
             size: 5,
+            visibility: AssetVisibility.Timeline,
             ...(mode === 'metadata' ? { originalFileName: query } : {}),
             ...(mode === 'description' ? { description: query } : {}),
             ...(mode === 'ocr' ? { ocr: query } : {}),

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -710,14 +710,22 @@ export class GlobalSearchManager {
    * (#869). The thumbnail already 400s, so the row rendered as a blank tile with a
    * readable name.
    *
-   * Only an explicit refusal purges. 400/403/404 mirror `activateAlbum`'s stale-entry
-   * branch — Gallery's `requireAccess` answers 400 (BadRequestException) for both "row
-   * missing" and "no access", so it sits alongside the canonical 404/403. A network
-   * failure leaves history intact rather than erasing it on a dropped connection, and an
-   * abort (palette closed mid-flight) is a no-op because the next open re-runs the check.
+   * Two things drop a row:
    *
-   * An elevated session resolves its own locked assets just fine, so entries survive
-   * while the folder is unlocked and are dropped on the first open after it re-locks.
+   *  - The server refuses it. 400/403/404 mirror `activateAlbum`'s stale-entry branch —
+   *    Gallery's `requireAccess` answers 400 (BadRequestException) for both "row missing"
+   *    and "no access", so it sits alongside the canonical 404/403. This is the deleted-
+   *    asset and lapsed-PIN case.
+   *  - It resolves but sits in the locked folder. Moving a photo there requires an
+   *    elevated session (`asset.service.ts` `requireElevatedPermission`), so the caller
+   *    can still resolve it for the rest of the PIN window — a refusal-only check would
+   *    leave the row up for 15+ minutes right after the user locked it. Gating on the
+   *    visibility instead also matches the palette's searches, which pin Timeline, so a
+   *    locked photo is not reachable from the palette by any route.
+   *
+   * A network failure leaves history intact rather than erasing it on a dropped
+   * connection, and an abort (palette closed mid-flight) is a no-op because the next open
+   * re-runs the check.
    */
   async validatePhotoRecents() {
     const photos = getEntries().filter(
@@ -729,7 +737,11 @@ export class GlobalSearchManager {
     await Promise.all(
       photos.map(async (entry) => {
         try {
-          await getAssetInfo({ id: entry.assetId }, { signal: this.closeSignal });
+          const asset = await getAssetInfo({ id: entry.assetId }, { signal: this.closeSignal });
+          if (asset.visibility === AssetVisibility.Locked) {
+            removeEntry(entry.id);
+            this.recentsRevision++;
+          }
         } catch (error: unknown) {
           if (error instanceof Error && error.name === 'AbortError') {
             return;


### PR DESCRIPTION
Closes #869.

Two parts of the global search palette could show photos that live in the locked folder.

## Palette searches did not set a visibility

The palette's photo providers called `searchSmart` / `searchAssets` without `visibility`, so the server default applied. That default is `not-locked` for a normal session, but plain `undefined` — no visibility filter — while the session is elevated. Entering the PIN once therefore pulled locked-folder photos into ordinary palette results for the rest of the PIN window, which slides forward on activity.

The main search page (`routes/(user)/search/.../+page.svelte`) already pins `visibility: timeline` on every request, so it was never affected. The palette now sends the same thing and its results no longer depend on the PIN state.

Side effect worth noting: like the main search page, the palette will no longer return archived assets. That is a behaviour change, and it makes the two surfaces consistent.

## RECENT rows were never re-checked

`cmdk-recent` persists photo rows to localStorage as `{kind:'photo', assetId, label}`, where `label` is the filename. Nothing revalidated them, so a photo that was searched and then moved into the locked folder kept its filename in the RECENT list. The thumbnail request already fails, so the row rendered as a blank tile with a readable filename, and activating it landed on the error page instead of quietly disappearing.

`open()` now re-checks the photo rows and drops the ones the server no longer returns — 400/403/404, matching the stale-entry branch `activateAlbum` / `activateSpace` already have (Gallery's `requireAccess` answers 400 for both "row missing" and "no access"). A network failure or an abort leaves the list alone, so a dropped connection does not erase history. An elevated session still resolves its own locked assets, so rows survive while the folder is unlocked and are dropped on the first open after it re-locks.

This also cleans up rows for deleted assets, which had the same staleness.

## Not changed

- The server-side default (`dto.visibility ?? (elevated ? undefined : 'not-locked')`) is upstream's and is left alone — every web surface now pins its own visibility, so the fork does not need to diverge.
- Photo activation stays synchronous. Adding a round trip there would make every recent-photo click wait on the server for a case `open()` already handles.
- `person` / `tag` / `place` recents still are not revalidated. Those labels are not tied to locked state; worth a follow-up for deleted entities.

## Tests

TDD, both fixes watched failing first:

- `photos pins visibility to timeline in smart mode` / `... in metadata mode`
- `photo recents revalidation` — drops on 400/403/404 (parameterised), keeps on success, keeps on a status-less network error, ignores non-photo rows, bumps `recentsRevision` so an open palette re-renders, and runs on `open()`

Full web unit suite: 294 files / 3996 tests passing. `tsc --noEmit` clean, eslint clean on the changed files.