### PR TITLE
fix(mobile): cap the When filter's year list like every other section (#820)

### DIFF
--- a/mobile/lib/presentation/widgets/filter_sheet/deep/when_accordion_section.widget.dart
+++ b/mobile/lib/presentation/widgets/filter_sheet/deep/when_accordion_section.widget.dart
@@ -9,15 +9,35 @@ import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dar
 import 'package:immich_mobile/providers/photos_filter/temporal_utils.dart';
 import 'package:immich_mobile/providers/photos_filter/time_buckets.provider.dart';
 
+/// Preview cap: the deep section shows at most this many year rows by default,
+/// plus at most this many beyond-cap years that the active date range covers
+/// (pinned so a filter the user already set stays visible).
+const int _kPreviewCap = 10;
+
+/// True when [year] overlaps the active date-range filter.
+///
+/// Both bounds unset means "no date filter" — nothing is pinned. A single bound
+/// is treated as open-ended, so `takenBefore` alone matches every earlier year;
+/// the caller bounds how many of those it actually pins.
+bool _rangeCoversYear({required int year, DateTime? after, DateTime? before}) {
+  if (after == null && before == null) return false;
+  if (after != null && after.year > year) return false;
+  if (before != null && before.year < year) return false;
+  return true;
+}
+
 /// WhenAccordionSection — Deep-snap section for the "When" filter dimension.
 ///
-/// Lists years (descending) with a trailing count. Tapping a year expands an
-/// inline 4×3 month grid below the row. Only one year is expanded at a time —
-/// tapping another year collapses the first. Tapping a month sets the date
-/// range filter to the whole month; tapping the same month twice clears it.
+/// Lists years (descending) with a trailing count, capped to [_kPreviewCap]
+/// so a library spanning many years does not produce an endless section (#820).
+/// Tapping a year expands an inline 4×3 month grid below the row. Only one year
+/// is expanded at a time — tapping another year collapses the first. Tapping a
+/// month sets the date range filter to the whole month; tapping the same month
+/// twice clears it.
 ///
 /// A body "N years →" row below the year list delegates to [onOpenPicker]
-/// — tapping it opens the full when-picker.
+/// — tapping it opens the full when-picker. [_SearchMoreRow] reports the total
+/// year count, not the capped preview length.
 class WhenAccordionSection extends ConsumerStatefulWidget {
   final VoidCallback? onOpenPicker;
   const WhenAccordionSection({super.key, this.onOpenPicker});
@@ -53,6 +73,9 @@ class _WhenAccordionSectionState extends ConsumerState<WhenAccordionSection> {
     final bucketsAsync = ref.watch(timeBucketsProvider(filter));
     final yearsAsync = bucketsAsync.whenData(aggregateYears);
     final count = yearsAsync.valueOrNull?.length ?? 0;
+    // Undebounced so a just-picked range pins its year on the next frame.
+    final takenAfter = ref.watch(photosFilterProvider.select((f) => f.date.takenAfter));
+    final takenBefore = ref.watch(photosFilterProvider.select((f) => f.date.takenBefore));
 
     return DeepSectionScaffold<YearCount>(
       sectionId: FilterSectionId.when,
@@ -60,20 +83,28 @@ class _WhenAccordionSectionState extends ConsumerState<WhenAccordionSection> {
       emptyCaptionKey: 'filter_sheet_deep_empty_when',
       items: yearsAsync,
       onRetry: () => ref.invalidate(timeBucketsProvider(filter)),
-      childBuilder: (years) => Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          for (final year in years)
-            _YearRow(
-              year: year,
-              buckets: bucketsAsync.valueOrNull ?? const [],
-              expanded: _expandedYear == year.year,
-              onToggle: () => _setExpandedYear(_expandedYear == year.year ? null : year.year),
-            ),
-          if (count > 0) _SearchMoreRow(count: count, onOpenPicker: widget.onOpenPicker),
-        ],
-      ),
+      childBuilder: (years) {
+        final pinned = years
+            .skip(_kPreviewCap)
+            .where((y) => _rangeCoversYear(year: y.year, after: takenAfter, before: takenBefore))
+            .take(_kPreviewCap);
+        final display = [...years.take(_kPreviewCap), ...pinned];
+
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            for (final year in display)
+              _YearRow(
+                year: year,
+                buckets: bucketsAsync.valueOrNull ?? const [],
+                expanded: _expandedYear == year.year,
+                onToggle: () => _setExpandedYear(_expandedYear == year.year ? null : year.year),
+              ),
+            if (count > 0) _SearchMoreRow(count: count, onOpenPicker: widget.onOpenPicker),
+          ],
+        );
+      },
     );
   }
 }

--- a/mobile/test/presentation/widgets/filter_sheet/deep/when_accordion_section_test.dart
+++ b/mobile/test/presentation/widgets/filter_sheet/deep/when_accordion_section_test.dart
@@ -25,6 +25,16 @@ List<BucketLite> _seed({Map<String, int> counts = const {'2024-06-01': 12, '2024
   for (final e in counts.entries) (timeBucket: e.key, count: e.value),
 ];
 
+/// One bucket per year, descending from [newest] for [count] consecutive years.
+List<BucketLite> _seedYears(int count, {int newest = 2026}) => [
+  for (var i = 0; i < count; i++) (timeBucket: '${newest - i}-06-01', count: 10 + i),
+];
+
+/// Long year lists exceed the 800×600 test viewport. In the app the section is
+/// a child of `DeepContent`'s ListView, so scroll it here too — otherwise the
+/// harness reports a RenderFlex overflow that the real layout never hits.
+Widget _scrolled(Widget child) => Material(child: SingleChildScrollView(child: child));
+
 void main() {
   group('WhenAccordionSection', () {
     testWidgets('renders year rows in descending order', (tester) async {
@@ -201,6 +211,98 @@ void main() {
       // Basic assertion: month pill exists. Detailed color check is brittle
       // in widget tests; presence + basic selection semantics is enough.
       expect(find.byKey(const Key('when-month-2024-6')), findsOneWidget);
+    });
+
+    // #820: When was the only Deep section rendering its list uncapped — a
+    // library spanning 73 years produced 73 rows every time the section was
+    // expanded. Cap the preview like People (6) / Tags / Camera / Places (10).
+    testWidgets('caps the preview to the 10 most recent years', (tester) async {
+      await tester.pumpConsumerWidget(
+        _scrolled(const WhenAccordionSection(onOpenPicker: null)),
+        overrides: [_noCollapsed(), timeBucketsProvider.overrideWith((ref, filter) => Future.value(_seedYears(15)))],
+      );
+      await tester.pumpAndSettle();
+
+      // 2026..2017 — the 10 most recent.
+      for (var y = 2026; y > 2016; y--) {
+        expect(find.byKey(Key('when-year-$y')), findsOneWidget, reason: '$y is within the cap');
+      }
+      // 2016..2012 — beyond the cap, reachable via "N years →".
+      for (var y = 2016; y >= 2012; y--) {
+        expect(find.byKey(Key('when-year-$y')), findsNothing, reason: '$y is beyond the cap');
+      }
+    });
+
+    // Mirrors the "selected suggestions beyond the cap are pinned" rule the
+    // People / Tags / Camera / Places sections follow: a year the user already
+    // filtered on must stay visible even when it sits past the cap.
+    testWidgets('pins a beyond-cap year covered by the active date range', (tester) async {
+      await tester.pumpConsumerWidget(
+        _scrolled(const WhenAccordionSection(onOpenPicker: null)),
+        overrides: [
+          _noCollapsed(),
+          timeBucketsProvider.overrideWith(
+            (ref, filter) => Future.value([..._seedYears(15), (timeBucket: '1953-04-01', count: 42)]),
+          ),
+        ],
+      );
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(tester.element(find.byType(WhenAccordionSection)));
+      container
+          .read(photosFilterProvider.notifier)
+          .setDateRange(start: DateTime(1953, 4, 1), end: DateTime(1953, 5, 0, 23, 59, 59));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('when-year-1953')), findsOneWidget, reason: 'selected year is pinned past the cap');
+      // Unselected overflow stays hidden.
+      expect(find.byKey(const Key('when-year-2016')), findsNothing);
+    });
+
+    // Guard: the pin must not become a backdoor that re-expands the whole list.
+    // An open-ended "before 2015" range overlaps 19 of the seeded years.
+    testWidgets('an open-ended date range cannot re-expand the section past the cap', (tester) async {
+      await tester.pumpConsumerWidget(
+        _scrolled(const WhenAccordionSection(onOpenPicker: null)),
+        overrides: [_noCollapsed(), timeBucketsProvider.overrideWith((ref, filter) => Future.value(_seedYears(30)))],
+      );
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(tester.element(find.byType(WhenAccordionSection)));
+      container.read(photosFilterProvider.notifier).setDateRange(start: null, end: DateTime(2015, 12, 31));
+      await tester.pumpAndSettle();
+
+      // Newest overlapping years pin; the long tail stays behind "N years →".
+      expect(find.byKey(const Key('when-year-2015')), findsOneWidget);
+      expect(find.byKey(const Key('when-year-2005')), findsNothing, reason: 'pinned overflow is itself bounded');
+      expect(find.byKey(const Key('when-year-1997')), findsNothing, reason: 'pinned overflow is itself bounded');
+    });
+
+    testWidgets('≤10 years renders all, no over-cap', (tester) async {
+      await tester.pumpConsumerWidget(
+        _scrolled(const WhenAccordionSection(onOpenPicker: null)),
+        overrides: [_noCollapsed(), timeBucketsProvider.overrideWith((ref, filter) => Future.value(_seedYears(4)))],
+      );
+      await tester.pumpAndSettle();
+
+      for (var y = 2026; y > 2022; y--) {
+        expect(find.byKey(Key('when-year-$y')), findsOneWidget);
+      }
+    });
+
+    // The capped preview must not shrink the picker affordance's count — it
+    // advertises how many years the picker reaches, not how many are shown.
+    testWidgets('"N years →" reports the total year count, not the capped preview length', (tester) async {
+      await tester.pumpConsumerWidget(
+        _scrolled(const WhenAccordionSection(onOpenPicker: null)),
+        overrides: [_noCollapsed(), timeBucketsProvider.overrideWith((ref, filter) => Future.value(_seedYears(15)))],
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.descendant(of: find.byKey(const Key('when-section-search-more')), matching: find.text('15 years →')),
+        findsOneWidget,
+      );
     });
   });
 }


### PR DESCRIPTION
Closes #820 (partially — see the scope note below).

## Problem

`WhenAccordionSection` was the only Deep filter section rendering its full list uncapped:

| Section | Cap | Source |
|---|---|---|
| People | 6 | `photosFilterSuggestionsProvider` (top-N bounded server-side) |
| Tags / Camera / Places | 10 | `photosFilterSuggestionsProvider` (top-N bounded server-side) |
| **When** | **none** | `timeBucketsProvider` — every year in the library |

The sibling sections are bounded server-side anyway, so only When could grow without limit. A library spanning 73 years rendered 73 rows every time the section was expanded — the "very long, permanently expanded list" in the report.

## Change

Cap the preview at 10 years, and pin any beyond-cap year the active date range covers so a filter the user already set stays visible — the same "selected suggestions beyond the cap are pinned" rule People/Tags/Camera/Places follow.

```dart
final pinned = years
    .skip(_kPreviewCap)
    .where((y) => _rangeCoversYear(year: y.year, after: takenAfter, before: takenBefore))
    .take(_kPreviewCap);
final display = [...years.take(_kPreviewCap), ...pinned];
```

The pinned set is itself capped. `SearchDateFilter` permits half-open ranges (`active_chips` renders "Before MMM yyyy"), and a plain overlap rule would let `takenBefore` alone pin every earlier year — reopening the exact wall this fixes. There's a test for that.

The `N years →` row still reports the total year count, not the preview length, so it keeps advertising what the picker reaches.

## Scope note

Two of the three asks in #820 were already fixed by #758, which landed 2026-07-27 — six days *after* the issue was filed — and has not shipped yet (it's in `v5.3.0-rc.0` only). `CollapsibleSection` gave When its chevron, and the `Search N years →` row moved into the section body. The reporter filed against a build predating that. Only the uncapped list was still live on `main`.

So closing #820 should mention that collapsibility and the search shortcut arrive with the next release regardless of this PR.

## Tests

TDD, three RED→GREEN cycles with each failure observed before implementing:

1. `caps the preview to the 10 most recent years` — red: "2016 is beyond the cap — Found 1 widget, none expected"
2. `pins a beyond-cap year covered by the active date range` — red: "Found 0 widgets with key 'when-year-1953'"
3. `an open-ended date range cannot re-expand the section past the cap` — red: "Found 0 widgets with key 'when-year-2015'"

Plus two guards: `≤10 years renders all, no over-cap`, and `"N years →" reports the total year count`. The second was mutation-tested (`count` → `display.length`) to confirm it actually fails — not a green-either-way assertion.

New tests wrap the widget in a `SingleChildScrollView`, since 11+ rows overflow the 800×600 test viewport. In the app the section is a child of `DeepContent`'s `ListView`, so this matches real layout rather than papering over one.

## Verification

- Full mobile suite: **2979 passed, 1 skipped, 0 failures**
- `when_accordion_section_test.dart`: 16/16 (was 11)
- `dart analyze --fatal-infos lib test`: no issues
- `dart format`: clean on both changed files

Not verified: no simulator or device run, so the visual result at 10 rows is unconfirmed by me.