### PR TITLE
fix(mobile): show a loader while a filtered search is in flight (#901)

### DIFF
--- a/mobile/lib/presentation/widgets/timeline/timeline_empty_state.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline_empty_state.widget.dart
@@ -4,20 +4,25 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/photos_filter_search.provider.dart';
 import 'package:immich_mobile/providers/sync_status.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 import 'package:immich_mobile/widgets/common/immich_loading_indicator.dart';
 
 /// Shown on the main Photos timeline when it resolves to zero assets.
 ///
-/// Three states, in priority order:
-///  1. a photos filter is active but matched nothing -> a compact "no results"
-///     state that lets the user clear the filter (never tells an existing user
-///     to enable backup);
-///  2. the initial remote sync is still running -> a loading indicator, so the
+/// Four states, in priority order:
+///  1. a photos filter is active and its search request is still in flight -> a
+///     loading indicator. The search-backed timeline service starts at zero
+///     assets, so without this the "no results" state would be rendered for the
+///     whole duration of every search request (#901);
+///  2. a photos filter is active and the search has answered with nothing -> a
+///     compact "no results" state that lets the user clear the filter (never
+///     tells an existing user to enable backup);
+///  3. the initial remote sync is still running -> a loading indicator, so the
 ///     brief empty bucket emission during sync (the upstream "blank timeline"
 ///     race) never flashes the onboarding state for accounts that have photos;
-///  3. otherwise the account simply has no backed-up photos yet -> a first-run
+///  4. otherwise the account simply has no backed-up photos yet -> a first-run
 ///     onboarding state pointing at backup.
 class TimelineEmptyState extends ConsumerWidget {
   const TimelineEmptyState({super.key});
@@ -26,6 +31,12 @@ class TimelineEmptyState extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final hasActiveFilter = ref.watch(photosFilterProvider.select((f) => !f.isEmpty));
     if (hasActiveFilter) {
+      // Read from inside the TimelineRouteScope, same as the load-more footer, so
+      // this is the scoped notifier actually feeding the timeline.
+      final isSearching = ref.watch(photosFilterSearchProvider.select((s) => s.isLoading));
+      if (isSearching) {
+        return const Center(child: ImmichLoadingIndicator());
+      }
       return const _FilteredEmpty();
     }
 

--- a/mobile/test/presentation/widgets/timeline/timeline_empty_state_integration_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_empty_state_integration_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:drift/drift.dart' as drift;
@@ -10,22 +11,29 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/config/app_config.dart';
 import 'package:immich_mobile/domain/models/config/timeline_config.dart';
+import 'package:immich_mobile/domain/models/search_result.model.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
 import 'package:immich_mobile/domain/models/timeline_temporal_scope.model.dart';
 import 'package:immich_mobile/domain/models/user.model.dart';
+import 'package:immich_mobile/domain/services/search.service.dart';
 import 'package:immich_mobile/domain/services/store.service.dart';
 import 'package:immich_mobile/domain/services/timeline.service.dart';
 import 'package:immich_mobile/domain/services/user.service.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
+import 'package:immich_mobile/infrastructure/repositories/settings.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
+import 'package:immich_mobile/models/search/search_filter.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline_empty_state.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline_route_scope.dart';
+import 'package:immich_mobile/providers/infrastructure/db.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/search.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/settings.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/user.provider.dart' as infra;
+import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/timeline_query.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:immich_mobile/widgets/common/immich_loading_indicator.dart';
@@ -40,6 +48,21 @@ import '../../../test_utils.dart';
 class _MockTimelineFactory extends Mock implements TimelineFactory {}
 
 class _MockUserService extends Mock implements UserService {}
+
+class _MockSearchService extends Mock implements SearchService {}
+
+class _FakeSearchFilter extends Fake implements SearchFilter {}
+
+/// Yields a fixed [SearchFilter] from build() so the 800 ms timeline debounce
+/// picks it up on its first read instead of a timer later.
+class _FixedFilter extends PhotosFilterNotifier {
+  _FixedFilter(this._initial);
+
+  final SearchFilter _initial;
+
+  @override
+  SearchFilter build() => _initial;
+}
 
 class _StubCurrentUserNotifier extends CurrentUserProvider {
   _StubCurrentUserNotifier(super.service, UserDto user) {
@@ -130,6 +153,58 @@ Future<TimelineService> _pumpTimeline(
   return service;
 }
 
+/// Wires the REAL search chain behind an active photos filter:
+///   SearchService (mocked at the network boundary) → photosFilterSearchProvider
+///   (real, scoped by TimelineRouteScope) → TimelineFactory.fromAssetStream
+///   (real) → TimelineService → Timeline → TimelineEmptyState.
+///
+/// `fromAssetStream` emits an empty bucket list immediately, so the empty state is
+/// built while page 1 is still in flight — the #901 window. Returns the completer
+/// that lets the test decide when (and with what) the search answers.
+Future<Completer<SearchResult?>> _pumpSearchingTimeline(WidgetTester tester, Drift db) async {
+  final completer = Completer<SearchResult?>();
+  final search = _MockSearchService();
+  when(() => search.search(any(), any())).thenAnswer((_) => completer.future);
+
+  final user = _testUser();
+  final userService = _MockUserService();
+  when(() => userService.tryGetMyUser()).thenReturn(user);
+  when(() => userService.watchMyUser()).thenAnswer((_) => const Stream<UserDto?>.empty());
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        appConfigProvider.overrideWithValue(const AppConfig(timeline: TimelineConfig(tilesPerRow: 3))),
+        driftProvider.overrideWithValue(db),
+        searchServiceProvider.overrideWithValue(search),
+        infra.userServiceProvider.overrideWithValue(userService),
+        currentUserProvider.overrideWith((ref) => _StubCurrentUserNotifier(userService, user)),
+        timelineUsersProvider.overrideWith((_) => Stream<List<String>>.value([user.id])),
+        photosFilterProvider.overrideWith(() => _FixedFilter(SearchFilter.empty()..context = 'mountain')),
+      ],
+      child: EasyLocalization(
+        supportedLocales: const [Locale('en')],
+        path: '../i18n',
+        fallbackLocale: const Locale('en'),
+        child: MaterialApp(
+          home: DefaultAssetBundle(
+            bundle: _FakeAssetBundle(),
+            child: const TimelineRouteScope(
+              timelineServiceBuilder: buildPhotosTimelineRouteService,
+              child: Timeline(appBar: null, bottomSheet: null, withScrubber: false, emptyWidget: TimelineEmptyState()),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  // Not pumpAndSettle: the loading indicator animates forever.
+  for (var i = 0; i < 5; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+  return completer;
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -142,8 +217,10 @@ void main() {
     await initializeDateFormatting('en');
     registerFallbackValue(const TimelineTemporalScope.none());
     registerFallbackValue(GroupAssetsBy.day);
+    registerFallbackValue(_FakeSearchFilter());
     db = Drift(drift.DatabaseConnection(NativeDatabase.memory(), closeStreamsSynchronously: true));
     await StoreService.init(storeRepository: DriftStoreRepository(db), listenUpdates: false);
+    await SettingsRepository.ensureInitialized(db);
   });
 
   setUp(() async {
@@ -180,6 +257,32 @@ void main() {
       // onData resolved with a non-empty grid: neither the loader nor the empty state.
       expect(find.byType(ImmichLoadingIndicator), findsNothing);
       expect(find.byType(TimelineEmptyState), findsNothing);
+    });
+  });
+
+  group('filtered search empty state (#901)', () {
+    testWidgets('holds a loader while page 1 is in flight, then falls back to the no-results state', (tester) async {
+      final completer = await _pumpSearchingTimeline(tester, db);
+
+      // The search-backed service already emitted its (empty) bucket list, so the
+      // empty state is on screen — but the server has not answered yet, so it must
+      // not claim there is nothing to find.
+      expect(find.byType(TimelineEmptyState), findsOneWidget);
+      expect(find.byType(ImmichLoadingIndicator), findsOneWidget);
+      expect(find.byIcon(Icons.search_off_rounded), findsNothing);
+
+      // Server answers with no matches: now the no-results state is the truth.
+      completer.complete(null);
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.byType(ImmichLoadingIndicator), findsNothing);
+      expect(find.byIcon(Icons.search_off_rounded), findsOneWidget);
+
+      // Tear the tree down inside the test so Riverpod's autoDispose scheduler
+      // timer fires here rather than tripping the "timer still pending" invariant.
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
     });
   });
 }

--- a/mobile/test/presentation/widgets/timeline/timeline_empty_state_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_empty_state_test.dart
@@ -1,14 +1,20 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:easy_localization/easy_localization.dart' hide TextDirection;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/search_result.model.dart';
+import 'package:immich_mobile/domain/services/search.service.dart';
 import 'package:immich_mobile/models/search/search_filter.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline_empty_state.widget.dart';
 import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/photos_filter_search.provider.dart';
 import 'package:immich_mobile/providers/sync_status.provider.dart';
 import 'package:immich_mobile/widgets/common/immich_loading_indicator.dart';
+import 'package:mocktail/mocktail.dart';
 
 import '../../../widget_tester_extensions.dart';
 
@@ -31,6 +37,10 @@ class _FixedSync extends SyncStatusNotifier {
   @override
   SyncStatusState build() => _initial;
 }
+
+class _MockSearchService extends Mock implements SearchService {}
+
+class _FakeSearchFilter extends Fake implements SearchFilter {}
 
 /// 1×1 transparent PNG so Image.asset resolves without the real asset bundle.
 final _transparentPng = base64Decode(
@@ -55,9 +65,21 @@ class _FakeAssetBundle extends CachingAssetBundle {
 }
 
 void main() {
+  setUpAll(() => registerFallbackValue(_FakeSearchFilter()));
+
   Widget withFakeAssets(Widget child) => DefaultAssetBundle(bundle: _FakeAssetBundle(), child: child);
 
   SearchFilter activeFilter() => SearchFilter.empty().copyWith()..context = 'beach';
+
+  /// Overrides the filter-driven search with one whose page-1 request answers
+  /// with [page1]. Pass a never-completing future to hold it in flight.
+  Override searchOverride(Future<SearchResult?> page1) {
+    final service = _MockSearchService();
+    when(() => service.search(any(), any())).thenAnswer((_) => page1);
+    return photosFilterSearchProvider.overrideWith(
+      (ref) => PhotosFilterSearchNotifier(search: service, filter: activeFilter()),
+    );
+  }
 
   testWidgets('first-run state shows the onboarding title and an Enable Backup action', (tester) async {
     await tester.pumpConsumerWidget(
@@ -88,6 +110,27 @@ void main() {
     expect(find.text('timeline_empty_title'), findsNothing);
   });
 
+  // #901: the search-backed timeline starts at zero assets, so the empty state is
+  // built while the page-1 request is still in flight. It must not claim there is
+  // nothing to find before the server has answered.
+  testWidgets('while the filtered search is still in flight it shows a loader, not the no-results state', (
+    tester,
+  ) async {
+    await tester.pumpConsumerWidgetRaw(
+      const TimelineEmptyState(),
+      overrides: [
+        photosFilterProvider.overrideWith(() => _FixedFilter(activeFilter())),
+        syncStatusProvider.overrideWith(() => _FixedSync(const SyncStatusState())),
+        searchOverride(Completer<SearchResult?>().future),
+      ],
+    );
+    await tester.pump();
+
+    expect(find.byType(ImmichLoadingIndicator), findsOneWidget);
+    expect(find.text('timeline_empty_filtered_title'), findsNothing);
+    expect(find.text('timeline_empty_clear_filters'), findsNothing);
+  });
+
   testWidgets('an active filter shows the no-results state and clearing it resets the filter', (tester) async {
     await tester.pumpConsumerWidget(
       const TimelineEmptyState(),
@@ -96,6 +139,8 @@ void main() {
         // syncing so that after the reset we deterministically land on the loader
         // (no asset/router needed) rather than the first-run state.
         syncStatusProvider.overrideWith(() => _FixedSync(const SyncStatusState(remoteSyncStatus: SyncStatus.syncing))),
+        // Search settled with nothing: only now is "no matching photos" the truth.
+        searchOverride(Future<SearchResult?>.value()),
       ],
     );
     await tester.pump();


### PR DESCRIPTION
Fixes #901.

## Problem

Searching on mobile showed **"No matching photos"** for a few seconds before the results appeared.

## Root cause

`TimelineEmptyState` chose between the no-results state and a loader using only two signals: is a photos filter active, and is the initial *local* remote sync running. It had no view of the filter-driven search request itself.

When the debounced filter lands, `photosTimelineQueryProvider` swaps the timeline over to the search-backed `TimelineService`. That service's `bucketSource` yields immediately from `getAssets()`, which is still empty while `PhotosFilterSearchNotifier` has its page-1 request in flight — so the timeline resolves to zero assets and, with a filter active, rendered "No matching photos" for the entire duration of the request.

## Fix

While a filter is active, hold the loading indicator until the page-1 search settles; only then fall back to the no-results state. `photosFilterSearchProvider` is read from inside the `TimelineRouteScope`, the same way the load-more footer does, so this is the scoped notifier actually feeding the timeline.

## Tests (TDD)

Both tests were written first and confirmed to fail against the unfixed widget (`Found 0 widgets with type "ImmichLoadingIndicator"`).

- `timeline_empty_state_test.dart` — with a filter active and the search held in flight, the loader renders and neither the no-results title nor its clear-filters action appears. The existing no-results test now pins a *settled* empty search, so it asserts the state for the right reason.
- `timeline_empty_state_integration_test.dart` — wires the real chain (mocked `SearchService` → real `photosFilterSearchProvider` scoped by `TimelineRouteScope` → real `TimelineFactory.fromAssetStream` → `Timeline` → `TimelineEmptyState`) and drives the request completion, covering the provider-scoping the fix depends on.

Full mobile suite: 2894 passed. `dart analyze --fatal-infos lib test` and the `dart format` gate are clean.