### PR TITLE
fix(web): touch-friendly search palette entry and `/` shortcut

### DIFF
--- a/docs/superpowers/plans/2026-07-30-touch-search-entry.md
+++ b/docs/superpowers/plans/2026-07-30-touch-search-entry.md
@@ -25,40 +25,42 @@
 
 These were confirmed empirically in this worktree. Do not re-litigate them; build on them.
 
-| Fact | Evidence |
-|---|---|
-| `user.pointer({ keys: '[TouchA]', target })` dispatches `pointerdown` with `pointerType === 'touch'` | probed, passing |
-| An **unprevented** touch tap **focuses** the input | probed, passing — this is why the guard matters |
-| `preventDefault()` on a touch `pointerdown` **suppresses** that focus | probed, passing — `not.toHaveFocus()` is a real assertion |
-| `user.click(target)` dispatches `pointerdown` with `pointerType === 'mouse'` | probed, passing |
-| `PointerEvent` constructor exists and carries `pointerType` | probed, passing |
-| `fireEvent.pointerDown(el, { pointerType: 'pen' })` delivers `'pen'` | probed, passing |
-| `fireEvent.pointerDown(el)` yields `pointerType === ''` | probed, passing |
+| Fact                                                                                                 | Evidence                                                  |
+| ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `user.pointer({ keys: '[TouchA]', target })` dispatches `pointerdown` with `pointerType === 'touch'` | probed, passing                                           |
+| An **unprevented** touch tap **focuses** the input                                                   | probed, passing — this is why the guard matters           |
+| `preventDefault()` on a touch `pointerdown` **suppresses** that focus                                | probed, passing — `not.toHaveFocus()` is a real assertion |
+| `user.click(target)` dispatches `pointerdown` with `pointerType === 'mouse'`                         | probed, passing                                           |
+| `PointerEvent` constructor exists and carries `pointerType`                                          | probed, passing                                           |
+| `fireEvent.pointerDown(el, { pointerType: 'pen' })` delivers `'pen'`                                 | probed, passing                                           |
+| `fireEvent.pointerDown(el)` yields `pointerType === ''`                                              | probed, passing                                           |
 
 **The plan itself was dry-run before being finalised.** Task 1's tests were applied against unmodified source and produced exactly the failures Step 2 claims (`3 failed | 20 passed`). Task 3's module and spec were written and run in full (`20 passed`). Both were then reverted, so the tree is clean and every task still starts from RED. Every line number, code block, and expected tally below is copied from that run — not estimated.
 
 ## File Structure
 
-| File | Responsibility |
-|---|---|
-| `src/lib/components/global-search/global-search.svelte` (modify) | Route touch taps to the modal; hold the "focus never downgrades an open modal" invariant; hide the chip on coarse pointers |
-| `src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts` (modify) | Cover pointer routing and chip visibility |
-| `src/lib/utils/search-shortcut.ts` (create) | The `/` descriptors and the editable-target guard — pure, no Svelte |
-| `src/lib/utils/search-shortcut.spec.ts` (create) | Cover the descriptors against the real matcher, and the guard |
-| `src/routes/+layout.svelte` (modify) | Wire the `/` descriptors into the existing `use:shortcuts` array |
-| `src/lib/components/timeline/actions/TimelineKeyboardActions.svelte` (modify) | Remove `/` → Explore and its now-unused imports |
-| `src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte` (modify) | Remove `/` → Explore |
-| `src/lib/modals/ShortcutsModal.svelte` (modify) | Document `/` |
+| File                                                                                      | Responsibility                                                                                                             |
+| ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `src/lib/components/global-search/global-search.svelte` (modify)                          | Route touch taps to the modal; hold the "focus never downgrades an open modal" invariant; hide the chip on coarse pointers |
+| `src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts` (modify) | Cover pointer routing and chip visibility                                                                                  |
+| `src/lib/utils/search-shortcut.ts` (create)                                               | The `/` descriptors and the editable-target guard — pure, no Svelte                                                        |
+| `src/lib/utils/search-shortcut.spec.ts` (create)                                          | Cover the descriptors against the real matcher, and the guard                                                              |
+| `src/routes/+layout.svelte` (modify)                                                      | Wire the `/` descriptors into the existing `use:shortcuts` array                                                           |
+| `src/lib/components/timeline/actions/TimelineKeyboardActions.svelte` (modify)             | Remove `/` → Explore and its now-unused imports                                                                            |
+| `src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte` (modify)       | Remove `/` → Explore                                                                                                       |
+| `src/lib/modals/ShortcutsModal.svelte` (modify)                                           | Document `/`                                                                                                               |
 
 ---
 
 ### Task 1: Route touch taps to the modal palette
 
 **Files:**
+
 - Modify: `web/src/lib/components/global-search/global-search.svelte:485-489` (the `openDropdown` function) and `:631-651` (the dropdown `Command.Input`)
 - Test: `web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts`
 
 **Interfaces:**
+
 - Consumes: nothing from earlier tasks.
 - Produces: no exported symbols. Behaviour later tasks rely on: `globalSearchManager.presentation === 'modal'` after a touch tap, and `openDropdown` refusing to run while a modal is open.
 
@@ -73,66 +75,66 @@ import { fireEvent, render, screen } from '@testing-library/svelte';
 ```
 
 ```ts
-  it('opens the modal palette when the search field is tapped', async () => {
-    const openSpy = vi.spyOn(globalSearchManager, 'open');
-    const user = userEvent.setup();
+it('opens the modal palette when the search field is tapped', async () => {
+  const openSpy = vi.spyOn(globalSearchManager, 'open');
+  const user = userEvent.setup();
 
-    render(GlobalSearchInputTrigger);
+  render(GlobalSearchInputTrigger);
 
-    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
-    await user.pointer({ keys: '[TouchA]', target: input });
+  const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+  await user.pointer({ keys: '[TouchA]', target: input });
 
-    expect(openSpy).toHaveBeenCalledWith('modal');
-    expect(globalSearchManager.presentation).toBe('modal');
-    expect(document.querySelector('[data-cmdk-dropdown-panel]')).toBeNull();
-  });
+  expect(openSpy).toHaveBeenCalledWith('modal');
+  expect(globalSearchManager.presentation).toBe('modal');
+  expect(document.querySelector('[data-cmdk-dropdown-panel]')).toBeNull();
+});
 
-  it('does not focus the search field when it is tapped', async () => {
-    const user = userEvent.setup();
+it('does not focus the search field when it is tapped', async () => {
+  const user = userEvent.setup();
 
-    render(GlobalSearchInputTrigger);
+  render(GlobalSearchInputTrigger);
 
-    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
-    await user.pointer({ keys: '[TouchA]', target: input });
+  const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+  await user.pointer({ keys: '[TouchA]', target: input });
 
-    expect(input).not.toHaveFocus();
-  });
+  expect(input).not.toHaveFocus();
+});
 
-  it('opens the inline dropdown for pen input rather than the modal', async () => {
-    const user = userEvent.setup();
+it('opens the inline dropdown for pen input rather than the modal', async () => {
+  const user = userEvent.setup();
 
-    render(GlobalSearchInputTrigger);
+  render(GlobalSearchInputTrigger);
 
-    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
-    await fireEvent.pointerDown(input, { pointerType: 'pen' });
-    await user.click(input);
+  const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+  await fireEvent.pointerDown(input, { pointerType: 'pen' });
+  await user.click(input);
 
-    expect(globalSearchManager.presentation).toBe('dropdown');
-  });
+  expect(globalSearchManager.presentation).toBe('dropdown');
+});
 
-  it('opens the inline dropdown when a pointerdown carries no pointer type', async () => {
-    const user = userEvent.setup();
+it('opens the inline dropdown when a pointerdown carries no pointer type', async () => {
+  const user = userEvent.setup();
 
-    render(GlobalSearchInputTrigger);
+  render(GlobalSearchInputTrigger);
 
-    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
-    await fireEvent.pointerDown(input);
-    await user.click(input);
+  const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+  await fireEvent.pointerDown(input);
+  await user.click(input);
 
-    expect(globalSearchManager.presentation).toBe('dropdown');
-  });
+  expect(globalSearchManager.presentation).toBe('dropdown');
+});
 
-  it('does not let focus downgrade an open modal to the inline dropdown', async () => {
-    render(GlobalSearchInputTrigger);
+it('does not let focus downgrade an open modal to the inline dropdown', async () => {
+  render(GlobalSearchInputTrigger);
 
-    globalSearchManager.open('modal');
+  globalSearchManager.open('modal');
 
-    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
-    await fireEvent.focus(input);
+  const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+  await fireEvent.focus(input);
 
-    expect(globalSearchManager.presentation).toBe('modal');
-    expect(document.querySelector('[data-cmdk-dropdown-panel]')).toBeNull();
-  });
+  expect(globalSearchManager.presentation).toBe('modal');
+  expect(document.querySelector('[data-cmdk-dropdown-panel]')).toBeNull();
+});
 ```
 
 - [ ] **Step 2: Run the tests and confirm they fail for the right reason**
@@ -152,38 +154,38 @@ The two `pointerType` tests (`pen`, none) **pass already** — they pin behaviou
 In `global-search.svelte`, replace the existing `openDropdown` function (currently at `:485-489`):
 
 ```ts
-  function openDropdown() {
-    if (!showDropdownPanel) {
-      manager.open('dropdown');
-    }
+function openDropdown() {
+  if (!showDropdownPanel) {
+    manager.open('dropdown');
   }
+}
 ```
 
 with:
 
 ```ts
-  function openDropdown() {
-    // Focus must never downgrade an open modal to the inline dropdown.
-    // `showDropdownPanel` is false while the modal is open, so without this the
-    // next focus event would call open('dropdown') and clobber the presentation.
-    if (manager.isOpen && manager.presentation === 'modal') {
-      return;
-    }
-    if (!showDropdownPanel) {
-      manager.open('dropdown');
-    }
+function openDropdown() {
+  // Focus must never downgrade an open modal to the inline dropdown.
+  // `showDropdownPanel` is false while the modal is open, so without this the
+  // next focus event would call open('dropdown') and clobber the presentation.
+  if (manager.isOpen && manager.presentation === 'modal') {
+    return;
   }
+  if (!showDropdownPanel) {
+    manager.open('dropdown');
+  }
+}
 
-  function openModalOnTouch(event: PointerEvent) {
-    if (event.pointerType !== 'touch') {
-      return;
-    }
-    // preventDefault is load-bearing: it suppresses the focus this tap would
-    // otherwise produce on pointer release, and it stops iOS raising the soft
-    // keyboard against an input the modal is about to cover.
-    event.preventDefault();
-    manager.open('modal');
+function openModalOnTouch(event: PointerEvent) {
+  if (event.pointerType !== 'touch') {
+    return;
   }
+  // preventDefault is load-bearing: it suppresses the focus this tap would
+  // otherwise produce on pointer release, and it stops iOS raising the soft
+  // keyboard against an input the modal is about to cover.
+  event.preventDefault();
+  manager.open('modal');
+}
 ```
 
 - [ ] **Step 4: Wire the handler to the dropdown input**
@@ -221,10 +223,12 @@ git commit -m "fix(web): open the modal palette when the search bar is tapped (#
 ### Task 2: Hide the hotkey chip on coarse pointers
 
 **Files:**
+
 - Modify: `web/src/lib/components/global-search/global-search.svelte:652-656` (the `<kbd>` block)
 - Test: `web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts`
 
 **Interfaces:**
+
 - Consumes: nothing from Task 1.
 - Produces: no exported symbols.
 
@@ -250,8 +254,8 @@ vi.mock('$lib/stores/media-query-manager.svelte', () => ({
 Then reset it in the existing `beforeEach`, after `sessionStorage.clear();`:
 
 ```ts
-    mediaState.pointerCoarse = false;
-    mediaState.minLg = false;
+mediaState.pointerCoarse = false;
+mediaState.minLg = false;
 ```
 
 - [ ] **Step 2: Run the suite to confirm the mock changed nothing**
@@ -265,31 +269,31 @@ Expected: PASS, same count as after Task 1. The mock's defaults match the global
 Append inside the same `describe` block:
 
 ```ts
-  it('hides the keyboard hint when the pointer is coarse', () => {
-    mediaState.pointerCoarse = true;
+it('hides the keyboard hint when the pointer is coarse', () => {
+  mediaState.pointerCoarse = true;
 
-    render(GlobalSearchInputTrigger);
+  render(GlobalSearchInputTrigger);
 
-    expect(screen.queryByText(/^(⌘K|Ctrl\+K)$/)).not.toBeInTheDocument();
-  });
+  expect(screen.queryByText(/^(⌘K|Ctrl\+K)$/)).not.toBeInTheDocument();
+});
 
-  it('keeps the search field usable when the keyboard hint is hidden', () => {
-    mediaState.pointerCoarse = true;
+it('keeps the search field usable when the keyboard hint is hidden', () => {
+  mediaState.pointerCoarse = true;
 
-    render(GlobalSearchInputTrigger);
+  render(GlobalSearchInputTrigger);
 
-    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
-    expect(input).toBeInTheDocument();
-    expect(screen.getByTestId('cmdk-input-trigger')).toBeInTheDocument();
-  });
+  const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+  expect(input).toBeInTheDocument();
+  expect(screen.getByTestId('cmdk-input-trigger')).toBeInTheDocument();
+});
 
-  it('shows the keyboard hint when the pointer is not coarse', () => {
-    mediaState.pointerCoarse = false;
+it('shows the keyboard hint when the pointer is not coarse', () => {
+  mediaState.pointerCoarse = false;
 
-    render(GlobalSearchInputTrigger);
+  render(GlobalSearchInputTrigger);
 
-    expect(screen.getByText(/^(⌘K|Ctrl\+K)$/)).toBeInTheDocument();
-  });
+  expect(screen.getByText(/^(⌘K|Ctrl\+K)$/)).toBeInTheDocument();
+});
 ```
 
 - [ ] **Step 4: Run the tests and confirm the first one fails**
@@ -334,10 +338,12 @@ git commit -m "fix(web): hide the Ctrl+K hint on touch devices (#862)"
 ### Task 3: Create the `/` shortcut module
 
 **Files:**
+
 - Create: `web/src/lib/utils/search-shortcut.ts`
 - Test: `web/src/lib/utils/search-shortcut.spec.ts`
 
 **Interfaces:**
+
 - Consumes: `matchesShortcut` and the `ShortcutOptions` type from `$lib/actions/shortcut`.
 - Produces:
   - `isEditableTarget(element: Element | null): boolean`
@@ -544,12 +550,14 @@ git commit -m "feat(web): add / shortcut descriptors for global search"
 ### Task 4: Wire `/` in, remove `/` → Explore, and document it
 
 **Files:**
+
 - Modify: `web/src/routes/+layout.svelte:4` (import) and `:279-307` (the `use:shortcuts` array, closing `]}` on 307)
 - Modify: `web/src/lib/components/timeline/actions/TimelineKeyboardActions.svelte:2`, `:17`, `:119`
 - Modify: `web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte:274`
 - Modify: `web/src/lib/modals/ShortcutsModal.svelte:35`
 
 **Interfaces:**
+
 - Consumes: `searchShortcuts(open: () => void): ShortcutOptions[]` from Task 3.
 - Produces: nothing.
 
@@ -560,7 +568,7 @@ This task has no unit test of its own. It is wiring plus two deletions; the logi
 In `web/src/routes/+layout.svelte`, add the import next to the existing shortcut import at `:4`:
 
 ```ts
-  import { searchShortcuts } from '$lib/utils/search-shortcut';
+import { searchShortcuts } from '$lib/utils/search-shortcut';
 ```
 
 Then add a single spread as the **last** element of the `use:shortcuts` array, after the `{ ctrl: true, key: '/' }` entry's closing `},`:
@@ -593,13 +601,13 @@ In `web/src/lib/components/timeline/actions/TimelineKeyboardActions.svelte`, del
 That was the only use of both imports in this file, so also delete line 2:
 
 ```ts
-  import { goto } from '$app/navigation';
+import { goto } from '$app/navigation';
 ```
 
 and line 17:
 
 ```ts
-  import { Route } from '$lib/route';
+import { Route } from '$lib/route';
 ```
 
 Change nothing else in either file.
@@ -659,6 +667,7 @@ Start the dev stack (`make dev` from the repo root) and confirm by hand, since t
 **Spec coverage.** Every section of the spec maps to a task: decision 1 and 4 → Task 1; decision 5 and 7 → Task 2; decisions 2 and 3 plus both edge-case fixes (shift layouts, `type="search"`) → Tasks 3 and 4; the `openDropdown` invariant → Task 1; the ShortcutsModal entry and both upstream deletions → Task 4. Decision 6 (iPad modal keeps its current size) is a deliberate no-op and needs no task.
 
 **Deviations from the spec, and why.**
+
 1. The spec said to import `matchesShortcut` / `ShortcutOptions` from `@immich/ui`. The codebase actually routes these through the fork-local barrel `$lib/actions/shortcut`, which is what `TimelineKeyboardActions.svelte` uses. The plan follows the codebase.
 2. The spec described the test environment as jsdom and proposed `vi.spyOn(mediaQueryManager, 'pointerCoarse', 'get')`. It is happy-dom, `matchMedia` is globally stubbed to `matches: false`, and the codebase's established pattern is a hoisted-state `vi.mock`. The plan uses that pattern.
 3. The spec left the per-platform `⌘K` / `Ctrl+K` label rows as optional-if-brittle. The plan drops them, with the reason recorded in Task 2, and keeps a label-agnostic regex.

--- a/docs/superpowers/plans/2026-07-30-touch-search-entry.md
+++ b/docs/superpowers/plans/2026-07-30-touch-search-entry.md
@@ -35,6 +35,8 @@ These were confirmed empirically in this worktree. Do not re-litigate them; buil
 | `fireEvent.pointerDown(el, { pointerType: 'pen' })` delivers `'pen'` | probed, passing |
 | `fireEvent.pointerDown(el)` yields `pointerType === ''` | probed, passing |
 
+**The plan itself was dry-run before being finalised.** Task 1's tests were applied against unmodified source and produced exactly the failures Step 2 claims (`3 failed | 20 passed`). Task 3's module and spec were written and run in full (`20 passed`). Both were then reverted, so the tree is clean and every task still starts from RED. Every line number, code block, and expected tally below is copied from that run — not estimated.
+
 ## File Structure
 
 | File | Responsibility |
@@ -137,12 +139,13 @@ import { fireEvent, render, screen } from '@testing-library/svelte';
 
 Run: `pnpm exec vitest run src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts`
 
-Expected: 3 failures.
-- `opens the modal palette when the search field is tapped` — fails because the touch tap focuses the input, `openDropdown` fires, and `presentation` is `'dropdown'`.
-- `does not focus the search field when it is tapped` — fails because nothing prevents the tap's default.
-- `does not let focus downgrade an open modal to the inline dropdown` — fails because `openDropdown` flips `presentation` to `'dropdown'`.
+Expected — this exact tally, confirmed by running it: **`Tests  3 failed | 20 passed (23)`**
 
-The two `pointerType` tests (`pen`, none) should already **pass** — they pin behaviour that must survive the change. If either fails here, stop and re-read the file; something else is wrong.
+- `opens the modal palette when the search field is tapped` — `AssertionError: expected "open" to be called with arguments: [ 'modal' ]`. The touch tap focuses the input, `openDropdown` fires, and `presentation` is `'dropdown'`.
+- `does not focus the search field when it is tapped` — fails because nothing prevents the tap's default.
+- `does not let focus downgrade an open modal to the inline dropdown` — `AssertionError: expected 'dropdown' to be 'modal'`.
+
+The two `pointerType` tests (`pen`, none) **pass already** — they pin behaviour that must survive the change. If either fails here, stop and re-read the file; something else is wrong.
 
 - [ ] **Step 3: Add the touch handler and the modal guard**
 
@@ -527,9 +530,7 @@ Write the null check as `element !== null && …`, not `element?.closest(…) !=
 
 Run: `pnpm exec vitest run src/lib/utils/search-shortcut.spec.ts`
 
-Expected: PASS, 17 tests.
-
-If `does not open search while typing in a textarea` or the search-input test fails on the `expect(document.activeElement).toBe(field)` line, happy-dom did not apply focus; switch that assertion's setup to append the element to `document.body` before calling `focus()` rather than assigning `innerHTML`.
+Expected — confirmed by running it: **`Tests  20 passed (20)`**. (Twenty, not fourteen: the `it.each` block expands to six.) happy-dom applies focus correctly here, so the two `expect(document.activeElement).toBe(field)` sanity assertions pass as written.
 
 - [ ] **Step 5: Commit**
 
@@ -543,7 +544,7 @@ git commit -m "feat(web): add / shortcut descriptors for global search"
 ### Task 4: Wire `/` in, remove `/` → Explore, and document it
 
 **Files:**
-- Modify: `web/src/routes/+layout.svelte:4` (import) and `:279-306` (the `use:shortcuts` array)
+- Modify: `web/src/routes/+layout.svelte:4` (import) and `:279-307` (the `use:shortcuts` array, closing `]}` on 307)
 - Modify: `web/src/lib/components/timeline/actions/TimelineKeyboardActions.svelte:2`, `:17`, `:119`
 - Modify: `web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte:274`
 - Modify: `web/src/lib/modals/ShortcutsModal.svelte:35`

--- a/docs/superpowers/plans/2026-07-30-touch-search-entry.md
+++ b/docs/superpowers/plans/2026-07-30-touch-search-entry.md
@@ -1,0 +1,667 @@
+# Touch Search Entry + `/` Shortcut Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give touch devices a working, honest way into the search palette (issue #862), and make `/` open it.
+
+**Architecture:** Tapping the nav search bar with a finger opens the modal palette instead of the cramped inline dropdown, decided per event via `PointerEvent.pointerType`. The `Ctrl+K` chip is hidden when the pointer is coarse. `/` becomes an alias for the existing `Ctrl+K` path, replacing the old `/` → Explore binding, with its guard and descriptors extracted into a small pure module so they are directly testable.
+
+**Tech Stack:** SvelteKit 2 / Svelte 5 runes, TypeScript, `bits-ui` Command, `@immich/ui` shortcut actions, Vitest 4 + happy-dom + `@testing-library/svelte` + `@testing-library/user-event` 14.
+
+**Spec:** `docs/superpowers/specs/2026-07-30-touch-search-entry-design.md`
+
+## Global Constraints
+
+- All work happens in `web/`. Run every command from `web/` unless stated otherwise.
+- `@immich/sdk` must be built before tests will run: `pnpm --filter @immich/sdk build` from the repo root. Already done in this worktree; redo it if `Failed to resolve import "@immich/sdk"` appears.
+- Baseline before any change: `pnpm test` → **4001 passed | 2 skipped | 8 todo, 0 failures**. An `ECONNREFUSED ::1:3000` block in the output is expected background noise, not a failure.
+- Import shortcut helpers from `$lib/actions/shortcut`, **never** from `@immich/ui` directly. That barrel re-exports `matchesShortcut`, `shortcut`, `shortcuts`, `shouldIgnoreEvent`, `Shortcut`, and `ShortcutOptions`, and is the established convention in this codebase.
+- Test environment is **happy-dom**, not jsdom. `matchMedia` is globally stubbed in `src/test-data/setup.ts` to always return `matches: false`, so every `MediaQuery` reads `false` unless the module is mocked.
+- Mock media queries with the hoisted-state `vi.mock` pattern already used in `src/lib/components/global-search/__tests__/global-search.spec.ts`. Do not use `vi.spyOn(mediaQueryManager, ...)`.
+- Never add a `Co-Authored-By: Claude` trailer or "Generated with Claude Code" line to any commit.
+- `GalleryViewer.svelte` and `TimelineKeyboardActions.svelte` are upstream files. Changes there must be pure deletions — no reformatting, renaming, or reordering.
+
+## Verified Environment Facts
+
+These were confirmed empirically in this worktree. Do not re-litigate them; build on them.
+
+| Fact | Evidence |
+|---|---|
+| `user.pointer({ keys: '[TouchA]', target })` dispatches `pointerdown` with `pointerType === 'touch'` | probed, passing |
+| An **unprevented** touch tap **focuses** the input | probed, passing — this is why the guard matters |
+| `preventDefault()` on a touch `pointerdown` **suppresses** that focus | probed, passing — `not.toHaveFocus()` is a real assertion |
+| `user.click(target)` dispatches `pointerdown` with `pointerType === 'mouse'` | probed, passing |
+| `PointerEvent` constructor exists and carries `pointerType` | probed, passing |
+| `fireEvent.pointerDown(el, { pointerType: 'pen' })` delivers `'pen'` | probed, passing |
+| `fireEvent.pointerDown(el)` yields `pointerType === ''` | probed, passing |
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/lib/components/global-search/global-search.svelte` (modify) | Route touch taps to the modal; hold the "focus never downgrades an open modal" invariant; hide the chip on coarse pointers |
+| `src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts` (modify) | Cover pointer routing and chip visibility |
+| `src/lib/utils/search-shortcut.ts` (create) | The `/` descriptors and the editable-target guard — pure, no Svelte |
+| `src/lib/utils/search-shortcut.spec.ts` (create) | Cover the descriptors against the real matcher, and the guard |
+| `src/routes/+layout.svelte` (modify) | Wire the `/` descriptors into the existing `use:shortcuts` array |
+| `src/lib/components/timeline/actions/TimelineKeyboardActions.svelte` (modify) | Remove `/` → Explore and its now-unused imports |
+| `src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte` (modify) | Remove `/` → Explore |
+| `src/lib/modals/ShortcutsModal.svelte` (modify) | Document `/` |
+
+---
+
+### Task 1: Route touch taps to the modal palette
+
+**Files:**
+- Modify: `web/src/lib/components/global-search/global-search.svelte:485-489` (the `openDropdown` function) and `:631-651` (the dropdown `Command.Input`)
+- Test: `web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: no exported symbols. Behaviour later tasks rely on: `globalSearchManager.presentation === 'modal'` after a touch tap, and `openDropdown` refusing to run while a modal is open.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these five tests inside the existing `describe('global-search-input-trigger', ...)` block, after the test named `'switches from dropdown to modal presentation on the keyboard launcher shortcut'`.
+
+Add `fireEvent` to the existing import on line 1 so it reads:
+
+```ts
+import { fireEvent, render, screen } from '@testing-library/svelte';
+```
+
+```ts
+  it('opens the modal palette when the search field is tapped', async () => {
+    const openSpy = vi.spyOn(globalSearchManager, 'open');
+    const user = userEvent.setup();
+
+    render(GlobalSearchInputTrigger);
+
+    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+    await user.pointer({ keys: '[TouchA]', target: input });
+
+    expect(openSpy).toHaveBeenCalledWith('modal');
+    expect(globalSearchManager.presentation).toBe('modal');
+    expect(document.querySelector('[data-cmdk-dropdown-panel]')).toBeNull();
+  });
+
+  it('does not focus the search field when it is tapped', async () => {
+    const user = userEvent.setup();
+
+    render(GlobalSearchInputTrigger);
+
+    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+    await user.pointer({ keys: '[TouchA]', target: input });
+
+    expect(input).not.toHaveFocus();
+  });
+
+  it('opens the inline dropdown for pen input rather than the modal', async () => {
+    const user = userEvent.setup();
+
+    render(GlobalSearchInputTrigger);
+
+    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+    await fireEvent.pointerDown(input, { pointerType: 'pen' });
+    await user.click(input);
+
+    expect(globalSearchManager.presentation).toBe('dropdown');
+  });
+
+  it('opens the inline dropdown when a pointerdown carries no pointer type', async () => {
+    const user = userEvent.setup();
+
+    render(GlobalSearchInputTrigger);
+
+    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+    await fireEvent.pointerDown(input);
+    await user.click(input);
+
+    expect(globalSearchManager.presentation).toBe('dropdown');
+  });
+
+  it('does not let focus downgrade an open modal to the inline dropdown', async () => {
+    render(GlobalSearchInputTrigger);
+
+    globalSearchManager.open('modal');
+
+    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+    await fireEvent.focus(input);
+
+    expect(globalSearchManager.presentation).toBe('modal');
+    expect(document.querySelector('[data-cmdk-dropdown-panel]')).toBeNull();
+  });
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail for the right reason**
+
+Run: `pnpm exec vitest run src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts`
+
+Expected: 3 failures.
+- `opens the modal palette when the search field is tapped` — fails because the touch tap focuses the input, `openDropdown` fires, and `presentation` is `'dropdown'`.
+- `does not focus the search field when it is tapped` — fails because nothing prevents the tap's default.
+- `does not let focus downgrade an open modal to the inline dropdown` — fails because `openDropdown` flips `presentation` to `'dropdown'`.
+
+The two `pointerType` tests (`pen`, none) should already **pass** — they pin behaviour that must survive the change. If either fails here, stop and re-read the file; something else is wrong.
+
+- [ ] **Step 3: Add the touch handler and the modal guard**
+
+In `global-search.svelte`, replace the existing `openDropdown` function (currently at `:485-489`):
+
+```ts
+  function openDropdown() {
+    if (!showDropdownPanel) {
+      manager.open('dropdown');
+    }
+  }
+```
+
+with:
+
+```ts
+  function openDropdown() {
+    // Focus must never downgrade an open modal to the inline dropdown.
+    // `showDropdownPanel` is false while the modal is open, so without this the
+    // next focus event would call open('dropdown') and clobber the presentation.
+    if (manager.isOpen && manager.presentation === 'modal') {
+      return;
+    }
+    if (!showDropdownPanel) {
+      manager.open('dropdown');
+    }
+  }
+
+  function openModalOnTouch(event: PointerEvent) {
+    if (event.pointerType !== 'touch') {
+      return;
+    }
+    // preventDefault is load-bearing: it suppresses the focus this tap would
+    // otherwise produce on pointer release, and it stops iOS raising the soft
+    // keyboard against an input the modal is about to cover.
+    event.preventDefault();
+    manager.open('modal');
+  }
+```
+
+- [ ] **Step 4: Wire the handler to the dropdown input**
+
+In the `variant === 'dropdown'` branch, add `onpointerdown` to `Command.Input` immediately after the existing `onfocus` line (currently `:636`):
+
+```svelte
+          onfocus={openDropdown}
+          onpointerdown={openModalOnTouch}
+```
+
+Leave every other attribute on that element untouched.
+
+- [ ] **Step 5: Run the tests and confirm they pass**
+
+Run: `pnpm exec vitest run src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts`
+
+Expected: PASS, all tests in the file including the pre-existing ones.
+
+- [ ] **Step 6: Check for regressions in the sibling suite**
+
+Run: `pnpm exec vitest run src/lib/components/global-search`
+
+Expected: PASS. The palette suite is large and exercises both presentations; a failure here means the guard is too broad.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/components/global-search/global-search.svelte src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
+git commit -m "fix(web): open the modal palette when the search bar is tapped (#862)"
+```
+
+---
+
+### Task 2: Hide the hotkey chip on coarse pointers
+
+**Files:**
+- Modify: `web/src/lib/components/global-search/global-search.svelte:652-656` (the `<kbd>` block)
+- Test: `web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: no exported symbols.
+
+- [ ] **Step 1: Add the media query mock to the spec file**
+
+This spec file does not currently mock the media query manager. Add the mock below the existing `vi.mock('$app/state', ...)` line. It must supply **both** getters — `global-search.svelte:310` reads `minLg` and the trigger reads it too, so omitting one breaks unrelated tests.
+
+```ts
+const { mediaState } = vi.hoisted(() => ({ mediaState: { pointerCoarse: false, minLg: false } }));
+
+vi.mock('$lib/stores/media-query-manager.svelte', () => ({
+  mediaQueryManager: {
+    get pointerCoarse() {
+      return mediaState.pointerCoarse;
+    },
+    get minLg() {
+      return mediaState.minLg;
+    },
+  },
+}));
+```
+
+Then reset it in the existing `beforeEach`, after `sessionStorage.clear();`:
+
+```ts
+    mediaState.pointerCoarse = false;
+    mediaState.minLg = false;
+```
+
+- [ ] **Step 2: Run the suite to confirm the mock changed nothing**
+
+Run: `pnpm exec vitest run src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts`
+
+Expected: PASS, same count as after Task 1. The mock's defaults match the global `matchMedia` stub, so this step is a no-op by design. If anything fails, the mock is missing a getter the component reads.
+
+- [ ] **Step 3: Write the failing tests**
+
+Append inside the same `describe` block:
+
+```ts
+  it('hides the keyboard hint when the pointer is coarse', () => {
+    mediaState.pointerCoarse = true;
+
+    render(GlobalSearchInputTrigger);
+
+    expect(screen.queryByText(/^(⌘K|Ctrl\+K)$/)).not.toBeInTheDocument();
+  });
+
+  it('keeps the search field usable when the keyboard hint is hidden', () => {
+    mediaState.pointerCoarse = true;
+
+    render(GlobalSearchInputTrigger);
+
+    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+    expect(input).toBeInTheDocument();
+    expect(screen.getByTestId('cmdk-input-trigger')).toBeInTheDocument();
+  });
+
+  it('shows the keyboard hint when the pointer is not coarse', () => {
+    mediaState.pointerCoarse = false;
+
+    render(GlobalSearchInputTrigger);
+
+    expect(screen.getByText(/^(⌘K|Ctrl\+K)$/)).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 4: Run the tests and confirm the first one fails**
+
+Run: `pnpm exec vitest run src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts`
+
+Expected: 1 failure — `hides the keyboard hint when the pointer is coarse`, because the chip renders unconditionally. The other two pass already.
+
+- [ ] **Step 5: Wrap the chip**
+
+In `global-search.svelte`, wrap the `<kbd>` block in the dropdown branch. Keep the class list byte-identical — only the `{#if}` wrapper and indentation change:
+
+```svelte
+        {#if !mediaQueryManager.pointerCoarse}
+          <kbd
+            class="hidden shrink-0 rounded-lg border border-gray-300 bg-white px-2 py-1 font-mono text-[11px] font-semibold tracking-wide text-gray-500 sm:inline-block dark:border-immich-dark-gray dark:bg-immich-dark-bg dark:text-gray-300"
+          >
+            {hotkeyLabel}
+          </kbd>
+        {/if}
+```
+
+`mediaQueryManager` is already imported at `:24` — do not add a second import.
+
+- [ ] **Step 6: Run the tests and confirm they pass**
+
+Run: `pnpm exec vitest run src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/components/global-search/global-search.svelte src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
+git commit -m "fix(web): hide the Ctrl+K hint on touch devices (#862)"
+```
+
+**Note on scope:** per-platform label assertions (`⌘K` on Apple, `Ctrl+K` elsewhere) are deliberately not tested. `isApplePlatform` is a module-scope `const` at `global-search.svelte:44`, evaluated once at import, so stubbing `navigator.platform` in a test has no effect without `vi.resetModules()` plus a dynamic import. That behaviour predates this change and is untouched by it. The regex above accepts either label.
+
+---
+
+### Task 3: Create the `/` shortcut module
+
+**Files:**
+- Create: `web/src/lib/utils/search-shortcut.ts`
+- Test: `web/src/lib/utils/search-shortcut.spec.ts`
+
+**Interfaces:**
+- Consumes: `matchesShortcut` and the `ShortcutOptions` type from `$lib/actions/shortcut`.
+- Produces:
+  - `isEditableTarget(element: Element | null): boolean`
+  - `searchShortcuts(open: () => void): ShortcutOptions[]` — returns exactly two descriptors, `{ key: '/' }` and `{ key: '/', shift: true }`, in that order. Task 4 spreads the result into `use:shortcuts`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `web/src/lib/utils/search-shortcut.spec.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import { matchesShortcut } from '$lib/actions/shortcut';
+import { isEditableTarget, searchShortcuts } from './search-shortcut';
+
+const keydown = (init: KeyboardEventInit) => new KeyboardEvent('keydown', init);
+
+const countMatches = (event: KeyboardEvent) =>
+  searchShortcuts(() => {}).filter((option) => matchesShortcut(event, option.shortcut)).length;
+
+const fire = (open: () => void, event: KeyboardEvent) => {
+  for (const option of searchShortcuts(open)) {
+    if (matchesShortcut(event, option.shortcut)) {
+      option.onShortcut(event as KeyboardEvent & { currentTarget: HTMLElement });
+    }
+  }
+};
+
+const focusHtml = (html: string) => {
+  document.body.innerHTML = html;
+  const element = document.body.firstElementChild as HTMLElement;
+  element.focus();
+  return element;
+};
+
+describe('isEditableTarget', () => {
+  it.each([
+    ['a text input', '<input type="text" />'],
+    ['a search input', '<input type="search" />'],
+    ['a number input', '<input type="number" />'],
+    ['a textarea', '<textarea></textarea>'],
+    ['a select', '<select></select>'],
+    ['a contenteditable element', '<div contenteditable="true"></div>'],
+  ])('treats %s as editable', (_name, html) => {
+    document.body.innerHTML = html;
+
+    expect(isEditableTarget(document.body.firstElementChild)).toBe(true);
+  });
+
+  it('treats an element nested inside a contenteditable region as editable', () => {
+    document.body.innerHTML = '<div contenteditable="true"><span id="inner">hi</span></div>';
+
+    expect(isEditableTarget(document.querySelector('#inner'))).toBe(true);
+  });
+
+  it('does not treat an explicitly non-editable region as editable', () => {
+    document.body.innerHTML = '<div contenteditable="false"></div>';
+
+    expect(isEditableTarget(document.body.firstElementChild)).toBe(false);
+  });
+
+  it('does not treat an ordinary element as editable', () => {
+    document.body.innerHTML = '<div></div>';
+
+    expect(isEditableTarget(document.body.firstElementChild)).toBe(false);
+  });
+
+  it('returns false for null rather than throwing', () => {
+    expect(isEditableTarget(null)).toBe(false);
+  });
+});
+
+describe('searchShortcuts', () => {
+  it('registers a bare slash and a shifted slash, in that order', () => {
+    expect(searchShortcuts(() => {}).map((option) => option.shortcut)).toEqual([
+      { key: '/' },
+      { key: '/', shift: true },
+    ]);
+  });
+
+  it('matches a bare slash exactly once', () => {
+    expect(countMatches(keydown({ key: '/' }))).toBe(1);
+  });
+
+  it('matches a shifted slash exactly once, for layouts where slash needs shift', () => {
+    expect(countMatches(keydown({ key: '/', shiftKey: true }))).toBe(1);
+  });
+
+  it('leaves question mark to the keyboard shortcuts modal', () => {
+    expect(countMatches(keydown({ key: '?', shiftKey: true }))).toBe(0);
+  });
+
+  it('leaves ctrl+slash to the search mode cycle', () => {
+    expect(countMatches(keydown({ key: '/', ctrlKey: true }))).toBe(0);
+  });
+
+  it('ignores slash with alt or meta held', () => {
+    expect(countMatches(keydown({ key: '/', altKey: true }))).toBe(0);
+    expect(countMatches(keydown({ key: '/', metaKey: true }))).toBe(0);
+  });
+
+  it('opens search when nothing is being edited', () => {
+    document.body.innerHTML = '';
+    const open = vi.fn();
+
+    fire(open, keydown({ key: '/' }));
+
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens search from a shifted slash when nothing is being edited', () => {
+    document.body.innerHTML = '';
+    const open = vi.fn();
+
+    fire(open, keydown({ key: '/', shiftKey: true }));
+
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not open search while typing in a search input', () => {
+    const field = focusHtml('<input type="search" />');
+    expect(document.activeElement).toBe(field);
+    const open = vi.fn();
+
+    fire(open, keydown({ key: '/' }));
+
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('does not open search while typing in a textarea', () => {
+    const field = focusHtml('<textarea></textarea>');
+    expect(document.activeElement).toBe(field);
+    const open = vi.fn();
+
+    fire(open, keydown({ key: '/' }));
+
+    expect(open).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Run: `pnpm exec vitest run src/lib/utils/search-shortcut.spec.ts`
+
+Expected: FAIL — the whole suite errors with `Failed to resolve import "./search-shortcut"`.
+
+- [ ] **Step 3: Write the module**
+
+Create `web/src/lib/utils/search-shortcut.ts`:
+
+```ts
+import type { ShortcutOptions } from '$lib/actions/shortcut';
+
+const EDITABLE_SELECTOR = 'input, textarea, select, [contenteditable]:not([contenteditable="false"])';
+
+/** True when the element is, or sits inside, something the user can type into. */
+export const isEditableTarget = (element: Element | null): boolean =>
+  element !== null && element.closest(EDITABLE_SELECTOR) !== null;
+
+/**
+ * Descriptors binding `/` to the global search palette.
+ *
+ * Two of them, because `matchesShortcut` compares modifiers strictly
+ * (`Boolean(shortcut.shift) === event.shiftKey`) and several common layouts
+ * produce `/` with Shift held — QWERTZ and Spanish use Shift+7, AZERTY Shift+:.
+ * A lone `{ key: '/' }` would be dead for all of them. There is no clash with
+ * `?`, which arrives as `event.key === '?'` on US layouts.
+ */
+export const searchShortcuts = (open: () => void): ShortcutOptions[] => {
+  const openUnlessEditing = () => {
+    // `shouldIgnoreEvent` in @immich/ui only skips a fixed list of input types
+    // (textarea, text, date, datetime-local, email, password), so `type="search"`
+    // and `type="number"` fields would otherwise swallow a typed `/`.
+    if (isEditableTarget(document.activeElement)) {
+      return;
+    }
+    open();
+  };
+
+  return [
+    { shortcut: { key: '/' }, onShortcut: openUnlessEditing },
+    { shortcut: { key: '/', shift: true }, onShortcut: openUnlessEditing },
+  ];
+};
+```
+
+Write the null check as `element !== null && …`, not `element?.closest(…) !== null` — the optional-chaining form yields `undefined !== null`, which is `true`, so it would report `null` as editable and silently kill the shortcut. The `isEditableTarget(null)` test catches exactly that.
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+Run: `pnpm exec vitest run src/lib/utils/search-shortcut.spec.ts`
+
+Expected: PASS, 17 tests.
+
+If `does not open search while typing in a textarea` or the search-input test fails on the `expect(document.activeElement).toBe(field)` line, happy-dom did not apply focus; switch that assertion's setup to append the element to `document.body` before calling `focus()` rather than assigning `innerHTML`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/utils/search-shortcut.ts src/lib/utils/search-shortcut.spec.ts
+git commit -m "feat(web): add / shortcut descriptors for global search"
+```
+
+---
+
+### Task 4: Wire `/` in, remove `/` → Explore, and document it
+
+**Files:**
+- Modify: `web/src/routes/+layout.svelte:4` (import) and `:279-306` (the `use:shortcuts` array)
+- Modify: `web/src/lib/components/timeline/actions/TimelineKeyboardActions.svelte:2`, `:17`, `:119`
+- Modify: `web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte:274`
+- Modify: `web/src/lib/modals/ShortcutsModal.svelte:35`
+
+**Interfaces:**
+- Consumes: `searchShortcuts(open: () => void): ShortcutOptions[]` from Task 3.
+- Produces: nothing.
+
+This task has no unit test of its own. It is wiring plus two deletions; the logic it wires was fully covered in Task 3, and the verification is type-check, lint, and the full suite. Do not invent a `+layout.svelte` test — there is no spec file for it and no precedent in the codebase.
+
+- [ ] **Step 1: Wire the shortcuts into the layout**
+
+In `web/src/routes/+layout.svelte`, add the import next to the existing shortcut import at `:4`:
+
+```ts
+  import { searchShortcuts } from '$lib/utils/search-shortcut';
+```
+
+Then add a single spread as the **last** element of the `use:shortcuts` array, after the `{ ctrl: true, key: '/' }` entry's closing `},`:
+
+```svelte
+    ...searchShortcuts(openModalSearch),
+  ]}
+```
+
+`openModalSearch` is already defined at `:235` and carries the feature-flag guard and `toggle('modal')` semantics. Pass it by reference — do not wrap or reimplement it.
+
+- [ ] **Step 2: Remove `/` → Explore from the gallery viewer**
+
+In `web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte`, delete line 274 in full:
+
+```svelte
+        { shortcut: { key: '/' }, onShortcut: () => goto(Route.explore()) },
+```
+
+Leave the imports alone — `goto` and `Route` each have another use in this file.
+
+- [ ] **Step 3: Remove `/` → Explore from the timeline**
+
+In `web/src/lib/components/timeline/actions/TimelineKeyboardActions.svelte`, delete line 119 in full:
+
+```svelte
+      { shortcut: { key: '/' }, onShortcut: () => goto(Route.explore()) },
+```
+
+That was the only use of both imports in this file, so also delete line 2:
+
+```ts
+  import { goto } from '$app/navigation';
+```
+
+and line 17:
+
+```ts
+  import { Route } from '$lib/route';
+```
+
+Change nothing else in either file.
+
+- [ ] **Step 4: Document the shortcut**
+
+In `web/src/lib/modals/ShortcutsModal.svelte`, add a row directly after line 35:
+
+```svelte
+        { key: ['Ctrl', 'k'], action: $t('shortcut_open_global_search') },
+        { key: ['/'], action: $t('shortcut_open_global_search') },
+```
+
+Reusing `shortcut_open_global_search` keeps the change to zero new i18n strings — the key already exists at `i18n/en.json:2608`. Listing the same action twice under different keys is intentional; they are aliases.
+
+- [ ] **Step 5: Type-check and lint**
+
+Run from the repo root:
+
+```bash
+make check-web
+make lint-web
+```
+
+Expected: both clean. This is the step that catches the unused `goto` / `Route` imports if Step 3 was done partially.
+
+- [ ] **Step 6: Run the full web suite**
+
+Run from `web/`: `pnpm test`
+
+Expected: **0 failures**, and a total at or above the 4001-passed baseline. No existing test asserts `/` → Explore, so the deletions should not move any count downward.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/routes/+layout.svelte \
+  src/lib/components/timeline/actions/TimelineKeyboardActions.svelte \
+  src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte \
+  src/lib/modals/ShortcutsModal.svelte
+git commit -m "feat(web): open global search with /"
+```
+
+- [ ] **Step 8: Manual verification**
+
+Start the dev stack (`make dev` from the repo root) and confirm by hand, since these paths have no automated coverage:
+
+1. Press `/` on the timeline — the modal palette opens, and you do **not** land on Explore.
+2. Open a photo in the asset viewer and press `/` — the palette opens over the viewer. This is the intended change from the old behaviour, where `/` was suppressed there.
+3. Focus the space albums search field (`type="search"`) and type `/` — the character is inserted and the palette stays closed.
+4. Press `?` — the keyboard shortcuts modal opens and lists `/` for Open global search.
+5. In responsive device mode with touch emulation, tap the nav search bar — the modal palette opens and the `Ctrl+K` chip is absent.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every section of the spec maps to a task: decision 1 and 4 → Task 1; decision 5 and 7 → Task 2; decisions 2 and 3 plus both edge-case fixes (shift layouts, `type="search"`) → Tasks 3 and 4; the `openDropdown` invariant → Task 1; the ShortcutsModal entry and both upstream deletions → Task 4. Decision 6 (iPad modal keeps its current size) is a deliberate no-op and needs no task.
+
+**Deviations from the spec, and why.**
+1. The spec said to import `matchesShortcut` / `ShortcutOptions` from `@immich/ui`. The codebase actually routes these through the fork-local barrel `$lib/actions/shortcut`, which is what `TimelineKeyboardActions.svelte` uses. The plan follows the codebase.
+2. The spec described the test environment as jsdom and proposed `vi.spyOn(mediaQueryManager, 'pointerCoarse', 'get')`. It is happy-dom, `matchMedia` is globally stubbed to `matches: false`, and the codebase's established pattern is a hoisted-state `vi.mock`. The plan uses that pattern.
+3. The spec left the per-platform `⌘K` / `Ctrl+K` label rows as optional-if-brittle. The plan drops them, with the reason recorded in Task 2, and keeps a label-agnostic regex.
+
+**Placeholder scan.** No TBDs, no "handle edge cases", no "similar to Task N". Every code step carries the literal code.
+
+**Type consistency.** `isEditableTarget(element: Element | null): boolean` and `searchShortcuts(open: () => void): ShortcutOptions[]` are declared in Task 3's Interfaces block, defined in Task 3 Step 3, and consumed in Task 4 Step 1 under exactly those names. `openModalOnTouch` and `openDropdown` are local to `global-search.svelte` and referenced only within Task 1.

--- a/docs/superpowers/specs/2026-07-30-touch-search-entry-design.md
+++ b/docs/superpowers/specs/2026-07-30-touch-search-entry-design.md
@@ -32,8 +32,10 @@ Separately, we want `/` to open search, matching the GitHub/Gmail/Slack conventi
 | 6 | The iPad modal keeps its **current large centred size** | Already comfortable, needs no new CSS; full-bleed styling can follow if it reads cramped |
 | 7 | Chip visibility uses `{#if}` on `mediaQueryManager.pointerCoarse`, not a CSS media query | jsdom does not evaluate CSS media queries, so `{#if}` is the testable form |
 
-Decision 7 costs a one-frame flash: `MediaQuery` has no SSR value, so the chip renders during SSR
-and is removed on hydration. Accepted in exchange for real assertions.
+Decision 7 does not cost a flash: `web/src/routes/+layout.ts:9` sets `export const ssr = false`, so
+this app never server-renders any route. `MediaQuery` having no SSR value would only matter if there
+were an SSR pass to read it during — there isn't, so the chip's first render is already
+client-side and already has the real `pointerCoarse` value.
 
 Decision 4 covers `pointerType === 'touch'` only. `'pen'` keeps the dropdown — an Apple Pencil tap
 on a tablet arguably wants the modal too, but a Surface pen paired with a keyboard does not, and pen
@@ -43,7 +45,7 @@ input on this surface is rare. Pinned by test so the choice is deliberate rather
 
 | Interaction | Before | After |
 |---|---|---|
-| Tap nav search bar (finger) | focus → inline dropdown, soft keyboard covers it | **modal palette**, no soft keyboard |
+| Tap nav search bar (finger) | focus → inline dropdown, soft keyboard covers it | **modal palette**; its own input autofocuses, so the keyboard opens against the modal instead |
 | Click nav search bar (mouse / trackpad / pen) | inline dropdown | unchanged |
 | Tab to nav search bar | inline dropdown | unchanged |
 | `Ctrl+K` / `⌘K` | modal palette | unchanged |
@@ -67,7 +69,9 @@ The `preventDefault()` is load-bearing for two reasons, and both belong in a cod
 
 - it suppresses the focus that would otherwise fire `onfocus={openDropdown}`, which calls
   `manager.open('dropdown')` and clobbers `presentation` straight back to `'dropdown'`;
-- it stops iOS raising the soft keyboard against an input that is about to be covered by the modal.
+- it stops iOS raising the soft keyboard against *this inline input*, which the modal is about to
+  cover. The modal's own `Command.Input` autofocuses once it opens, so the keyboard still appears —
+  just against the modal's input instead of this one.
 
 **Hide the chip on coarse pointers.** Wrap the `<kbd>` block (L652–656) in
 `{#if !mediaQueryManager.pointerCoarse}`. `mediaQueryManager` is already imported at L24. The
@@ -267,7 +271,7 @@ by the unit tests above.
 | Risk | Mitigation |
 |---|---|
 | Users relying on `/` → Explore lose it | Sidebar entry unchanged; `/` = search is the stronger convention |
-| One-frame chip flash on touch after hydration | Accepted for testability; swap to a CSS variant if it proves visible |
+| ~~One-frame chip flash on touch after hydration~~ — does not apply | `web/src/routes/+layout.ts:9` sets `ssr = false`; there is no SSR render pass, so there is nothing for hydration to reconcile away |
 | `preventDefault()` on pointerdown blocks focus more broadly than intended | Guarded to `pointerType === 'touch'`; mouse, pen, and keyboard paths each covered by test |
 | A browser focuses the nav input by a path `preventDefault()` misses | The `openDropdown` early-return holds the invariant independently |
 | Upstream edits conflict on rebase | Pure deletions in two files, three lines total |

--- a/docs/superpowers/specs/2026-07-30-touch-search-entry-design.md
+++ b/docs/superpowers/specs/2026-07-30-touch-search-entry-design.md
@@ -22,15 +22,15 @@ Separately, we want `/` to open search, matching the GitHub/Gmail/Slack conventi
 
 ## Decisions
 
-| # | Decision | Rationale |
-|---|---|---|
-| 1 | On touch, tapping the search bar opens the **modal** palette, not the inline dropdown | Full-height below 640px, large centred card above; no soft-keyboard occlusion |
-| 2 | `/` **replaces** the existing `/` → Explore binding | `/` = search is the near-universal convention; Explore stays reachable from the sidebar |
-| 3 | `/` opens the **same modal palette** `Ctrl+K` opens | One surface, one documented behaviour, works where the nav bar is hidden |
-| 4 | Touch is detected **per event** via `PointerEvent.pointerType` | Exact per-interaction; an iPad user gets the modal by finger and the dropdown by trackpad |
-| 5 | The `<kbd>` chip is **hidden** when `pointer: coarse` | Removes the misleading hint; the whole bar becomes the tap target |
-| 6 | The iPad modal keeps its **current large centred size** | Already comfortable, needs no new CSS; full-bleed styling can follow if it reads cramped |
-| 7 | Chip visibility uses `{#if}` on `mediaQueryManager.pointerCoarse`, not a CSS media query | jsdom does not evaluate CSS media queries, so `{#if}` is the testable form |
+| #   | Decision                                                                                 | Rationale                                                                                 |
+| --- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| 1   | On touch, tapping the search bar opens the **modal** palette, not the inline dropdown    | Full-height below 640px, large centred card above; no soft-keyboard occlusion             |
+| 2   | `/` **replaces** the existing `/` → Explore binding                                      | `/` = search is the near-universal convention; Explore stays reachable from the sidebar   |
+| 3   | `/` opens the **same modal palette** `Ctrl+K` opens                                      | One surface, one documented behaviour, works where the nav bar is hidden                  |
+| 4   | Touch is detected **per event** via `PointerEvent.pointerType`                           | Exact per-interaction; an iPad user gets the modal by finger and the dropdown by trackpad |
+| 5   | The `<kbd>` chip is **hidden** when `pointer: coarse`                                    | Removes the misleading hint; the whole bar becomes the tap target                         |
+| 6   | The iPad modal keeps its **current large centred size**                                  | Already comfortable, needs no new CSS; full-bleed styling can follow if it reads cramped  |
+| 7   | Chip visibility uses `{#if}` on `mediaQueryManager.pointerCoarse`, not a CSS media query | jsdom does not evaluate CSS media queries, so `{#if}` is the testable form                |
 
 Decision 7 does not cost a flash: `web/src/routes/+layout.ts:9` sets `export const ssr = false`, so
 this app never server-renders any route. `MediaQuery` having no SSR value would only matter if there
@@ -43,18 +43,18 @@ input on this surface is rare. Pinned by test so the choice is deliberate rather
 
 ## Behaviour
 
-| Interaction | Before | After |
-|---|---|---|
-| Tap nav search bar (finger) | focus → inline dropdown, soft keyboard covers it | **modal palette**; its own input autofocuses, so the keyboard opens against the modal instead |
-| Click nav search bar (mouse / trackpad / pen) | inline dropdown | unchanged |
-| Tab to nav search bar | inline dropdown | unchanged |
-| `Ctrl+K` / `⌘K` | modal palette | unchanged |
-| **`/`** | go to Explore | **modal palette** |
-| **`/` on layouts where `/` needs Shift** | dead | **modal palette** |
-| `Ctrl+/` | cycle search mode | unchanged |
-| `?` | shortcuts modal | unchanged |
-| Magnify button below 640px | modal palette | unchanged |
-| `Ctrl+K` chip shown | always ≥640px | only when `pointer: coarse` is false |
+| Interaction                                   | Before                                           | After                                                                                         |
+| --------------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| Tap nav search bar (finger)                   | focus → inline dropdown, soft keyboard covers it | **modal palette**; its own input autofocuses, so the keyboard opens against the modal instead |
+| Click nav search bar (mouse / trackpad / pen) | inline dropdown                                  | unchanged                                                                                     |
+| Tab to nav search bar                         | inline dropdown                                  | unchanged                                                                                     |
+| `Ctrl+K` / `⌘K`                               | modal palette                                    | unchanged                                                                                     |
+| **`/`**                                       | go to Explore                                    | **modal palette**                                                                             |
+| **`/` on layouts where `/` needs Shift**      | dead                                             | **modal palette**                                                                             |
+| `Ctrl+/`                                      | cycle search mode                                | unchanged                                                                                     |
+| `?`                                           | shortcuts modal                                  | unchanged                                                                                     |
+| Magnify button below 640px                    | modal palette                                    | unchanged                                                                                     |
+| `Ctrl+K` chip shown                           | always ≥640px                                    | only when `pointer: coarse` is false                                                          |
 
 ## Implementation
 
@@ -69,7 +69,7 @@ The `preventDefault()` is load-bearing for two reasons, and both belong in a cod
 
 - it suppresses the focus that would otherwise fire `onfocus={openDropdown}`, which calls
   `manager.open('dropdown')` and clobbers `presentation` straight back to `'dropdown'`;
-- it stops iOS raising the soft keyboard against *this inline input*, which the modal is about to
+- it stops iOS raising the soft keyboard against _this inline input_, which the modal is about to
   cover. The modal's own `Command.Input` autofocuses once it opens, so the keyboard still appears —
   just against the modal's input instead of this one.
 
@@ -79,7 +79,7 @@ existing `hidden … sm:inline-block` classes stay, so sub-640px behaviour is un
 
 **Guard the modal against focus downgrade.** `openDropdown` currently reads
 `if (!showDropdownPanel) { manager.open('dropdown') }`. `showDropdownPanel` is false whenever the
-palette is open *as a modal*, so any focus landing on the nav input while the modal is open flips
+palette is open _as a modal_, so any focus landing on the nav input while the modal is open flips
 `presentation` back to `'dropdown'`. Tighten it to return early when
 `manager.isOpen && manager.presentation === 'modal'`. This is the invariant behind the
 `preventDefault()` above — focus must never downgrade an open modal — and holds even if a browser or
@@ -102,7 +102,7 @@ The module exports two things:
 [
   { shortcut: { key: '/' }, onShortcut: guarded },
   { shortcut: { key: '/', shift: true }, onShortcut: guarded },
-]
+];
 ```
 
 **Why two descriptors.** `matchesShortcut` in `@immich/ui` compares modifiers strictly:
@@ -174,18 +174,18 @@ So focus arrives at **release**, after our `pointerdown` handler has already set
 and clobbers the presentation back to `'dropdown'` — which is exactly the RED signal the first test
 should produce. `expect(input).not.toHaveFocus()` is therefore a real assertion, not a jsdom artefact.
 
-| Scenario | Expected |
-|---|---|
-| Finger tap, full press+release | `open` called with `'modal'`; no `[data-cmdk-dropdown-panel]` in the DOM |
-| Finger tap | input is **not** focused (`preventDefault()` suppressed the release-time focus) |
-| Finger tap | `presentation` is still `'modal'` after release (the clobber regression) |
-| Mouse click | `open` called with `'dropdown'`; panel present (regression guard for decision 4) |
-| Pen input (`pointerType: 'pen'`) | dropdown, not modal (pins decision 4's scope) |
-| `pointerType` absent/empty (synthetic `pointerdown`) | falls through to dropdown |
-| Keyboard focus via Tab, no pointer event | dropdown, on touch-capable devices too |
-| Tap while the dropdown is already open | ends in `presentation === 'modal'` |
-| Tap, close modal, tap again | reopens the modal; no stuck presentation state |
-| Focus the nav input while the modal is open | stays `'modal'` (the `openDropdown` guard) |
+| Scenario                                             | Expected                                                                         |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Finger tap, full press+release                       | `open` called with `'modal'`; no `[data-cmdk-dropdown-panel]` in the DOM         |
+| Finger tap                                           | input is **not** focused (`preventDefault()` suppressed the release-time focus)  |
+| Finger tap                                           | `presentation` is still `'modal'` after release (the clobber regression)         |
+| Mouse click                                          | `open` called with `'dropdown'`; panel present (regression guard for decision 4) |
+| Pen input (`pointerType: 'pen'`)                     | dropdown, not modal (pins decision 4's scope)                                    |
+| `pointerType` absent/empty (synthetic `pointerdown`) | falls through to dropdown                                                        |
+| Keyboard focus via Tab, no pointer event             | dropdown, on touch-capable devices too                                           |
+| Tap while the dropdown is already open               | ends in `presentation === 'modal'`                                               |
+| Tap, close modal, tap again                          | reopens the modal; no stuck presentation state                                   |
+| Focus the nav input while the modal is open          | stays `'modal'` (the `openDropdown` guard)                                       |
 
 ### `global-search-input-trigger.spec.ts` — chip visibility
 
@@ -199,13 +199,13 @@ no effect on an already-imported module, so those two rows require `vi.resetModu
 pre-existing behaviour this change does not touch — and keep the presence/absence rows, which are
 the ones that matter for #862.
 
-| Scenario | Expected |
-|---|---|
-| `pointerCoarse` true | no `<kbd>` in the DOM |
-| `pointerCoarse` false | `<kbd>` present |
-| `pointerCoarse` false, non-Apple platform | reads `Ctrl+K` |
-| `pointerCoarse` false, Apple platform | reads `⌘K` |
-| Either value | input keeps `role="combobox"` and its accessible name — the chip is not part of the name |
+| Scenario                                  | Expected                                                                                 |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `pointerCoarse` true                      | no `<kbd>` in the DOM                                                                    |
+| `pointerCoarse` false                     | `<kbd>` present                                                                          |
+| `pointerCoarse` false, non-Apple platform | reads `Ctrl+K`                                                                           |
+| `pointerCoarse` false, Apple platform     | reads `⌘K`                                                                               |
+| Either value                              | input keeps `role="combobox"` and its accessible name — the chip is not part of the name |
 
 Aside, not a bug to fix here: iPadOS Safari reports `navigator.platform === 'MacIntel'`, so iPads
 already render `⌘K` rather than `Ctrl+K` — consistent with the screenshot in #862. Hiding the chip on
@@ -217,22 +217,22 @@ Tests target the pure module and drive `@immich/ui`'s real `matchesShortcut` aga
 `KeyboardEvent`s, so the layout-sensitivity fix is verified against the actual matcher rather than a
 reimplementation of it. `open` is a `vi.fn()`.
 
-| Scenario | Expected |
-|---|---|
-| `searchShortcuts(open)` shape | exactly two descriptors: `{ key: '/' }` and `{ key: '/', shift: true }` |
-| `{ key: '/', shiftKey: false }` | matches exactly one descriptor |
-| `{ key: '/', shiftKey: true }` (QWERTZ / AZERTY / Spanish / Italian) | matches exactly one descriptor |
-| `{ key: '?', shiftKey: true }` (US Shift+/) | matches neither — the shortcuts modal keeps `?` |
-| `{ key: '/', ctrlKey: true }` | matches neither — `Ctrl+/` stays the mode-cycle binding |
-| `{ key: '/', altKey: true }` / `{ key: '/', metaKey: true }` | match neither |
-| `onShortcut` with `document.activeElement` unfocused (`body`) | `open` called once |
-| `onShortcut` with `<input type="text">` focused | `open` not called |
-| `onShortcut` with `<input type="search">` focused | `open` not called — the gap `shouldIgnoreEvent` misses |
-| `onShortcut` with `<input type="number">` focused | `open` not called |
-| `onShortcut` with `<textarea>` focused | `open` not called |
-| `onShortcut` with `<select>` focused | `open` not called |
-| `onShortcut` with a `[contenteditable]` element focused | `open` not called |
-| `isEditableTarget(null)` | `false`, no throw |
+| Scenario                                                             | Expected                                                                |
+| -------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `searchShortcuts(open)` shape                                        | exactly two descriptors: `{ key: '/' }` and `{ key: '/', shift: true }` |
+| `{ key: '/', shiftKey: false }`                                      | matches exactly one descriptor                                          |
+| `{ key: '/', shiftKey: true }` (QWERTZ / AZERTY / Spanish / Italian) | matches exactly one descriptor                                          |
+| `{ key: '?', shiftKey: true }` (US Shift+/)                          | matches neither — the shortcuts modal keeps `?`                         |
+| `{ key: '/', ctrlKey: true }`                                        | matches neither — `Ctrl+/` stays the mode-cycle binding                 |
+| `{ key: '/', altKey: true }` / `{ key: '/', metaKey: true }`         | match neither                                                           |
+| `onShortcut` with `document.activeElement` unfocused (`body`)        | `open` called once                                                      |
+| `onShortcut` with `<input type="text">` focused                      | `open` not called                                                       |
+| `onShortcut` with `<input type="search">` focused                    | `open` not called — the gap `shouldIgnoreEvent` misses                  |
+| `onShortcut` with `<input type="number">` focused                    | `open` not called                                                       |
+| `onShortcut` with `<textarea>` focused                               | `open` not called                                                       |
+| `onShortcut` with `<select>` focused                                 | `open` not called                                                       |
+| `onShortcut` with a `[contenteditable]` element focused              | `open` not called                                                       |
+| `isEditableTarget(null)`                                             | `false`, no throw                                                       |
 
 Two `/` behaviours are wiring, not module logic, and are confirmed by reading the rendered layout
 rather than by a unit test: the feature-flag guard and the `toggle('modal')` semantics come from
@@ -268,34 +268,34 @@ by the unit tests above.
 
 ## Risks
 
-| Risk | Mitigation |
-|---|---|
-| Users relying on `/` → Explore lose it | Sidebar entry unchanged; `/` = search is the stronger convention |
-| ~~One-frame chip flash on touch after hydration~~ — does not apply | `web/src/routes/+layout.ts:9` sets `ssr = false`; there is no SSR render pass, so there is nothing for hydration to reconcile away |
-| `preventDefault()` on pointerdown blocks focus more broadly than intended | Guarded to `pointerType === 'touch'`; mouse, pen, and keyboard paths each covered by test |
-| A browser focuses the nav input by a path `preventDefault()` misses | The `openDropdown` early-return holds the invariant independently |
-| Upstream edits conflict on rebase | Pure deletions in two files, three lines total |
+| Risk                                                                      | Mitigation                                                                                                                         |
+| ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Users relying on `/` → Explore lose it                                    | Sidebar entry unchanged; `/` = search is the stronger convention                                                                   |
+| ~~One-frame chip flash on touch after hydration~~ — does not apply        | `web/src/routes/+layout.ts:9` sets `ssr = false`; there is no SSR render pass, so there is nothing for hydration to reconcile away |
+| `preventDefault()` on pointerdown blocks focus more broadly than intended | Guarded to `pointerType === 'touch'`; mouse, pen, and keyboard paths each covered by test                                          |
+| A browser focuses the nav input by a path `preventDefault()` misses       | The `openDropdown` early-return holds the invariant independently                                                                  |
+| Upstream edits conflict on rebase                                         | Pure deletions in two files, three lines total                                                                                     |
 
 ## Verified against the codebase
 
 Every anchor and claim below was confirmed in this worktree before the plan was written.
 
-| Claim | Confirmed |
-|---|---|
-| `mediaQueryManager` imported at `global-search.svelte:24`; `pointerCoarse` is an object-literal getter | yes — spy-able with `vi.spyOn(…, 'get')` |
-| `isApplePlatform` / `hotkeyLabel` at `global-search.svelte:44-45` | yes — module scope, hence the `resetModules` note |
-| `Command.Input` at `global-search.svelte:631`, `<kbd>` at `652-656` | yes |
-| `openModalSearch` at `+layout.svelte:235`, `use:shortcuts` array at `279` | yes |
-| `/` → Explore at `GalleryViewer.svelte:274` and `TimelineKeyboardActions.svelte:119` | yes |
-| `goto` (L2) and `Route` (L17) unused in `TimelineKeyboardActions` after deletion | yes — both have exactly one use, that line |
-| `goto` / `Route` still used elsewhere in `GalleryViewer` | yes — two uses each, imports stay |
-| `Ctrl+K` row at `ShortcutsModal.svelte:35`; `shortcut_open_global_search` exists | yes — `i18n/en.json:2608`, no new strings |
-| `matchesShortcut` compares modifiers strictly | yes — `Boolean(shortcut.shift) === event.shiftKey` |
-| `shouldIgnoreEvent` allowlist misses `type="search"` | yes — one use, `space-albums-controls.svelte:108` |
-| No `contenteditable` anywhere in `web/src` | yes — guard clause is forward-looking only |
-| `Command.Input` renders `type="text"` | yes — `bits-ui` `CommandInputState.props` |
-| `matchesShortcut` / `ShortcutOptions` importable from `@immich/ui` | yes — `export * from './actions/shortcut.js'` |
-| Explore still reachable without the shortcut | yes — `UserSidebar.svelte:67` |
-| No existing spec covers `+layout.svelte` or the `/` → Explore binding | yes — hence the extracted module |
-| Playwright defines only `Desktop Chrome` projects | yes |
-| userEvent honours `preventDefault()` on `pointerdown` for touch | yes — `pointer/index.js:80` → `pointer/mouse.js:76-79` |
+| Claim                                                                                                  | Confirmed                                              |
+| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
+| `mediaQueryManager` imported at `global-search.svelte:24`; `pointerCoarse` is an object-literal getter | yes — spy-able with `vi.spyOn(…, 'get')`               |
+| `isApplePlatform` / `hotkeyLabel` at `global-search.svelte:44-45`                                      | yes — module scope, hence the `resetModules` note      |
+| `Command.Input` at `global-search.svelte:631`, `<kbd>` at `652-656`                                    | yes                                                    |
+| `openModalSearch` at `+layout.svelte:235`, `use:shortcuts` array at `279`                              | yes                                                    |
+| `/` → Explore at `GalleryViewer.svelte:274` and `TimelineKeyboardActions.svelte:119`                   | yes                                                    |
+| `goto` (L2) and `Route` (L17) unused in `TimelineKeyboardActions` after deletion                       | yes — both have exactly one use, that line             |
+| `goto` / `Route` still used elsewhere in `GalleryViewer`                                               | yes — two uses each, imports stay                      |
+| `Ctrl+K` row at `ShortcutsModal.svelte:35`; `shortcut_open_global_search` exists                       | yes — `i18n/en.json:2608`, no new strings              |
+| `matchesShortcut` compares modifiers strictly                                                          | yes — `Boolean(shortcut.shift) === event.shiftKey`     |
+| `shouldIgnoreEvent` allowlist misses `type="search"`                                                   | yes — one use, `space-albums-controls.svelte:108`      |
+| No `contenteditable` anywhere in `web/src`                                                             | yes — guard clause is forward-looking only             |
+| `Command.Input` renders `type="text"`                                                                  | yes — `bits-ui` `CommandInputState.props`              |
+| `matchesShortcut` / `ShortcutOptions` importable from `@immich/ui`                                     | yes — `export * from './actions/shortcut.js'`          |
+| Explore still reachable without the shortcut                                                           | yes — `UserSidebar.svelte:67`                          |
+| No existing spec covers `+layout.svelte` or the `/` → Explore binding                                  | yes — hence the extracted module                       |
+| Playwright defines only `Desktop Chrome` projects                                                      | yes                                                    |
+| userEvent honours `preventDefault()` on `pointerdown` for touch                                        | yes — `pointer/index.js:80` → `pointer/mouse.js:76-79` |

--- a/docs/superpowers/specs/2026-07-30-touch-search-entry-design.md
+++ b/docs/superpowers/specs/2026-07-30-touch-search-entry-design.md
@@ -58,7 +58,7 @@ input on this surface is rare. Pinned by test so the choice is deliberate rather
 
 ### `web/src/lib/components/global-search/global-search.svelte`
 
-Both edits sit in the `variant === 'dropdown'` branch.
+Three edits: two in the `variant === 'dropdown'` markup, one in the script block.
 
 **Route touch taps to the modal.** `Command.Input` (~L631) gains an `onpointerdown` handler: when
 `event.pointerType === 'touch'`, call `event.preventDefault()` and `manager.open('modal')`.
@@ -73,35 +73,58 @@ The `preventDefault()` is load-bearing for two reasons, and both belong in a cod
 `{#if !mediaQueryManager.pointerCoarse}`. `mediaQueryManager` is already imported at L24. The
 existing `hidden … sm:inline-block` classes stay, so sub-640px behaviour is unchanged.
 
-### `web/src/routes/+layout.svelte`
+**Guard the modal against focus downgrade.** `openDropdown` currently reads
+`if (!showDropdownPanel) { manager.open('dropdown') }`. `showDropdownPanel` is false whenever the
+palette is open *as a modal*, so any focus landing on the nav input while the modal is open flips
+`presentation` back to `'dropdown'`. Tighten it to return early when
+`manager.isOpen && manager.presentation === 'modal'`. This is the invariant behind the
+`preventDefault()` above — focus must never downgrade an open modal — and holds even if a browser or
+assistive technology focuses the input by a path `preventDefault()` does not cover.
 
-Add two entries to the existing `use:shortcuts` array, both calling the existing `openModalSearch()`:
+### `web/src/lib/utils/search-shortcut.ts` (new)
+
+The `/` binding needs a guard, and `+layout.svelte` has no spec file and no precedent for testing
+layout-level shortcuts — it is a large component with many dependencies. Putting the logic in a small
+pure module makes all of it directly testable and leaves `+layout.svelte` with nothing but wiring.
+
+The module exports two things:
+
+- `isEditableTarget(element: Element | null): boolean` — true for `input`, `textarea`, `select`, or
+  anything matching `[contenteditable]`.
+- `searchShortcuts(open: () => void): ShortcutOptions[]` — returns the two descriptors below, each
+  wrapping `open` in an `isEditableTarget(document.activeElement)` bail-out.
 
 ```js
-{ shortcut: { key: '/' }, onShortcut: openSearchFromSlash },
-{ shortcut: { key: '/', shift: true }, onShortcut: openSearchFromSlash },
+[
+  { shortcut: { key: '/' }, onShortcut: guarded },
+  { shortcut: { key: '/', shift: true }, onShortcut: guarded },
+]
 ```
 
-Reusing `openModalSearch()` inherits its feature-flag guard and `toggle('modal')` semantics.
-
-**Why two bindings.** `matchesShortcut` in `@immich/ui` compares modifiers strictly:
+**Why two descriptors.** `matchesShortcut` in `@immich/ui` compares modifiers strictly:
 `Boolean(shortcut.shift) === event.shiftKey`. On German QWERTZ, Spanish and Italian layouts `/` is
 Shift+7; on AZERTY it is Shift+:. All emit `event.key === '/'` with `shiftKey: true`, so a lone
 `{ key: '/' }` never matches and the shortcut is dead for those users. There is no collision with
-`?`: on US layouts Shift+/ emits `event.key === '?'`, so the shift variant only fires on layouts
+`?`: on US layouts Shift+/ emits `event.key === '?'`, so the shift descriptor only fires on layouts
 where Shift genuinely produces `/`.
 
-**Why a wrapper rather than `openModalSearch` directly.** `@immich/ui`'s `shouldIgnoreEvent` skips
-shortcuts only for `type` in `textarea, text, date, datetime-local, email, password`. It misses
-`type="search"` — used by `space-albums-controls.svelte:108` — so typing `/` in the space album
-filter would open the palette instead of inserting the character. `type="number"` (6 uses) is
-uncovered too. `openSearchFromSlash` bails when `document.activeElement` is an editable element
-(`input`, `textarea`, `select`, or `[contenteditable]`) and otherwise delegates to
-`openModalSearch()`. The app has no `contenteditable` today; including it keeps the guard correct if
-one appears.
+**Why the editable guard.** `@immich/ui`'s `shouldIgnoreEvent` skips shortcuts only for `type` in
+`textarea, text, date, datetime-local, email, password`. It misses `type="search"` — used by
+`space-albums-controls.svelte:108` — so typing `/` in the space album filter would open the palette
+instead of inserting the character. `type="number"` (6 uses) is uncovered too. The app has no
+`contenteditable` today; including it keeps the guard correct if one appears.
 
-`Command.Input` renders `type="text"`, so `/` typed into the palette itself is already ignored by
-the built-in guard; the wrapper reinforces it rather than changing it.
+`Command.Input` renders `type="text"`, so `/` typed into the palette itself is already ignored by the
+built-in guard; this guard reinforces it rather than changing it.
+
+`matchesShortcut`, `shouldIgnoreEvent` and the `ShortcutOptions` type are all public — `@immich/ui`'s
+entry point does `export * from './actions/shortcut.js'` — so tests can drive the real matcher rather
+than reimplementing it.
+
+### `web/src/routes/+layout.svelte`
+
+Spread `searchShortcuts(openModalSearch)` into the existing `use:shortcuts` array. Passing
+`openModalSearch` inherits its feature-flag guard and `toggle('modal')` semantics unchanged.
 
 ### Upstream files — remove `/` → Explore
 
@@ -123,7 +146,8 @@ documented, so nothing is removed.
 `/` → Explore was suppressed while the asset viewer was open (`TimelineKeyboardActions` returns an
 empty shortcut list when `assetViewerManager.isViewing`). The new `/` binding lives at the layout
 level, so it fires over the asset viewer as well. This matches `Ctrl+K`, which is already global, so
-the two aliases stay consistent. Pinned by test.
+the two aliases stay consistent. This follows from where the binding is registered rather than from
+any branch in our own code, so it is recorded here and checked by hand, not by a unit test.
 
 ## Test plan
 
@@ -135,20 +159,41 @@ before the corresponding implementation lands. Tests are named as behaviour stat
 
 Extends the existing suite, which already asserts click → dropdown.
 
+`user.pointer({ keys: '[TouchA]', target: input })` performs a full press **and** release, which
+matters here. userEvent models the browser faithfully: `press()` dispatches `pointerdown` and records
+`pointer.isPrevented`, skipping `mouse.down` for touch; `release()` then calls
+`mouse.down(instance, keyDef, isPrevented)` (`system/pointer/index.js:80`), and `mouse.down` runs
+`focusElement(target)` only when `isPrevented` is false (`system/pointer/mouse.js:76-79`).
+
+So focus arrives at **release**, after our `pointerdown` handler has already set
+`presentation = 'modal'`. Without `preventDefault()`, that release-time focus fires `openDropdown`
+and clobbers the presentation back to `'dropdown'` — which is exactly the RED signal the first test
+should produce. `expect(input).not.toHaveFocus()` is therefore a real assertion, not a jsdom artefact.
+
 | Scenario | Expected |
 |---|---|
-| Finger tap (`user.pointer({ keys: '[TouchA]', target: input })`) | `open` called with `'modal'`; no `[data-cmdk-dropdown-panel]` in the DOM |
-| Finger tap | the pointerdown event's default is prevented (`defaultPrevented === true` on a dispatched event) |
+| Finger tap, full press+release | `open` called with `'modal'`; no `[data-cmdk-dropdown-panel]` in the DOM |
+| Finger tap | input is **not** focused (`preventDefault()` suppressed the release-time focus) |
+| Finger tap | `presentation` is still `'modal'` after release (the clobber regression) |
 | Mouse click | `open` called with `'dropdown'`; panel present (regression guard for decision 4) |
 | Pen input (`pointerType: 'pen'`) | dropdown, not modal (pins decision 4's scope) |
-| `pointerType` absent/empty (synthetic event) | falls through to dropdown |
+| `pointerType` absent/empty (synthetic `pointerdown`) | falls through to dropdown |
 | Keyboard focus via Tab, no pointer event | dropdown, on touch-capable devices too |
-| Tap while the dropdown is already open | ends in `presentation === 'modal'`, opened once |
+| Tap while the dropdown is already open | ends in `presentation === 'modal'` |
 | Tap, close modal, tap again | reopens the modal; no stuck presentation state |
+| Focus the nav input while the modal is open | stays `'modal'` (the `openDropdown` guard) |
 
 ### `global-search-input-trigger.spec.ts` — chip visibility
 
-`mediaQueryManager.pointerCoarse` is a getter, stubbed per test.
+`mediaQueryManager.pointerCoarse` is an object-literal getter, so
+`vi.spyOn(mediaQueryManager, 'pointerCoarse', 'get')` stubs it per test.
+
+The two label rows need more care: `isApplePlatform` is a **module-scope** `const` in
+`global-search.svelte:44`, evaluated once at import. Stubbing `navigator.platform` inside a test has
+no effect on an already-imported module, so those two rows require `vi.resetModules()` plus a dynamic
+`import()` after the stub is in place. If that proves brittle, drop the two label rows — they cover
+pre-existing behaviour this change does not touch — and keep the presence/absence rows, which are
+the ones that matter for #862.
 
 | Scenario | Expected |
 |---|---|
@@ -158,27 +203,48 @@ Extends the existing suite, which already asserts click → dropdown.
 | `pointerCoarse` false, Apple platform | reads `⌘K` |
 | Either value | input keeps `role="combobox"` and its accessible name — the chip is not part of the name |
 
-### `/` shortcut
+Aside, not a bug to fix here: iPadOS Safari reports `navigator.platform === 'MacIntel'`, so iPads
+already render `⌘K` rather than `Ctrl+K` — consistent with the screenshot in #862. Hiding the chip on
+coarse pointers makes the distinction moot on those devices.
+
+### `search-shortcut.spec.ts` — the `/` binding
+
+Tests target the pure module and drive `@immich/ui`'s real `matchesShortcut` against synthetic
+`KeyboardEvent`s, so the layout-sensitivity fix is verified against the actual matcher rather than a
+reimplementation of it. `open` is a `vi.fn()`.
 
 | Scenario | Expected |
 |---|---|
-| `/` with no modifiers, nothing focused | `openModalSearch` called |
-| `/` with `shiftKey: true` (QWERTZ/AZERTY) | `openModalSearch` called |
-| `?` (US Shift+/, `event.key === '?'`) | shortcuts modal opens; palette does not |
-| `Ctrl+/` | cycles search mode; palette does not open |
-| `/` while an `<input type="text">` is focused | no palette; character inserted |
-| `/` while an `<input type="search">` is focused | no palette (the gap `shouldIgnoreEvent` misses) |
-| `/` while a `<textarea>` is focused | no palette |
-| `/` while a `[contenteditable]` is focused | no palette |
-| `/` while the palette modal is open and its input focused | no toggle; character typed into the query |
-| `/` with the `search` feature flag off | no-op, no throw |
-| `/` with feature flags not yet loaded | no-op, no throw (`valueOrUndefined` path) |
-| `/` while the asset viewer is open | palette opens (documents the intended change above) |
+| `searchShortcuts(open)` shape | exactly two descriptors: `{ key: '/' }` and `{ key: '/', shift: true }` |
+| `{ key: '/', shiftKey: false }` | matches exactly one descriptor |
+| `{ key: '/', shiftKey: true }` (QWERTZ / AZERTY / Spanish / Italian) | matches exactly one descriptor |
+| `{ key: '?', shiftKey: true }` (US Shift+/) | matches neither — the shortcuts modal keeps `?` |
+| `{ key: '/', ctrlKey: true }` | matches neither — `Ctrl+/` stays the mode-cycle binding |
+| `{ key: '/', altKey: true }` / `{ key: '/', metaKey: true }` | match neither |
+| `onShortcut` with `document.activeElement` unfocused (`body`) | `open` called once |
+| `onShortcut` with `<input type="text">` focused | `open` not called |
+| `onShortcut` with `<input type="search">` focused | `open` not called — the gap `shouldIgnoreEvent` misses |
+| `onShortcut` with `<input type="number">` focused | `open` not called |
+| `onShortcut` with `<textarea>` focused | `open` not called |
+| `onShortcut` with `<select>` focused | `open` not called |
+| `onShortcut` with a `[contenteditable]` element focused | `open` not called |
+| `isEditableTarget(null)` | `false`, no throw |
+
+Two `/` behaviours are wiring, not module logic, and are confirmed by reading the rendered layout
+rather than by a unit test: the feature-flag guard and the `toggle('modal')` semantics come from
+`openModalSearch`, which this change passes through untouched and which the `Ctrl+K` path already
+exercises; and `/` firing over the asset viewer follows from the binding living at layout level,
+the same as `Ctrl+K`.
+
+`/` typed into the palette's own input needs no test — `Command.Input` renders `type="text"`, which
+`shouldIgnoreEvent` already covers, and the editable guard covers it a second time.
 
 ### Regression
 
 - `Ctrl+K` and `⌘K` still open the modal on their respective platforms.
-- Explore is no longer reachable by `/` on the timeline or in the gallery viewer.
+- Explore is no longer reachable by `/` on the timeline or in the gallery viewer. No existing test
+  asserts that binding, so the deletions break nothing — the two removals are covered only by the
+  behaviour table above.
 - `svelte-check` and `tsc --noEmit` clean — catches the unused `goto` / `Route` imports.
 
 Verification runs `pnpm test` in `web/`, plus `make check-web` and `make lint-web`.
@@ -190,7 +256,7 @@ by the unit tests above.
 ## Out of scope
 
 - Full-bleed modal styling on tablets (decision 6).
-- Rewriting `@immich/ui`'s `shouldIgnoreEvent`; the local `openSearchFromSlash` guard covers the `/`
+- Rewriting `@immich/ui`'s `shouldIgnoreEvent`; the local `isEditableTarget` guard covers the `/`
   binding without patching a dependency.
 - Extending the shift-variant fix to other bare-key shortcuts (`f`, `i`, `x`, `g`, …), which have
   the same layout sensitivity. Pre-existing, unrelated to #862.
@@ -203,4 +269,29 @@ by the unit tests above.
 | Users relying on `/` → Explore lose it | Sidebar entry unchanged; `/` = search is the stronger convention |
 | One-frame chip flash on touch after hydration | Accepted for testability; swap to a CSS variant if it proves visible |
 | `preventDefault()` on pointerdown blocks focus more broadly than intended | Guarded to `pointerType === 'touch'`; mouse, pen, and keyboard paths each covered by test |
+| A browser focuses the nav input by a path `preventDefault()` misses | The `openDropdown` early-return holds the invariant independently |
 | Upstream edits conflict on rebase | Pure deletions in two files, three lines total |
+
+## Verified against the codebase
+
+Every anchor and claim below was confirmed in this worktree before the plan was written.
+
+| Claim | Confirmed |
+|---|---|
+| `mediaQueryManager` imported at `global-search.svelte:24`; `pointerCoarse` is an object-literal getter | yes — spy-able with `vi.spyOn(…, 'get')` |
+| `isApplePlatform` / `hotkeyLabel` at `global-search.svelte:44-45` | yes — module scope, hence the `resetModules` note |
+| `Command.Input` at `global-search.svelte:631`, `<kbd>` at `652-656` | yes |
+| `openModalSearch` at `+layout.svelte:235`, `use:shortcuts` array at `279` | yes |
+| `/` → Explore at `GalleryViewer.svelte:274` and `TimelineKeyboardActions.svelte:119` | yes |
+| `goto` (L2) and `Route` (L17) unused in `TimelineKeyboardActions` after deletion | yes — both have exactly one use, that line |
+| `goto` / `Route` still used elsewhere in `GalleryViewer` | yes — two uses each, imports stay |
+| `Ctrl+K` row at `ShortcutsModal.svelte:35`; `shortcut_open_global_search` exists | yes — `i18n/en.json:2608`, no new strings |
+| `matchesShortcut` compares modifiers strictly | yes — `Boolean(shortcut.shift) === event.shiftKey` |
+| `shouldIgnoreEvent` allowlist misses `type="search"` | yes — one use, `space-albums-controls.svelte:108` |
+| No `contenteditable` anywhere in `web/src` | yes — guard clause is forward-looking only |
+| `Command.Input` renders `type="text"` | yes — `bits-ui` `CommandInputState.props` |
+| `matchesShortcut` / `ShortcutOptions` importable from `@immich/ui` | yes — `export * from './actions/shortcut.js'` |
+| Explore still reachable without the shortcut | yes — `UserSidebar.svelte:67` |
+| No existing spec covers `+layout.svelte` or the `/` → Explore binding | yes — hence the extracted module |
+| Playwright defines only `Desktop Chrome` projects | yes |
+| userEvent honours `preventDefault()` on `pointerdown` for touch | yes — `pointer/index.js:80` → `pointer/mouse.js:76-79` |

--- a/docs/superpowers/specs/2026-07-30-touch-search-entry-design.md
+++ b/docs/superpowers/specs/2026-07-30-touch-search-entry-design.md
@@ -1,0 +1,206 @@
+# Touch search entry + `/` shortcut
+
+Fixes [#862](https://github.com/open-noodle/gallery/issues/862) — the `Ctrl+K` search hint has no
+touch equivalent on iPad/iPhone — and adds `/` as a second way to open the palette.
+
+## Problem
+
+The nav bar search field renders a `<kbd>` chip reading `Ctrl+K` (or `⌘K` on Apple platforms) at
+every viewport ≥640px. On a keyboardless iPad the chip advertises a shortcut that cannot be typed,
+and the chip itself is decorative — not a button.
+
+The palette is in fact reachable by touch today:
+
+- below 640px a magnify `IconButton` in `NavigationBar.svelte` opens the modal palette;
+- at 640px and above, tapping the search field focuses it, and `onfocus` opens the inline dropdown.
+
+So the defect is the affordance, not raw reachability. Two things make the tap path poor on a
+tablet: the inline dropdown is cramped, and focusing a real `<input>` raises the iOS soft keyboard,
+which covers the dropdown it just opened.
+
+Separately, we want `/` to open search, matching the GitHub/Gmail/Slack convention.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | On touch, tapping the search bar opens the **modal** palette, not the inline dropdown | Full-height below 640px, large centred card above; no soft-keyboard occlusion |
+| 2 | `/` **replaces** the existing `/` → Explore binding | `/` = search is the near-universal convention; Explore stays reachable from the sidebar |
+| 3 | `/` opens the **same modal palette** `Ctrl+K` opens | One surface, one documented behaviour, works where the nav bar is hidden |
+| 4 | Touch is detected **per event** via `PointerEvent.pointerType` | Exact per-interaction; an iPad user gets the modal by finger and the dropdown by trackpad |
+| 5 | The `<kbd>` chip is **hidden** when `pointer: coarse` | Removes the misleading hint; the whole bar becomes the tap target |
+| 6 | The iPad modal keeps its **current large centred size** | Already comfortable, needs no new CSS; full-bleed styling can follow if it reads cramped |
+| 7 | Chip visibility uses `{#if}` on `mediaQueryManager.pointerCoarse`, not a CSS media query | jsdom does not evaluate CSS media queries, so `{#if}` is the testable form |
+
+Decision 7 costs a one-frame flash: `MediaQuery` has no SSR value, so the chip renders during SSR
+and is removed on hydration. Accepted in exchange for real assertions.
+
+Decision 4 covers `pointerType === 'touch'` only. `'pen'` keeps the dropdown — an Apple Pencil tap
+on a tablet arguably wants the modal too, but a Surface pen paired with a keyboard does not, and pen
+input on this surface is rare. Pinned by test so the choice is deliberate rather than incidental.
+
+## Behaviour
+
+| Interaction | Before | After |
+|---|---|---|
+| Tap nav search bar (finger) | focus → inline dropdown, soft keyboard covers it | **modal palette**, no soft keyboard |
+| Click nav search bar (mouse / trackpad / pen) | inline dropdown | unchanged |
+| Tab to nav search bar | inline dropdown | unchanged |
+| `Ctrl+K` / `⌘K` | modal palette | unchanged |
+| **`/`** | go to Explore | **modal palette** |
+| **`/` on layouts where `/` needs Shift** | dead | **modal palette** |
+| `Ctrl+/` | cycle search mode | unchanged |
+| `?` | shortcuts modal | unchanged |
+| Magnify button below 640px | modal palette | unchanged |
+| `Ctrl+K` chip shown | always ≥640px | only when `pointer: coarse` is false |
+
+## Implementation
+
+### `web/src/lib/components/global-search/global-search.svelte`
+
+Both edits sit in the `variant === 'dropdown'` branch.
+
+**Route touch taps to the modal.** `Command.Input` (~L631) gains an `onpointerdown` handler: when
+`event.pointerType === 'touch'`, call `event.preventDefault()` and `manager.open('modal')`.
+
+The `preventDefault()` is load-bearing for two reasons, and both belong in a code comment:
+
+- it suppresses the focus that would otherwise fire `onfocus={openDropdown}`, which calls
+  `manager.open('dropdown')` and clobbers `presentation` straight back to `'dropdown'`;
+- it stops iOS raising the soft keyboard against an input that is about to be covered by the modal.
+
+**Hide the chip on coarse pointers.** Wrap the `<kbd>` block (L652–656) in
+`{#if !mediaQueryManager.pointerCoarse}`. `mediaQueryManager` is already imported at L24. The
+existing `hidden … sm:inline-block` classes stay, so sub-640px behaviour is unchanged.
+
+### `web/src/routes/+layout.svelte`
+
+Add two entries to the existing `use:shortcuts` array, both calling the existing `openModalSearch()`:
+
+```js
+{ shortcut: { key: '/' }, onShortcut: openSearchFromSlash },
+{ shortcut: { key: '/', shift: true }, onShortcut: openSearchFromSlash },
+```
+
+Reusing `openModalSearch()` inherits its feature-flag guard and `toggle('modal')` semantics.
+
+**Why two bindings.** `matchesShortcut` in `@immich/ui` compares modifiers strictly:
+`Boolean(shortcut.shift) === event.shiftKey`. On German QWERTZ, Spanish and Italian layouts `/` is
+Shift+7; on AZERTY it is Shift+:. All emit `event.key === '/'` with `shiftKey: true`, so a lone
+`{ key: '/' }` never matches and the shortcut is dead for those users. There is no collision with
+`?`: on US layouts Shift+/ emits `event.key === '?'`, so the shift variant only fires on layouts
+where Shift genuinely produces `/`.
+
+**Why a wrapper rather than `openModalSearch` directly.** `@immich/ui`'s `shouldIgnoreEvent` skips
+shortcuts only for `type` in `textarea, text, date, datetime-local, email, password`. It misses
+`type="search"` — used by `space-albums-controls.svelte:108` — so typing `/` in the space album
+filter would open the palette instead of inserting the character. `type="number"` (6 uses) is
+uncovered too. `openSearchFromSlash` bails when `document.activeElement` is an editable element
+(`input`, `textarea`, `select`, or `[contenteditable]`) and otherwise delegates to
+`openModalSearch()`. The app has no `contenteditable` today; including it keeps the guard correct if
+one appears.
+
+`Command.Input` renders `type="text"`, so `/` typed into the palette itself is already ignored by
+the built-in guard; the wrapper reinforces it rather than changing it.
+
+### Upstream files — remove `/` → Explore
+
+- `web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte:274` — delete the
+  binding. `goto` and `Route` each have another use in the file, so imports stay. One-line diff.
+- `web/src/lib/components/timeline/actions/TimelineKeyboardActions.svelte:119` — delete the binding
+  **and** the now-unused `goto` (L2) and `Route` (L17) imports, or lint fails. Three-line diff.
+
+Both are upstream files; the diffs are pure deletions, which rebase cleanly.
+
+### `web/src/lib/modals/ShortcutsModal.svelte`
+
+Add `{ key: ['/'], action: $t('shortcut_open_global_search') }` beside the existing `Ctrl+K` row.
+Reusing the existing i18n key means no new strings across the locale files. `/` → Explore was never
+documented, so nothing is removed.
+
+## Behaviour change worth naming
+
+`/` → Explore was suppressed while the asset viewer was open (`TimelineKeyboardActions` returns an
+empty shortcut list when `assetViewerManager.isViewing`). The new `/` binding lives at the layout
+level, so it fires over the asset viewer as well. This matches `Ctrl+K`, which is already global, so
+the two aliases stay consistent. Pinned by test.
+
+## Test plan
+
+TDD throughout: every test below is written first and observed failing for the intended reason
+before the corresponding implementation lands. Tests are named as behaviour statements
+(`it('opens the modal palette when the search bar is tapped')`).
+
+### `global-search-input-trigger.spec.ts` — pointer routing
+
+Extends the existing suite, which already asserts click → dropdown.
+
+| Scenario | Expected |
+|---|---|
+| Finger tap (`user.pointer({ keys: '[TouchA]', target: input })`) | `open` called with `'modal'`; no `[data-cmdk-dropdown-panel]` in the DOM |
+| Finger tap | the pointerdown event's default is prevented (`defaultPrevented === true` on a dispatched event) |
+| Mouse click | `open` called with `'dropdown'`; panel present (regression guard for decision 4) |
+| Pen input (`pointerType: 'pen'`) | dropdown, not modal (pins decision 4's scope) |
+| `pointerType` absent/empty (synthetic event) | falls through to dropdown |
+| Keyboard focus via Tab, no pointer event | dropdown, on touch-capable devices too |
+| Tap while the dropdown is already open | ends in `presentation === 'modal'`, opened once |
+| Tap, close modal, tap again | reopens the modal; no stuck presentation state |
+
+### `global-search-input-trigger.spec.ts` — chip visibility
+
+`mediaQueryManager.pointerCoarse` is a getter, stubbed per test.
+
+| Scenario | Expected |
+|---|---|
+| `pointerCoarse` true | no `<kbd>` in the DOM |
+| `pointerCoarse` false | `<kbd>` present |
+| `pointerCoarse` false, non-Apple platform | reads `Ctrl+K` |
+| `pointerCoarse` false, Apple platform | reads `⌘K` |
+| Either value | input keeps `role="combobox"` and its accessible name — the chip is not part of the name |
+
+### `/` shortcut
+
+| Scenario | Expected |
+|---|---|
+| `/` with no modifiers, nothing focused | `openModalSearch` called |
+| `/` with `shiftKey: true` (QWERTZ/AZERTY) | `openModalSearch` called |
+| `?` (US Shift+/, `event.key === '?'`) | shortcuts modal opens; palette does not |
+| `Ctrl+/` | cycles search mode; palette does not open |
+| `/` while an `<input type="text">` is focused | no palette; character inserted |
+| `/` while an `<input type="search">` is focused | no palette (the gap `shouldIgnoreEvent` misses) |
+| `/` while a `<textarea>` is focused | no palette |
+| `/` while a `[contenteditable]` is focused | no palette |
+| `/` while the palette modal is open and its input focused | no toggle; character typed into the query |
+| `/` with the `search` feature flag off | no-op, no throw |
+| `/` with feature flags not yet loaded | no-op, no throw (`valueOrUndefined` path) |
+| `/` while the asset viewer is open | palette opens (documents the intended change above) |
+
+### Regression
+
+- `Ctrl+K` and `⌘K` still open the modal on their respective platforms.
+- Explore is no longer reachable by `/` on the timeline or in the gallery viewer.
+- `svelte-check` and `tsc --noEmit` clean — catches the unused `goto` / `Route` imports.
+
+Verification runs `pnpm test` in `web/`, plus `make check-web` and `make lint-web`.
+
+No Playwright coverage: `e2e/playwright.config.ts` defines only `Desktop Chrome` projects, and
+standing up a touch project for one interaction is not proportionate. The tap path is fully covered
+by the unit tests above.
+
+## Out of scope
+
+- Full-bleed modal styling on tablets (decision 6).
+- Rewriting `@immich/ui`'s `shouldIgnoreEvent`; the local `openSearchFromSlash` guard covers the `/`
+  binding without patching a dependency.
+- Extending the shift-variant fix to other bare-key shortcuts (`f`, `i`, `x`, `g`, …), which have
+  the same layout sensitivity. Pre-existing, unrelated to #862.
+- The sub-640px magnify button, which already works.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Users relying on `/` → Explore lose it | Sidebar entry unchanged; `/` = search is the stronger convention |
+| One-frame chip flash on touch after hydration | Accepted for testability; swap to a CSS variant if it proves visible |
+| `preventDefault()` on pointerdown blocks focus more broadly than intended | Guarded to `pointerType === 'touch'`; mouse, pen, and keyboard paths each covered by test |
+| Upstream edits conflict on rebase | Pure deletions in two files, three lines total |

--- a/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
@@ -255,6 +255,53 @@ describe('global-search-input-trigger', () => {
     expect(document.querySelector('[data-cmdk-dropdown-panel]')).toBeNull();
   });
 
+  it('upgrades an already-open inline dropdown to the modal when tapped', async () => {
+    const user = userEvent.setup();
+
+    render(GlobalSearchInputTrigger);
+
+    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+    await user.click(input);
+    expect(globalSearchManager.presentation).toBe('dropdown');
+
+    await user.pointer({ keys: '[TouchA]', target: input });
+
+    expect(globalSearchManager.presentation).toBe('modal');
+    expect(document.querySelector('[data-cmdk-dropdown-panel]')).toBeNull();
+  });
+
+  it('reopens the modal on a second tap after the first modal was closed', async () => {
+    const user = userEvent.setup();
+
+    render(GlobalSearchInputTrigger);
+
+    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+    await user.pointer({ keys: '[TouchA]', target: input });
+    expect(globalSearchManager.presentation).toBe('modal');
+
+    globalSearchManager.close();
+    expect(globalSearchManager.isOpen).toBe(false);
+
+    await user.pointer({ keys: '[TouchA]', target: input });
+
+    expect(globalSearchManager.isOpen).toBe(true);
+    expect(globalSearchManager.presentation).toBe('modal');
+    expect(document.querySelector('[data-cmdk-dropdown-panel]')).toBeNull();
+  });
+
+  it('opens the inline dropdown, not the modal, when focus arrives via Tab with no pointer event', async () => {
+    const user = userEvent.setup();
+
+    render(GlobalSearchInputTrigger);
+
+    await user.tab();
+
+    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+    expect(input).toHaveFocus();
+    expect(globalSearchManager.presentation).toBe('dropdown');
+    expect(document.querySelector('[data-cmdk-dropdown-panel]')).not.toBeNull();
+  });
+
   it('renders the placeholder and hotkey hint', () => {
     render(GlobalSearchInputTrigger);
 

--- a/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
@@ -15,6 +15,19 @@ const { mockPage } = vi.hoisted(() => ({
 
 vi.mock('$app/state', () => ({ page: mockPage }));
 
+const { mediaState } = vi.hoisted(() => ({ mediaState: { pointerCoarse: false, minLg: false } }));
+
+vi.mock('$lib/stores/media-query-manager.svelte', () => ({
+  mediaQueryManager: {
+    get pointerCoarse() {
+      return mediaState.pointerCoarse;
+    },
+    get minLg() {
+      return mediaState.minLg;
+    },
+  },
+}));
+
 describe('global-search-input-trigger', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -23,6 +36,8 @@ describe('global-search-input-trigger', () => {
     mockPage.route.id = null;
     mockPage.params = {};
     sessionStorage.clear();
+    mediaState.pointerCoarse = false;
+    mediaState.minLg = false;
   });
 
   it('opens a dropdown from an editable search field', async () => {
@@ -312,5 +327,31 @@ describe('global-search-input-trigger', () => {
     await user.click(screen.getByText('search_sort_oldest'));
 
     expect(applySortSpy).toHaveBeenCalledWith('asc', '');
+  });
+
+  it('hides the keyboard hint when the pointer is coarse', () => {
+    mediaState.pointerCoarse = true;
+
+    render(GlobalSearchInputTrigger);
+
+    expect(screen.queryByText(/^(⌘K|Ctrl\+K)$/)).not.toBeInTheDocument();
+  });
+
+  it('keeps the search field usable when the keyboard hint is hidden', () => {
+    mediaState.pointerCoarse = true;
+
+    render(GlobalSearchInputTrigger);
+
+    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+    expect(input).toBeInTheDocument();
+    expect(screen.getByTestId('cmdk-input-trigger')).toBeInTheDocument();
+  });
+
+  it('shows the keyboard hint when the pointer is not coarse', () => {
+    mediaState.pointerCoarse = false;
+
+    render(GlobalSearchInputTrigger);
+
+    expect(screen.getByText(/^(⌘K|Ctrl\+K)$/)).toBeInTheDocument();
   });
 });

--- a/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search-input-trigger.spec.ts
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { globalSearchManager } from '$lib/managers/global-search-manager.svelte';
@@ -175,6 +175,67 @@ describe('global-search-input-trigger', () => {
     await user.keyboard('{Control>}k{/Control}');
 
     expect(globalSearchManager.isOpen).toBe(true);
+    expect(globalSearchManager.presentation).toBe('modal');
+    expect(document.querySelector('[data-cmdk-dropdown-panel]')).toBeNull();
+  });
+
+  it('opens the modal palette when the search field is tapped', async () => {
+    const openSpy = vi.spyOn(globalSearchManager, 'open');
+    const user = userEvent.setup();
+
+    render(GlobalSearchInputTrigger);
+
+    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+    await user.pointer({ keys: '[TouchA]', target: input });
+
+    expect(openSpy).toHaveBeenCalledWith('modal');
+    expect(globalSearchManager.presentation).toBe('modal');
+    expect(document.querySelector('[data-cmdk-dropdown-panel]')).toBeNull();
+  });
+
+  it('does not focus the search field when it is tapped', async () => {
+    const user = userEvent.setup();
+
+    render(GlobalSearchInputTrigger);
+
+    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+    await user.pointer({ keys: '[TouchA]', target: input });
+
+    expect(input).not.toHaveFocus();
+  });
+
+  it('opens the inline dropdown for pen input rather than the modal', async () => {
+    const user = userEvent.setup();
+
+    render(GlobalSearchInputTrigger);
+
+    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+    await fireEvent.pointerDown(input, { pointerType: 'pen' });
+    await user.click(input);
+
+    expect(globalSearchManager.presentation).toBe('dropdown');
+  });
+
+  it('opens the inline dropdown when a pointerdown carries no pointer type', async () => {
+    const user = userEvent.setup();
+
+    render(GlobalSearchInputTrigger);
+
+    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+    await fireEvent.pointerDown(input);
+    await user.click(input);
+
+    expect(globalSearchManager.presentation).toBe('dropdown');
+  });
+
+  it('does not let focus downgrade an open modal to the inline dropdown', async () => {
+    render(GlobalSearchInputTrigger);
+
+    globalSearchManager.open('modal');
+
+    const input = screen.getByRole('combobox', { name: 'cmdk_placeholder' });
+    await fireEvent.focus(input);
+
     expect(globalSearchManager.presentation).toBe('modal');
     expect(document.querySelector('[data-cmdk-dropdown-panel]')).toBeNull();
   });

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -483,9 +483,26 @@
   }
 
   function openDropdown() {
+    // Focus must never downgrade an open modal to the inline dropdown.
+    // `showDropdownPanel` is false while the modal is open, so without this the
+    // next focus event would call open('dropdown') and clobber the presentation.
+    if (manager.isOpen && manager.presentation === 'modal') {
+      return;
+    }
     if (!showDropdownPanel) {
       manager.open('dropdown');
     }
+  }
+
+  function openModalOnTouch(event: PointerEvent) {
+    if (event.pointerType !== 'touch') {
+      return;
+    }
+    // preventDefault is load-bearing: it suppresses the focus this tap would
+    // otherwise produce on pointer release, and it stops iOS raising the soft
+    // keyboard against an input the modal is about to cover.
+    event.preventDefault();
+    manager.open('modal');
   }
 
   function onKeyDown(e: KeyboardEvent) {
@@ -634,6 +651,7 @@
           placeholder={$t('cmdk_placeholder')}
           maxlength={256}
           onfocus={openDropdown}
+          onpointerdown={openModalOnTouch}
           oninput={(event) => {
             inputEditRevision++;
             syncInputCaret(event);

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -499,8 +499,10 @@
       return;
     }
     // preventDefault is load-bearing: it suppresses the focus this tap would
-    // otherwise produce on pointer release, and it stops iOS raising the soft
-    // keyboard against an input the modal is about to cover.
+    // otherwise produce on pointer release, so iOS never raises the soft
+    // keyboard against this inline input, which the modal is about to cover.
+    // The modal's own Command.Input autofocuses once it opens, so the keyboard
+    // still appears — just against the modal's input rather than this one.
     event.preventDefault();
     manager.open('modal');
   }

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -667,11 +667,13 @@
           }}
           class="min-w-0 flex-1 bg-transparent text-sm text-gray-800 placeholder:text-gray-500 focus:outline-none dark:text-gray-100 dark:placeholder:text-gray-300"
         />
-        <kbd
-          class="hidden shrink-0 rounded-lg border border-gray-300 bg-white px-2 py-1 font-mono text-[11px] font-semibold tracking-wide text-gray-500 sm:inline-block dark:border-immich-dark-gray dark:bg-immich-dark-bg dark:text-gray-300"
-        >
-          {hotkeyLabel}
-        </kbd>
+        {#if !mediaQueryManager.pointerCoarse}
+          <kbd
+            class="hidden shrink-0 rounded-lg border border-gray-300 bg-white px-2 py-1 font-mono text-[11px] font-semibold tracking-wide text-gray-500 sm:inline-block dark:border-immich-dark-gray dark:bg-immich-dark-bg dark:text-gray-300"
+          >
+            {hotkeyLabel}
+          </kbd>
+        {/if}
       </div>
 
       {#if showDropdownPanel}

--- a/web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte
@@ -271,7 +271,6 @@
 
       const shortcuts: ShortcutOptions[] = [
         { shortcut: { key: '?', shift: true }, onShortcut: handleOpenShortcutModal },
-        { shortcut: { key: '/' }, onShortcut: () => goto(Route.explore()) },
         { shortcut: { key: 'A', ctrl: true }, onShortcut: () => selectAllAssets() },
         ...(arrowNavigation
           ? [

--- a/web/src/lib/components/timeline/actions/TimelineKeyboardActions.svelte
+++ b/web/src/lib/components/timeline/actions/TimelineKeyboardActions.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { goto } from '$app/navigation';
   import { shortcuts, type ShortcutOptions } from '$lib/actions/shortcut';
   import {
     setFocusToAsset as setFocusAssetInit,
@@ -14,7 +13,6 @@
   import AssetDeleteConfirmModal from '$lib/modals/AssetDeleteConfirmModal.svelte';
   import NavigateToDateModal from '$lib/modals/NavigateToDateModal.svelte';
   import ShortcutsModal from '$lib/modals/ShortcutsModal.svelte';
-  import { Route } from '$lib/route';
   import { keyboardManager } from '$lib/stores/keyboard-manager.svelte';
   import { showDeleteModal } from '$lib/stores/preferences.store';
   import { searchStore } from '$lib/stores/search.svelte';
@@ -116,7 +114,6 @@
 
     const shortcuts: ShortcutOptions[] = [
       { shortcut: { key: '?', shift: true }, onShortcut: handleOpenShortcutModal },
-      { shortcut: { key: '/' }, onShortcut: () => goto(Route.explore()) },
       { shortcut: { key: 'A', ctrl: true }, onShortcut: () => selectAllAssets(timelineManager, assetInteraction) },
       { shortcut: { key: 'ArrowRight' }, onShortcut: () => setFocusTo('earlier', 'asset') },
       { shortcut: { key: 'ArrowLeft' }, onShortcut: () => setFocusTo('later', 'asset') },

--- a/web/src/lib/modals/ShortcutsModal.svelte
+++ b/web/src/lib/modals/ShortcutsModal.svelte
@@ -33,6 +33,7 @@
         { key: ['x'], action: $t('select') },
         { key: ['Esc'], action: $t('back_close_deselect') },
         { key: ['Ctrl', 'k'], action: $t('shortcut_open_global_search') },
+        { key: ['/'], action: $t('shortcut_open_global_search') },
         { key: ['Ctrl', '/'], action: $t('shortcut_cycle_search_mode') },
         { key: ['Ctrl', '⇧', 'k'], action: $t('open_the_search_filters') },
       ],

--- a/web/src/lib/utils/search-shortcut.spec.ts
+++ b/web/src/lib/utils/search-shortcut.spec.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from 'vitest';
+import { matchesShortcut } from '$lib/actions/shortcut';
+import { isEditableTarget, searchShortcuts } from './search-shortcut';
+
+const keydown = (init: KeyboardEventInit) => new KeyboardEvent('keydown', init);
+
+const countMatches = (event: KeyboardEvent) =>
+  searchShortcuts(() => {}).filter((option) => matchesShortcut(event, option.shortcut)).length;
+
+const fire = (open: () => void, event: KeyboardEvent) => {
+  for (const option of searchShortcuts(open)) {
+    if (matchesShortcut(event, option.shortcut)) {
+      option.onShortcut(event as KeyboardEvent & { currentTarget: HTMLElement });
+    }
+  }
+};
+
+const focusHtml = (html: string) => {
+  document.body.innerHTML = html;
+  const element = document.body.firstElementChild as HTMLElement;
+  element.focus();
+  return element;
+};
+
+describe('isEditableTarget', () => {
+  it.each([
+    ['a text input', '<input type="text" />'],
+    ['a search input', '<input type="search" />'],
+    ['a number input', '<input type="number" />'],
+    ['a textarea', '<textarea></textarea>'],
+    ['a select', '<select></select>'],
+    ['a contenteditable element', '<div contenteditable="true"></div>'],
+  ])('treats %s as editable', (_name, html) => {
+    document.body.innerHTML = html;
+
+    expect(isEditableTarget(document.body.firstElementChild)).toBe(true);
+  });
+
+  it('treats an element nested inside a contenteditable region as editable', () => {
+    document.body.innerHTML = '<div contenteditable="true"><span id="inner">hi</span></div>';
+
+    expect(isEditableTarget(document.querySelector('#inner'))).toBe(true);
+  });
+
+  it('does not treat an explicitly non-editable region as editable', () => {
+    document.body.innerHTML = '<div contenteditable="false"></div>';
+
+    expect(isEditableTarget(document.body.firstElementChild)).toBe(false);
+  });
+
+  it('does not treat an ordinary element as editable', () => {
+    document.body.innerHTML = '<div></div>';
+
+    expect(isEditableTarget(document.body.firstElementChild)).toBe(false);
+  });
+
+  it('returns false for null rather than throwing', () => {
+    expect(isEditableTarget(null)).toBe(false);
+  });
+});
+
+describe('searchShortcuts', () => {
+  it('registers a bare slash and a shifted slash, in that order', () => {
+    expect(searchShortcuts(() => {}).map((option) => option.shortcut)).toEqual([
+      { key: '/' },
+      { key: '/', shift: true },
+    ]);
+  });
+
+  it('matches a bare slash exactly once', () => {
+    expect(countMatches(keydown({ key: '/' }))).toBe(1);
+  });
+
+  it('matches a shifted slash exactly once, for layouts where slash needs shift', () => {
+    expect(countMatches(keydown({ key: '/', shiftKey: true }))).toBe(1);
+  });
+
+  it('leaves question mark to the keyboard shortcuts modal', () => {
+    expect(countMatches(keydown({ key: '?', shiftKey: true }))).toBe(0);
+  });
+
+  it('leaves ctrl+slash to the search mode cycle', () => {
+    expect(countMatches(keydown({ key: '/', ctrlKey: true }))).toBe(0);
+  });
+
+  it('ignores slash with alt or meta held', () => {
+    expect(countMatches(keydown({ key: '/', altKey: true }))).toBe(0);
+    expect(countMatches(keydown({ key: '/', metaKey: true }))).toBe(0);
+  });
+
+  it('opens search when nothing is being edited', () => {
+    document.body.innerHTML = '';
+    const open = vi.fn();
+
+    fire(open, keydown({ key: '/' }));
+
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens search from a shifted slash when nothing is being edited', () => {
+    document.body.innerHTML = '';
+    const open = vi.fn();
+
+    fire(open, keydown({ key: '/', shiftKey: true }));
+
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not open search while typing in a search input', () => {
+    const field = focusHtml('<input type="search" />');
+    expect(document.activeElement).toBe(field);
+    const open = vi.fn();
+
+    fire(open, keydown({ key: '/' }));
+
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('does not open search while typing in a textarea', () => {
+    const field = focusHtml('<textarea></textarea>');
+    expect(document.activeElement).toBe(field);
+    const open = vi.fn();
+
+    fire(open, keydown({ key: '/' }));
+
+    expect(open).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/utils/search-shortcut.spec.ts
+++ b/web/src/lib/utils/search-shortcut.spec.ts
@@ -89,7 +89,7 @@ describe('searchShortcuts', () => {
   });
 
   it('opens search when nothing is being edited', () => {
-    document.body.innerHTML = '';
+    document.body.replaceChildren();
     const open = vi.fn();
 
     fire(open, keydown({ key: '/' }));
@@ -98,7 +98,7 @@ describe('searchShortcuts', () => {
   });
 
   it('opens search from a shifted slash when nothing is being edited', () => {
-    document.body.innerHTML = '';
+    document.body.replaceChildren();
     const open = vi.fn();
 
     fire(open, keydown({ key: '/', shiftKey: true }));

--- a/web/src/lib/utils/search-shortcut.spec.ts
+++ b/web/src/lib/utils/search-shortcut.spec.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
-import { matchesShortcut } from '$lib/actions/shortcut';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { matchesShortcut, shortcuts } from '$lib/actions/shortcut';
 import { isEditableTarget, searchShortcuts } from './search-shortcut';
 
 const keydown = (init: KeyboardEventInit) => new KeyboardEvent('keydown', init);
@@ -124,5 +124,94 @@ describe('searchShortcuts', () => {
     fire(open, keydown({ key: '/' }));
 
     expect(open).not.toHaveBeenCalled();
+  });
+});
+
+// These tests drive the REAL `shortcuts` action from `$lib/actions/shortcut` — attached
+// to a live DOM node, dispatching real `keydown` events at the focused element — rather
+// than calling `option.onShortcut` directly like `fire()` above does. `fire()` cannot
+// exercise `preventDefault` ordering because it bypasses the action entirely; the action
+// itself calls `event.preventDefault()` *before* `onShortcut` runs whenever a descriptor's
+// `preventDefault` option is left at its default of `true`. That ordering is exactly what
+// regressed: `searchShortcuts` used to omit `preventDefault: false`, so typing `/` into a
+// `type="search"` field (e.g. the space albums filter) got its keydown cancelled — and
+// hence the character silently swallowed — even though `openUnlessEditing` correctly
+// declined to open the palette. Revert the `preventDefault: false` / manual
+// `event.preventDefault()` pairing in `search-shortcut.ts` and the `type="search"` case
+// below fails: `defaultPrevented` becomes `true` even though `open` is never called.
+describe('searchShortcuts wired through the real shortcuts action', () => {
+  let cleanup: (() => void) | undefined;
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+    document.body.replaceChildren();
+  });
+
+  const attach = (open: () => void) => {
+    document.body.replaceChildren();
+    const root = document.createElement('div');
+    document.body.append(root);
+    const action = shortcuts(root, searchShortcuts(open));
+    cleanup = () => {
+      action.destroy?.();
+      root.remove();
+    };
+    return root;
+  };
+
+  const dispatchSlash = (target: EventTarget) => {
+    const event = new KeyboardEvent('keydown', { key: '/', bubbles: true, cancelable: true });
+    target.dispatchEvent(event);
+    return event;
+  };
+
+  it('opens search and marks the keydown as prevented when nothing is focused', () => {
+    const open = vi.fn();
+    const root = attach(open);
+    const inert = document.createElement('div');
+    root.append(inert);
+
+    const event = dispatchSlash(inert);
+
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('does not open search and leaves the keydown unprevented while a search input is focused', () => {
+    const open = vi.fn();
+    const root = attach(open);
+    const input = document.createElement('input');
+    input.type = 'search';
+    root.append(input);
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    const event = dispatchSlash(input);
+
+    expect(open).not.toHaveBeenCalled();
+    // The regression: without `preventDefault: false` on the descriptors plus a manual
+    // `event.preventDefault()` gated on actually opening, the action's own default
+    // (`preventDefault: true`) cancels this keydown before `openUnlessEditing` ever runs,
+    // silently swallowing the `/` the user typed instead of inserting it.
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('does not open search and leaves the keydown unprevented while a text input is focused', () => {
+    const open = vi.fn();
+    const root = attach(open);
+    const input = document.createElement('input');
+    input.type = 'text';
+    root.append(input);
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    const event = dispatchSlash(input);
+
+    // Handled entirely by the action's own `shouldIgnoreEvent`, which recognises
+    // `type="text"` and `continue`s past every descriptor without ever calling
+    // `preventDefault` — this case never reaches `searchShortcuts`' own guard.
+    expect(open).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
   });
 });

--- a/web/src/lib/utils/search-shortcut.ts
+++ b/web/src/lib/utils/search-shortcut.ts
@@ -1,0 +1,33 @@
+import type { ShortcutOptions } from '$lib/actions/shortcut';
+
+const EDITABLE_SELECTOR = 'input, textarea, select, [contenteditable]:not([contenteditable="false"])';
+
+/** True when the element is, or sits inside, something the user can type into. */
+export const isEditableTarget = (element: Element | null): boolean =>
+  element !== null && element.closest(EDITABLE_SELECTOR) !== null;
+
+/**
+ * Descriptors binding `/` to the global search palette.
+ *
+ * Two of them, because `matchesShortcut` compares modifiers strictly
+ * (`Boolean(shortcut.shift) === event.shiftKey`) and several common layouts
+ * produce `/` with Shift held — QWERTZ and Spanish use Shift+7, AZERTY Shift+:.
+ * A lone `{ key: '/' }` would be dead for all of them. There is no clash with
+ * `?`, which arrives as `event.key === '?'` on US layouts.
+ */
+export const searchShortcuts = (open: () => void): ShortcutOptions[] => {
+  const openUnlessEditing = () => {
+    // `shouldIgnoreEvent` in @immich/ui only skips a fixed list of input types
+    // (textarea, text, date, datetime-local, email, password), so `type="search"`
+    // and `type="number"` fields would otherwise swallow a typed `/`.
+    if (isEditableTarget(document.activeElement)) {
+      return;
+    }
+    open();
+  };
+
+  return [
+    { shortcut: { key: '/' }, onShortcut: openUnlessEditing },
+    { shortcut: { key: '/', shift: true }, onShortcut: openUnlessEditing },
+  ];
+};

--- a/web/src/lib/utils/search-shortcut.ts
+++ b/web/src/lib/utils/search-shortcut.ts
@@ -16,18 +16,30 @@ export const isEditableTarget = (element: Element | null): boolean =>
  * `?`, which arrives as `event.key === '?'` on US layouts.
  */
 export const searchShortcuts = (open: () => void): ShortcutOptions[] => {
-  const openUnlessEditing = () => {
+  const openUnlessEditing = (event: KeyboardEvent) => {
     // `shouldIgnoreEvent` in @immich/ui only skips a fixed list of input types
     // (textarea, text, date, datetime-local, email, password), so `type="search"`
     // and `type="number"` fields would otherwise swallow a typed `/`.
     if (isEditableTarget(document.activeElement)) {
       return;
     }
+    // `shortcuts()` in @immich/ui calls `event.preventDefault()` BEFORE invoking
+    // `onShortcut` whenever a descriptor's `preventDefault` option is left at its
+    // default of `true` — before we ever get a chance to check `isEditableTarget`.
+    // Cancelling `keydown` suppresses the browser's own text-insertion behaviour,
+    // so if we let that default stand, declining to open the palette above would
+    // still swallow the `/` the user typed into a `type="search"` field. To keep
+    // both outcomes correct we set `preventDefault: false` on both descriptors
+    // below and call `event.preventDefault()` ourselves, only on the branch that
+    // actually opens the palette. Do NOT delete this call or drop the
+    // `preventDefault: false` options — that reintroduces a silent dead key on
+    // every editable field on every page (see #862 follow-up regression).
+    event.preventDefault();
     open();
   };
 
   return [
-    { shortcut: { key: '/' }, onShortcut: openUnlessEditing },
-    { shortcut: { key: '/', shift: true }, onShortcut: openUnlessEditing },
+    { shortcut: { key: '/' }, onShortcut: openUnlessEditing, preventDefault: false },
+    { shortcut: { key: '/', shift: true }, onShortcut: openUnlessEditing, preventDefault: false },
   ];
 };

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -19,6 +19,7 @@
   import { closeWebsocketConnection, openWebsocketConnection, websocketStore } from '$lib/stores/websocket';
   import { copyToClipboard } from '$lib/utils';
   import { maintenanceShouldRedirect } from '$lib/utils/maintenance';
+  import { searchShortcuts } from '$lib/utils/search-shortcut';
   import { getServerConfig } from '@immich/sdk';
   import {
     modalManager,
@@ -304,6 +305,7 @@
         globalSearchManager.setMode(next);
       },
     },
+    ...searchShortcuts(openModalSearch),
   ]}
 />
 


### PR DESCRIPTION
Fixes #862, and adds `/` as a way to open the search palette.

## The problem

The nav search bar shows a `Ctrl+K` / `⌘K` chip on every viewport ≥640px. On a keyboardless iPad that advertises a shortcut the user cannot type, and the chip is decorative — not a button.

The palette was in fact reachable by touch (tap the bar, or the magnify button below 640px), so the real defect was the affordance rather than raw reachability. Two things also made the tap path poor on a tablet: the inline dropdown is cramped, and focusing a real `<input>` raises the iOS keyboard over the dropdown it just opened.

## What changed

| Interaction | Before | After |
|---|---|---|
| Tap nav search bar (finger) | inline dropdown, keyboard covers it | **modal palette** |
| Click bar (mouse / trackpad / pen), or Tab to it | inline dropdown | unchanged |
| `Ctrl+K` / `⌘K` | modal palette | unchanged |
| **`/`** | go to Explore | **modal palette** |
| **`/` where the layout needs Shift** | dead | **modal palette** |
| `Ctrl+/`, `?` | unchanged | unchanged |
| `Ctrl+K` chip | always ≥640px | only when `pointer: coarse` is false |

Touch is detected **per event** via `PointerEvent.pointerType`, not per device — so an iPad user gets the modal from a finger and the inline dropdown from a trackpad, in the same session.

`/` replaces the previous `/` → Explore binding (Explore is still in the sidebar). It is now documented in the keyboard shortcuts modal, which it never was.

## Two non-obvious bugs found on the way

**Non-US keyboards.** `matchesShortcut` compares modifiers strictly, and QWERTZ/Spanish/Italian produce `/` as Shift+7, AZERTY as Shift+:. A lone `{ key: '/' }` descriptor would have been a dead shortcut for all of them, so there are two descriptors. No clash with `?`, which arrives as `event.key === '?'` on US layouts.

**`/` as a silent dead key.** `@immich/ui`'s `shortcuts` action calls `preventDefault()` *before* `onShortcut`, so an editable-target guard that merely declines to open the palette still swallows the character. Typing `2024/Summer` into the space-albums filter would have lost the `/` with no palette either. Fixed by setting `preventDefault: false` on both descriptors and calling `preventDefault()` only on the branch that actually opens.

## Notes

- `GalleryViewer.svelte` and `TimelineKeyboardActions.svelte` are upstream files; both changes are pure deletions to keep the rebase surface minimal.
- No new i18n strings — the shortcuts modal reuses `shortcut_open_global_search` for both aliases.
- Design doc and implementation plan are included under `docs/superpowers/`.

## Testing

`4035 passed | 0 failures` (baseline 4001, +34 new). `check:typescript`, `check:svelte`, and `lint` all clean.

New coverage: pointer routing (touch/mouse/pen/absent-type/Tab, plus modal-downgrade guard), chip visibility on coarse pointers, and the `/` binding driven through the real `shortcuts` action across editable and non-editable targets.

Still worth a manual pass on a physical iPad/iPhone: unit tests cannot confirm iOS Safari raises the soft keyboard against the modal's autofocused input inside the tap gesture.
