### PR TITLE
fix(web): stack the timeline top section above the month layers (#878)

### DIFF
--- a/web/src/lib/components/timeline/Timeline.spec.ts
+++ b/web/src/lib/components/timeline/Timeline.spec.ts
@@ -511,3 +511,57 @@ describe('Timeline scroll-space scaling', () => {
     );
   });
 });
+
+describe('Timeline top section stacking', () => {
+  beforeEach(() => {
+    testState.grouping = 'day';
+    testState.assetCount = 1;
+    testState.viewportHeight = 600;
+    testState.viewportWidth = 390;
+    testState.domHeight = 296;
+    testState.renderOffset = 0;
+    testState.months = [];
+  });
+
+  // The top section and every month layer are transform-positioned siblings, so each one is its own
+  // stacking context with `z-index: auto` — painting order then falls back to DOM order and the month
+  // layers cover whatever the top section overflows downwards. Header overlays that hang below the
+  // section (the person page's name-suggestion dropdown, #878) were painted under the day-title row
+  // and swallowed its clicks. A `z-index` on the top section is the only lift that works: an overlay's
+  // own z-index is trapped inside this section's stacking context.
+  it('paints the top section above the month layers so overflowing header overlays stay clickable', () => {
+    testState.months = [
+      {
+        viewId: 'month:2015-01',
+        isInOrNearViewport: false,
+        isLoaded: false,
+        top: 0,
+        height: 240,
+        title: 'Jan 2015',
+      },
+    ];
+
+    const { getByTestId } = renderTimeline();
+
+    expect(Number(getByTestId('timeline-top-section').style.zIndex)).toBeGreaterThan(0);
+  });
+
+  it('leaves the month layers at the default stacking level', () => {
+    // The lift above only holds while months stay at `z-index: auto`. If a month layer ever gains its
+    // own z-index, the top section's has to be re-derived against it rather than silently losing.
+    testState.months = [
+      {
+        viewId: 'month:2015-01',
+        isInOrNearViewport: false,
+        isLoaded: false,
+        top: 0,
+        height: 240,
+        title: 'Jan 2015',
+      },
+    ];
+
+    const { getByTestId } = renderTimeline();
+
+    expect(getByTestId('timeline-month-skeleton').style.zIndex).toBe('');
+  });
+});

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -734,6 +734,11 @@
     class:invisible
     style:height={timelineManager.domHeight + 'px'}
   >
+    <!-- `z-index` is load-bearing: this section and every month layer below are transform-positioned,
+         so each is its own stacking context at `z-index: auto` and painting order falls back to DOM
+         order — the months would cover anything this section overflows downwards. Header overlays that
+         hang below it (the person page's name-suggestion dropdown, #878) were painted under the
+         day-title row and lost its clicks; their own z-index can't help, being trapped in here. -->
     <section
       bind:clientHeight={timelineManager.topSectionHeight}
       class:invisible
@@ -742,6 +747,7 @@
       style:left="0"
       style:right="0"
       style:transform={`translate3d(0,${timelineManager.renderOffset}px,0)`}
+      style:z-index="1"
     >
       {@render children?.()}
       {#if isEmpty}


### PR DESCRIPTION
Fixes #878.

## Problem

Typing into the person page's name/nickname field shows a suggestion dropdown that hangs below the header. Where it overlaps the timeline's date label, the date label is painted on top and takes the click, so the suggestion cannot be selected in that strip.

## Root cause

In `Timeline.svelte`, the top section and every month layer are absolutely positioned **siblings**, and each one carries a `translate3d` transform. A transform creates a stacking context, so both sat at `z-index: auto` — painting order then falls back to DOM order, and the month layers (later in the DOM) cover whatever the top section overflows downwards.

The dropdown's own `absolute z-1` cannot help: it is trapped inside the top section's stacking context, so the lift has to be applied to the section itself.

## Fix

One line — `style:z-index="1"` on the top section, plus a comment recording why it is load-bearing.

## Evidence

Probed against a real build (demo instance, v5.3.0) at one fixed point inside a suggestion, with the element rect verified stable across all three measurements:

| top-section `z-index` | `document.elementFromPoint` hit |
| --- | --- |
| none (shipped) | `"Sat, Jul 19, 2025"` — the date label |
| `1` | `"Steffen"` — the suggestion |
| reverted to none | `"Sat, Jul 19, 2025"` again |

## Blast radius

The lift applies to every timeline surface, not just the person page — that is the intent, since any header overlay that overflows the top section hit the same trap.

- `#asset-grid` has `contain: strict`, so it is a stacking context and the new `z-index` cannot escape it to reach the scrubber (`z-1`) or the mobile grouping control (`z-20`), both of which live outside it.
- The section's own box is only as tall as its in-flow content, so thumbnails below the header keep receiving their clicks (verified on the live page).

## Tests

Two tests added to `Timeline.spec.ts`, written before the fix and watched failing:

- the top section paints above the month layers
- the month layers stay at the default stacking level — the invariant the lift depends on

## Verification

- `vitest run` (full web suite): 4003 passed
- `check:typescript`: clean
- `check:svelte`: 571 files, 0 errors, 0 warnings
- `eslint`: 0 errors (the 8 warnings are pre-existing — verified identical with the change stashed)
- prettier: clean