### PR TITLE
fix(web): gate the asset share button on ownership (#871)

### DIFF
--- a/web/src/lib/services/asset.service.spec.ts
+++ b/web/src/lib/services/asset.service.spec.ts
@@ -1,4 +1,4 @@
-import { AssetEditAction, getAssetInfo, type AssetEditActionItemDto } from '@immich/sdk';
+import { AssetEditAction, getAssetInfo, type AssetEditActionItemDto, type AssetResponseDto } from '@immich/sdk';
 import { modalManager, toastManager } from '@immich/ui';
 import { vitest } from 'vitest';
 import { authManager } from '$lib/managers/auth-manager.svelte';
@@ -105,6 +105,16 @@ describe('AssetService', () => {
       setSharedLink(undefined);
       const asset = assetFactory.build({ ownerId });
       const assetActions = getAssetActions(() => '', asset);
+      expect(assetActions.Share.$if?.()).toStrictEqual(true);
+    });
+
+    it('should offer the share action if a shared link stripped the asset owner', () => {
+      // A `showMetadata: false` shared link returns SanitizedAssetResponseDto, which omits `ownerId`
+      // altogether, so ownership is unknowable client-side. The owner still has to get the button.
+      authManager.setUser(userAdminFactory.build({ id: 'owner' }));
+      setSharedLink(sharedLinkFactory.build({ allowDownload: false }));
+      const { ownerId: _, ...sanitized } = assetFactory.build();
+      const assetActions = getAssetActions(() => '', sanitized as AssetResponseDto);
       expect(assetActions.Share.$if?.()).toStrictEqual(true);
     });
 

--- a/web/src/lib/services/asset.service.spec.ts
+++ b/web/src/lib/services/asset.service.spec.ts
@@ -98,6 +98,26 @@ describe('AssetService', () => {
       const assetActions = getAssetActions(() => '', asset);
       expect(assetActions.SharedLinkDownload.$if?.()).toStrictEqual(true);
     });
+
+    it('should offer the share action if the user owns the asset', () => {
+      const ownerId = 'owner';
+      authManager.setUser(userAdminFactory.build({ id: ownerId }));
+      setSharedLink(undefined);
+      const asset = assetFactory.build({ ownerId });
+      const assetActions = getAssetActions(() => '', asset);
+      expect(assetActions.Share.$if?.()).toStrictEqual(true);
+    });
+
+    it('should not offer the share action if the user does not own the asset', () => {
+      // Server-side `Permission.AssetShare` is owner ∪ partner only — album or space membership
+      // grants no share access, so a shared-album/space viewer would get
+      // "Not found or no asset.share access" from POST /shared-links (#871).
+      authManager.setUser(userAdminFactory.build({ id: 'non-owner' }));
+      setSharedLink(undefined);
+      const asset = assetFactory.build({ ownerId: 'owner' });
+      const assetActions = getAssetActions(() => '', asset);
+      expect(assetActions.Share.$if?.()).toStrictEqual(false);
+    });
   });
 
   describe('normalizeAngle', () => {

--- a/web/src/lib/services/asset.service.ts
+++ b/web/src/lib/services/asset.service.ts
@@ -128,15 +128,19 @@ export const getAssetActions = ($t: MessageFormatter, asset: AssetResponseDto & 
   const isOwner = !!(authUser && authUser.id === asset.ownerId);
   const smartSearchEnabled = featureFlagsManager.value.smartSearch;
 
+  // Server-side `Permission.AssetShare` is owner ∪ partner only, so album or space membership grants
+  // no share access. Gating on `authUser` alone offered a shared-album/space viewer a button that
+  // `POST /shared-links` then rejected with "Not found or no asset.share access" (#871).
+  //
+  // `|| !asset.ownerId`: a `showMetadata: false` shared link returns SanitizedAssetResponseDto, which
+  // omits `ownerId` altogether, so ownership is unknowable client-side there — treat unknown as
+  // shareable rather than hiding the button from the owner of the asset they linked.
+  const canShare = !!authUser && (isOwner || !asset.ownerId);
+
   const Share: ActionItem = {
-    // `isOwner`, not just `authUser`: server-side `Permission.AssetShare` is owner ∪ partner only,
-    // so album or space membership grants no share access. Without the ownership check a viewer of
-    // a shared album/space was offered the button and POST /shared-links answered
-    // "Not found or no asset.share access" only after the form was filled in (#871). Matches the
-    // owner-only narrowing the bulk CreateSharedLinkAction already applies to its selection.
     title: $t('share'),
     icon: mdiShareVariantOutline,
-    $if: () => isOwner && !asset.isTrashed && asset.visibility !== AssetVisibility.Locked,
+    $if: () => canShare && !asset.isTrashed && asset.visibility !== AssetVisibility.Locked,
     onAction: () => modalManager.show(SharedLinkCreateModal, { assetIds: [asset.id] }),
   };
 

--- a/web/src/lib/services/asset.service.ts
+++ b/web/src/lib/services/asset.service.ts
@@ -129,9 +129,14 @@ export const getAssetActions = ($t: MessageFormatter, asset: AssetResponseDto & 
   const smartSearchEnabled = featureFlagsManager.value.smartSearch;
 
   const Share: ActionItem = {
+    // `isOwner`, not just `authUser`: server-side `Permission.AssetShare` is owner ∪ partner only,
+    // so album or space membership grants no share access. Without the ownership check a viewer of
+    // a shared album/space was offered the button and POST /shared-links answered
+    // "Not found or no asset.share access" only after the form was filled in (#871). Matches the
+    // owner-only narrowing the bulk CreateSharedLinkAction already applies to its selection.
     title: $t('share'),
     icon: mdiShareVariantOutline,
-    $if: () => !!(authUser && !asset.isTrashed && asset.visibility !== AssetVisibility.Locked),
+    $if: () => isOwner && !asset.isTrashed && asset.visibility !== AssetVisibility.Locked,
     onAction: () => modalManager.show(SharedLinkCreateModal, { assetIds: [asset.id] }),
   };
 


### PR DESCRIPTION
Fixes #871.

## Problem

In the asset viewer, the share button was offered to any authenticated viewer:

```ts
$if: () => !!(authUser && !asset.isTrashed && asset.visibility !== AssetVisibility.Locked),
```

Server-side `Permission.AssetShare` (`server/src/utils/access.ts`) resolves to **owner ∪ partner** only — unlike `AssetView`/`AssetDownload`, it has no album or space arm. So a viewer of a shared album or a shared space saw the button, filled in the shared-link form, and only then got `Not found or no asset.share access` back from `POST /shared-links`.

`AssetViewerNavBar.svelte` renders `Actions.Share` unconditionally, so `$if` was the only gate.

## Fix

```ts
const canShare = !!authUser && (isOwner || !asset.ownerId);
```

`isOwner` was already computed a few lines above for `SharedLinkDownload`, `Favorite`, etc.

The `|| !asset.ownerId` arm is load-bearing: a `showMetadata: false` shared link returns `SanitizedAssetResponseDto` (`server/src/dtos/asset-response.dto.ts`), which **omits `ownerId` entirely** and casts to `AssetResponseDto`. A plain ownership check therefore also hid the button from the owner of the asset they had linked themselves — caught by `navbar.e2e-spec.ts` "visible owner actions" (second commit). Ownership is genuinely unknowable client-side when the server withholds it, so unknown owner is treated as shareable; guests are still excluded by `authUser`.

| Case | Before | After |
| --- | --- | --- |
| Owner, normal app | shown | shown |
| Shared album / space viewer | shown → server error | hidden |
| Owner via metadata-stripped shared link | shown | shown |
| Guest via shared link | hidden | hidden |

## Known limits

- A logged-in **non-owner** opening someone else's metadata-stripped shared link still sees the button. Undecidable client-side — the server deliberately withholds the owner there.
- The server would also accept a **partner's** asset, and this gate does not. The web app has no global partner registry (partners are fetched per-page in `user-settings`, `sharing/+page.ts`, `PartnerSelectionModal`), so an exact owner ∪ partner check would mean new client state. Owner-only is the same line the bulk `CreateSharedLinkAction` already draws. Net effect: on the partner page the per-asset share button no longer appears for a partner's asset.

The album-level share button is unaffected — `getAlbumActions().Share` already has `$if: () => isOwned`, and uses `Permission.AlbumShare` (owner ∪ editor).

## Tests

TDD throughout — each test was written first and watched fail:

- `should not offer the share action if the user does not own the asset` — the #871 regression test (failed with `expected true to strictly equal false`)
- `should offer the share action if the user owns the asset` — guards against over-restricting
- `should offer the share action if a shared link stripped the asset owner` — reproduces the e2e regression at unit level (failed with `expected false to strictly equal true`)

Verified from `web/`: full unit suite (294 files / 4006 tests), `check:typescript`, `check:svelte` (571 files, 0 problems), `lint` (0 errors), `prettier --check` all clean. CI green including E2E Web.