### PR TITLE
fix(web): animate the branded loading spinner (#900)

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -56,8 +56,8 @@ run = [
 [tasks.open-api-typescript]
 run = [
   "oazapfts --optimistic --argumentStyle=object --useEnumType --allSchemas open-api/immich-openapi-specs.json packages/sdk/src/fetch-client.ts",
-  { task = "//:sdk:install" },
-  { task = "//:sdk:build" },
+  { task = ":sdk:install" },
+  { task = ":sdk:build" },
 ]
 
 [tasks.open-api-dart]
@@ -75,7 +75,7 @@ run = "bash ./bin/generate-dart-sdk.sh"
 [tasks.open-api]
 env = { SHARP_IGNORE_GLOBAL_LIBVIPS = true }
 run = [
-  { task = "//:plugins" },
+  { task = ":plugins" },
   { task = "//server:install" },
   { task = "//server:build" },
   { task = "//server:sync-open-api" },
@@ -89,33 +89,33 @@ run = "node ./dist/bin/sync-sql.js"
 
 # TODO dev, prod, and e2e should be de-duplicated by using env but for some reason I ran into issues
 [tasks.dev]
-depends = "//:plugins"
+depends = ":plugins"
 dir = "docker"
 interactive = true
 env = { COMPOSE_BAKE = true }
 run = "docker compose -f ./docker-compose.dev.yml up --remove-orphans"
-depends_post = "//:dev-down"
+depends_post = ":dev-down"
 
 [tasks.dev-update]
-run = { task = "//:dev", args = ["--build", "-V"] }
+run = { task = ":dev", args = ["--build", "-V"] }
 
 [tasks.dev-scale]
-run = { task = "//:dev", args = ["--build", "-V", "--scale immich-server=3"] }
+run = { task = ":dev", args = ["--build", "-V", "--scale immich-server=3"] }
 
 [tasks.dev-down]
 dir = "docker"
 run = "docker compose -f ./docker-compose.dev.yml down --remove-orphans"
 
 [tasks.prod]
-depends = "//:plugins"
+depends = ":plugins"
 dir = "docker"
 interactive = true
 env = { COMPOSE_BAKE = true }
 run = "docker compose -f ./docker-compose.prod.yml up --build --remove-orphans"
-depends_post = "//:prod-down"
+depends_post = ":prod-down"
 
 [tasks.prod-scale]
-run = { task = "//:prod", args = [
+run = { task = ":prod", args = [
   "--build",
   "-V",
   "--scale immich-server=3",
@@ -127,23 +127,23 @@ dir = "docker"
 run = "docker compose -f ./docker-compose.prod.yml down --remove-orphans"
 
 [tasks.e2e]
-depends = "//:plugins"
+depends = ":plugins"
 dir = "e2e"
 interactive = true
 env = { COMPOSE_BAKE = true }
 run = "docker compose -f ./docker-compose.yml up --remove-orphans"
-depends_post = "//:e2e-down"
+depends_post = ":e2e-down"
 
 [tasks.e2e-dev]
-depends = "//:plugins"
+depends = ":plugins"
 dir = "e2e"
 interactive = true
 env = { COMPOSE_BAKE = true }
 run = "docker compose -f ./docker-compose.dev.yml up --remove-orphans"
-depends_post = "//:e2e-dev-down"
+depends_post = ":e2e-dev-down"
 
 [tasks.e2e-update]
-run = { task = "//:e2e", args = ["--build", '-V'] }
+run = { task = ":e2e", args = ["--build", '-V'] }
 
 [tasks.e2e-down]
 dir = "e2e"
@@ -177,5 +177,5 @@ run = [
   "find . -name '.svelte-kit' -type d -prune -exec rm -rf '{}' +",
   "find . -name 'coverage' -type d -prune -exec rm -rf '{}' +",
   "find . -name '.pnpm-store' -type d -prune -exec rm -rf '{}' +",
-  { task = "//:*-down" },
+  { task = ":*-down" },
 ]

--- a/web/src/lib/components/shared-components/LoadingSpinner.spec.ts
+++ b/web/src/lib/components/shared-components/LoadingSpinner.spec.ts
@@ -34,6 +34,19 @@ describe('LoadingSpinner Component', () => {
     expect(img?.className).toContain('h-5');
   });
 
+  it('should animate so it reads as a loading indicator, not a static logo', () => {
+    const { container } = render(LoadingSpinner);
+    const img = container.querySelector('[data-testid="loading-spinner"]');
+    expect(img?.className).toContain('animate-spin');
+  });
+
+  it('should keep animating when a custom class is supplied', () => {
+    const { container } = render(LoadingSpinner, { props: { class: 'custom-spinner' } });
+    const img = container.querySelector('[data-testid="loading-spinner"]');
+    expect(img?.className).toContain('animate-spin');
+    expect(img?.className).toContain('custom-spinner');
+  });
+
   it('should load gallery loader SVG', () => {
     const { container } = render(LoadingSpinner);
     const img = container.querySelector('[data-testid="loading-spinner"]');

--- a/web/src/lib/components/shared-components/LoadingSpinner.svelte
+++ b/web/src/lib/components/shared-components/LoadingSpinner.svelte
@@ -23,7 +23,7 @@
 <div>
   <img
     role="status"
-    class={[sizeClasses[size], className].filter(Boolean).join(' ')}
+    class={['animate-spin', sizeClasses[size], className].filter(Boolean).join(' ')}
     {src}
     alt={$t('loading')}
     data-testid="loading-spinner"


### PR DESCRIPTION
Fixes #900.

## Root cause

`LoadingSpinner.svelte` renders `/gallery-loader.svg` (or `-dark`) in a plain `<img>` whose only classes are the size class and any caller-supplied class:

```svelte
class={[sizeClasses[size], className].filter(Boolean).join(' ')}
```

Those two assets are **byte-identical copies of `gallery-logo-mark*.svg`** and contain no `<animate>`/`<animateTransform>` element:

```
22a31216c002a349c1d619b12f25cfaf7e2207a8  gallery-loader.svg
22a31216c002a349c1d619b12f25cfaf7e2207a8  gallery-logo-mark.svg
dd98c0ed45dac34902717d07485473f0c7a6e679  gallery-loader-dark.svg
dd98c0ed45dac34902717d07485473f0c7a6e679  gallery-logo-mark-dark.svg
```

So nothing moved: no animation inside the SVG, and none applied to the element. That is the static logo in the report — it affects all 25 fork call-sites of the branded spinner, including the two in the issue (the centred `size="giant"` indicator on the search page, and the `size="large"` indicator on video-thumbnail hover).

The app-shell boot splash is not affected because `app.html` rotates its container itself (`#stencil { animation: … loadspin 8s linear infinite }`) — the component simply had no equivalent.

For history: the loader carried a SMIL `animateTransform` at the original fork squash; it lost the animation in #327 and became an exact copy of the logo mark in #494.

## Fix

Add `animate-spin` to the spinner image. This matches how the boot splash animates the same artwork, and matches the generic `@immich/ui` `LoadingSpinner` the fork swaps out (also `animate-spin`). The static artwork is left untouched, so `Logo variant="icon" transparent` — which shares `gallery-loader.svg` as branding on the auth page — stays static as intended.

## Tests

Added to `LoadingSpinner.spec.ts`, written first and confirmed failing (`expected 'h-5' to contain 'animate-spin'`) before the change:

- `should animate so it reads as a loading indicator, not a static logo`
- `should keep animating when a custom class is supplied` — guards against a caller-supplied class replacing rather than appending

## Verification

- `pnpm vitest run` (web): **294 files passed, 4005 tests passed**, exit 0
- `pnpm vite build`: exit 0, and the emitted CSS confirms the class is not a no-op:
  ```
  .animate-spin{animation:var(--animate-spin)}
  --animate-spin:spin 1s linear infinite;
  @keyframes spin{to{transform:rotate(360deg)}}
  ```
- `pnpm format` clean · `pnpm check:typescript` clean · `pnpm check:svelte` 571 files, 0 errors, 0 warnings · `pnpm lint` 0 errors (3 pre-existing warning files, untouched here)
- `tools/upstream-preflight` `branded-spinner.spec.ts` guard still passes 2/2

Not visually confirmed in a running stack — the evidence above is the emitted CSS rather than a screenshot.
