### PR TITLE
fix(mobile): restore iOS swipe-back on the Spaces page (#899)

### DIFF
--- a/mobile/lib/routing/router.dart
+++ b/mobile/lib/routing/router.dart
@@ -158,11 +158,10 @@ class AppRouter extends RootStackRouter {
     AutoRoute(page: WhatsNewRoute.page, guards: [_duplicateGuard]),
     AutoRoute(page: AppLogRoute.page, guards: [_duplicateGuard]),
     AutoRoute(page: AppLogDetailRoute.page, guards: [_duplicateGuard]),
-    CustomRoute(
-      page: SpacesRoute.page,
-      guards: [_authGuard, _duplicateGuard],
-      transitionsBuilder: TransitionsBuilders.slideLeft,
-    ),
+    // Keep the platform page transition: a CustomRoute would render its own
+    // transitionsBuilder instead of the PageTransitionsTheme, and iOS would
+    // never install the Cupertino edge swipe-back gesture (#899).
+    AutoRoute(page: SpacesRoute.page, guards: [_authGuard, _duplicateGuard]),
     AutoRoute(page: SpaceDetailRoute.page, guards: [_authGuard, _duplicateGuard]),
     AutoRoute(page: SpaceMembersRoute.page, guards: [_authGuard, _duplicateGuard]),
     AutoRoute(page: SpaceAlbumsRoute.page, guards: [_authGuard, _duplicateGuard]),

--- a/mobile/test/routing/router_test.dart
+++ b/mobile/test/routing/router_test.dart
@@ -1,0 +1,53 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/providers/gallery_permission.provider.dart';
+import 'package:immich_mobile/routing/router.dart';
+import 'package:immich_mobile/services/api.service.dart';
+import 'package:immich_mobile/services/auth.service.dart';
+import 'package:immich_mobile/services/local_auth.service.dart';
+import 'package:immich_mobile/services/secure_storage.service.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockApiService extends Mock implements ApiService {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockGalleryPermissionNotifier extends Mock implements GalleryPermissionNotifier {}
+
+class _MockSecureStorageService extends Mock implements SecureStorageService {}
+
+class _MockLocalAuthService extends Mock implements LocalAuthService {}
+
+void main() {
+  late AppRouter router;
+
+  setUp(() {
+    // The guards only stash their dependencies at construction time, so mocks
+    // are enough to read the route table back.
+    router = AppRouter(
+      _MockApiService(),
+      _MockAuthService(),
+      _MockGalleryPermissionNotifier(),
+      _MockSecureStorageService(),
+      _MockLocalAuthService(),
+    );
+  });
+
+  /// The route type auto_route actually builds the page route from: the
+  /// explicitly declared [AutoRoute.type], or the router-wide default when the
+  /// route does not declare one.
+  RouteType effectiveRouteType(String routeName) {
+    final route = router.routes.firstWhere((route) => route.name == routeName);
+    return route.type ?? router.defaultRouteType;
+  }
+
+  group('AppRouter page transitions', () {
+    // A CustomRouteType renders its own transitionsBuilder instead of
+    // delegating to the platform PageTransitionsTheme, so iOS never wraps the
+    // page in the Cupertino back-gesture detector and the edge swipe-back
+    // silently does nothing.
+    test('Spaces uses the platform page transition so iOS keeps swipe-back', () {
+      expect(effectiveRouteType('SpacesRoute'), isA<MaterialRouteType>());
+    });
+  });
+}


### PR DESCRIPTION
Fixes #899.

## Problem

On iOS the left-edge swipe-back gesture does nothing on the Spaces list page, while it works on every other page.

## Root cause

`SpacesRoute` was the only pushed Spaces page registered as a `CustomRoute`:

```dart
CustomRoute(
  page: SpacesRoute.page,
  guards: [_authGuard, _duplicateGuard],
  transitionsBuilder: TransitionsBuilders.slideLeft,
),
```

auto_route builds a `CustomRouteType` into `_CustomPageBasedPageRouteBuilder`, whose `buildTransitions` calls the supplied `transitionsBuilder` directly and never delegates to `Theme.of(context).pageTransitionsTheme`. On iOS that theme is what resolves to `CupertinoPageTransitionsBuilder`, and that builder is what wraps the page in the Cupertino back-gesture detector. With a custom transition the detector is never installed, so there is no edge-swipe gesture to trigger.

Every sibling space page (`SpaceDetailRoute`, `SpaceMembersRoute`, `SpaceAlbumsRoute`, `SpaceAlbumDetailRoute`) is a plain `AutoRoute`, picking up the router's `defaultRouteType` of `RouteType.material()` — which is why they all behave correctly.

## Fix

Register `SpacesRoute` as a plain `AutoRoute` like its siblings. The platform transition on iOS is a right-to-left slide anyway, so the visual result is effectively unchanged — it is now just platform-native and carries the gesture.

The two remaining `CustomRoute` space entries (`SpaceLinkAlbumRoute`, `SpaceMemberSelectionRoute`) are deliberately left alone: they use `slideBottom` as modal-style sheets, where iOS does not offer an edge swipe-back either.

## Test

Added `mobile/test/routing/router_test.dart`, which reads the effective `RouteType` back off the router config and asserts `SpacesRoute` uses the platform page transition. Verified it fails before the fix (`Actual: <Instance of 'CustomRouteType'>`) and passes after.

## Verification

- `flutter test test/routing/router_test.dart` — red before the fix, green after
- `flutter test` (full mobile suite) — 2893 passed, 1 skipped, 0 failures
- `dart analyze --fatal-infos lib test` — no issues
- `dart format` over the CI-gated `lib` scope — 0 changed
- `dart run build_runner build --delete-conflicting-outputs` — no generated-file drift