### PR TITLE
fix(web): apply search-palette tag picks as a filter, not a /search jump (#894)

### DIFF
--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -1102,13 +1102,11 @@ describe('activate()', () => {
     expect(entries[0]).toMatchObject({ kind: 'place', id: 'place:48.8566:2.3522', label: 'Paris' });
   });
 
-  it('activate("tag", item) navigates to /search with tagIds and records recent entry', () => {
+  it('activate("tag", item) filters the current timeline by the tag and records recent entry', () => {
     const m = new GlobalSearchManager();
     m.open();
     m.activate('tag', { id: 't1', name: 'beach' });
-    const firstCall = vi.mocked(goto).mock.calls[0]?.[0] as string;
-    expect(firstCall).toContain('/search');
-    expect(decodeURIComponent(firstCall)).toContain('"tagIds":["t1"]');
+    expect(goto).toHaveBeenCalledWith('/photos?tags=t1');
     const entries = getEntries();
     expect(entries[0]).toMatchObject({ kind: 'tag', id: 'tag:t1', tagId: 't1', label: 'beach' });
   });
@@ -2652,8 +2650,7 @@ describe('activateRecent()', () => {
     const m = new GlobalSearchManager();
     m.open();
     m.activateRecent({ kind: 'tag', id: 'tag:t1', tagId: 't1', label: 'beach', lastUsed: 1 });
-    const firstCall = vi.mocked(goto).mock.calls[0]?.[0] as string;
-    expect(firstCall).toContain('/search');
+    expect(goto).toHaveBeenCalledWith('/photos?tags=t1');
     expect(m.isOpen).toBe(false);
   });
 
@@ -6668,5 +6665,116 @@ describe('field-search mode navigation (filename / description / ocr)', () => {
 
     const fieldNav = vi.mocked(goto).mock.calls.find((c) => String(c[0]).includes('description='));
     expect(fieldNav).toBeUndefined();
+  });
+});
+
+describe('tag activation navigation', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    localStorage.clear();
+    resetRecentStore();
+    mockPage.url = new URL('https://gallery.test/photos');
+  });
+
+  const lastGoto = () => vi.mocked(goto).mock.calls.at(-1)?.[0] as string | undefined;
+
+  it('lands on the filterable timeline, not the deprecated /search page', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('tag', { id: 't1', name: 'beach' });
+
+    expect(lastGoto()).toBe('/photos?tags=t1');
+  });
+
+  it('preserves the current searchable-page filters (AND)', () => {
+    const m = new GlobalSearchManager();
+    m.registerSearchablePageFilters(() => ({ ...createFilterState(), personIds: ['p1'], rating: 3 }));
+
+    m.activate('tag', { id: 't1', name: 'beach' });
+
+    const dest = lastGoto();
+    expect(dest).toContain('people=p1');
+    expect(dest).toContain('rating=3');
+    expect(dest).toContain('tags=t1');
+  });
+
+  it('keeps tags already active on the page and appends the new one', () => {
+    const m = new GlobalSearchManager();
+    m.registerSearchablePageFilters(() => ({ ...createFilterState(), tagIds: ['t0'] }));
+
+    m.activate('tag', { id: 't1', name: 'beach' });
+
+    expect(lastGoto()).toBe('/photos?tags=t0%2Ct1');
+  });
+
+  it('does not duplicate a tag that is already filtering the page', () => {
+    const m = new GlobalSearchManager();
+    m.registerSearchablePageFilters(() => ({ ...createFilterState(), tagIds: ['t1'] }));
+
+    m.activate('tag', { id: 't1', name: 'beach' });
+
+    expect(lastGoto()).toBe('/photos?tags=t1');
+  });
+
+  it('drops a stale smart query so the tag filter is the only constraint', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/photos?q=sunset');
+
+    m.activate('tag', { id: 't1', name: 'beach' });
+
+    expect(lastGoto()).toBe('/photos?tags=t1');
+  });
+
+  it('targets /photos when the current page is not filterable', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/map');
+
+    m.activate('tag', { id: 't1', name: 'beach' });
+
+    expect(lastGoto()).toBe('/photos?tags=t1');
+  });
+
+  it('stays on a space timeline so the tag filters the space', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1');
+
+    m.activate('tag', { id: 't1', name: 'beach' });
+
+    expect(lastGoto()).toBe('/spaces/space-1?tags=t1');
+  });
+
+  it('caches the tag name for the destination so the filter chip is not a raw id', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('tag', { id: 't1', name: 'beach' });
+
+    expect(storeTypedSearchNames).toHaveBeenCalledWith('/photos?tags=t1', {
+      personNames: new Map(),
+      tagNames: new Map([['t1', 'beach']]),
+    });
+  });
+
+  it('caches no name for a nameless tag so the chip falls back to the id, not a blank label', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('tag', { id: 't1' });
+
+    expect(storeTypedSearchNames).toHaveBeenCalledWith('/photos?tags=t1', {
+      personNames: new Map(),
+      tagNames: new Map(),
+    });
+  });
+
+  it('routes a recent tag entry to the filterable timeline too', () => {
+    const m = new GlobalSearchManager();
+    addEntry({ kind: 'tag', id: 'tag:t1', tagId: 't1', label: 'beach', lastUsed: 1 });
+
+    m.activateRecent({ kind: 'tag', id: 'tag:t1', tagId: 't1', label: 'beach', lastUsed: 1 });
+
+    expect(lastGoto()).toBe('/photos?tags=t1');
+    expect(storeTypedSearchNames).toHaveBeenCalledWith('/photos?tags=t1', {
+      personNames: new Map(),
+      tagNames: new Map([['t1', 'beach']]),
+    });
   });
 });

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -1654,6 +1654,37 @@ export class GlobalSearchManager {
     void goto(buildSearchablePageUrl(base, '', this.searchSortOrder, filters) ?? '/photos');
   }
 
+  /**
+   * Navigate the current searchable page (or `/photos`) to the timeline filtered by `tagId`.
+   * Tag rows used to open the deprecated `/search?query=` page, which ignores the filter panel
+   * and rendered nothing for a tag the palette had just suggested (#894). Routing through the
+   * searchable-page URL AND-s the tag into whatever the surface is already filtered by, so the
+   * user stays where they were with one more filter chip. The tag name is handed to the
+   * typed-search name cache so that chip reads "beach" instead of a raw uuid.
+   */
+  private navigateToTagResults(tagId: string, tagName: string): void {
+    const current = this.searchablePageFiltersProvider?.() ?? createFilterState();
+    const filters: FilterState = {
+      ...current,
+      tagIds: current.tagIds.includes(tagId) ? current.tagIds : [...current.tagIds, tagId],
+    };
+    // Same targeting rule as navigateToFieldResults: a tag is always a filtered timeline, so
+    // skip buildSearchDestination and its /map `q=` special-case, which would drop the filter.
+    // Ephemeral URL object for destination construction only; no reactive state is retained.
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity
+    const base = getSearchablePageBasePath(page.url.pathname) ? page.url : new URL('/photos', page.url);
+    const destination = buildSearchablePageUrl(base, '', this.searchSortOrder, filters) ?? '/photos';
+    // An empty name must stay OUT of the map: active-filters-bar falls back to the raw id only
+    // for a missing entry, so caching '' would render a blank chip.
+    // Ephemeral maps, serialized into sessionStorage by storeTypedSearchNames on the next line;
+    // nothing reads them reactively, so plain Maps are correct here.
+    /* eslint-disable svelte/prefer-svelte-reactivity */
+    const tagNames = tagName ? new Map([[tagId, tagName]]) : new Map<string, string>();
+    storeTypedSearchNames(destination, { personNames: new Map(), tagNames });
+    /* eslint-enable svelte/prefer-svelte-reactivity */
+    void goto(destination);
+  }
+
   async applySearchSort(sortOrder: SearchablePageSortOrder, text = this.query) {
     this.searchSortOrder = sortOrder;
 
@@ -1805,7 +1836,7 @@ export class GlobalSearchManager {
           label: t.name ?? '',
           lastUsed: now,
         });
-        void goto(Route.search({ tagIds: [t.id] }));
+        this.navigateToTagResults(t.id, t.name ?? '');
         break;
       }
       case 'nav': {
@@ -1944,7 +1975,7 @@ export class GlobalSearchManager {
         break;
       }
       case 'tag': {
-        void goto(Route.search({ tagIds: [entry.tagId] }));
+        this.navigateToTagResults(entry.tagId, entry.label);
         break;
       }
       case 'navigate': {


### PR DESCRIPTION
Closes part of #894.

## Problem

Picking a **Tag** row in the search palette navigated to the deprecated `/search?query={"tagIds":[...]}` page, which ignores the filter panel and rendered "No results" for a tag the palette had *just* suggested.

#723 moved the palette's field modes (filename / description / OCR) onto the filterable timeline, but entity activation was never converted — tags still called `Route.search(...)`. All four tag-row call sites funnel through `manager.activate('tag', item)`, so the whole bug lives in `GlobalSearchManager`.

## Fix

New `navigateToTagResults(tagId, tagName)`, a sibling of the existing `navigateToFieldResults`:

- AND-s the tag into the current page's **live** filters instead of replacing them
- targets the current searchable page (`/photos`, `/recently-added`, `/spaces/{id}`), falling back to `/photos` when the surface isn't filterable (e.g. `/map`)
- drops a stale smart `?q=` so the tag is the only constraint
- hands the tag name to the typed-search name cache so the filter chip reads `beach`, not a raw uuid

Applies to both fresh tag rows and tag entries in Recents.

One subtlety: `active-filters-bar` does `tagNames?.get(id) ?? id`, so an **empty** cached name renders a blank chip — worse than the id fallback. A nameless tag is therefore deliberately left out of the map rather than cached as `''`.

## Tests

TDD — 11 new tests, each watched failing against the old `/search` destination first:

- lands on the filterable timeline, not `/search`
- preserves existing page filters (AND)
- appends to tags already active; doesn't duplicate one already applied
- drops a stale smart `?q=`
- `/map` → `/photos`; a space page stays on the space
- caches the tag name; caches nothing for a nameless tag
- recent tag entries take the same route

Two pre-existing tests asserted the old `/search` destination and were updated.

## Verification

- `pnpm vitest run` (web) — 4013 passed, 0 failed
- `pnpm check:typescript` — clean
- `pnpm check:svelte` — 571 files, 0 errors, 0 warnings
- `pnpm lint` — 0 errors (8 pre-existing warnings, none in touched files)
- `prettier --check` — clean

## Not covered by this PR

- **Filename mode returning nothing** (#894's second half) is a separate, still-open bug with a different root cause. Tracked in #894; not addressed here.
- The **duplicate "Strand" tag suggestion** in the reporter's screenshot is in the tag provider's matching, not navigation, and is untouched here.
