### PR TITLE
fix(mobile): start each search at Relevance and hide memories while filtering (#902)

### DIFF
--- a/mobile/lib/presentation/pages/dev/main_timeline.page.dart
+++ b/mobile/lib/presentation/pages/dev/main_timeline.page.dart
@@ -12,11 +12,15 @@ import 'package:immich_mobile/presentation/widgets/timeline/timeline_empty_state
 import 'package:immich_mobile/presentation/widgets/timeline/timeline_grouping_selector.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline_route_scope.dart';
 import 'package:immich_mobile/providers/feature_message.provider.dart';
-import 'package:immich_mobile/providers/infrastructure/memory.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/memory_lane.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/photos_filter_search.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/timeline_query.provider.dart';
 import 'package:immich_mobile/widgets/common/immich_sliver_app_bar.dart';
+
+/// Scroll offset the memories strip occupies at the top of the timeline —
+/// matches [DriftMemoryLane]'s own max height so the scrubber lines up.
+const double _memoryLaneHeight = 200;
 
 @RoutePage()
 class MainTimelinePage extends ConsumerStatefulWidget {
@@ -52,7 +56,9 @@ class _MainTimelinePageState extends ConsumerState<MainTimelinePage> {
 
   @override
   Widget build(BuildContext context) {
-    final hasMemories = ref.watch(driftMemoryFutureProvider.select((state) => state.value?.isNotEmpty ?? false));
+    // The memories strip is browse-only: an active search or filter takes the
+    // space back so results start at the top of the viewport (#902, web parity).
+    final showMemories = ref.watch(photosMemoryLaneVisibleProvider);
     return TimelineRouteScope(
       timelineServiceBuilder: buildPhotosTimelineRouteService,
       // The main Photos timeline is the only route on the app-level grouping, so its
@@ -77,13 +83,13 @@ class _MainTimelinePageState extends ConsumerState<MainTimelinePage> {
                 return false;
               },
               child: Timeline(
-                topSliverWidget: const SliverMainAxisGroup(
+                topSliverWidget: SliverMainAxisGroup(
                   slivers: [
-                    PhotosFilterSubheader(),
-                    SliverToBoxAdapter(child: DriftMemoryLane()),
+                    const PhotosFilterSubheader(),
+                    if (showMemories) const SliverToBoxAdapter(child: DriftMemoryLane()),
                   ],
                 ),
-                topSliverWidgetHeight: hasMemories ? 200 : 0,
+                topSliverWidgetHeight: showMemories ? _memoryLaneHeight : 0,
                 showStorageIndicator: true,
                 appBar: const PhotosTimelineAppBar(),
                 bottomSliverWidget: const _SearchLoadMoreFooter(),

--- a/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
@@ -470,14 +470,14 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> with WidgetsBi
         _daySwitchRequested = false;
         _drainingTarget = null;
       case ScrollDrainAction.switchToDayGrouping:
-        // Overview groupings render cards, not tiles. Drill to day the same way a
-        // card tap does, then keep retrying until the rebuilt segments arrive.
-        // `attempts` MUST increment here: if the grouping is pinned and set() is a
+        // Overview modes render cards, not tiles. Drill to the photo grid the same
+        // way a card tap does, then keep retrying until the rebuilt segments arrive.
+        // `attempts` MUST increment here: if the mode is pinned and set() is a
         // no-op, the budget is the only thing that ends this loop.
         _scrollDrainAttempts++;
         if (!_daySwitchRequested) {
           _daySwitchRequested = true;
-          unawaited(ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.day));
+          unawaited(ref.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.all));
         }
         WidgetsBinding.instance.addPostFrameCallback((_) => _attemptScrollDrain());
       case ScrollDrainAction.retry:

--- a/mobile/lib/providers/photos_filter/memory_lane.provider.dart
+++ b/mobile/lib/providers/photos_filter/memory_lane.provider.dart
@@ -1,0 +1,15 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/providers/infrastructure/memory.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
+
+/// Whether the Photos timeline should render the memories strip above the grid.
+///
+/// Memories are a browse-mode affordance. Web's photos page mounts the carousel
+/// only while nothing is being searched or filtered (`!hasActiveFilters`), so
+/// results start at the top of the viewport instead of being pushed down by a
+/// strip unrelated to the query — mobile matches that here (#902).
+final photosMemoryLaneVisibleProvider = Provider<bool>((ref) {
+  final hasMemories = ref.watch(driftMemoryFutureProvider.select((memories) => memories.value?.isNotEmpty ?? false));
+  final isFiltering = ref.watch(photosFilterProvider.select((filter) => !filter.isEmpty));
+  return hasMemories && !isFiltering;
+});

--- a/mobile/lib/providers/photos_filter/photos_filter.provider.dart
+++ b/mobile/lib/providers/photos_filter/photos_filter.provider.dart
@@ -21,10 +21,18 @@ class PhotosFilterNotifier extends Notifier<SearchFilter> {
   // SearchFilter.copyWith null-coalesces, so use cascade to set nullable fields.
   void setText(String text) {
     final next = state.copyWith()..context = text.isEmpty ? null : text;
-    // Relevance is only valid for smart (text) search; coerce to Newest for metadata.
-    state = (next.context == null && next.sort == SearchSortOrder.relevance)
-        ? next.copyWith(sort: SearchSortOrder.newest)
-        : next;
+    // Every new query starts over at Relevance, matching web: the search palette
+    // resets `searchSortOrder` to relevance when a session opens on an empty query
+    // and when the query is cleared (global-search-manager `open()` /
+    // `activateSearch('')`). A sort the user picks therefore applies to the results
+    // in front of them and is dropped once they search for something else.
+    //
+    // The sort is deliberately *not* rewritten to a date order for metadata-only
+    // filters — relevance degrades to newest-first where it has to (no `order` on
+    // the search request, date grouping in the timeline, "Newest first" in the sort
+    // sheet). Coercing the stored value instead used to pin the app to Newest first
+    // for the rest of the session once a query had been cleared (#902).
+    state = next.context == state.context ? next : next.copyWith(sort: SearchSortOrder.relevance);
   }
 
   void setSort(SearchSortOrder sort) => state = state.copyWith(sort: sort);

--- a/mobile/test/presentation/pages/dev/main_timeline_memory_lane_test.dart
+++ b/mobile/test/presentation/pages/dev/main_timeline_memory_lane_test.dart
@@ -1,0 +1,163 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' show DatabaseConnection;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/memory.model.dart';
+import 'package:immich_mobile/domain/models/search_result.model.dart';
+import 'package:immich_mobile/domain/models/store.model.dart';
+import 'package:immich_mobile/domain/models/user.model.dart';
+import 'package:immich_mobile/domain/services/feature_message.service.dart';
+import 'package:immich_mobile/domain/services/search.service.dart';
+import 'package:immich_mobile/domain/services/store.service.dart';
+import 'package:immich_mobile/domain/services/user.service.dart';
+import 'package:immich_mobile/entities/store.entity.dart';
+import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
+import 'package:immich_mobile/infrastructure/repositories/settings.repository.dart';
+import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
+import 'package:immich_mobile/models/search/search_filter.model.dart';
+import 'package:immich_mobile/presentation/pages/dev/main_timeline.page.dart';
+import 'package:immich_mobile/presentation/widgets/memory/memory_lane.widget.dart';
+import 'package:immich_mobile/providers/api.provider.dart';
+import 'package:immich_mobile/providers/feature_message.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/db.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/memory.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/search.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/user.provider.dart' as infra;
+import 'package:immich_mobile/providers/photos_filter/filter_count.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:immich_mobile/services/api.service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../mock_http_override.dart';
+import '../../../test_utils.dart';
+
+class _MockSearch extends Mock implements SearchService {}
+
+class _MockApiService extends Mock implements ApiService {}
+
+class _MockUserService extends Mock implements UserService {}
+
+class _FakeFilter extends Fake implements SearchFilter {}
+
+class _StubFeatureMessageService implements FeatureMessageService {
+  @override
+  bool shouldShow() => false;
+
+  @override
+  Future<void> markSeen() async {}
+}
+
+class _StubUserNotifier extends CurrentUserProvider {
+  _StubUserNotifier(super.service, UserDto? initial) {
+    state = initial;
+  }
+}
+
+final _testUser = UserDto(
+  id: 'test-user-1',
+  email: 'test@example.com',
+  name: 'Test User',
+  profileChangedAt: DateTime(2024, 1, 1),
+);
+
+DriftMemory _memory() => DriftMemory(
+  id: 'memory-1',
+  createdAt: DateTime(2024),
+  updatedAt: DateTime(2024),
+  ownerId: _testUser.id,
+  type: MemoryTypeEnum.onThisDay,
+  data: const MemoryData({'year': 2019}),
+  isSaved: false,
+  memoryAt: DateTime(2019, 8, 1),
+  assets: [TestUtils.createRemoteAsset(id: 'memory-asset-1')],
+);
+
+ProviderContainer _makeContainer({required SearchService search, required Drift db}) {
+  final mockUserSvc = _MockUserService();
+  when(() => mockUserSvc.tryGetMyUser()).thenReturn(_testUser);
+  when(() => mockUserSvc.watchMyUser()).thenAnswer((_) => const Stream.empty());
+  return ProviderContainer(
+    overrides: [
+      driftProvider.overrideWithValue(db),
+      searchServiceProvider.overrideWithValue(search),
+      apiServiceProvider.overrideWithValue(_MockApiService()),
+      infra.userServiceProvider.overrideWithValue(mockUserSvc),
+      currentUserProvider.overrideWith((ref) => _StubUserNotifier(mockUserSvc, _testUser)),
+      timelineUsersProvider.overrideWith((_) => Stream.value([_testUser.id])),
+      photosFilterCountProvider.overrideWith((ref) => 0),
+      featureMessageServiceProvider.overrideWithValue(_StubFeatureMessageService()),
+      driftMemoryFutureProvider.overrideWith((ref) async => [_memory()]),
+    ],
+  );
+}
+
+void main() {
+  late Drift db;
+
+  setUpAll(() async {
+    HttpOverrides.global = MockHttpOverrides();
+    registerFallbackValue(_FakeFilter());
+    db = Drift(DatabaseConnection(NativeDatabase.memory(), closeStreamsSynchronously: true));
+    await StoreService.init(storeRepository: DriftStoreRepository(db));
+    await SettingsRepository.ensureInitialized(db);
+    await Store.put(StoreKey.serverEndpoint, 'http://localhost:0');
+  });
+  tearDownAll(() => db.close());
+
+  // #902 — web's photos page renders the memories carousel only while browsing
+  // (`!hasActiveFilters`), so search results start at the top of the viewport
+  // instead of being pushed down by a strip that is irrelevant to the query.
+  testWidgets('the memories strip drops out of the timeline while a search is active', (tester) async {
+    tester.view.physicalSize = const Size(1080, 2340);
+    tester.view.devicePixelRatio = 2.75;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    // Without EasyLocalization the filter subheader renders raw i18n keys, which
+    // overflow its Row. Suppress that known layout overflow (same as the
+    // infinite-scroll test) so the widget assertions can run.
+    final prevOnError = FlutterError.onError;
+    FlutterError.onError = (details) {
+      if (details.exception.toString().contains('overflowed')) return;
+      prevOnError?.call(details);
+    };
+    addTearDown(() => FlutterError.onError = prevOnError);
+
+    final search = _MockSearch();
+    when(() => search.search(any(), any())).thenAnswer((_) async => const SearchResult(assets: [], nextPage: null));
+
+    final container = _makeContainer(search: search, db: db);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: MainTimelinePage()),
+      ),
+    );
+    for (var i = 0; i < 10; i++) {
+      await tester.pump(const Duration(milliseconds: 40));
+    }
+    expect(find.byType(DriftMemoryLane), findsOneWidget, reason: 'browsing an unfiltered timeline shows memories');
+
+    container.read(photosFilterProvider.notifier).setText('beach');
+    for (var i = 0; i < 30; i++) {
+      await tester.pump(const Duration(milliseconds: 40));
+    }
+    expect(find.byType(DriftMemoryLane), findsNothing, reason: 'a search result set is not a place for memories');
+
+    container.read(photosFilterProvider.notifier).reset();
+    for (var i = 0; i < 30; i++) {
+      await tester.pump(const Duration(milliseconds: 40));
+    }
+    expect(find.byType(DriftMemoryLane), findsOneWidget, reason: 'clearing the search restores the strip');
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(seconds: 1));
+    container.dispose();
+  });
+}

--- a/mobile/test/presentation/widgets/timeline/scroll_drain_test.dart
+++ b/mobile/test/presentation/widgets/timeline/scroll_drain_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/fixed/segment.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/overview/overview_segment.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/scroll_drain.dart';
@@ -212,6 +213,6 @@ TimelineOverviewSegment _overviewSegment() => TimelineOverviewSegment(
   endOffset: 100,
   firstAssetIndex: 0,
   bucket: TimeBucket(date: DateTime(2026, 1), assetCount: 12),
-  groupBy: GroupAssetsBy.year,
+  mode: TimelineOverviewMode.years,
   header: HeaderType.none,
 );

--- a/mobile/test/providers/photos_filter/memory_lane_provider_test.dart
+++ b/mobile/test/providers/photos_filter/memory_lane_provider_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/memory.model.dart';
+import 'package:immich_mobile/providers/infrastructure/memory.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/memory_lane.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
+
+DriftMemory _memory() => DriftMemory(
+  id: 'memory-1',
+  createdAt: DateTime(2024),
+  updatedAt: DateTime(2024),
+  ownerId: 'user-1',
+  type: MemoryTypeEnum.onThisDay,
+  data: const MemoryData({'year': 2019}),
+  isSaved: false,
+  memoryAt: DateTime(2019, 8, 1),
+  assets: const [],
+);
+
+ProviderContainer _container({required List<DriftMemory> memories}) {
+  final c = ProviderContainer(overrides: [driftMemoryFutureProvider.overrideWith((ref) async => memories)]);
+  addTearDown(c.dispose);
+  return c;
+}
+
+void main() {
+  test('the strip shows while browsing an unfiltered timeline', () async {
+    final c = _container(memories: [_memory()]);
+    await c.read(driftMemoryFutureProvider.future);
+    expect(c.read(photosMemoryLaneVisibleProvider), isTrue);
+  });
+
+  test('the strip hides once a search is active', () async {
+    // #902: web's photos page renders the memories carousel only when no filter
+    // or search is active, so results are not pushed down the viewport.
+    final c = _container(memories: [_memory()]);
+    await c.read(driftMemoryFutureProvider.future);
+    c.read(photosFilterProvider.notifier).setText('beach');
+    expect(c.read(photosMemoryLaneVisibleProvider), isFalse);
+  });
+
+  test('the strip hides for a metadata-only filter too', () async {
+    final c = _container(memories: [_memory()]);
+    await c.read(driftMemoryFutureProvider.future);
+    c.read(photosFilterProvider.notifier).setFavouritesOnly(true);
+    expect(c.read(photosMemoryLaneVisibleProvider), isFalse);
+  });
+
+  test('the strip comes back when the filter is cleared', () async {
+    final c = _container(memories: [_memory()]);
+    await c.read(driftMemoryFutureProvider.future);
+    final notifier = c.read(photosFilterProvider.notifier);
+    notifier.setText('beach');
+    notifier.reset();
+    expect(c.read(photosMemoryLaneVisibleProvider), isTrue);
+  });
+
+  test('the strip stays hidden when there are no memories', () async {
+    final c = _container(memories: const []);
+    await c.read(driftMemoryFutureProvider.future);
+    expect(c.read(photosMemoryLaneVisibleProvider), isFalse);
+  });
+}

--- a/mobile/test/providers/photos_filter/photos_filter_provider_test.dart
+++ b/mobile/test/providers/photos_filter/photos_filter_provider_test.dart
@@ -436,14 +436,74 @@ void main() {
     expect(c.read(photosFilterProvider).sort, SearchSortOrder.oldest);
   });
 
-  test('clearing text while Relevance coerces sort to Newest', () {
-    final c = ProviderContainer();
-    addTearDown(c.dispose);
-    final n = c.read(photosFilterProvider.notifier);
-    n.setText('beach');
-    n.setSort(SearchSortOrder.relevance);
-    n.setText('');
-    expect(c.read(photosFilterProvider).sort, SearchSortOrder.newest);
+  // #902 — web parity. Web starts every search at relevance (global-search-manager
+  // `open()` / `activateSearch('')`) and never rewrites the stored order into a date
+  // order; relevance degrades to newest-first at query-build time for metadata-only
+  // filters. Mobile used to coerce relevance→newest as soon as the query emptied,
+  // which pinned the app to "Newest first" for every later search.
+  group('sort resets with the query', () {
+    test('clearing the query returns the sort to Relevance', () {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+      final n = c.read(photosFilterProvider.notifier);
+      n.setText('beach');
+      n.setSort(SearchSortOrder.newest);
+      n.setText('');
+      expect(c.read(photosFilterProvider).sort, SearchSortOrder.relevance);
+    });
+
+    test('the next search after a cleared query is sorted by Relevance', () {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+      final n = c.read(photosFilterProvider.notifier);
+      n.setText('beach');
+      n.setSort(SearchSortOrder.newest);
+      n.setText('');
+      n.setText('sunset');
+      expect(c.read(photosFilterProvider).sort, SearchSortOrder.relevance);
+    });
+
+    test('editing the query into a new one resets a manually chosen sort', () {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+      final n = c.read(photosFilterProvider.notifier);
+      n.setText('beach');
+      n.setSort(SearchSortOrder.oldest);
+      n.setText('beaches');
+      expect(c.read(photosFilterProvider).sort, SearchSortOrder.relevance);
+    });
+
+    test('re-applying the same query keeps the chosen sort', () {
+      // The search bar re-sends the current text on submit; that is not a new
+      // search and must not throw away the order the user just picked.
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+      final n = c.read(photosFilterProvider.notifier);
+      n.setText('beach');
+      n.setSort(SearchSortOrder.newest);
+      n.setText('beach');
+      expect(c.read(photosFilterProvider).sort, SearchSortOrder.newest);
+    });
+
+    test('the chosen sort survives edits to other filter dimensions', () {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+      final n = c.read(photosFilterProvider.notifier);
+      n.setText('beach');
+      n.setSort(SearchSortOrder.oldest);
+      n.setFavouritesOnly(true);
+      expect(c.read(photosFilterProvider).sort, SearchSortOrder.oldest);
+    });
+
+    test('clearing the query via its chip also returns the sort to Relevance', () {
+      final c = ProviderContainer();
+      addTearDown(c.dispose);
+      final n = c.read(photosFilterProvider.notifier);
+      n.setText('beach');
+      n.setSort(SearchSortOrder.oldest);
+      n.removeChip(const TextChipId());
+      expect(c.read(photosFilterProvider).sort, SearchSortOrder.relevance);
+    });
   });
 
   test('setSimilarTo builds an assetId-only image filter', () {


### PR DESCRIPTION
Fixes the mobile search behaviours reported in #902 by matching what web already does.

## Sort order

`PhotosFilterNotifier.setText` rewrote a stored `relevance` sort into `newest` whenever the query emptied, and nothing ever wrote `relevance` back. The first time a user cleared the search box — the X button, or just backspacing to nothing — the app was pinned to **Newest first** for every later search in that session, which is what the report describes.

The coercion was never needed: relevance already degrades to newest-first wherever it has to.

| layer | relevance with no query |
| --- | --- |
| `SearchApiRepository._order` | omits `order` → server default `AssetOrder.Desc` |
| `buildPhotosTimelineQuery` | `isRelevance` requires a smart query, so results stay date-grouped |
| `SortIconButton` | offers only Newest/Oldest and shows Newest as selected |

So the stored sort now stays put, and is reset to `relevance` whenever the query itself changes — the same contract as web's search palette, where `searchSortOrder` returns to relevance as a session opens on an empty query and when the query is cleared (`global-search-manager.svelte.ts` `open()` / `activateSearch('')`). A sort the user picks applies to the results in front of them and is dropped once they search for something else. Re-submitting the same text is not a new search, so it keeps the chosen order.

## Memories strip

Web's photos page mounts the memories carousel only while nothing is being searched or filtered (`{#if authManager.preferences.memories.enabled && !hasActiveFilters}`), so results start at the top of the viewport. Mobile kept it pinned above search results.

`photosMemoryLaneVisibleProvider` now gates both the sliver and the scroll offset reserved for it, hiding the strip for any active filter or search — same trigger as web's `hasActiveFilters`.

## Result layout

The third observation in the report — a compact grid for Relevance, month/day headers for the date orders — already matches web (`space-search-results.svelte` groups by month unless `sortMode === 'relevance'`), so it is unchanged. With Relevance working as the default again, searches open in the compact grid the reporter preferred.

## Tests

TDD, all red before the change:

- `photos_filter_provider_test.dart` — clearing the query returns the sort to Relevance; the next search after a clear is by Relevance; editing the query into a new one resets a manually chosen sort; re-applying the same query keeps it; edits to other filter dimensions keep it; clearing via the query chip also resets. Replaces the test that asserted the old `relevance → newest` coercion.
- `memory_lane_provider_test.dart` — strip visible while browsing, hidden for a text search, hidden for a metadata-only filter, back after a clear, never shown without memories.
- `main_timeline_memory_lane_test.dart` — pumps `MainTimelinePage` and asserts `DriftMemoryLane` leaves and re-enters the tree as a search starts and clears.

Full mobile suite green (2903 passed), `dart analyze --fatal-infos lib test` clean, `dart format` gate clean.

## Manual check

Not yet run on a device — the search flow (type → sort → clear → search again) and the memories strip are worth a look on an RC build.
