### PR TITLE
fix(web): include shared-space assets in palette filename/description/OCR search (#894)

### DIFF
--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -662,6 +662,28 @@ describe('real providers', () => {
     );
   });
 
+  // #894: the field modes (filename / description / OCR) omitted `withSharedSpaces`, so the
+  // palette searched only the user's OWN assets. A Space member whose photos live in a Space
+  // owned by someone else got an empty Photos section — while smart search, which does send
+  // the flag, worked. `withSharedSpaces` is inherited from BaseSearchSchema onto
+  // MetadataSearchDto and honoured by SearchService.searchMetadata, so the omission was the
+  // whole bug. Keep every field mode aligned with smart mode here.
+  it.each(['metadata', 'description', 'ocr'] as const)(
+    'photos includes shared-space assets in %s mode',
+    async (mode) => {
+      localStorage.setItem('searchQueryType', mode);
+      const m = new GlobalSearchManager();
+      m.setQuery('Strand');
+      await vi.advanceTimersByTimeAsync(200);
+      expect(searchAssets).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadataSearchDto: expect.objectContaining({ withSharedSpaces: true }),
+        }),
+        expect.anything(),
+      );
+    },
+  );
+
   it('people provider calls searchPerson with name and withHidden=false', async () => {
     const m = new GlobalSearchManager();
     m.setQuery('alice');

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -2693,12 +2693,18 @@ export class GlobalSearchManager {
             const items = response.assets.items;
             return items.length === 0 ? { status: 'empty' } : { status: 'ok', items, total: items.length };
           }
-          // MetadataSearchDto does not have a withSharedSpaces field — shared-space
-          // scoping for metadata search would require passing spaceId, which we do not
-          // have in the palette. Only smart search includes shared-space content in v1.
+          // withSharedSpaces:true for the same reason as smart mode above — without it the
+          // field modes searched only the user's OWN assets, so a Space member whose photos
+          // live in someone else's Space saw an empty Photos section while smart search
+          // worked (#894). `withSharedSpaces` is inherited from BaseSearchSchema onto
+          // MetadataSearchDto and honoured by SearchService.searchMetadata; only
+          // SmartSearchDto re-declares it, which previously made it look smart-only.
+          // Safe to send unconditionally: the server rejects withSharedSpaces only when
+          // combined with spaceId, which the palette never sends here.
           const metadataSearchDto: MetadataSearchDto = {
             size: 5,
             visibility: AssetVisibility.Timeline,
+            withSharedSpaces: true,
             ...(mode === 'metadata' && { originalFileName: query }),
             ...(mode === 'description' && { description: query }),
             ...(mode === 'ocr' && { ocr: query }),


### PR DESCRIPTION
Fixes the second half of #894 (the first half — tag rows jumping to the deprecated `/search` page — is #895).

## Problem

In the search palette, switching to **Dateiname / Filename** (or Description, or OCR) and searching for a term that plainly exists in the library returned nothing for the reporter, while Places and Tags suggestions populated normally.

The photos provider sends `withSharedSpaces: true` for smart mode, but the field modes built a `MetadataSearchDto` without it:

```ts
// MetadataSearchDto does not have a withSharedSpaces field — shared-space
// scoping for metadata search would require passing spaceId, which we do not
// have in the palette. Only smart search includes shared-space content in v1.
```

**That comment is wrong**, which is why the omission survived review:

| Claim | Reality |
|---|---|
| `MetadataSearchDto` lacks the field | `MetadataSearchSchema` → `RandomSearchSchema` → `BaseSearchWithResultsSchema` → `BaseSearchSchema`, and `search.dto.ts:62` declares `withSharedSpaces`. `SmartSearchSchema:104` merely **re-declares it redundantly** — almost certainly the source of the misconception |
| Server honors it only for smart search | `SearchService.searchMetadata` passes `dto.withSharedSpaces` to `getTimelineSpaceIds` (`search.service.ts:177`) |
| SDK doesn't expose it | `MetadataSearchDto.withSharedSpaces?: boolean` is generated in `fetch-client.ts` |

So the field modes were silently **owner-scoped**. A Space member whose photos live in a Space owned by someone else saw an empty Photos section. Places and Tags still populated because `searchPlaces` queries the geodata table and `getAllTags` isn't asset-ownership-scoped — only the photos provider is.

## Fix

Send `withSharedSpaces: true` on the metadata DTO too, and replace the stale comment with the actual contract.

This is not a placebo — `searchAssetBuilder` branches on the resulting `timelineSpaceIds`:

- `database.ts:846` applies the **owner-only** scope precisely when `timelineSpaceIds` is absent
- `database.ts:761` widens to shared-space assets when it is present

Safe to send unconditionally: the server rejects `withSharedSpaces` only in combination with `spaceId` (`search.service.ts:147`), which the palette never sends on this path.

## Scope

This affects the palette's **suggestion list** only. The committed destination was already correct — `buildPhotosTimelineOptions` sets `withSharedSpaces: true` (`photos-filter-options.ts:22`), so pressing Enter did show results. It's the empty suggestion list that reads as "no results".

## Tests

TDD — one `it.each` over all three field modes, watched failing first (all 3 red, `searchAssets` called without the flag), then green.

## Verification

- `pnpm vitest run` (web) — 4006 passed, 0 failed
- `pnpm check:typescript` — clean
- `pnpm check:svelte` — 571 files, 0 errors, 0 warnings
- `pnpm lint` — 0 errors (8 pre-existing warnings, none in touched files)
- `prettier --check` — clean

## Manual verification worth doing

Needs a **non-owner Space member** account (the bug is invisible to a library owner, which is why it couldn't be reproduced locally): as that user, open the palette, switch to Filename, and search a term from a filename that exists only in a Space owned by someone else. Before this change the Photos section is empty; after, it lists the assets.