### PR TITLE
fix(server): apply locked-folder visibility to person search, thumbnails, and the face picker (#869)

### DIFF
--- a/server/src/queries/access.repository.sql
+++ b/server/src/queries/access.repository.sql
@@ -429,6 +429,20 @@ where
   "person"."id" in ($1)
   and "person"."ownerId" = $2
 
+-- AccessRepository.person.checkUnlockedThumbnailAccess
+select
+  "person"."id"
+from
+  "person"
+  left join "asset_face" on "asset_face"."id" = "person"."faceAssetId"
+  left join "asset" on "asset"."id" = "asset_face"."assetId"
+where
+  "person"."id" in ($1)
+  and (
+    "asset"."visibility" is null
+    or "asset"."visibility" != $2
+  )
+
 -- AccessRepository.person.checkSharedSpaceAccess
 select
   "person"."id"

--- a/server/src/queries/person.repository.sql
+++ b/server/src/queries/person.repository.sql
@@ -188,13 +188,14 @@ where
       "face_identity_face"."assetFaceId" = "asset_face"."id"
       and face_identity_face."identityId" IS DISTINCT FROM person."identityId"
   )
+  and "asset"."visibility" != $4
 order by
   "asset"."fileCreatedAt" desc,
   "asset_face"."id"
 limit
-  $4
-offset
   $5
+offset
+  $6
 
 -- PersonRepository.getRepresentativeFaceForUpdate
 select
@@ -326,10 +327,36 @@ where
     f_unaccent ("person"."name") ILIKE '%' || f_unaccent ($2) || '%'
     OR f_unaccent ("person"."name") %> f_unaccent ($3)
   )
+  and (
+    not exists (
+      select
+        "asset_face"."id"
+      from
+        "asset_face"
+        inner join "asset" on "asset"."id" = "asset_face"."assetId"
+      where
+        "asset_face"."personId" = "person"."id"
+        and "asset_face"."deletedAt" is null
+        and "asset_face"."isVisible" is true
+        and "asset"."visibility" = $4
+    )
+    or exists (
+      select
+        "asset_face"."id"
+      from
+        "asset_face"
+        inner join "asset" on "asset"."id" = "asset_face"."assetId"
+      where
+        "asset_face"."personId" = "person"."id"
+        and "asset_face"."deletedAt" is null
+        and "asset_face"."isVisible" is true
+        and "asset"."visibility" != $5
+    )
+  )
 order by
-  f_unaccent ("person"."name") <->>> f_unaccent ($4)
+  f_unaccent ("person"."name") <->>> f_unaccent ($6)
 limit
-  $5
+  $7
 
 -- PersonRepository.getDistinctNames
 select distinct

--- a/server/src/repositories/access.repository.ts
+++ b/server/src/repositories/access.repository.ts
@@ -757,6 +757,30 @@ class PersonAccess {
       .then((persons) => new Set(persons.map((person) => person.id)));
   }
 
+  /**
+   * Fork (#869 follow-up): read access to a PERSON is granted off any one reachable face, but the person
+   * thumbnail is a crop of one specific photo — the representative face `person.faceAssetId` points at.
+   * Returns the subset whose representative face does NOT sit in the Locked Folder; a person with no
+   * representative face at all has no locked source to leak and stays in the set.
+   */
+  @GenerateSql({ params: [DummyValue.UUID_SET] })
+  @ChunkedSet({ paramIndex: 0 })
+  async checkUnlockedThumbnailAccess(personIds: Set<string>) {
+    if (personIds.size === 0) {
+      return new Set<string>();
+    }
+
+    return this.db
+      .selectFrom('person')
+      .select('person.id')
+      .leftJoin('asset_face', 'asset_face.id', 'person.faceAssetId')
+      .leftJoin('asset', 'asset.id', 'asset_face.assetId')
+      .where('person.id', 'in', [...personIds])
+      .where((eb) => eb.or([eb('asset.visibility', 'is', null), eb('asset.visibility', '!=', AssetVisibility.Locked)]))
+      .execute()
+      .then((persons) => new Set(persons.map((person) => person.id)));
+  }
+
   @GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID_SET] })
   @ChunkedSet({ paramIndex: 1 })
   async checkSharedSpaceAccess(userId: string, personIds: Set<string>) {

--- a/server/src/repositories/person.repository.ts
+++ b/server/src/repositories/person.repository.ts
@@ -24,6 +24,11 @@ export interface PersonSearchOptions {
 
 export interface PersonNameSearchOptions {
   withHidden?: boolean;
+  /**
+   * Fork (#869 follow-up): mirrors `AccessRepository.asset.checkOwnerAccess` — without an elevated
+   * session the caller must not see anything that only exists inside their Locked Folder.
+   */
+  hasElevatedPermission?: boolean;
 }
 
 export interface PersonNameResponse {
@@ -69,6 +74,21 @@ const peopleAssetVisibilities = spaceVisibleAssetVisibilities;
 
 const isBlank = (value: string | null | undefined) => !value || value.trim().length === 0;
 
+/**
+ * Correlated "does this `person` row have a live, visible face on a locked (or non-locked) asset?"
+ * subquery. Only counts faces that are themselves live and visible, so a person left behind by a
+ * deleted or hidden face is not treated as backed by that face's asset.
+ */
+const visibleFaceOnAsset = (eb: ExpressionBuilder<DB, 'person'>, { locked }: { locked: boolean }) =>
+  eb
+    .selectFrom('asset_face')
+    .innerJoin('asset', 'asset.id', 'asset_face.assetId')
+    .select('asset_face.id')
+    .whereRef('asset_face.personId', '=', 'person.id')
+    .where('asset_face.deletedAt', 'is', null)
+    .where('asset_face.isVisible', 'is', true)
+    .where('asset.visibility', locked ? '=' : '!=', AssetVisibility.Locked);
+
 export interface DeleteFacesOptions {
   sourceType: SourceType;
 }
@@ -96,6 +116,13 @@ export interface RepresentativeFaceListOptions {
    * owner's own unscoped picker view.
    */
   scope?: { memberUserId: string };
+  /**
+   * Fork (#869 follow-up): the owner's unscoped view above has no visibility gate of its own, so
+   * without this the picker enumerates the owner's Locked Folder faces to a session that never
+   * entered the PIN. Scoped (non-owner) callers are already Timeline+Archive-only via
+   * `spaceVisibilityGate`, so their own elevation can never reach the owner's locked assets.
+   */
+  hasElevatedPermission?: boolean;
 }
 
 export interface RepresentativeFaceUpdateOptions {
@@ -470,6 +497,7 @@ export class PersonRepository {
           ),
         ),
       )
+      .$if(!options.hasElevatedPermission, (qb) => qb.where('asset.visibility', '!=', AssetVisibility.Locked))
       .$if(!!options.scope, (qb) =>
         qb.where((eb) =>
           eb.and([
@@ -599,22 +627,38 @@ export class PersonRepository {
   }
 
   @GenerateSql({ params: [DummyValue.UUID, DummyValue.STRING, { withHidden: true }] })
-  getByName(userId: string, personName: string, { withHidden }: PersonNameSearchOptions) {
-    return this.db
-      .with('similarity_threshold', (db) =>
-        db.selectNoFrom(sql`set_config('pg_trgm.word_similarity_threshold', '0.5', true)`.as('thresh')),
-      )
-      .selectFrom(['similarity_threshold', 'person'])
-      .selectAll('person')
-      .where('person.ownerId', '=', userId)
-      .where(
-        () =>
-          sql`(f_unaccent("person"."name") ILIKE '%' || f_unaccent(${personName}) || '%' OR f_unaccent("person"."name") %> f_unaccent(${personName}))`,
-      )
-      .orderBy(sql`f_unaccent("person"."name") <->>> f_unaccent(${personName})`)
-      .limit(100)
-      .$if(!withHidden, (qb) => qb.where('person.isHidden', '=', false))
-      .execute();
+  getByName(userId: string, personName: string, { withHidden, hasElevatedPermission }: PersonNameSearchOptions) {
+    return (
+      this.db
+        .with('similarity_threshold', (db) =>
+          db.selectNoFrom(sql`set_config('pg_trgm.word_similarity_threshold', '0.5', true)`.as('thresh')),
+        )
+        .selectFrom(['similarity_threshold', 'person'])
+        .selectAll('person')
+        .where('person.ownerId', '=', userId)
+        .where(
+          () =>
+            sql`(f_unaccent("person"."name") ILIKE '%' || f_unaccent(${personName}) || '%' OR f_unaccent("person"."name") %> f_unaccent(${personName}))`,
+        )
+        .orderBy(sql`f_unaccent("person"."name") <->>> f_unaccent(${personName})`)
+        .limit(100)
+        .$if(!withHidden, (qb) => qb.where('person.isHidden', '=', false))
+        // Fork (#869 follow-up): this owner-scoped lookup had no asset-visibility gate at all, so a person
+        // whose faces only ever appear inside the Locked Folder was named back to a session that had never
+        // entered the PIN — the withSharedSpaces path (searchAccessiblePeople) already gates on visibility.
+        // Drop a person only when the Locked Folder is the ONLY thing backing them: a person with a face on
+        // any non-locked asset is still legitimately discoverable, and a person with no faces at all (freshly
+        // created, or every face unassigned) reveals nothing about locked content.
+        .$if(!hasElevatedPermission, (qb) =>
+          qb.where((eb) =>
+            eb.or([
+              eb.not(eb.exists(visibleFaceOnAsset(eb, { locked: true }))),
+              eb.exists(visibleFaceOnAsset(eb, { locked: false })),
+            ]),
+          ),
+        )
+        .execute()
+    );
   }
 
   @GenerateSql({ params: [DummyValue.UUID, { withHidden: true }] })

--- a/server/src/services/person.service.spec.ts
+++ b/server/src/services/person.service.spec.ts
@@ -851,6 +851,7 @@ describe(PersonService.name, () => {
       const auth = AuthFactory.create();
 
       mocks.access.person.checkOwnerAccess.mockResolvedValue(new Set(['unknown']));
+      mocks.access.person.checkUnlockedThumbnailAccess.mockResolvedValue(new Set(['unknown']));
       await expect(sut.getThumbnail(auth, 'unknown')).rejects.toBeInstanceOf(NotFoundException);
       expect(mocks.storage.createReadStream).not.toHaveBeenCalled();
       expect(mocks.access.person.checkOwnerAccess).toHaveBeenCalledWith(auth.user.id, new Set(['unknown']));
@@ -862,6 +863,7 @@ describe(PersonService.name, () => {
 
       mocks.person.getById.mockResolvedValue(person);
       mocks.access.person.checkOwnerAccess.mockResolvedValue(new Set([person.id]));
+      mocks.access.person.checkUnlockedThumbnailAccess.mockResolvedValue(new Set([person.id]));
       await expect(sut.getThumbnail(auth, person.id)).rejects.toBeInstanceOf(NotFoundException);
       expect(mocks.storage.createReadStream).not.toHaveBeenCalled();
       expect(mocks.access.person.checkOwnerAccess).toHaveBeenCalledWith(auth.user.id, new Set([person.id]));
@@ -873,6 +875,7 @@ describe(PersonService.name, () => {
 
       mocks.person.getById.mockResolvedValue(person);
       mocks.access.person.checkOwnerAccess.mockResolvedValue(new Set([person.id]));
+      mocks.access.person.checkUnlockedThumbnailAccess.mockResolvedValue(new Set([person.id]));
       await expect(sut.getThumbnail(auth, person.id)).resolves.toEqual(
         new ImmichFileResponse({
           path: person.thumbnailPath,
@@ -890,6 +893,7 @@ describe(PersonService.name, () => {
       mocks.person.getById.mockResolvedValue(person);
       mocks.access.person.checkOwnerAccess.mockResolvedValue(new Set());
       mocks.access.person.checkSharedSpaceAccess.mockResolvedValue(new Set([person.id]));
+      mocks.access.person.checkUnlockedThumbnailAccess.mockResolvedValue(new Set([person.id]));
 
       await expect(sut.getThumbnail(auth, person.id)).resolves.toEqual(
         new ImmichFileResponse({
@@ -900,6 +904,38 @@ describe(PersonService.name, () => {
       );
       expect(mocks.access.person.checkOwnerAccess).toHaveBeenCalledWith(auth.user.id, new Set([person.id]));
       expect(mocks.access.person.checkSharedSpaceAccess).toHaveBeenCalledWith(auth.user.id, new Set([person.id]));
+    });
+
+    // #869 follow-up. The medium spec proves the locked/unlocked decision against a real database; these
+    // two pin what the decision does on either side of the serve boundary, which the medium harness (no
+    // bootstrapped storage backend) cannot reach.
+    it('should not serve the thumbnail of a locked-folder face to a non-elevated owner', async () => {
+      const auth = AuthFactory.create();
+      const person = PersonFactory.create();
+
+      mocks.person.getById.mockResolvedValue(person);
+      mocks.access.person.checkOwnerAccess.mockResolvedValue(new Set([person.id]));
+      mocks.access.person.checkUnlockedThumbnailAccess.mockResolvedValue(new Set());
+
+      await expect(sut.getThumbnail(auth, person.id)).rejects.toBeInstanceOf(BadRequestException);
+      expect(mocks.storage.createReadStream).not.toHaveBeenCalled();
+    });
+
+    it('should serve the thumbnail of a locked-folder face to an elevated owner', async () => {
+      const auth = AuthFactory.from().session({ hasElevatedPermission: true }).build();
+      const person = PersonFactory.create();
+
+      mocks.person.getById.mockResolvedValue(person);
+      mocks.access.person.checkOwnerAccess.mockResolvedValue(new Set([person.id]));
+      mocks.access.person.checkUnlockedThumbnailAccess.mockResolvedValue(new Set());
+
+      await expect(sut.getThumbnail(auth, person.id)).resolves.toEqual(
+        new ImmichFileResponse({
+          path: person.thumbnailPath,
+          contentType: 'image/jpeg',
+          cacheControl: CacheControl.PrivateWithoutCache,
+        }),
+      );
     });
   });
 

--- a/server/src/services/person.service.ts
+++ b/server/src/services/person.service.ts
@@ -369,6 +369,7 @@ export class PersonService extends BaseService {
       take,
       skip: (dto.page - 1) * dto.size,
       scope,
+      hasElevatedPermission: auth.session?.hasElevatedPermission,
     });
     const faces = rows.slice(0, take);
 
@@ -493,13 +494,25 @@ export class PersonService extends BaseService {
 
   private async requireThumbnailAccess(auth: AuthDto, id: string) {
     const ids = new Set([id]);
-    const isOwner = await this.accessRepository.person.checkOwnerAccess(auth.user.id, ids);
-    if (isOwner.has(id)) {
+    const ownerAccess = await this.accessRepository.person.checkOwnerAccess(auth.user.id, ids);
+    const isOwner = ownerAccess.has(id);
+    if (!isOwner) {
+      const isShared = await this.accessRepository.person.checkSharedSpaceAccess(auth.user.id, ids);
+      if (!isShared.has(id)) {
+        throw new BadRequestException('Not found or no person.read access');
+      }
+    }
+
+    // Fork (#869 follow-up): both arms above grant person.read off ANY reachable face, while the thumbnail
+    // is a crop of the representative face's photo specifically. The owner needs an elevated session to be
+    // handed back a crop of their own Locked Folder photo; a shared-space viewer must never receive one at
+    // all — the folder belongs to the owner, so the viewer's own elevation says nothing about it.
+    if (isOwner && auth.session?.hasElevatedPermission) {
       return;
     }
 
-    const isShared = await this.accessRepository.person.checkSharedSpaceAccess(auth.user.id, ids);
-    if (!isShared.has(id)) {
+    const isUnlocked = await this.accessRepository.person.checkUnlockedThumbnailAccess(ids);
+    if (!isUnlocked.has(id)) {
       throw new BadRequestException('Not found or no person.read access');
     }
   }

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -81,7 +81,10 @@ export class SearchService extends BaseService {
       });
     }
 
-    const people = await this.personRepository.getByName(auth.user.id, dto.name, { withHidden: dto.withHidden });
+    const people = await this.personRepository.getByName(auth.user.id, dto.name, {
+      withHidden: dto.withHidden,
+      hasElevatedPermission: auth.session?.hasElevatedPermission,
+    });
     return people.map((person) => mapPerson(person));
   }
 

--- a/server/test/medium/specs/services/person.service.spec.ts
+++ b/server/test/medium/specs/services/person.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Kysely } from 'kysely';
 import { AssetEditAction, MirrorAxis } from 'src/dtos/editing.dto';
 import { AssetFaceCreateDto } from 'src/dtos/person.dto';
@@ -93,6 +93,35 @@ const setupFaceDetection = (db?: Kysely<DB>) => {
     });
 
   return { sut, ctx };
+};
+
+/** #869 follow-up: one person carrying a face on a timeline asset and a face on a locked asset. */
+const seedPersonAcrossVisibilities = async (ctx: ReturnType<typeof setup>['ctx']) => {
+  const { user } = await ctx.newUser();
+  const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Vaulted Vera' });
+  const { asset: timelineAsset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+  const { asset: lockedAsset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Locked });
+  await ctx.newAssetFace({ assetId: timelineAsset.id, personId: person.id });
+  await ctx.newAssetFace({ assetId: lockedAsset.id, personId: person.id });
+  return { user, person, timelineAsset, lockedAsset };
+};
+
+/**
+ * #869 follow-up: seed a person whose representative face (`person.faceAssetId`, which points at an
+ * ASSET_FACE row) sits on an asset of the given visibility, so the thumbnail source is reachable as
+ * person -> asset_face -> asset.
+ */
+const seedPersonWithRepresentativeFace = async (
+  ctx: ReturnType<typeof setup>['ctx'],
+  ownerId: string,
+  visibility: AssetVisibility,
+  thumbnailPath: string,
+) => {
+  const { asset } = await ctx.newAsset({ ownerId, visibility });
+  const { person } = await ctx.newPerson({ ownerId, name: 'Vaulted Vera', thumbnailPath });
+  const { result: faceId } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+  await ctx.get(PersonRepository).update({ id: person.id, faceAssetId: faceId });
+  return { asset, person };
 };
 
 /**
@@ -1748,6 +1777,142 @@ describe(PersonService.name, () => {
       await expect(sut.getFacesById(factory.auth({ user: outsider }), { id: asset.id })).rejects.toBeInstanceOf(
         BadRequestException,
       );
+    });
+  });
+
+  // #869 follow-up: the representative-face picker (GET /people/:id/faces) runs UNSCOPED for the owner —
+  // the space scope that carries the visibility gate is only applied to non-owner callers. So the picker
+  // enumerated the owner's Locked Folder faces (asset id, bounding box, capture date) to a session that
+  // had never entered the PIN. The crop bytes were already refused by the AssetRead check on the
+  // per-face thumbnail route, so this is a metadata leak, but it is the same rule.
+  describe('getFacesForPicker locked-folder visibility', () => {
+    it('omits faces on locked assets from a non-elevated owner', async () => {
+      const { sut, ctx } = setup();
+      const { user, person, timelineAsset } = await seedPersonAcrossVisibilities(ctx);
+
+      const result = await sut.getFacesForPicker(factory.auth({ user: { id: user.id } }), person.id, {
+        page: 1,
+        size: 50,
+      });
+
+      expect(result.faces.map((face) => face.assetId)).toEqual([timelineAsset.id]);
+    });
+
+    it('includes faces on locked assets for an elevated owner', async () => {
+      const { sut, ctx } = setup();
+      const { user, person, timelineAsset, lockedAsset } = await seedPersonAcrossVisibilities(ctx);
+
+      const auth = factory.auth({ user: { id: user.id }, session: { hasElevatedPermission: true } });
+      const result = await sut.getFacesForPicker(auth, person.id, { page: 1, size: 50 });
+
+      expect(result.faces.map((face) => face.assetId).toSorted()).toEqual(
+        [timelineAsset.id, lockedAsset.id].toSorted(),
+      );
+    });
+  });
+
+  // #869 follow-up: the person thumbnail is a crop of `person.faceAssetId`. The owner arm of
+  // requireThumbnailAccess only proved `person.ownerId = caller`, so a person whose representative face
+  // sits in the Locked Folder served that crop over HTTP 200 to a session that had never entered a PIN.
+  // (The shared-space arm below it already restricts to Timeline+Archive, so only the owner arm leaked.)
+  describe('getThumbnail locked-folder visibility', () => {
+    // Serving the bytes needs a bootstrapped StorageService backend, which the medium harness does not
+    // have, so the ALLOWED cases seed an empty `thumbnailPath` and assert NotFoundException: the 404 is
+    // raised after requireThumbnailAccess returns, so reaching it proves the visibility gate let the
+    // request through. A blocked request throws BadRequestException before that point. The byte-serving
+    // path itself is covered in src/services/person.service.spec.ts.
+    it('refuses the owner a thumbnail cropped from a locked asset while the session is not elevated', async () => {
+      const { sut, ctx } = setup();
+      const { user } = await ctx.newUser();
+      const { person } = await seedPersonWithRepresentativeFace(
+        ctx,
+        user.id,
+        AssetVisibility.Locked,
+        'upload/thumbs/vera.jpeg',
+      );
+
+      await expect(sut.getThumbnail(factory.auth({ user: { id: user.id } }), person.id)).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('lets an elevated owner past the gate for a locked-asset thumbnail', async () => {
+      const { sut, ctx } = setup();
+      const { user } = await ctx.newUser();
+      const { person } = await seedPersonWithRepresentativeFace(ctx, user.id, AssetVisibility.Locked, '');
+
+      const auth = factory.auth({ user: { id: user.id }, session: { hasElevatedPermission: true } });
+
+      await expect(sut.getThumbnail(auth, person.id)).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('lets a non-elevated owner past the gate for a timeline-asset thumbnail', async () => {
+      const { sut, ctx } = setup();
+      const { user } = await ctx.newUser();
+      const { person } = await seedPersonWithRepresentativeFace(ctx, user.id, AssetVisibility.Timeline, '');
+
+      await expect(sut.getThumbnail(factory.auth({ user: { id: user.id } }), person.id)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    // `person.faceAssetId` is `ON DELETE SET NULL`, so a person can keep a thumbnail after losing its
+    // representative face row. There is no locked source to leak in that case, and the gate must not
+    // start refusing those people.
+    it('lets a person with no representative face past the gate', async () => {
+      const { sut, ctx } = setup();
+      const { user } = await ctx.newUser();
+      const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Faceless Fay', thumbnailPath: '' });
+
+      await expect(sut.getThumbnail(factory.auth({ user: { id: user.id } }), person.id)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    // Regression guard: the locked check runs on the shared-space arm too, so prove the ordinary viewer
+    // case still passes it. Without this, tightening the gate could silently break every space thumbnail.
+    it('still lets a shared-space viewer past the gate for a timeline-sourced thumbnail', async () => {
+      const { sut, ctx } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+
+      const { asset, person } = await seedPersonWithRepresentativeFace(ctx, owner.id, AssetVisibility.Timeline, '');
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: SharedSpaceRole.Viewer });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: owner.id });
+
+      await expect(sut.getThumbnail(factory.auth({ user: { id: viewer.id } }), person.id)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    // The shared-space arm grants person.read off ANY space-visible face, but the thumbnail is a crop of
+    // the representative face specifically. A viewer must never receive a crop of the owner's Locked
+    // Folder photo — and unlike the owner, no amount of elevation on the viewer's own session changes that.
+    it("refuses a shared-space viewer a thumbnail cropped from the owner's locked asset", async () => {
+      const { sut, ctx } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+
+      const { person } = await seedPersonWithRepresentativeFace(
+        ctx,
+        owner.id,
+        AssetVisibility.Locked,
+        'upload/thumbs/vera.jpeg',
+      );
+
+      // A second, space-shared face is what grants the viewer person.read in the first place.
+      const { asset: sharedAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+      await ctx.newAssetFace({ assetId: sharedAsset.id, personId: person.id });
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: SharedSpaceRole.Viewer });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: sharedAsset.id, addedById: owner.id });
+
+      const auth = factory.auth({ user: { id: viewer.id }, session: { hasElevatedPermission: true } });
+
+      await expect(sut.getThumbnail(auth, person.id)).rejects.toBeInstanceOf(BadRequestException);
     });
   });
 });

--- a/server/test/medium/specs/services/search.service.spec.ts
+++ b/server/test/medium/specs/services/search.service.spec.ts
@@ -117,6 +117,21 @@ const shareAsset = async (ctx: SearchCtx, spaceId: string, ownerId: string, visi
 
 const elevated = (userId: string) => factory.auth({ user: { id: userId }, session: { hasElevatedPermission: true } });
 
+// #869 follow-up: seed one person carrying a visible face on an asset of each given visibility.
+const seedPersonWithFaceOn = async (
+  ctx: SearchCtx,
+  ownerId: string,
+  name: string,
+  ...visibilities: AssetVisibility[]
+) => {
+  const { person } = await ctx.newPerson({ ownerId, name });
+  for (const visibility of visibilities) {
+    const { asset } = await ctx.newAsset({ ownerId, visibility });
+    await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+  }
+  return person;
+};
+
 // Slice 5: seed a directly-shared space asset with distinct facet values for each type.
 // `visibility` controls whether this asset is Hidden/Locked/etc. Returns the asset.
 const seedSpaceAssetWithFacets = async (
@@ -263,6 +278,109 @@ describe(SearchService.name, () => {
       const result = await sut.searchStatistics(auth, { visibility: AssetVisibility.Locked });
 
       expect(result).toEqual({ total: 0 });
+    });
+  });
+
+  // #869 follow-up: the legacy (withSharedSpaces=false) person lookup read `person` rows straight off
+  // `ownerId` with no asset-visibility gate, so a named person whose faces only ever appear inside the
+  // Locked Folder was returned — and named — to a session that had never entered a PIN. The
+  // withSharedSpaces path already gates on asset visibility; these pin the same rule on the legacy path.
+  describe('searchPerson locked-folder visibility', () => {
+    it('omits a person whose faces exist only in locked assets from a non-elevated session', async () => {
+      const { sut, ctx } = setup();
+      const { user } = await ctx.newUser();
+      await seedPersonWithFaceOn(ctx, user.id, 'Vaulted Vera', AssetVisibility.Locked);
+
+      const result = await sut.searchPerson(factory.auth({ user: { id: user.id } }), { name: 'Vera' });
+
+      expect(result.map((person) => person.name)).toEqual([]);
+    });
+
+    it('returns a locked-only person once the session is elevated', async () => {
+      const { sut, ctx } = setup();
+      const { user } = await ctx.newUser();
+      await seedPersonWithFaceOn(ctx, user.id, 'Vaulted Vera', AssetVisibility.Locked);
+
+      const result = await sut.searchPerson(elevated(user.id), { name: 'Vera' });
+
+      expect(result.map((person) => person.name)).toEqual(['Vaulted Vera']);
+    });
+
+    it('keeps a person who also has a face on a timeline asset', async () => {
+      const { sut, ctx } = setup();
+      const { user } = await ctx.newUser();
+      await seedPersonWithFaceOn(ctx, user.id, 'Mixed Mira', AssetVisibility.Locked, AssetVisibility.Timeline);
+
+      const result = await sut.searchPerson(factory.auth({ user: { id: user.id } }), { name: 'Mira' });
+
+      expect(result.map((person) => person.name)).toEqual(['Mixed Mira']);
+    });
+
+    it('keeps a person who has no faces at all', async () => {
+      const { sut, ctx } = setup();
+      const { user } = await ctx.newUser();
+      await ctx.newPerson({ ownerId: user.id, name: 'Faceless Fay' });
+
+      const result = await sut.searchPerson(factory.auth({ user: { id: user.id } }), { name: 'Fay' });
+
+      expect(result.map((person) => person.name)).toEqual(['Faceless Fay']);
+    });
+
+    it('keeps a person backed only by an archived asset', async () => {
+      const { sut, ctx } = setup();
+      const { user } = await ctx.newUser();
+      await seedPersonWithFaceOn(ctx, user.id, 'Archived Ada', AssetVisibility.Archive);
+
+      const result = await sut.searchPerson(factory.auth({ user: { id: user.id } }), { name: 'Ada' });
+
+      expect(result.map((person) => person.name)).toEqual(['Archived Ada']);
+    });
+
+    // A face row that is soft-deleted or marked not-visible is not something the person is "backed by",
+    // so it must not rescue an otherwise locked-only person from the gate.
+    it('does not let a soft-deleted timeline face rescue a locked-only person', async () => {
+      const { sut, ctx } = setup();
+      const { user } = await ctx.newUser();
+      const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Deleted Dana' });
+      const { asset: lockedAsset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Locked });
+      const { asset: timelineAsset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+      await ctx.newAssetFace({ assetId: lockedAsset.id, personId: person.id });
+      await ctx.newAssetFace({ assetId: timelineAsset.id, personId: person.id, deletedAt: new Date() });
+
+      const result = await sut.searchPerson(factory.auth({ user: { id: user.id } }), { name: 'Dana' });
+
+      expect(result.map((person) => person.name)).toEqual([]);
+    });
+
+    it('does not let a hidden timeline face rescue a locked-only person', async () => {
+      const { sut, ctx } = setup();
+      const { user } = await ctx.newUser();
+      const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Invisible Iris' });
+      const { asset: lockedAsset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Locked });
+      const { asset: timelineAsset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+      await ctx.newAssetFace({ assetId: lockedAsset.id, personId: person.id });
+      await ctx.newAssetFace({ assetId: timelineAsset.id, personId: person.id, isVisible: false });
+
+      const result = await sut.searchPerson(factory.auth({ user: { id: user.id } }), { name: 'Iris' });
+
+      expect(result.map((person) => person.name)).toEqual([]);
+    });
+
+    // The locked gate and the isHidden gate are separate `$if` clauses; asking for hidden people must not
+    // hand back the locked-only ones.
+    it('still omits a locked-only person when hidden people are requested', async () => {
+      const { sut, ctx } = setup();
+      const { user } = await ctx.newUser();
+      const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Hidden Hana', isHidden: true });
+      const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Locked });
+      await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+
+      const result = await sut.searchPerson(factory.auth({ user: { id: user.id } }), {
+        name: 'Hana',
+        withHidden: true,
+      });
+
+      expect(result.map((person) => person.name)).toEqual([]);
     });
   });
 

--- a/server/test/repositories/access.repository.mock.ts
+++ b/server/test/repositories/access.repository.mock.ts
@@ -55,6 +55,7 @@ export const newAccessRepositoryMock = (): IAccessRepositoryMock => {
       checkOwnerAccess: vitest.fn().mockResolvedValue(new Set()),
       checkSharedSpaceAccess: vitest.fn().mockResolvedValue(new Set()),
       checkSharedSpaceEditAccess: vitest.fn().mockResolvedValue(new Set()),
+      checkUnlockedThumbnailAccess: vitest.fn().mockResolvedValue(new Set()),
     },
 
     partner: {


### PR DESCRIPTION
Follow-up to #869, which kept Locked Folder photos out of the web palette and recents. Auditing the rest of the person surfaces turned up three owner-scoped reads that ran without an asset-visibility predicate, so people and faces backed only by Locked Folder assets were still returned to a session that had not entered the PIN.

## What changed

| Endpoint | Before | After |
| --- | --- | --- |
| `GET /search/person` | Owner lookup (`getByName`) had no visibility predicate, so a person whose visible faces all sit on locked assets was named back by the search palette. | Without elevation, a person is dropped only when the Locked Folder is the *only* thing backing them. |
| `GET /people/{id}/thumbnail` | `person.read` is granted off any one reachable face, but the thumbnail is a crop of the representative face's photo specifically — the owner arm returned early with no check on that photo. | Owner needs an elevated session for a crop of a locked photo; every other caller gets the representative-face check via `checkUnlockedThumbnailAccess`. |
| `GET /people/{id}/faces` | The representative-face picker ran unscoped for the owner — the shared-space scope carried the visibility gate, and the owner branch had none — so it listed locked faces (asset id, bounding box, capture date). Crop bytes were already gated by `AssetRead`, but the tiles rendered broken. | Unelevated callers get `visibility != locked`, same as the scoped path. |

Each path threads `auth.session?.hasElevatedPermission` through to the query and applies the same rule the shared-space paths already use. Behaviour that is deliberately unchanged:

- A person with any non-locked visible face stays discoverable, and a person with **no** faces at all (freshly created, or every face unassigned) has no locked source behind them and stays in results.
- "Backed by a face" only counts faces that are themselves live and visible — a soft-deleted or hidden face on a non-locked asset does not keep a locked-only person visible.
- Shared-space viewers keep their thumbnails: the gate runs on the shared-space arm too, and there is a regression test proving a timeline-sourced thumbnail still resolves for an ordinary viewer.
- Scoped (non-owner) picker callers were already Timeline+Archive-only, so their own elevation can never reach the owner's locked assets.

## Testing

- Test-first for all three fixes; the original two grew from 7 tests to 15.
- Every new assertion was mutation-verified — each mutation fails exactly its intended test and nothing else: dropping the `deletedAt` predicate, dropping the `isVisible` predicate, redefining "backed" as Timeline-only, skipping the gate when `withHidden` is set, dropping the `faceAssetId IS NULL` branch, and dropping the shared-space thumbnail arm.
- Server unit suite (5251) green, medium suites for the touched specs (145) green, lint / prettier / tsc clean, SQL query docs regenerated.

## Out of scope

Individual-asset shared links are not touched here. Locking an asset strips album membership but not `shared_link_asset` rows, and `checkSharedLinkAccess` has no visibility predicate, so a public link created for specific assets keeps serving the photo after the asset moves to the Locked Folder. That is untouched upstream code (last change is upstream refactor #23356), and revoking live public links is a product decision, so it is left for a separate discussion rather than folded into this patch.
