### PR TITLE
fix: scope Explore/Places locations to shared spaces and link tiles to /photos (#867)

### DIFF
--- a/server/src/queries/asset.repository.sql
+++ b/server/src/queries/asset.repository.sql
@@ -931,12 +931,61 @@ from
   inner join "asset_exif" on "asset"."id" = "asset_exif"."assetId"
   inner join "cities" on "asset_exif"."city" = "cities"."city"
 where
-  "ownerId" = $2::uuid
-  and "visibility" = $3
-  and "type" = $4
+  (
+    "asset"."ownerId" = $2::uuid
+    or exists (
+      select
+        1 as "exists"
+      from
+        "shared_space_asset"
+      where
+        "shared_space_asset"."assetId" = "asset"."id"
+        and "shared_space_asset"."spaceId" = any ($3::uuid[])
+    )
+    or exists (
+      select
+        1 as "exists"
+      from
+        "shared_space_library"
+      where
+        "shared_space_library"."libraryId" = "asset"."libraryId"
+        and "shared_space_library"."spaceId" = any ($4::uuid[])
+    )
+    or (
+      exists (
+        select
+          1 as "exists"
+        from
+          "shared_space_album"
+          inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          and "album"."deletedAt" is null
+        where
+          "album_asset"."assetId" = "asset"."id"
+          and "shared_space_album"."spaceId" = any ($5::uuid[])
+          and "shared_space_album"."showInTimeline" = $6
+      )
+      or exists (
+        select
+          1 as "exists"
+        from
+          "shared_space_album"
+          inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+          and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          and "album"."deletedAt" is null
+        where
+          "album_space_asset"."assetId" = "asset"."id"
+          and "shared_space_album"."spaceId" = any ($7::uuid[])
+          and "shared_space_album"."showInTimeline" = $8
+      )
+    )
+  )
+  and "visibility" = $9
+  and "type" = $10
   and "deletedAt" is null
 limit
-  $5
+  $11
 
 -- AssetRepository.getRecentlyCreatedAssetIds
 select

--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -1055,14 +1055,63 @@ with recursive
         "asset_exif"
         inner join "asset" on "asset"."id" = "asset_exif"."assetId"
       where
-        "asset"."ownerId" = any ($1::uuid[])
-        and "asset"."visibility" = $2
-        and "asset"."type" = $3
+        (
+          "asset"."ownerId" = any ($1::uuid[])
+          or exists (
+            select
+              1 as "exists"
+            from
+              "shared_space_asset"
+            where
+              "shared_space_asset"."assetId" = "asset"."id"
+              and "shared_space_asset"."spaceId" = any ($2::uuid[])
+          )
+          or exists (
+            select
+              1 as "exists"
+            from
+              "shared_space_library"
+            where
+              "shared_space_library"."libraryId" = "asset"."libraryId"
+              and "shared_space_library"."spaceId" = any ($3::uuid[])
+          )
+          or (
+            exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_album"
+                inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+                inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                and "album"."deletedAt" is null
+              where
+                "album_asset"."assetId" = "asset"."id"
+                and "shared_space_album"."spaceId" = any ($4::uuid[])
+                and "shared_space_album"."showInTimeline" = $5
+            )
+            or exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_album"
+                inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+                and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+                inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                and "album"."deletedAt" is null
+              where
+                "album_space_asset"."assetId" = "asset"."id"
+                and "shared_space_album"."spaceId" = any ($6::uuid[])
+                and "shared_space_album"."showInTimeline" = $7
+            )
+          )
+        )
+        and "asset"."visibility" = $8
+        and "asset"."type" = $9
         and "asset"."deletedAt" is null
       order by
         "city"
       limit
-        $4
+        $10
     )
     union all
     (
@@ -1079,15 +1128,64 @@ with recursive
             "asset_exif"
             inner join "asset" on "asset"."id" = "asset_exif"."assetId"
           where
-            "asset"."ownerId" = any ($5::uuid[])
-            and "asset"."visibility" = $6
-            and "asset"."type" = $7
+            (
+              "asset"."ownerId" = any ($11::uuid[])
+              or exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_asset"
+                where
+                  "shared_space_asset"."assetId" = "asset"."id"
+                  and "shared_space_asset"."spaceId" = any ($12::uuid[])
+              )
+              or exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_library"
+                where
+                  "shared_space_library"."libraryId" = "asset"."libraryId"
+                  and "shared_space_library"."spaceId" = any ($13::uuid[])
+              )
+              or (
+                exists (
+                  select
+                    1 as "exists"
+                  from
+                    "shared_space_album"
+                    inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+                    inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                    and "album"."deletedAt" is null
+                  where
+                    "album_asset"."assetId" = "asset"."id"
+                    and "shared_space_album"."spaceId" = any ($14::uuid[])
+                    and "shared_space_album"."showInTimeline" = $15
+                )
+                or exists (
+                  select
+                    1 as "exists"
+                  from
+                    "shared_space_album"
+                    inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+                    and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+                    inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                    and "album"."deletedAt" is null
+                  where
+                    "album_space_asset"."assetId" = "asset"."id"
+                    and "shared_space_album"."spaceId" = any ($16::uuid[])
+                    and "shared_space_album"."showInTimeline" = $17
+                )
+              )
+            )
+            and "asset"."visibility" = $18
+            and "asset"."type" = $19
             and "asset"."deletedAt" is null
             and "asset_exif"."city" > "cte"."city"
           order by
             "city"
           limit
-            $8
+            $20
         ) as "l" on true
     )
   )

--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import {
+  expressionBuilder,
   ExpressionBuilder,
   Insertable,
   Kysely,
@@ -173,6 +174,12 @@ export interface MemoryLocationCluster {
 interface AssetExploreFieldOptions {
   maxFields: number;
   minAssetsPerField: number;
+  /**
+   * #867: spaces the viewer kept on their home timeline. When set, the city scan widens from
+   * "assets I own" to "assets I own OR reach through one of these spaces", so the Explore places
+   * strip matches what the location filter and the filtered timeline already show.
+   */
+  timelineSpaceIds?: string[];
 }
 
 interface AssetGetByChecksumOptions {
@@ -1527,8 +1534,13 @@ export class AssetRepository {
     return query.executeTakeFirstOrThrow();
   }
 
-  @GenerateSql({ params: [DummyValue.UUID, { minAssetsPerField: 5, maxFields: 12 }] })
-  async getAssetIdByCity(ownerId: string, { minAssetsPerField, maxFields }: AssetExploreFieldOptions) {
+  @GenerateSql({
+    params: [DummyValue.UUID, { minAssetsPerField: 5, maxFields: 12, timelineSpaceIds: [DummyValue.UUID] }],
+  })
+  async getAssetIdByCity(
+    ownerId: string,
+    { minAssetsPerField, maxFields, timelineSpaceIds }: AssetExploreFieldOptions,
+  ) {
     const items = await this.db
       .with('cities', (qb) =>
         qb
@@ -1544,7 +1556,27 @@ export class AssetRepository {
       .distinctOn('asset_exif.city')
       .select(['assetId as data', 'asset_exif.city as value'])
       .$narrowType<{ value: NotNull }>()
-      .where('ownerId', '=', asUuid(ownerId))
+      // #867: own assets, plus anything reachable through a space the viewer kept on their
+      // timeline. The Timeline-only visibility gate below already covers the space arms' own
+      // requirement (archived/hidden/locked space assets never reach the strip).
+      //
+      // The branches are built from a detached `expressionBuilder<DB, 'asset'>()` rather than the
+      // callback's own `eb`: the `cities` CTE widens this query's schema to `DB & { cities }`, which
+      // no longer satisfies the shared helpers' `ExpressionBuilder<DB, keyof DB>` parameter. The
+      // emitted SQL is identical — the branches only ever reference `asset.*`.
+      .where((eb) =>
+        eb.or([
+          eb('asset.ownerId', '=', asUuid(ownerId)),
+          ...(timelineSpaceIds?.length
+            ? spaceAssetPathBranches(expressionBuilder<DB, 'asset'>(), {
+                correlateAssetId: 'asset.id',
+                correlateLibraryId: 'asset.libraryId',
+                scope: { spaceIds: timelineSpaceIds },
+                requireShowInTimeline: true,
+              })
+            : []),
+        ]),
+      )
       .where('visibility', '=', AssetVisibility.Timeline)
       .where('type', '=', AssetType.Image)
       .where('deletedAt', 'is', null)

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -1,5 +1,14 @@
 import { Injectable } from '@nestjs/common';
-import { Kysely, OrderByDirection, Selectable, SelectQueryBuilder, ShallowDehydrateObject, sql, SqlBool } from 'kysely';
+import {
+  expressionBuilder,
+  Kysely,
+  OrderByDirection,
+  Selectable,
+  SelectQueryBuilder,
+  ShallowDehydrateObject,
+  sql,
+  SqlBool,
+} from 'kysely';
 import { InjectKysely } from 'nestjs-kysely';
 import { columns } from 'src/database';
 import { DummyValue, GenerateSql } from 'src/decorators';
@@ -986,15 +995,35 @@ export class SearchRepository {
       .execute();
   }
 
-  @GenerateSql({ params: [[DummyValue.UUID]] })
-  getAssetsByCity(userIds: string[]) {
+  @GenerateSql({ params: [[DummyValue.UUID], [DummyValue.UUID]] })
+  getAssetsByCity(userIds: string[], timelineSpaceIds?: string[]) {
+    // #867: the places page is the "view all" of the Explore strip, so it carries the same scope —
+    // own (and partner) assets, plus anything reachable through a space the viewer kept on their
+    // timeline. Built from a detached expression builder because the recursive `cte` widens the
+    // schema of the builders below past the shared helpers' `ExpressionBuilder<DB, keyof DB>`; the
+    // predicate only ever references `asset.*`, so the emitted SQL is unaffected.
+    const viewerScope = () => {
+      const eb = expressionBuilder<DB, 'asset'>();
+      return eb.or([
+        eb('asset.ownerId', '=', anyUuid(userIds)),
+        ...(timelineSpaceIds?.length
+          ? spaceAssetPathBranches(eb, {
+              correlateAssetId: 'asset.id',
+              correlateLibraryId: 'asset.libraryId',
+              scope: { spaceIds: timelineSpaceIds },
+              requireShowInTimeline: true,
+            })
+          : []),
+      ]);
+    };
+
     return this.db
       .withRecursive('cte', (qb) => {
         const base = qb
           .selectFrom('asset_exif')
           .select(['city', 'assetId'])
           .innerJoin('asset', 'asset.id', 'asset_exif.assetId')
-          .where('asset.ownerId', '=', anyUuid(userIds))
+          .where(viewerScope())
           .where('asset.visibility', '=', AssetVisibility.Timeline)
           .where('asset.type', '=', AssetType.Image)
           .where('asset.deletedAt', 'is', null)
@@ -1010,7 +1039,7 @@ export class SearchRepository {
                 .selectFrom('asset_exif')
                 .select(['city', 'assetId'])
                 .innerJoin('asset', 'asset.id', 'asset_exif.assetId')
-                .where('asset.ownerId', '=', anyUuid(userIds))
+                .where(viewerScope())
                 .where('asset.visibility', '=', AssetVisibility.Timeline)
                 .where('asset.type', '=', AssetType.Image)
                 .where('asset.deletedAt', 'is', null)

--- a/server/src/services/search.service.spec.ts
+++ b/server/src/services/search.service.spec.ts
@@ -108,6 +108,7 @@ describe(SearchService.name, () => {
       const asset = AssetFactory.from()
         .exif({ latitude: 42, longitude: 69, city: 'city', state: 'state', country: 'country' })
         .build();
+      mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([]);
       mocks.asset.getAssetIdByCity.mockResolvedValue({
         fieldName: 'exifInfo.city',
         items: [{ value: 'city', data: asset.id }],
@@ -128,6 +129,56 @@ describe(SearchService.name, () => {
       const result = await sut.getExploreData(auth);
 
       expect(result).toEqual(expectedResponse);
+    });
+
+    // #867: the Explore "Places" strip was owner-scoped, so a space member saw no tile for a city
+    // that only exists on assets shared with them. Scope it like every other home surface: own
+    // assets plus the spaces the member kept in their timeline.
+    it('scopes explore cities to the viewer plus their timeline-enabled shared spaces', async () => {
+      const auth = AuthFactory.create();
+      const spaceId = newUuid();
+      mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([{ spaceId }]);
+      mocks.asset.getAssetIdByCity.mockResolvedValue({ fieldName: 'exifInfo.city', items: [] });
+      mocks.asset.getRecentlyCreatedAssetIds.mockResolvedValue({ fieldName: 'createdAt', items: [] });
+      mocks.asset.getByIdsWithAllRelationsButStacks.mockResolvedValue([]);
+
+      await sut.getExploreData(auth);
+
+      expect(mocks.sharedSpace.getSpaceIdsForTimeline).toHaveBeenCalledWith(auth.user.id);
+      expect(mocks.asset.getAssetIdByCity).toHaveBeenCalledWith(
+        auth.user.id,
+        expect.objectContaining({ timelineSpaceIds: [spaceId] }),
+      );
+    });
+
+    it('leaves the city scope owner-only when the viewer has no timeline-enabled spaces', async () => {
+      const auth = AuthFactory.create();
+      mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([]);
+      mocks.asset.getAssetIdByCity.mockResolvedValue({ fieldName: 'exifInfo.city', items: [] });
+      mocks.asset.getRecentlyCreatedAssetIds.mockResolvedValue({ fieldName: 'createdAt', items: [] });
+      mocks.asset.getByIdsWithAllRelationsButStacks.mockResolvedValue([]);
+
+      await sut.getExploreData(auth);
+
+      expect(mocks.asset.getAssetIdByCity).toHaveBeenCalledWith(auth.user.id, {
+        maxFields: 12,
+        minAssetsPerField: 5,
+        timelineSpaceIds: undefined,
+      });
+    });
+
+    // The "recently added" strip stays owner-scoped on purpose — it answers "what did *I* just
+    // add", and /recently-added itself is an owner surface.
+    it('leaves the recently-added strip owner-scoped', async () => {
+      const auth = AuthFactory.create();
+      mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([{ spaceId: newUuid() }]);
+      mocks.asset.getAssetIdByCity.mockResolvedValue({ fieldName: 'exifInfo.city', items: [] });
+      mocks.asset.getRecentlyCreatedAssetIds.mockResolvedValue({ fieldName: 'createdAt', items: [] });
+      mocks.asset.getByIdsWithAllRelationsButStacks.mockResolvedValue([]);
+
+      await sut.getExploreData(auth);
+
+      expect(mocks.asset.getRecentlyCreatedAssetIds).toHaveBeenCalledWith(auth.user.id, 12);
     });
   });
 
@@ -1826,12 +1877,25 @@ describe(SearchService.name, () => {
   describe('getAssetsByCity', () => {
     it('should get assets by city', async () => {
       const asset = AssetFactory.from().build();
+      mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([]);
       mocks.search.getAssetsByCity.mockResolvedValue([asset as any]);
 
       const result = await sut.getAssetsByCity(authStub.user1);
 
-      expect(mocks.search.getAssetsByCity).toHaveBeenCalledWith([authStub.user1.user.id]);
+      expect(mocks.search.getAssetsByCity).toHaveBeenCalledWith([authStub.user1.user.id], undefined);
       expect(result).toHaveLength(1);
+    });
+
+    // #867: /places is the "view all" of the same Explore strip, so it gets the same scope.
+    it('scopes the places page to the viewer plus their timeline-enabled shared spaces', async () => {
+      const spaceId = newUuid();
+      mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([{ spaceId }]);
+      mocks.search.getAssetsByCity.mockResolvedValue([]);
+
+      await sut.getAssetsByCity(authStub.user1);
+
+      expect(mocks.sharedSpace.getSpaceIdsForTimeline).toHaveBeenCalledWith(authStub.user1.user.id);
+      expect(mocks.search.getAssetsByCity).toHaveBeenCalledWith([authStub.user1.user.id], [spaceId]);
     });
   });
 

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -90,8 +90,16 @@ export class SearchService extends BaseService {
     return places.map((place) => mapPlaces(place));
   }
 
+  /**
+   * #867: the places strip is scoped like the home timeline (own + timeline-enabled spaces), not
+   * like an owner-private surface. Without it a space member saw no tile for a city that only
+   * exists on assets shared with them, even though the location filter listed that city and the
+   * filtered timeline returned those assets. The recently-added strip below stays owner-scoped — it
+   * answers "what did I just add", and /recently-added is itself an owner surface.
+   */
   async getExploreData(auth: AuthDto) {
-    const options = { maxFields: 12, minAssetsPerField: 5 };
+    const timelineSpaceIds = await this.getTimelineSpaceIds(auth, true);
+    const options = { maxFields: 12, minAssetsPerField: 5, timelineSpaceIds };
 
     const cities = await this.assetRepository.getAssetIdByCity(auth.user.id, options);
     const cityAssets = await this.assetRepository.getByIdsWithAllRelationsButStacks(
@@ -330,9 +338,11 @@ export class SearchService extends BaseService {
     return { ...result, people: result.people.toSorted((a, b) => a.name.localeCompare(b.name)) };
   }
 
+  /** #867: /places is the "view all" of the Explore strip, so it carries the same scope. */
   async getAssetsByCity(auth: AuthDto): Promise<AssetResponseDto[]> {
     const userIds = await this.getUserIdsToSearch(auth);
-    const assets = await this.searchRepository.getAssetsByCity(userIds);
+    const timelineSpaceIds = await this.getTimelineSpaceIds(auth, true);
+    const assets = await this.searchRepository.getAssetsByCity(userIds, timelineSpaceIds);
     return assets.map((asset) => mapAsset(asset));
   }
 

--- a/server/test/medium/specs/repositories/asset.repository.spec.ts
+++ b/server/test/medium/specs/repositories/asset.repository.spec.ts
@@ -1761,4 +1761,93 @@ describe(AssetRepository.name, () => {
       expect(assets.id).toEqual([matchingAsset.id]);
     });
   });
+
+  // #867: the Explore "Places" strip is fed by getAssetIdByCity, which only ever looked at
+  // `asset.ownerId`. A space viewer therefore got no tile for a city that exists only on assets
+  // shared with them, even though the same city showed up in the location filter and the filtered
+  // timeline returned those assets. Each test runs on its own database because the `cities` CTE
+  // and the `maxFields` limit are global — a city left behind by another test in this file would
+  // otherwise compete for the limited slots.
+  describe('getAssetIdByCity — shared-space scope (issue #867)', () => {
+    const exploreOptions = { minAssetsPerField: 1, maxFields: 12 };
+
+    it('surfaces a city that only exists on an asset shared directly into a timeline-enabled space', async () => {
+      const { ctx, sut } = setup(await getKyselyDB());
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Viewer });
+
+      const { asset } = await ctx.newAsset({ ownerId: owner.id });
+      await ctx.newExif({ assetId: asset.id, city: 'Reykjavik' });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: owner.id });
+
+      const withSpace = await sut.getAssetIdByCity(member.id, {
+        ...exploreOptions,
+        timelineSpaceIds: [space.id],
+      });
+      expect(withSpace.items).toEqual([{ value: 'Reykjavik', data: asset.id }]);
+
+      // Without the space scope the member is back to their own (empty) library.
+      const ownOnly = await sut.getAssetIdByCity(member.id, exploreOptions);
+      expect(ownOnly.items).toEqual([]);
+    });
+
+    it('surfaces a city from an album linked into the space, and hides it when the link is off-timeline', async () => {
+      const { ctx, sut } = setup(await getKyselyDB());
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Viewer });
+
+      const { asset } = await ctx.newAsset({ ownerId: owner.id });
+      await ctx.newExif({ assetId: asset.id, city: 'Reykjavik' });
+      const { result: album } = await ctx.newAlbum({ ownerId: owner.id }, [asset.id]);
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, showInTimeline: true });
+
+      const shown = await sut.getAssetIdByCity(member.id, { ...exploreOptions, timelineSpaceIds: [space.id] });
+      expect(shown.items).toEqual([{ value: 'Reykjavik', data: asset.id }]);
+
+      // A member who hid this album from their timeline must not get its cities back on Explore.
+      await ctx.database
+        .updateTable('shared_space_album')
+        .set({ showInTimeline: false })
+        .where('spaceId', '=', space.id)
+        .where('albumId', '=', album.id)
+        .execute();
+
+      const hidden = await sut.getAssetIdByCity(member.id, { ...exploreOptions, timelineSpaceIds: [space.id] });
+      expect(hidden.items).toEqual([]);
+    });
+
+    it('does not leak a city from a space the viewer does not belong to', async () => {
+      const { ctx, sut } = setup(await getKyselyDB());
+      const { user: owner } = await ctx.newUser();
+      const { user: outsider } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+
+      const { asset } = await ctx.newAsset({ ownerId: owner.id });
+      await ctx.newExif({ assetId: asset.id, city: 'Reykjavik' });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: owner.id });
+
+      // The outsider resolves no timeline spaces, so the space arm is never armed for them.
+      const result = await sut.getAssetIdByCity(outsider.id, exploreOptions);
+      expect(result.items).toEqual([]);
+    });
+
+    it('excludes hidden and archived space assets from the strip', async () => {
+      const { ctx, sut } = setup(await getKyselyDB());
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Viewer });
+
+      const { asset: archived } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Archive });
+      await ctx.newExif({ assetId: archived.id, city: 'Reykjavik' });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: archived.id, addedById: owner.id });
+
+      const result = await sut.getAssetIdByCity(member.id, { ...exploreOptions, timelineSpaceIds: [space.id] });
+      expect(result.items).toEqual([]);
+    });
+  });
 });

--- a/server/test/medium/specs/repositories/search.repository.spec.ts
+++ b/server/test/medium/specs/repositories/search.repository.spec.ts
@@ -1164,4 +1164,67 @@ describe(SearchRepository.name, () => {
       expect(tags.map((tag) => tag.value)).not.toContain('LockedTag');
     });
   });
+
+  // #867: /places ("view all" for the Explore strip) was scoped to own + partner assets only, so a
+  // space member saw none of the cities from the assets shared with them.
+  describe('getAssetsByCity — shared-space scope (issue #867)', () => {
+    it('returns a city that only exists on an asset shared into a timeline-enabled space', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: 'viewer' });
+
+      const { asset } = await ctx.newAsset({ ownerId: owner.id });
+      await ctx.newExif({ assetId: asset.id, city: 'Valparaiso' });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: owner.id });
+
+      const withSpace = await sut.getAssetsByCity([member.id], [space.id]);
+      expect(withSpace.map((item) => item.id)).toContain(asset.id);
+
+      const ownOnly = await sut.getAssetsByCity([member.id]);
+      expect(ownOnly.map((item) => item.id)).not.toContain(asset.id);
+    });
+
+    it('returns a city from an album linked into the space only while the link is on-timeline', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: 'viewer' });
+
+      const { asset } = await ctx.newAsset({ ownerId: owner.id });
+      await ctx.newExif({ assetId: asset.id, city: 'Ushuaia' });
+      const { result: album } = await ctx.newAlbum({ ownerId: owner.id }, [asset.id]);
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id, showInTimeline: true });
+
+      const shown = await sut.getAssetsByCity([member.id], [space.id]);
+      expect(shown.map((item) => item.id)).toContain(asset.id);
+
+      await ctx.database
+        .updateTable('shared_space_album')
+        .set({ showInTimeline: false })
+        .where('spaceId', '=', space.id)
+        .where('albumId', '=', album.id)
+        .execute();
+
+      const hidden = await sut.getAssetsByCity([member.id], [space.id]);
+      expect(hidden.map((item) => item.id)).not.toContain(asset.id);
+    });
+
+    it('does not return archived space assets', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: 'viewer' });
+
+      const { asset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Archive });
+      await ctx.newExif({ assetId: asset.id, city: 'Punta Arenas' });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: owner.id });
+
+      const result = await sut.getAssetsByCity([member.id], [space.id]);
+      expect(result.map((item) => item.id)).not.toContain(asset.id);
+    });
+  });
 });

--- a/web/src/lib/route.spec.ts
+++ b/web/src/lib/route.spec.ts
@@ -118,6 +118,21 @@ describe('Route', () => {
     });
   });
 
+  describe(Route.photos.name, () => {
+    it('should work', () => {
+      expect(Route.photos()).toBe('/photos');
+    });
+
+    // #867: place tiles now land on the filtered timeline instead of the deprecated /search view.
+    it('should support a city filter', () => {
+      expect(Route.photos({ city: 'Cape Town' })).toBe('/photos?city=Cape%20Town');
+    });
+
+    it('should ignore an empty city', () => {
+      expect(Route.photos({ city: '' })).toBe('/photos');
+    });
+  });
+
   describe('viewSpaceAlbum', () => {
     it('links to an album inside a space', () => {
       expect(Route.viewSpaceAlbum({ spaceId: 'space-1', albumId: 'album-2' })).toBe('/spaces/space-1/albums/album-2');

--- a/web/src/lib/route.ts
+++ b/web/src/lib/route.ts
@@ -100,7 +100,9 @@ export const Route = {
     `/spaces/${spaceId}/people/${personId}` + asQueryString(params),
 
   // photos
-  photos: (params?: { at?: string }) => '/photos' + asQueryString(params),
+  // `city` is a filter-panel param (SEARCHABLE_PAGE_FILTER_PARAMS) — /photos hydrates its filter
+  // state from the URL, so this lands on the timeline already narrowed to that place (#867).
+  photos: (params?: { at?: string; city?: string }) => '/photos' + asQueryString(params),
   viewAsset: ({ id }: { id: string }) => `/photos/${id}`,
   archive: () => '/archive',
   favorites: () => '/favorites',

--- a/web/src/routes/(user)/explore/+page.svelte
+++ b/web/src/routes/(user)/explore/+page.svelte
@@ -108,7 +108,7 @@
       <SingleGridRow class="grid grid-flow-col grid-auto-fill-28 gap-x-4 md:grid-auto-fill-36">
         {#snippet children({ itemCount })}
           {#each places.slice(0, itemCount) as item (item.data.id)}
-            <a class="relative" href={Route.search({ city: item.value })} draggable="false">
+            <a class="relative" href={Route.photos({ city: item.value })} draggable="false">
               <div class="flex justify-center overflow-hidden rounded-xl brightness-75 filter">
                 <img
                   src={getAssetMediaUrl({ id: item.data.id, size: AssetMediaSize.Thumbnail })}

--- a/web/src/routes/(user)/explore/explore-page.spec.ts
+++ b/web/src/routes/(user)/explore/explore-page.spec.ts
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/svelte';
 import type { Component } from 'svelte';
 import TestWrapper from '$lib/components/TestWrapper.svelte';
+import { assetFactory } from '@test-data/factories/asset-factory';
 import { personFactory } from '@test-data/factories/person-factory';
 import ExplorePage from './+page.svelte';
 
@@ -79,5 +80,22 @@ describe('Explore page', () => {
       'src',
       '/api/shared-spaces/space-1/people/space-person-1/thumbnail?updatedAt=2026-01-02T00%3A00%3A00.000Z',
     );
+  });
+
+  // #867: place tiles used to open the deprecated /search view, which is owner-scoped and cannot
+  // show shared-space assets. Send them to the filtered /photos timeline instead.
+  it('links a place tile to the photos timeline filtered by that city', () => {
+    renderPage(
+      [],
+      [
+        {
+          fieldName: 'exifInfo.city',
+          items: [{ value: 'Cape Town', data: assetFactory.build({ id: 'asset-1' }) }],
+        },
+      ],
+    );
+
+    const link = screen.getByRole('link', { name: /Cape Town/ });
+    expect(link).toHaveAttribute('href', '/photos?city=Cape%20Town');
   });
 });

--- a/web/src/routes/(user)/places/PlacesCardGroup.svelte
+++ b/web/src/routes/(user)/places/PlacesCardGroup.svelte
@@ -40,7 +40,7 @@
     <div class="flex flex-row flex-wrap gap-4">
       {#each places as item (item.id)}
         {@const city = item.exifInfo?.city}
-        <a class="relative" href={Route.search({ city })} draggable="false">
+        <a class="relative" href={Route.photos({ city: city ?? undefined })} draggable="false">
           <div
             class="flex w-[calc((100vw-(72px+5rem))/2)] max-w-39 justify-center overflow-hidden rounded-xl brightness-75 filter"
           >

--- a/web/src/routes/(user)/places/places-card-group.spec.ts
+++ b/web/src/routes/(user)/places/places-card-group.spec.ts
@@ -1,0 +1,25 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/svelte';
+import type { Component } from 'svelte';
+import TestWrapper from '$lib/components/TestWrapper.svelte';
+import { assetFactory } from '@test-data/factories/asset-factory';
+import PlacesCardGroup from './PlacesCardGroup.svelte';
+
+function renderGroup(city: string) {
+  const props = { places: [assetFactory.build({ id: 'asset-1', exifInfo: { city } })] };
+
+  return render(TestWrapper as Component<{ component: typeof PlacesCardGroup; componentProps: typeof props }>, {
+    component: PlacesCardGroup,
+    componentProps: props,
+  });
+}
+
+describe('PlacesCardGroup', () => {
+  // #867: same reasoning as the Explore strip — /search cannot surface shared-space assets, the
+  // filtered /photos timeline can.
+  it('links a place card to the photos timeline filtered by that city', () => {
+    renderGroup('Cape Town');
+
+    expect(screen.getByRole('link', { name: /Cape Town/ })).toHaveAttribute('href', '/photos?city=Cape%20Town');
+  });
+});


### PR DESCRIPTION
Fixes #867.

## The bug

A space viewer saw none of the shared photos' locations on Explore. Reported symptoms, all reproduced:

- a city that exists only on space-shared assets got **no tile** on `/explore` (or `/places`)
- a city the viewer *also* has their own photos in got a tile, but clicking it showed **only their own** photos

## Cause

Two separate owner-scoped queries feed those surfaces:

| Surface | Query | Old scope |
| --- | --- | --- |
| `/explore` places strip | `AssetRepository.getAssetIdByCity` | `asset.ownerId = <viewer>` |
| `/places` ("view all") | `SearchRepository.getAssetsByCity` | `asset.ownerId = any(own + partners)` |

Neither knew about shared spaces — which is why the same city *did* appear in the location filter and the filtered timeline (those already pass `withSharedSpaces`), making the strip look inconsistent with the rest of the app.

The second symptom was the tile link: both tiles pointed at `Route.search({ city })`, the deprecated `/search` view, which is owner-scoped too.

## Fix

**Server** — both queries take the viewer's timeline-enabled spaces (`getSpaceIdsForTimeline`) and widen from "assets I own" to "assets I own OR reach through one of those spaces", via the existing `spaceAssetPathBranches` helper, so all three access paths (direct asset / linked library / linked album + cross-owner contributions) are covered with the same `showInTimeline` and album-not-deleted gating every other timeline surface uses. The existing `visibility = timeline` gate keeps archived/hidden/locked space assets out.

The recently-added strip stays owner-scoped on purpose — it answers "what did *I* just add", and `/recently-added` is itself an owner surface.

**Web** — place tiles on `/explore` and `/places` now link to `Route.photos({ city })` → `/photos?city=…`. `city` is already a filter-panel URL param, so the timeline hydrates with that filter applied, and `buildPhotosTimelineOptions` sends `withSharedSpaces: true` — so the drill-down shows own + partner + shared-space photos for that place.

## Tests

Written first, confirmed red, then green.

- **medium (real DB)** — `getAssetIdByCity` and `getAssetsByCity`: city surfaces via the direct-asset path and via a linked album; disappears when the album link is flipped `showInTimeline: false`; never leaks to a non-member; archived space assets excluded. Each asserts the with-space vs own-only contrast in the same test.
- **server unit** — the service resolves timeline spaces and passes them through; omits them when the viewer has none; the recently-added call stays owner-scoped.
- **web unit** — `Route.photos({ city })`, plus the Explore strip and the `/places` card group both linking to `/photos?city=…`.

Full suites green locally: server 5253 passed, web 4008 passed, plus `tsc --noEmit`, `eslint --max-warnings 0`, `prettier --check`, `svelte-check`. `server/src/queries/*.sql` regenerated for the `sql-schema-up-to-date` gate.

## Verifying by hand

As a space viewer with no own photos in that city: `/explore` → the shared city now has a tile → clicking it lands on `/photos?city=…` showing both shared and own photos.