### PR TITLE
fix(mobile): restore the Photo Grid "Group by" setting (#903)

### DIFF
--- a/docs/superpowers/plans/2026-08-02-timeline-grouping-upstream-divergence.md
+++ b/docs/superpowers/plans/2026-08-02-timeline-grouping-upstream-divergence.md
@@ -16,8 +16,9 @@
 - **All commands run from `mobile/`.**
 - **Formatter page width is 120** (`mobile/analysis_options.yaml:13`). Exceeding it changes how `dart format` wraps and can silently reindent whole blocks.
 - **Three blocking CI gates, all required:** `flutter test`, `dart analyze --fatal-infos lib test`, `dart format lib`. `dart analyze` is not a substitute for `flutter test`.
-- **Baseline: 2902 tests passing, 0 failures.** The count may only go up.
-- **No behaviour change.** Nothing in this plan alters what the app does. If an existing test needs its _assertions_ changed rather than just its _identifiers_, stop and escalate — the retype has changed semantics.
+- **Baseline: 2902 passing, 1 skipped, 0 failures** (measured on this branch, `00:59` wall clock). The passing count may only go up.
+- **No behaviour change, with one declared exception** (below). If an existing test needs its _assertions_ changed rather than just its _identifiers_, stop and escalate — unless it appears in the "Expected test churn" table, which lists every change that is legitimate.
+- **The one deliberate behaviour change: a pinned `TimelineArgs.groupBy` no longer selects the overview.** Today `timeline.state.dart` does `grouping = groupByArg ?? watch(...)`, so an explicit `groupBy: month` or `groupBy: year` renders overview cards. After this refactor a pinned grouping always means the flat grid at that granularity, because `TimelineArgs.groupBy` is upstream's field and means header granularity, not zoom level. **This is unreachable in production**: the only caller passing an explicit value is `cleanup_preview.page.dart:38`, which passes `GroupAssetsBy.day`. It is, however, reachable from tests — see the churn table.
 - **No production line before a failing test names it.** Every scenario must be observed red before it is trusted, by one of two routes: write-first for new behaviour, or characterise-then-mutate for existing behaviour.
 - **`normalizeGridGrouping` applies only where the persisted setting is read.** Never to a grouping a caller passed explicitly — `GroupAssetsBy.none` is live for relevance search.
 - **Commit after every task.** Never use `--no-verify`. Never add a `Co-Authored-By` trailer.
@@ -60,6 +61,45 @@
 | `lib/widgets/settings/asset_list_settings/asset_list_group_settings.dart` | Watch `timelineGridGroupingProvider`                 | 3+/1- → ~2+/1-       |
 | `lib/domain/services/timeline.service.dart`                               | Import moves to the new model file                   | ~unchanged           |
 | `lib/presentation/widgets/timeline/timeline.widget.dart`                  | 4 sites split between mode and `spec.groupBy`        | 280+/64- → ~284+/68- |
+
+### Test files in the blast radius — 16, not the 12 that #911 touched
+
+Enumerated with:
+
+```bash
+grep -rln "timelineGroupingProvider\|timelineBucketGroupingProvider\|findTimelineZoomAnchorSegment\|resolveGroupingChangeAnchorDate\|TimelineOverviewSegmentBuilder\|TimelineOverviewCard\|keyFor(" test/
+```
+
+| File                                                                        | Role                                        |
+| --------------------------------------------------------------------------- | ------------------------------------------- |
+| `presentation/widgets/timeline/timeline_segment_provider_test.dart`         | G-1…G-4, S-1…S-7                            |
+| `presentation/widgets/timeline/timeline_scroll_target_test.dart`            | Z-3…Z-6 — pure-function anchor guards       |
+| `presentation/widgets/timeline/timeline_grouping_anchor_test.dart`          | `resolveGroupingChangeAnchorDate`           |
+| `presentation/widgets/timeline/timeline_zoom_anchor_resolution_test.dart`   | widget-level anchor resolution              |
+| `presentation/widgets/timeline/timeline_route_scope_test.dart`              | R-1…R-5                                     |
+| `presentation/widgets/timeline/timeline_grouping_selector_test.dart`        | G-5                                         |
+| `presentation/widgets/timeline/timeline_grouping_bottom_pill_test.dart`     | P-1…P-5                                     |
+| `presentation/widgets/timeline/overview/overview_segment_builder_test.dart` | builder takes the mode                      |
+| `presentation/widgets/timeline/overview/timeline_overview_card_test.dart`   | card takes the mode                         |
+| `presentation/pages/dev/main_timeline_zoom_test.dart`                       | Z-7, Z-8                                    |
+| `presentation/pages/dev/timeline_filter_grouping_integration_test.dart`     | Q-4…Q-6                                     |
+| `presentation/pages/drift_favorite_page_test.dart`                          | route-scoped timeline                       |
+| `presentation/widgets/photos_filter/filter_subheader_test.dart`             | A-4                                         |
+| `providers/timeline/overview_drilldown_provider_test.dart`                  | Z-1, Z-2                                    |
+| `providers/timeline/photos_overview_zoom_provider_test.dart`                | A-1…A-3                                     |
+| `providers/photos_filter/timeline_query_provider_test.dart`                 | Q-1…Q-3, Q-7 — **stays on `GroupAssetsBy`** |
+
+The last five files in the list were **not** touched by #911 and are easy to miss.
+
+### Expected test churn
+
+These are the only changes beyond identifier renames that are legitimate. Anything else is an escalation.
+
+| File                                  | Change                                                                                                             | Why                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `timeline_segment_provider_test.dart` | `containerFor(GroupAssetsBy)` re-plumbed to drive `timelineOverviewModeProvider` instead of `TimelineArgs.groupBy` | Three tests (`year grouping uses overview segments`, `month grouping uses overview segments`, `TimeBuckets with month setting still use overview segments`) currently select the overview through the pinned-args path, which the declared behaviour change closes. The assertions are unchanged — only the input moves to the correct provider. |
+| `timeline_grouping_anchor_test.dart`  | The `day:`, `auto:` and `none:` tests collapse into one `all:` test                                                | `TimelineOverviewMode` has three values, not five. Nothing is lost: all three asserted the identical "always returns bucket date" behaviour.                                                                                                                                                                                                     |
+| `overview_segment_builder_test.dart`  | The `ArgumentError` case changes from `GroupAssetsBy.day` to `TimelineOverviewMode.all`                            | Same guard, narrower type.                                                                                                                                                                                                                                                                                                                       |
 
 ### Explicitly NOT changed
 
@@ -217,16 +257,10 @@ The `TimelineFactory.groupBy` getter body is unchanged:
 
 ```bash
 cd /Users/pierre/dev/gallery/.claude/worktrees/fix-903-photo-grid-group-by
-git diff --numstat upstream/main:mobile/lib/domain/models/timeline.model.dart HEAD:mobile/lib/domain/models/timeline.model.dart
+git diff --numstat upstream/main -- mobile/lib/domain/models/timeline.model.dart
 ```
 
-Expected: this still reports the pre-edit `12 2` because it compares committed trees. Instead check the working tree:
-
-```bash
-git diff --numstat upstream/main:mobile/lib/domain/models/timeline.model.dart -- mobile/lib/domain/models/timeline.model.dart
-```
-
-Expected: `2	2`.
+Expected: `2	2`. (This form diffs `upstream/main` against the **working tree** for that path, so it reflects uncommitted edits. Verified working.)
 
 ```bash
 cd mobile
@@ -251,85 +285,103 @@ Takes timeline.model.dart back to two enum values of divergence from upstream."
 
 ---
 
-## Task 2: Guard the `none` invariant before anything can break it
+## Task 2: Prove the `none` invariant is already guarded
 
-Test-only. This characterises live behaviour that later tasks must not disturb, and it must be in place _before_ `normalizeGridGrouping`'s call sites move around.
-
-**Files:**
-
-- Modify: `mobile/test/providers/photos_filter/timeline_query_provider_test.dart`
-
-**Interfaces:**
-
-- Consumes: `normalizeGridGrouping` (Task 1) — only to prove it is _not_ applied here.
-- Produces: nothing. Pure guard.
-
-**Scenarios:** Q-1 (Route B — the behaviour exists at `timeline_query.provider.dart:54`).
-
-- [ ] **Step 1: Read the existing relevance test**
-
-The file already contains `smart filter with relevance sort uses groupBy=none (flat)` around line 516-539, which captures `groupBy` from the factory call. Read it — the new test copies its capture harness exactly.
-
-- [ ] **Step 2: Write the characterisation test**
-
-Add to `mobile/test/providers/photos_filter/timeline_query_provider_test.dart`, next to the existing relevance test:
+No new test. `timeline_query_provider_test.dart:508` already carries Q-1 in full:
 
 ```dart
-    test('Q-1: relevance sort keeps groupBy=none even when the grid setting is month', () async {
-      // The persisted Group by setting must not reach a relevance-sorted search:
-      // it has no date order, so it queries flat. Normalizing `none` to `day` here
-      // would silently re-introduce date bucketing.
+    test('smart filter with relevance sort uses groupBy=none (flat)', () async {
+      ...
       when(() => factory.groupBy).thenReturn(GroupAssetsBy.month);
-      GroupAssetsBy? capturedGroupBy;
-      when(
-        () => factory.fromAssetStream(
-          any(),
-          groupBy: any(named: 'groupBy'),
-          temporalScope: any(named: 'temporalScope'),
-        ),
-      ).thenAnswer((inv) {
-        capturedGroupBy = inv.namedArguments[const Symbol('groupBy')] as GroupAssetsBy;
-        return service;
-      });
-
-      buildPhotosTimelineQuery(ref, relevanceSortedSmartFilter);
-
+      ...
       expect(capturedGroupBy, GroupAssetsBy.none);
+      verifyNever(() => factory.groupBy);
     });
 ```
 
-Match the surrounding tests' setup: reuse whatever local names they use for `factory`, `ref`, `service` and the relevance-sorted filter fixture rather than inventing new ones.
+It already stubs the persisted setting to `month` and asserts the relevance path ignores it. What has never been established is whether it would **fail** if someone normalized the explicit grouping — the exact mistake this refactor invites. Establish that now, before Task 1's `normalizeGridGrouping` move puts the function within easy reach of this file.
 
-- [ ] **Step 3: Run it and confirm it passes**
+**Files:**
+
+- Modify: none, unless Step 2 shows the guard is missing.
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: nothing. Verification only.
+
+**Scenarios:** Q-1 (Route B — mutation check on an existing test).
+
+- [ ] **Step 1: Run the existing test and confirm it passes**
 
 ```bash
+cd mobile
 ~/.local/share/mise/installs/flutter/3.44.8/bin/flutter test test/providers/photos_filter/timeline_query_provider_test.dart
 ```
 
-Expected: PASS. A characterisation test starts green — Step 4 is what makes it real.
+Expected: PASS.
 
-- [ ] **Step 4: Mutate to prove the test bites**
+- [ ] **Step 2: Mutate to prove it bites**
 
-Temporarily edit `mobile/lib/providers/photos_filter/timeline_query.provider.dart:54` to normalize the explicit grouping — the exact mistake this guards:
+Temporarily edit `mobile/lib/providers/photos_filter/timeline_query.provider.dart:54`, wrapping the whole expression so the explicit `none` gets normalized:
 
 ```dart
   final effectiveGroupBy = normalizeGridGrouping(isRelevance ? GroupAssetsBy.none : (groupBy ?? factory.groupBy));
 ```
 
-Re-run the file.
+Add the `timeline.model.dart` import if the analyzer asks for it. Re-run the file.
 
 Expected: FAIL — `Expected: <GroupAssetsBy.none> Actual: <GroupAssetsBy.day>`.
 
-**Revert the mutation.** Re-run and confirm PASS.
+- [ ] **Step 3: Revert the mutation**
 
-- [ ] **Step 5: Commit**
+Restore line 54 exactly:
 
-```bash
-git add mobile/test/providers/photos_filter/timeline_query_provider_test.dart
-git commit -m "test(mobile): pin relevance search to flat grouping regardless of the grid setting"
+```dart
+  final effectiveGroupBy = isRelevance ? GroupAssetsBy.none : (groupBy ?? factory.groupBy);
 ```
 
----
+Re-run the file. Expected: PASS.
+
+- [ ] **Step 4: Only if Step 2 stayed green, add the missing guard**
+
+If the mutation did not produce a red, the existing test is not load-bearing. Add this next to it and repeat Steps 2-3 against the new test:
+
+```dart
+    test('Q-1: relevance sort keeps groupBy=none even when the grid setting is month', () async {
+      final factory = _MockFactory();
+      final search = _MockSearch();
+      final fake = _FakeService();
+      when(() => search.search(any(), 1)).thenAnswer((_) async => const SearchResult(assets: []));
+      when(() => factory.groupBy).thenReturn(GroupAssetsBy.month);
+      GroupAssetsBy? capturedGroupBy;
+      when(
+        () => factory.fromAssetStream(
+          any(),
+          any(),
+          TimelineOrigin.search,
+          groupBy: any(named: 'groupBy'),
+          descending: any(named: 'descending'),
+        ),
+      ).thenAnswer((inv) {
+        capturedGroupBy = inv.namedArguments[const Symbol('groupBy')] as GroupAssetsBy;
+        return fake;
+      });
+
+      final container = _container(factory: factory, search: search, user: _user('u1'));
+      container.read(photosFilterProvider.notifier).setText('paris');
+      addTearDown(container.dispose);
+
+      container.read(photosTimelineQueryProvider);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+
+      expect(capturedGroupBy, GroupAssetsBy.none);
+    });
+```
+
+- [ ] **Step 5: Record the result**
+
+No commit is needed if nothing changed. Note in the PR description that the relevance-search invariant was mutation-verified, so a later reader knows the guard is real rather than incidental.
 
 ## Task 3: The provider layer
 
@@ -378,11 +430,19 @@ void main() {
     await SettingsRepository.ensureInitialized(db);
   });
 
-  setUp(() {
+  // SettingsRepository.instance is a process-wide singleton: without this clear, a value
+  // written by one test leaks into the next and the failures look like ordering flakes.
+  setUp(() async {
+    await SettingsRepository.instance.clear(SettingsKey.values);
     container = ProviderContainer();
   });
 
   tearDown(() => container.dispose());
+
+  tearDownAll(() async {
+    await SettingsRepository.instance.clear(SettingsKey.values);
+    await db.close();
+  });
 
   Future<void> setGridSetting(GroupAssetsBy value) =>
       SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, value);
@@ -946,7 +1006,11 @@ Where the same literal meant **header granularity**, it stays `GroupAssetsBy`. T
 
 In `main_timeline_zoom_test.dart`, the mock timeline-service factories must keep honouring the `groupBy` the production code passes rather than re-reading the setting. #911 fixed this; do not reintroduce it.
 
-**If any test needs its assertions changed rather than its identifiers, stop and escalate.**
+**If any test needs its assertions changed rather than its identifiers, stop and escalate — unless it is one of the three rows in the "Expected test churn" table above.** Those three are pre-declared and legitimate:
+
+- `timeline_segment_provider_test.dart` — `containerFor` moves off `TimelineArgs.groupBy` onto `timelineOverviewModeProvider` for the three overview tests
+- `timeline_grouping_anchor_test.dart` — the `day:`/`auto:`/`none:` trio collapses into one `all:` test
+- `overview_segment_builder_test.dart` — the `ArgumentError` case retypes
 
 - [ ] **Step 14: Run the full suite**
 
@@ -996,12 +1060,24 @@ stops showing as reindented against upstream."
 
 ## Task 5: Fill the remaining scenario gaps
 
-Everything compiles and the retype is done. This task adds the scenarios the existing suite never covered.
+Everything compiles and the retype is done. This task adds only what the existing suite genuinely lacks.
+
+**Before writing anything, note what is already covered** — the plan's earlier drafts overstated this:
+
+| Scenario      | Already covered by                                                                                                                                                    |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| G-1, G-2      | `month setting renders a grid with month-only headers`, `month + day setting renders a grid with day headers`                                                         |
+| G-3, G-4      | `selecting Months still renders the overview cards`, `selecting Years still renders the overview cards`                                                               |
+| S-1, S-2, S-3 | `date-less buckets with month setting fall back to fixed grid segments` and its year twin                                                                             |
+| B-1, B-2, B-5 | `scrubber_segments_test.dart` lines 27-78, including the empty and date-less early returns                                                                            |
+| Z-3, Z-4, Z-5 | `timeline_scroll_target_test.dart` — `resolves a year anchor in month grouping`, `resolves a month anchor in day grouping`, `ignores anchors in stale grouping modes` |
+
+Those are Route B carry-overs: they must survive Task 4's rename unchanged. Do not duplicate them.
 
 **Files:**
 
 - Modify: `mobile/test/presentation/widgets/timeline/timeline_segment_provider_test.dart`
-- Modify: `mobile/test/presentation/widgets/timeline/timeline_zoom_anchor_resolution_test.dart`
+- Modify: `mobile/test/presentation/widgets/timeline/timeline_scroll_target_test.dart`
 - Modify: `mobile/test/presentation/widgets/timeline/scrubber_segments_test.dart`
 - Modify: `mobile/test/widgets/settings/asset_list_group_settings_test.dart`
 - Create: `mobile/test/domain/services/timeline_factory_grouping_test.dart`
@@ -1011,30 +1087,53 @@ Everything compiles and the retype is done. This task adds the scenarios the exi
 - Consumes: everything from Tasks 1, 3 and 4.
 - Produces: nothing. Coverage only.
 
-**Scenarios:** S-4, S-5, S-6, S-7, Z-6, B-4, B-5, L-3, F-1…F-4.
+**Scenarios:** S-4, S-5, S-6, S-7, Z-6, B-3, B-4, L-3, F-1…F-4.
 
-- [ ] **Step 1: Write the failing empty-bucket tests (S-4, S-5)**
+- [ ] **Step 1: Write the empty-bucket-in-overview tests (S-4, S-5)**
 
-Add to `timeline_segment_provider_test.dart`. `isDateless` is `buckets.isNotEmpty && buckets.first is! TimeBucket`, so an **empty** list is _not_ dateless and an overview-mode timeline reaches `TimelineOverviewSegmentBuilder` with no buckets:
+`timeline_segment_provider_test.dart` already has `empty bucket list with month setting produces no segments and no throw`, but it drives the empty case through `TimelineArgs(groupBy: month)` — the pinned path, which after Task 4 means "All" and never reaches the overview builder. The overview-with-empty-buckets path therefore becomes uncovered. Restore it through the mode provider.
+
+Add inside the existing `group('grid grouping follows the persisted Group by setting', ...)`, which already has the Drift setup and the `settingsBackedContainer()` helper. Add an empty-bucket variant next to it:
 
 ```dart
+    ProviderContainer emptyBucketContainer() {
+      final service = TimelineService((
+        assetSource: (offset, count) async => const [],
+        bucketSource: () => Stream.value(const <Bucket>[]),
+        origin: TimelineOrigin.main,
+      ));
+
+      final container = ProviderContainer(
+        overrides: [
+          timelineServiceProvider.overrideWithValue(service),
+          timelineArgsProvider.overrideWithValue(const TimelineArgs(maxWidth: 390, maxHeight: 800, columnCount: 3)),
+        ],
+      );
+      addTearDown(() async {
+        container.dispose();
+        await service.dispose();
+      });
+      return container;
+    }
+
     test('S-4: empty buckets in Months mode produce no segments and do not throw', () async {
-      await setMode(TimelineOverviewMode.months);
-      bucketController.add(<Bucket>[]);
-      final segments = await readSegments();
+      final container = emptyBucketContainer();
+      await container.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.months);
+
+      final segments = await container.read(timelineSegmentProvider.future);
+
       expect(segments, isEmpty);
     });
 
     test('S-5: empty buckets in All mode with the month setting produce no segments', () async {
-      await setGridSetting(GroupAssetsBy.month);
-      await setMode(TimelineOverviewMode.all);
-      bucketController.add(<Bucket>[]);
-      final segments = await readSegments();
+      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
+      final container = emptyBucketContainer();
+
+      final segments = await container.read(timelineSegmentProvider.future);
+
       expect(segments, isEmpty);
     });
 ```
-
-Reuse the file's existing harness names for the bucket stream and segment read.
 
 - [ ] **Step 2: Run them**
 
@@ -1042,138 +1141,200 @@ Reuse the file's existing harness names for the bucket stream and segment read.
 ~/.local/share/mise/installs/flutter/3.44.8/bin/flutter test test/presentation/widgets/timeline/timeline_segment_provider_test.dart
 ```
 
-Expected: PASS — the loop in `generate()` never runs on an empty list.
+Expected: PASS — `TimelineOverviewSegmentBuilder.generate()`'s loop never runs on an empty list.
 
-**If either throws**, that is a real pre-existing bug on `main`. Fix it here by returning early from `TimelineOverviewSegmentBuilder.generate()` on empty input, and say so in the commit message.
+**If S-4 throws**, that is a real pre-existing bug reachable from the pill on an empty library. Fix it by returning early from `generate()` on empty input and say so in the commit message.
 
 - [ ] **Step 3: Write the pinned-grouping tests (S-6, S-7)**
 
+These pin the declared behaviour change. Add at top level, next to the existing `containerFor` tests:
+
 ```dart
-    test('S-6: a pinned groupBy never reaches the overview builder', () async {
-      await setMode(TimelineOverviewMode.months);
-      setPinnedGroupBy(GroupAssetsBy.day);
-      bucketController.add(timeBuckets);
-      final segments = await readSegments();
-      expect(segments.every((s) => s is! TimelineOverviewSegment), isTrue);
-    });
+  test('S-6: a pinned groupBy renders the flat grid and never the overview', () async {
+    // TimelineArgs.groupBy is upstream's header-granularity field, not a zoom level.
+    final container = containerFor(GroupAssetsBy.month);
 
-    test('S-7: with a pinned groupBy, mode and setting changes leave the segments alone', () async {
-      setPinnedGroupBy(GroupAssetsBy.day);
-      bucketController.add(timeBuckets);
-      final before = await readSegments();
+    final segments = await container.read(timelineSegmentProvider.future);
 
-      await setMode(TimelineOverviewMode.years);
-      await setGridSetting(GroupAssetsBy.month);
-      final after = await readSegments();
+    expect(segments, everyElement(isA<FixedSegment>()));
+    expect(segments.map((segment) => segment.header), everyElement(HeaderType.month));
+  });
 
-      expect(after.length, before.length);
-      expect(after.every((s) => s is! TimelineOverviewSegment), isTrue);
-    });
+  test('S-7: with a pinned groupBy, the mode is ignored', () async {
+    final container = containerFor(GroupAssetsBy.day);
+    await container.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.years);
+
+    final segments = await container.read(timelineSegmentProvider.future);
+
+    expect(segments, everyElement(isA<FixedSegment>()));
+  });
 ```
+
+`containerFor` keeps its `GroupAssetsBy` parameter — it sets `TimelineArgs.groupBy`, which stays `GroupAssetsBy`.
 
 - [ ] **Step 4: Write the critical anchor test (Z-6)**
 
-Add to `timeline_zoom_anchor_resolution_test.dart`:
+This belongs in `timeline_scroll_target_test.dart`, which tests `findTimelineZoomAnchorSegment` as a pure function — not in `timeline_zoom_anchor_resolution_test.dart`, which is widget-level.
+
+Reuse the file's existing segment fixtures. The point is that a month anchor resolves in **All** mode even when the segments were built at month granularity because Group by is Month:
 
 ```dart
-    test('Z-6: a month anchor still resolves in All mode when Group by is Month', () async {
-      // Regression guard: if the anchor is fed spec.groupBy instead of spec.mode, the
-      // month setting makes the granularity `month`, the `all` guard stops matching, and
-      // drilling from Months into All silently fails to scroll.
-      await setGridSetting(GroupAssetsBy.month);
-      final segments = monthGranularitySegments;
-      final target = findTimelineZoomAnchorSegment(
-        segments,
-        const TimelineZoomMonthAnchor(year: 2026, month: 3),
-        TimelineOverviewMode.all,
-      );
-      expect(target, isNotNull);
-    });
+  test('Z-6: findTimelineZoomAnchorSegment resolves a month anchor in All mode over month-granularity segments', () {
+    // Regression guard: if the anchor is handed spec.groupBy instead of spec.mode, a
+    // Group by = Month library makes the granularity `month`, the `all` guard stops
+    // matching, and drilling from Months into All silently fails to scroll.
+    final segments = _segments([
+      TimeBucket(date: DateTime(2026, 4), assetCount: 2),
+      TimeBucket(date: DateTime(2026, 3), assetCount: 2),
+    ]);
+
+    final target = findTimelineZoomAnchorSegment(
+      segments,
+      const TimelineZoomMonthAnchor(year: 2026, month: 3),
+      TimelineOverviewMode.all,
+    );
+
+    expect(target, isNotNull);
+    expect((target!.bucket as TimeBucket).date, DateTime(2026, 3));
+  });
 ```
+
+Match the file's own fixture builder — read the top of `timeline_scroll_target_test.dart` and use whatever it already uses to turn buckets into `List<Segment>` rather than introducing `_segments` if a differently-named helper exists.
 
 - [ ] **Step 5: Run it, then mutate to prove it bites**
 
 ```bash
-~/.local/share/mise/installs/flutter/3.44.8/bin/flutter test test/presentation/widgets/timeline/timeline_zoom_anchor_resolution_test.dart
+~/.local/share/mise/installs/flutter/3.44.8/bin/flutter test test/presentation/widgets/timeline/timeline_scroll_target_test.dart
 ```
 
 Expected: PASS.
 
-Then temporarily change the test's third argument from `TimelineOverviewMode.all` to `TimelineOverviewMode.months` — simulating the anchor being handed the wrong concept. Re-run.
+Now change the test's third argument to `TimelineOverviewMode.months` — simulating the anchor being handed the granularity concept instead of the zoom level. Re-run.
 
 Expected: FAIL — `Expected: not null; Actual: <null>`.
 
 **Revert** and confirm PASS.
 
-- [ ] **Step 6: Add the scrubber pins (B-4, B-5)**
+- [ ] **Step 6: Add the scrubber granularity pins (B-3, B-4)**
+
+`scrubber_segments_test.dart` already covers year vs month formatting and both empty cases. What is missing is the pin that the scrubber follows `spec.groupBy` — that a Group by = Month library still labels month+year:
 
 ```dart
-    test('B-4: All mode with Month + day still labels month+year', () {
-      final segments = buildScrubberSegments(
-        layoutSegments: dayGranularitySegments,
-        timelineHeight: 800,
-        groupBy: GroupAssetsBy.day,
-      );
-      expect(segments.first.scrollLabel, matches(RegExp(r'^\w+ \d{4}$')));
-    });
+  test('B-3: month granularity labels month+year', () {
+    final scrubberSegments = buildScrubberSegments(
+      layoutSegments: segments,
+      timelineHeight: 300,
+      groupBy: GroupAssetsBy.month,
+    );
 
-    test('B-5: date-less layout segments produce no scrubber segments', () {
-      final segments = buildScrubberSegments(
-        layoutSegments: datelessSegments,
-        timelineHeight: 800,
-        groupBy: GroupAssetsBy.day,
-      );
-      expect(segments, isEmpty);
-    });
+    expect(scrubberSegments.first.scrollLabel, isNot(matches(RegExp(r'^\d{4}$'))));
+  });
+
+  test('B-4: day granularity labels month+year, same as month', () {
+    final scrubberSegments = buildScrubberSegments(
+      layoutSegments: segments,
+      timelineHeight: 300,
+      groupBy: GroupAssetsBy.day,
+    );
+
+    expect(scrubberSegments.first.scrollLabel, isNot(matches(RegExp(r'^\d{4}$'))));
+  });
 ```
+
+Use the file's existing `segments` fixture. Assert "not a bare year" rather than a locale-specific month name — the label comes from `DateFormat.yMMM`, whose output varies by locale.
 
 - [ ] **Step 7: Add the legacy settings test (L-3)**
 
-Add to `asset_list_group_settings_test.dart`. Assert a radio is **selected** — "renders with nothing selected" is the actual failure mode:
+`asset_list_group_settings_test.dart` uses `tester.pumpConsumerWidget(const GroupSettings())` and clears settings in `setUp`. The widget renders `SettingsRadioListTile<GroupAssetsBy>`, which wraps a `RadioGroup` — the individual `RadioListTile`s carry no `groupValue`, so assert against the `SettingsRadioListTile` itself:
 
 ```dart
-    testWidgets('L-3: a stored year value falls back to Month + day selected', (tester) async {
-      await setGridSetting(GroupAssetsBy.year);
-      await pumpGroupSettings(tester);
+  testWidgets('a stored year value falls back to Month + day selected', (tester) async {
+    // The Year option shipped in a fork build, so a real user can have `year` stored.
+    // It must resolve to a selected radio, not an empty selection.
+    await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.year);
 
-      final monthDayTile = tester.widget<RadioListTile<GroupAssetsBy>>(
-        find.byWidgetPredicate(
-          (w) => w is RadioListTile<GroupAssetsBy> && w.value == GroupAssetsBy.day,
-        ),
-      );
-      expect(monthDayTile.groupValue, GroupAssetsBy.day);
-    });
+    await tester.pumpConsumerWidget(const GroupSettings());
+    await tester.pumpAndSettle();
+
+    final tile = tester.widget<SettingsRadioListTile<GroupAssetsBy>>(
+      find.byType(SettingsRadioListTile<GroupAssetsBy>),
+    );
+
+    expect(tile.groupBy, GroupAssetsBy.day);
+  });
 ```
 
-Match the widget type the settings screen actually renders — read `settings_radio_list_tile.dart` and assert against that type rather than assuming `RadioListTile`.
+Add the import for `package:immich_mobile/widgets/settings/settings_radio_list_tile.dart`.
 
-- [ ] **Step 8: Create the factory fallback tests (F-1…F-4)**
+- [ ] **Step 8: Mutate L-3 to prove it bites**
 
-Create `mobile/test/domain/services/timeline_factory_grouping_test.dart`, modelled on the existing `timeline_factory_temporal_scope_test.dart` in the same directory:
+Temporarily revert `asset_list_group_settings.dart` to read `appConfigProvider` directly without normalization. Re-run the file.
+
+Expected: FAIL — `Expected: <GroupAssetsBy.day> Actual: <GroupAssetsBy.year>`.
+
+**Revert** and confirm PASS.
+
+- [ ] **Step 9: Create the factory fallback tests (F-1…F-4)**
+
+Create `mobile/test/domain/services/timeline_factory_grouping_test.dart`, modelled on `timeline_factory_temporal_scope_test.dart` in the same directory, which mocks with `class _MockSettingsRepository extends Mock implements SettingsRepository {}` and stubs `when(() => settingsRepo.appConfig).thenReturn(const AppConfig())`:
 
 ```dart
-    test('F-1: month is preserved', () {
-      when(() => settingsRepository.appConfig).thenReturn(configWith(GroupAssetsBy.month));
-      expect(factory.groupBy, GroupAssetsBy.month);
-    });
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/domain/models/config/app_config.dart';
+import 'package:immich_mobile/domain/models/config/timeline_config.dart';
+import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/services/timeline.service.dart';
+import 'package:immich_mobile/infrastructure/repositories/settings.repository.dart';
+import 'package:immich_mobile/infrastructure/repositories/timeline.repository.dart';
+import 'package:mocktail/mocktail.dart';
 
-    test('F-2: day is preserved', () {
-      when(() => settingsRepository.appConfig).thenReturn(configWith(GroupAssetsBy.day));
-      expect(factory.groupBy, GroupAssetsBy.day);
-    });
+class _MockTimelineRepository extends Mock implements DriftTimelineRepository {}
 
-    test('F-3: a stored year falls back to day', () {
-      when(() => settingsRepository.appConfig).thenReturn(configWith(GroupAssetsBy.year));
-      expect(factory.groupBy, GroupAssetsBy.day);
-    });
+class _MockSettingsRepository extends Mock implements SettingsRepository {}
 
-    test('F-4: auto falls back to day', () {
-      when(() => settingsRepository.appConfig).thenReturn(configWith(GroupAssetsBy.auto));
-      expect(factory.groupBy, GroupAssetsBy.day);
-    });
+void main() {
+  late _MockSettingsRepository settingsRepo;
+  late TimelineFactory factory;
+
+  setUp(() {
+    settingsRepo = _MockSettingsRepository();
+    factory = TimelineFactory(timelineRepository: _MockTimelineRepository(), settingsRepository: settingsRepo);
+  });
+
+  void storedSetting(GroupAssetsBy value) {
+    when(() => settingsRepo.appConfig).thenReturn(AppConfig(timeline: TimelineConfig(groupAssetsBy: value)));
+  }
+
+  test('F-1: month is preserved', () {
+    storedSetting(GroupAssetsBy.month);
+    expect(factory.groupBy, GroupAssetsBy.month);
+  });
+
+  test('F-2: day is preserved', () {
+    storedSetting(GroupAssetsBy.day);
+    expect(factory.groupBy, GroupAssetsBy.day);
+  });
+
+  test('F-3: a leftover year falls back to day', () {
+    storedSetting(GroupAssetsBy.year);
+    expect(factory.groupBy, GroupAssetsBy.day);
+  });
+
+  test('F-4: auto falls back to day', () {
+    storedSetting(GroupAssetsBy.auto);
+    expect(factory.groupBy, GroupAssetsBy.day);
+  });
+
+  test('none falls back to day as a persisted value', () {
+    storedSetting(GroupAssetsBy.none);
+    expect(factory.groupBy, GroupAssetsBy.day);
+  });
+}
 ```
 
-- [ ] **Step 9: Run everything**
+Check `TimelineFactory`'s constructor parameter names against `lib/domain/services/timeline.service.dart` before running — they are private fields (`_timelineRepository`, `_settingsRepository`) exposed as named parameters.
+
+- [ ] **Step 10: Run everything**
 
 ```bash
 ~/.local/share/mise/installs/flutter/3.44.8/bin/flutter test
@@ -1181,16 +1342,14 @@ Create `mobile/test/domain/services/timeline_factory_grouping_test.dart`, modell
 ~/.local/share/mise/installs/flutter/3.44.8/bin/dart format lib
 ```
 
-Expected: all green, count up by ~12.
+Expected: 0 failures, count up by 12 over the Task 4 total.
 
-- [ ] **Step 10: Commit**
+- [ ] **Step 11: Commit**
 
 ```bash
 git add mobile/test
-git commit -m "test(mobile): cover the empty-bucket, pinned-grouping and legacy-setting edges"
+git commit -m "test(mobile): cover the empty-overview, pinned-grouping and legacy-setting edges"
 ```
-
----
 
 ## Task 6: Filter and integration scenarios, then verify the outcome
 
@@ -1239,7 +1398,7 @@ for f in mobile/lib/presentation/widgets/timeline/timeline.state.dart \
          mobile/lib/domain/models/timeline.model.dart \
          mobile/lib/widgets/settings/asset_list_settings/asset_list_group_settings.dart; do
   printf "%-60s " "$(basename $f)"
-  git diff --numstat "upstream/main:$f" -- "$f" | awk '{print $1"+/"$2"-"}'
+  git diff --numstat upstream/main -- "$f" | awk '{print $1"+/"$2"-"}'
 done
 ```
 
@@ -1290,10 +1449,23 @@ PR #911's body describes the original three-provider fix. Rewrite the "The fix" 
 
 ## Self-Review
 
-**Spec coverage.** Every design section maps to a task: §1 → Task 1; §2 → Task 3; §3 → Task 4 Step 10; §4 → Task 4 Steps 2-8; §5 → Task 4 Step 9; §6 → Task 2; §7 → Task 5 Step 7. All 63 scenarios are assigned: G-1…G-5, S-1…S-3 and R-1…R-5, Z-1…Z-5, Z-7…Z-8, A-1…A-4, P-1…P-5, B-1…B-3 are existing tests migrated in Task 4 Step 13; S-4…S-7, Z-6, B-4, B-5, L-3, F-1…F-4 are added in Task 5; L-1, L-2, L-4, L-5 in Task 1; M-1…M-7 in Task 3; Q-1 in Task 2; Q-2…Q-7 in Task 6.
+**Verified against the codebase, not from memory.** Every helper, signature and file path in this plan was checked against the working tree. The audit changed the plan in six substantive ways:
 
-**Two spec gaps found and handled here:** `overview_segment.model.dart` and `overview_representative_cache.provider.dart` are in the retype blast radius but absent from the spec's §4 list. Both are retyped in Task 4 (Steps 5 and 3) and the spec is corrected in Task 6 Step 5.
+1. **A design conflict surfaced.** `timeline_segment_provider_test.dart`'s `containerFor()` drives grouping through `TimelineArgs.groupBy`, which today selects the overview. The design maps a pinned `groupByArg` to "All", so three existing tests change input. This is now a declared behaviour change in Global Constraints plus a row in the churn table, rather than something the implementer would hit as a surprise escalation.
+2. **The test blast radius is 16 files, not the 12 #911 touched.** `timeline_scroll_target_test.dart`, `timeline_grouping_anchor_test.dart`, `overview_segment_builder_test.dart`, `timeline_overview_card_test.dart` and `drift_favorite_page_test.dart` were missing.
+3. **Q-1 is already covered** by `timeline_query_provider_test.dart:508`, which even asserts `verifyNever(() => factory.groupBy)`. Task 2 became a mutation check on the existing test instead of a near-duplicate.
+4. **Several scenarios were already covered** — G-1…G-4 by the `grid grouping follows the persisted Group by setting` group, S-1…S-3, B-1, B-2, B-5, Z-3…Z-5. Task 5 now opens with what not to duplicate.
+5. **Z-6 was in the wrong file.** It belongs in `timeline_scroll_target_test.dart` (pure function), not `timeline_zoom_anchor_resolution_test.dart` (widget-level).
+6. **L-3's assertion targeted a widget that carries no such field.** `SettingsRadioListTile<T>` wraps a `RadioGroup`; its `RadioListTile`s have no `groupValue`. The assertion now reads `SettingsRadioListTile<GroupAssetsBy>.groupBy`.
 
-**Type consistency.** `TimelineOverviewMode` values are `years`/`months`/`all` everywhere — never `year`/`month`/`day`. `TimelineGroupingSpec` is a record with fields `mode` and `groupBy`; every read uses `spec.mode` or `spec.groupBy`. The drilldown handler's second parameter is `mode` in the typedef, the implementation and the call site. `TimelineOverviewSegmentBuilder` takes `mode`, not `groupBy` — its inherited `SegmentBuilder.groupBy` stays at the upstream default and is unused.
+**Real names now used throughout:** `containerFor(...)`, `settingsBackedContainer()`, `SettingsRepository.instance.write(...)` / `.clear(SettingsKey.values)`, `tester.pumpConsumerWidget(const GroupSettings())`, `_MockFactory` / `_MockSearch` / `_FakeService` / `_container(...)` / `_user(...)`, `_MockSettingsRepository` + `AppConfig(timeline: TimelineConfig(...))`, `buildScrubberSegments(layoutSegments:, timelineHeight:, groupBy:)`.
 
-**Known risk.** Task 4 leaves the tree uncompilable between Steps 2 and 12. That is inherent to a Dart type flip and cannot be avoided without a temporary shim that would itself be churn. The task ends green, `dart analyze` is the intermediate signal, and Step 1 records the baseline to return to.
+**Verified facts:** baseline is 2902 passing / 1 skipped (measured, ~59s); `analysis_options.yaml:13` sets `page_width: 120`; the 4-entry dependency list is 124 chars and the 3-entry one 96; `SettingsRepository.write<T, U extends T>(SettingsKey<T>, U)` exists; `git diff --numstat upstream/main -- <path>` diffs against the working tree correctly.
+
+**Spec coverage.** §1 → Task 1; §2 → Task 3; §3 → Task 4 Step 10; §4 → Task 4 Steps 2-8; §5 → Task 4 Step 9; §6 → Task 2; §7 → Task 5 Step 7. All 63 scenarios are assigned to a task or listed as already-covered carry-overs.
+
+**Two spec gaps handled here:** `overview_segment.model.dart` and `overview_representative_cache.provider.dart` are in the retype blast radius but absent from the spec's §4 list. Both are retyped in Task 4 (Steps 5 and 3); the spec is corrected in Task 6 Step 5.
+
+**Type consistency.** `TimelineOverviewMode` values are `years`/`months`/`all` everywhere — never `year`/`month`/`day`. `TimelineGroupingSpec` is a record with fields `mode` and `groupBy`. The drilldown handler's second parameter is `mode` in the typedef, implementation and call site. `TimelineOverviewSegmentBuilder` takes `mode`; its inherited `SegmentBuilder.groupBy` stays at the upstream default, unused. `TimelineArgs.groupBy`, the scrubber chain and the query layer stay `GroupAssetsBy`.
+
+**Known risk.** Task 4 leaves the tree uncompilable between Steps 2 and 12. That is inherent to a Dart type flip and cannot be avoided without a temporary shim that would be its own churn. `dart analyze` is the intermediate signal, Step 1 records the baseline, and the task ends green.

--- a/docs/superpowers/plans/2026-08-02-timeline-grouping-upstream-divergence.md
+++ b/docs/superpowers/plans/2026-08-02-timeline-grouping-upstream-divergence.md
@@ -1,0 +1,1299 @@
+# Timeline Grouping Upstream-Divergence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the fork's Years/Months/All timeline selector its own type so it can no longer be confused with upstream's Group-by header granularity, and return the upstream-owned files PR #911 touched to near their original divergence.
+
+**Architecture:** A new fork-only `TimelineOverviewMode { years, months, all }` becomes the selector's state type. A single derived provider, `timelineGroupingSpecProvider`, resolves that mode plus the persisted Group-by setting into one record `(mode, groupBy)` — the only thing `timeline.state.dart` needs to watch. Upstream's `GroupAssetsBy` keeps its original meaning everywhere else: buckets, headers, the scrubber, and the query layer.
+
+**Tech Stack:** Flutter 3.44.8, Dart, Riverpod (`hooks_riverpod`), Drift, `flutter_test` + `mocktail`.
+
+**Spec:** `docs/superpowers/specs/2026-08-02-timeline-grouping-upstream-divergence-design.md`
+
+## Global Constraints
+
+- **Flutter 3.44.8 exactly.** Pinned in `mobile/mise.toml` (`"aqua:flutter/flutter" = "3.44.8"`). `mise exec` resolves the wrong version — invoke the binaries directly: `~/.local/share/mise/installs/flutter/3.44.8/bin/flutter` and `.../bin/dart`.
+- **All commands run from `mobile/`.**
+- **Formatter page width is 120** (`mobile/analysis_options.yaml:13`). Exceeding it changes how `dart format` wraps and can silently reindent whole blocks.
+- **Three blocking CI gates, all required:** `flutter test`, `dart analyze --fatal-infos lib test`, `dart format lib`. `dart analyze` is not a substitute for `flutter test`.
+- **Baseline: 2902 tests passing, 0 failures.** The count may only go up.
+- **No behaviour change.** Nothing in this plan alters what the app does. If an existing test needs its _assertions_ changed rather than just its _identifiers_, stop and escalate — the retype has changed semantics.
+- **No production line before a failing test names it.** Every scenario must be observed red before it is trusted, by one of two routes: write-first for new behaviour, or characterise-then-mutate for existing behaviour.
+- **`normalizeGridGrouping` applies only where the persisted setting is read.** Never to a grouping a caller passed explicitly — `GroupAssetsBy.none` is live for relevance search.
+- **Commit after every task.** Never use `--no-verify`. Never add a `Co-Authored-By` trailer.
+- **Landing branch:** `worktree-fix-903-photo-grid-group-by`, on top of PR #911.
+
+---
+
+## File Structure
+
+### Created
+
+| File                                                              | Responsibility                                                                                                      |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `mobile/lib/domain/models/timeline_grouping.model.dart`           | Fork-only vocabulary: `TimelineOverviewMode`, `TimelineGroupingSpec`, `normalizeGridGrouping`. Zero rebase surface. |
+| `mobile/test/domain/models/timeline_grouping_model_test.dart`     | L-1, L-2, L-4, L-5                                                                                                  |
+| `mobile/test/providers/timeline/timeline_grouping_spec_test.dart` | M-1…M-7                                                                                                             |
+| `mobile/test/domain/services/timeline_factory_grouping_test.dart` | F-1…F-4                                                                                                             |
+
+### Modified — fork-only (free to retype)
+
+| File                                                                       | Change                                                 |
+| -------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `lib/providers/timeline/timeline_grouping.provider.dart`                   | Rewrite: mode provider + grid provider + spec provider |
+| `lib/providers/timeline/overview_drilldown.provider.dart`                  | Handler typedef and switch take the mode               |
+| `lib/providers/timeline/overview_representative_cache.provider.dart`       | `keyFor` takes the mode                                |
+| `lib/presentation/widgets/timeline/timeline_grouping_selector.widget.dart` | Pill positions, labels, zoom cycle                     |
+| `lib/presentation/widgets/timeline/timeline_grouping_anchor.dart`          | `previousGroupBy` → `previousMode`                     |
+| `lib/presentation/widgets/timeline/timeline_scroll_target.dart`            | Anchor guards take the mode                            |
+| `lib/presentation/widgets/timeline/timeline_route_scope.dart`              | Overrides the mode provider, reads the spec            |
+| `lib/presentation/widgets/timeline/overview/overview_segment_builder.dart` | Takes the mode                                         |
+| `lib/presentation/widgets/timeline/overview/overview_segment.model.dart`   | Segment carries the mode                               |
+| `lib/presentation/widgets/timeline/overview/overview_card.dart`            | Card takes the mode                                    |
+
+### Modified — upstream-owned (keep the delta minimal)
+
+| File                                                                      | Change                                               | Divergence target    |
+| ------------------------------------------------------------------------- | ---------------------------------------------------- | -------------------- |
+| `lib/domain/models/timeline.model.dart`                                   | Remove `normalizeGridGrouping`                       | 12+/2- → 2+/2-       |
+| `lib/presentation/widgets/timeline/timeline.state.dart`                   | Single-provider watch, upstream indentation restored | 48+/20- → ~12+/3-    |
+| `lib/widgets/settings/asset_list_settings/asset_list_group_settings.dart` | Watch `timelineGridGroupingProvider`                 | 3+/1- → ~2+/1-       |
+| `lib/domain/services/timeline.service.dart`                               | Import moves to the new model file                   | ~unchanged           |
+| `lib/presentation/widgets/timeline/timeline.widget.dart`                  | 4 sites split between mode and `spec.groupBy`        | 280+/64- → ~284+/68- |
+
+### Explicitly NOT changed
+
+- `scrubber.widget.dart` (upstream, 45+/82-) and `scrubber_segments.dart` — the whole chain stays on `GroupAssetsBy` and receives `spec.groupBy`. Its `groupBy` is a pure granularity; only `year` is special-cased.
+- `timeline_query.provider.dart` — the explicit query grouping, including `GroupAssetsBy.none` for relevance search, is untouched.
+- `timeline.repository.dart`, `fixed/segment_builder.dart`, `segment_builder.dart`, `header.widget.dart` — `GroupAssetsBy.year` and `HeaderType.year` stay.
+
+---
+
+## Task 1: Fork-only vocabulary
+
+Pure addition. Nothing else changes yet, so the suite stays green throughout.
+
+**Files:**
+
+- Create: `mobile/lib/domain/models/timeline_grouping.model.dart`
+- Create: `mobile/test/domain/models/timeline_grouping_model_test.dart`
+- Modify: `mobile/lib/domain/models/timeline.model.dart` (remove `normalizeGridGrouping`, lines 5-14)
+- Modify: `mobile/lib/domain/services/timeline.service.dart` (import only)
+
+**Interfaces:**
+
+- Consumes: `GroupAssetsBy` from `package:immich_mobile/domain/models/timeline.model.dart`
+- Produces:
+  - `enum TimelineOverviewMode { years, months, all }`
+  - `typedef TimelineGroupingSpec = ({TimelineOverviewMode mode, GroupAssetsBy groupBy})`
+  - `GroupAssetsBy normalizeGridGrouping(GroupAssetsBy groupBy)`
+
+**Scenarios:** L-1, L-2, L-4, L-5 (Route A — this function has no direct test today).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mobile/test/domain/models/timeline_grouping_model_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
+
+void main() {
+  group('normalizeGridGrouping', () {
+    test('L-1: day stays day', () {
+      expect(normalizeGridGrouping(GroupAssetsBy.day), GroupAssetsBy.day);
+    });
+
+    test('L-2: month stays month', () {
+      expect(normalizeGridGrouping(GroupAssetsBy.month), GroupAssetsBy.month);
+    });
+
+    test('L-4: auto falls back to day', () {
+      expect(normalizeGridGrouping(GroupAssetsBy.auto), GroupAssetsBy.day);
+    });
+
+    test('L-5: none falls back to day as a persisted setting value', () {
+      expect(normalizeGridGrouping(GroupAssetsBy.none), GroupAssetsBy.day);
+    });
+
+    test('year, left behind by the removed Year option, falls back to day', () {
+      expect(normalizeGridGrouping(GroupAssetsBy.year), GroupAssetsBy.day);
+    });
+  });
+
+  group('TimelineOverviewMode', () {
+    test('has exactly the three selector positions', () {
+      expect(TimelineOverviewMode.values, [
+        TimelineOverviewMode.years,
+        TimelineOverviewMode.months,
+        TimelineOverviewMode.all,
+      ]);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+~/.local/share/mise/installs/flutter/3.44.8/bin/flutter test test/domain/models/timeline_grouping_model_test.dart
+```
+
+Expected: FAIL — `Target of URI doesn't exist: 'package:immich_mobile/domain/models/timeline_grouping.model.dart'`.
+
+- [ ] **Step 3: Create the model file**
+
+Create `mobile/lib/domain/models/timeline_grouping.model.dart`:
+
+```dart
+import 'package:immich_mobile/domain/models/timeline.model.dart';
+
+/// Which zoom level the timeline is at. Fork-only: upstream has no overview.
+///
+/// Deliberately NOT [GroupAssetsBy]. That type means "how coarse are the photo
+/// grid's date headers"; this one means "which zoom level is the timeline at".
+/// Storing the second in the first is what caused #903.
+enum TimelineOverviewMode { years, months, all }
+
+/// What the timeline should render for the current scope: which zoom level, and
+/// the bucket/header granularity that goes with it.
+typedef TimelineGroupingSpec = ({TimelineOverviewMode mode, GroupAssetsBy groupBy});
+
+/// Clamps the persisted "Photo Grid" -> "Group by" setting to the two granularities
+/// the grid renders: month + day headers ([GroupAssetsBy.day]) or month-only headers
+/// ([GroupAssetsBy.month]).
+///
+/// Legacy `auto`/`none`, and `year` left behind by the removed Year option, all fall
+/// back to day.
+///
+/// Apply this ONLY where the persisted setting is read. Never apply it to a grouping a
+/// caller passed explicitly: `timeline_query.provider.dart` passes [GroupAssetsBy.none]
+/// deliberately for relevance-sorted search, and normalizing it to day would silently
+/// re-introduce date bucketing there.
+GroupAssetsBy normalizeGridGrouping(GroupAssetsBy groupBy) =>
+    groupBy == GroupAssetsBy.month ? GroupAssetsBy.month : GroupAssetsBy.day;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+~/.local/share/mise/installs/flutter/3.44.8/bin/flutter test test/domain/models/timeline_grouping_model_test.dart
+```
+
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Remove the duplicate from the upstream model file**
+
+In `mobile/lib/domain/models/timeline.model.dart`, delete the whole `normalizeGridGrouping` block added by #911 (the doc comment and the function, between the `HeaderType` enum and `enum SortAssetsBy`). The file must read:
+
+```dart
+enum GroupAssetsBy { day, month, auto, none, year }
+
+enum HeaderType { none, month, day, monthAndDay, year }
+
+enum SortAssetsBy { taken, uploaded }
+```
+
+- [ ] **Step 6: Repoint the one production consumer**
+
+In `mobile/lib/domain/services/timeline.service.dart`, add the import (keep the existing `timeline.model.dart` import — `GroupAssetsBy` still comes from there):
+
+```dart
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
+```
+
+The `TimelineFactory.groupBy` getter body is unchanged:
+
+```dart
+  /// Fallback only: timeline routes pass groupBy explicitly from
+  /// `timelineGroupingSpecProvider`. The persisted setting is a grid header granularity, so
+  /// anything other than month (legacy `auto`/`none`, or `year` from the removed Year option)
+  /// falls back to day.
+  GroupAssetsBy get groupBy => normalizeGridGrouping(_settingsRepository.appConfig.timeline.groupAssetsBy);
+```
+
+- [ ] **Step 7: Verify divergence dropped and the suite is green**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/fix-903-photo-grid-group-by
+git diff --numstat upstream/main:mobile/lib/domain/models/timeline.model.dart HEAD:mobile/lib/domain/models/timeline.model.dart
+```
+
+Expected: this still reports the pre-edit `12 2` because it compares committed trees. Instead check the working tree:
+
+```bash
+git diff --numstat upstream/main:mobile/lib/domain/models/timeline.model.dart -- mobile/lib/domain/models/timeline.model.dart
+```
+
+Expected: `2	2`.
+
+```bash
+cd mobile
+~/.local/share/mise/installs/flutter/3.44.8/bin/flutter test
+~/.local/share/mise/installs/flutter/3.44.8/bin/dart analyze --fatal-infos lib test
+~/.local/share/mise/installs/flutter/3.44.8/bin/dart format lib
+```
+
+Expected: 2908 passing (2902 + 6), analyze clean, format reports no changes.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mobile/lib/domain/models/timeline_grouping.model.dart \
+        mobile/test/domain/models/timeline_grouping_model_test.dart \
+        mobile/lib/domain/models/timeline.model.dart \
+        mobile/lib/domain/services/timeline.service.dart
+git commit -m "refactor(mobile): move the grid grouping vocabulary to a fork-only model file
+
+Takes timeline.model.dart back to two enum values of divergence from upstream."
+```
+
+---
+
+## Task 2: Guard the `none` invariant before anything can break it
+
+Test-only. This characterises live behaviour that later tasks must not disturb, and it must be in place _before_ `normalizeGridGrouping`'s call sites move around.
+
+**Files:**
+
+- Modify: `mobile/test/providers/photos_filter/timeline_query_provider_test.dart`
+
+**Interfaces:**
+
+- Consumes: `normalizeGridGrouping` (Task 1) — only to prove it is _not_ applied here.
+- Produces: nothing. Pure guard.
+
+**Scenarios:** Q-1 (Route B — the behaviour exists at `timeline_query.provider.dart:54`).
+
+- [ ] **Step 1: Read the existing relevance test**
+
+The file already contains `smart filter with relevance sort uses groupBy=none (flat)` around line 516-539, which captures `groupBy` from the factory call. Read it — the new test copies its capture harness exactly.
+
+- [ ] **Step 2: Write the characterisation test**
+
+Add to `mobile/test/providers/photos_filter/timeline_query_provider_test.dart`, next to the existing relevance test:
+
+```dart
+    test('Q-1: relevance sort keeps groupBy=none even when the grid setting is month', () async {
+      // The persisted Group by setting must not reach a relevance-sorted search:
+      // it has no date order, so it queries flat. Normalizing `none` to `day` here
+      // would silently re-introduce date bucketing.
+      when(() => factory.groupBy).thenReturn(GroupAssetsBy.month);
+      GroupAssetsBy? capturedGroupBy;
+      when(
+        () => factory.fromAssetStream(
+          any(),
+          groupBy: any(named: 'groupBy'),
+          temporalScope: any(named: 'temporalScope'),
+        ),
+      ).thenAnswer((inv) {
+        capturedGroupBy = inv.namedArguments[const Symbol('groupBy')] as GroupAssetsBy;
+        return service;
+      });
+
+      buildPhotosTimelineQuery(ref, relevanceSortedSmartFilter);
+
+      expect(capturedGroupBy, GroupAssetsBy.none);
+    });
+```
+
+Match the surrounding tests' setup: reuse whatever local names they use for `factory`, `ref`, `service` and the relevance-sorted filter fixture rather than inventing new ones.
+
+- [ ] **Step 3: Run it and confirm it passes**
+
+```bash
+~/.local/share/mise/installs/flutter/3.44.8/bin/flutter test test/providers/photos_filter/timeline_query_provider_test.dart
+```
+
+Expected: PASS. A characterisation test starts green — Step 4 is what makes it real.
+
+- [ ] **Step 4: Mutate to prove the test bites**
+
+Temporarily edit `mobile/lib/providers/photos_filter/timeline_query.provider.dart:54` to normalize the explicit grouping — the exact mistake this guards:
+
+```dart
+  final effectiveGroupBy = normalizeGridGrouping(isRelevance ? GroupAssetsBy.none : (groupBy ?? factory.groupBy));
+```
+
+Re-run the file.
+
+Expected: FAIL — `Expected: <GroupAssetsBy.none> Actual: <GroupAssetsBy.day>`.
+
+**Revert the mutation.** Re-run and confirm PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/test/providers/photos_filter/timeline_query_provider_test.dart
+git commit -m "test(mobile): pin relevance search to flat grouping regardless of the grid setting"
+```
+
+---
+
+## Task 3: The provider layer
+
+Introduces the three providers. The old `timelineGroupingProvider` and `timelineBucketGroupingProvider` are **kept temporarily** so the tree still compiles; Task 4 migrates the consumers and deletes them.
+
+**Files:**
+
+- Modify: `mobile/lib/providers/timeline/timeline_grouping.provider.dart`
+- Create: `mobile/test/providers/timeline/timeline_grouping_spec_test.dart`
+
+**Interfaces:**
+
+- Consumes: `TimelineOverviewMode`, `TimelineGroupingSpec`, `normalizeGridGrouping` (Task 1); `appConfigProvider` from `package:immich_mobile/providers/infrastructure/settings.provider.dart`
+- Produces:
+  - `class TimelineOverviewModeNotifier extends Notifier<TimelineOverviewMode>` with `Future<void> set(TimelineOverviewMode mode)`
+  - `final timelineOverviewModeProvider` — `NotifierProvider<TimelineOverviewModeNotifier, TimelineOverviewMode>`, `build() => TimelineOverviewMode.all`
+  - `final timelineGridGroupingProvider` — `Provider<GroupAssetsBy>`
+  - `final timelineGroupingSpecProvider` — `Provider<TimelineGroupingSpec>`, `dependencies: [timelineOverviewModeProvider]`
+
+**Scenarios:** M-1…M-7 (Route A — none of these providers exist yet).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mobile/test/providers/timeline/timeline_grouping_spec_test.dart`. Follow the container/Drift setup already used by `test/providers/timeline/photos_overview_zoom_provider_test.dart` (in-memory Drift, `SettingsRepository.ensureInitialized`) so the persisted setting can be written:
+
+```dart
+import 'package:drift/drift.dart' as drift;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/settings_key.dart';
+import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
+import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
+import 'package:immich_mobile/infrastructure/repositories/settings.repository.dart';
+import 'package:immich_mobile/providers/timeline/timeline_grouping.provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Drift db;
+  late ProviderContainer container;
+
+  setUpAll(() async {
+    db = Drift(drift.DatabaseConnection(NativeDatabase.memory(), closeStreamsSynchronously: true));
+    await SettingsRepository.ensureInitialized(db);
+  });
+
+  setUp(() {
+    container = ProviderContainer();
+  });
+
+  tearDown(() => container.dispose());
+
+  Future<void> setGridSetting(GroupAssetsBy value) =>
+      SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, value);
+
+  Future<void> setMode(TimelineOverviewMode mode) =>
+      container.read(timelineOverviewModeProvider.notifier).set(mode);
+
+  group('timelineGroupingSpecProvider', () {
+    test('M-1: years queries and renders at year granularity', () async {
+      await setMode(TimelineOverviewMode.years);
+      final spec = container.read(timelineGroupingSpecProvider);
+      expect(spec.mode, TimelineOverviewMode.years);
+      expect(spec.groupBy, GroupAssetsBy.year);
+    });
+
+    test('M-2: months queries and renders at month granularity', () async {
+      await setMode(TimelineOverviewMode.months);
+      final spec = container.read(timelineGroupingSpecProvider);
+      expect(spec.mode, TimelineOverviewMode.months);
+      expect(spec.groupBy, GroupAssetsBy.month);
+    });
+
+    test('M-3: all with Month + day selected renders day headers', () async {
+      await setGridSetting(GroupAssetsBy.day);
+      await setMode(TimelineOverviewMode.all);
+      final spec = container.read(timelineGroupingSpecProvider);
+      expect(spec.mode, TimelineOverviewMode.all);
+      expect(spec.groupBy, GroupAssetsBy.day);
+    });
+
+    test('M-4: all with Month selected renders month headers — the #903 case', () async {
+      await setGridSetting(GroupAssetsBy.month);
+      await setMode(TimelineOverviewMode.all);
+      final spec = container.read(timelineGroupingSpecProvider);
+      expect(spec.mode, TimelineOverviewMode.all);
+      expect(spec.groupBy, GroupAssetsBy.month);
+    });
+
+    test('M-5: years ignores the grid setting', () async {
+      await setGridSetting(GroupAssetsBy.month);
+      await setMode(TimelineOverviewMode.years);
+      expect(container.read(timelineGroupingSpecProvider).groupBy, GroupAssetsBy.year);
+    });
+
+    test('M-6: on all, the spec follows a setting change', () async {
+      await setGridSetting(GroupAssetsBy.day);
+      await setMode(TimelineOverviewMode.all);
+      expect(container.read(timelineGroupingSpecProvider).groupBy, GroupAssetsBy.day);
+
+      await setGridSetting(GroupAssetsBy.month);
+      await container.pump();
+      expect(container.read(timelineGroupingSpecProvider).groupBy, GroupAssetsBy.month);
+    });
+
+    test('M-7: on months, a setting change leaves the spec alone', () async {
+      await setGridSetting(GroupAssetsBy.day);
+      await setMode(TimelineOverviewMode.months);
+      expect(container.read(timelineGroupingSpecProvider).groupBy, GroupAssetsBy.month);
+
+      await setGridSetting(GroupAssetsBy.month);
+      await container.pump();
+      expect(container.read(timelineGroupingSpecProvider).groupBy, GroupAssetsBy.month);
+    });
+
+    test('the mode starts at all', () {
+      expect(container.read(timelineOverviewModeProvider), TimelineOverviewMode.all);
+    });
+  });
+}
+```
+
+If `container.pump()` is unavailable in this Riverpod version, use `await Future<void>.delayed(Duration.zero)` — match whatever the existing timeline provider tests already do.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+~/.local/share/mise/installs/flutter/3.44.8/bin/flutter test test/providers/timeline/timeline_grouping_spec_test.dart
+```
+
+Expected: FAIL — `Undefined name 'timelineOverviewModeProvider'` and `'timelineGroupingSpecProvider'`.
+
+- [ ] **Step 3: Add the three providers**
+
+In `mobile/lib/providers/timeline/timeline_grouping.provider.dart`, add above the existing declarations (leave `TimelineGroupingNotifier`, `timelineGroupingProvider` and `timelineBucketGroupingProvider` in place for now — Task 4 removes them):
+
+```dart
+/// The active zoom level of the Years / Months / All selector.
+///
+/// View state only: it always starts at "All" and is never written to
+/// [SettingsKey.timelineGroupAssetsBy]. Persisting it there is what made the
+/// "Photo Grid" -> "Group by" setting flip the timeline into the overview cards (#903).
+class TimelineOverviewModeNotifier extends Notifier<TimelineOverviewMode> {
+  @override
+  TimelineOverviewMode build() => TimelineOverviewMode.all;
+
+  Future<void> set(TimelineOverviewMode mode) async {
+    state = mode;
+  }
+}
+
+/// The active zoom level for the current scope.
+///
+/// Scoped per-route by `TimelineRouteScope` (unless the route opts into `sharedGrouping`),
+/// so a change inside an album does not leak into the main Photos timeline. Widgets resolve
+/// the nearest scope automatically, but any PROVIDER that reads this must list it in its own
+/// `dependencies:` — otherwise its auto-scoped copy silently resolves the root mode.
+final timelineOverviewModeProvider = NotifierProvider<TimelineOverviewModeNotifier, TimelineOverviewMode>(
+  TimelineOverviewModeNotifier.new,
+);
+
+/// The persisted "Photo Grid" -> "Group by" setting: how coarse the grid's headers are.
+final timelineGridGroupingProvider = Provider<GroupAssetsBy>(
+  (ref) => normalizeGridGrouping(ref.watch(appConfigProvider.select((config) => config.timeline.groupAssetsBy))),
+);
+
+/// What to render for the current scope, and at what granularity.
+///
+/// Years / Months render the overview cards at that granularity. All renders the photo
+/// grid, whose header granularity is the persisted Group by setting.
+final timelineGroupingSpecProvider = Provider<TimelineGroupingSpec>((ref) {
+  final mode = ref.watch(timelineOverviewModeProvider);
+  return switch (mode) {
+    TimelineOverviewMode.years => (mode: mode, groupBy: GroupAssetsBy.year),
+    TimelineOverviewMode.months => (mode: mode, groupBy: GroupAssetsBy.month),
+    TimelineOverviewMode.all => (mode: mode, groupBy: ref.watch(timelineGridGroupingProvider)),
+  };
+  // timelineOverviewModeProvider must be listed so the auto-scoped copy of this provider
+  // inside a TimelineRouteScope resolves the ROUTE-LOCAL mode rather than the root one.
+}, dependencies: [timelineOverviewModeProvider]);
+```
+
+Add the import if missing:
+
+```dart
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
+```
+
+If `timelineGridGroupingProvider` already exists from #911, keep the single definition — do not declare it twice.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+~/.local/share/mise/installs/flutter/3.44.8/bin/flutter test test/providers/timeline/timeline_grouping_spec_test.dart
+```
+
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Run the whole suite**
+
+```bash
+~/.local/share/mise/installs/flutter/3.44.8/bin/flutter test
+```
+
+Expected: 2916 passing (2908 + 8), 0 failures. The old providers are untouched, so nothing regresses.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile/lib/providers/timeline/timeline_grouping.provider.dart \
+        mobile/test/providers/timeline/timeline_grouping_spec_test.dart
+git commit -m "feat(mobile): add the timeline overview mode and grouping spec providers"
+```
+
+---
+
+## Task 4: Migrate every consumer and delete the old providers
+
+Dart types flip atomically — the tree will not compile between Step 2 and Step 11. That is expected. The task's _deliverable_ is green; its middle is not.
+
+Work through the steps in order and only run the suite where the plan says to. Use `dart analyze` as the intermediate signal.
+
+**Files:**
+
+- Modify: `lib/providers/timeline/timeline_grouping.provider.dart` (delete the old)
+- Modify: `lib/providers/timeline/overview_drilldown.provider.dart`
+- Modify: `lib/providers/timeline/overview_representative_cache.provider.dart`
+- Modify: `lib/presentation/widgets/timeline/overview/overview_card.dart`
+- Modify: `lib/presentation/widgets/timeline/overview/overview_segment.model.dart`
+- Modify: `lib/presentation/widgets/timeline/overview/overview_segment_builder.dart`
+- Modify: `lib/presentation/widgets/timeline/timeline_grouping_selector.widget.dart`
+- Modify: `lib/presentation/widgets/timeline/timeline_grouping_anchor.dart`
+- Modify: `lib/presentation/widgets/timeline/timeline_scroll_target.dart`
+- Modify: `lib/presentation/widgets/timeline/timeline_route_scope.dart`
+- Modify: `lib/presentation/widgets/timeline/timeline.widget.dart`
+- Modify: `lib/presentation/widgets/timeline/timeline.state.dart`
+
+**Interfaces:**
+
+- Consumes: everything Task 3 produced.
+- Produces:
+  - `typedef TimelineOverviewDrilldownHandler = Future<void> Function(TimeBucket bucket, TimelineOverviewMode mode)`
+  - `TimelineOverviewRepresentativeCacheNotifier.keyFor(TimelineOverviewMode mode, DateTime date)`
+  - `TimelineOverviewSegmentBuilder({required List<Bucket> buckets, required TimelineOverviewMode mode})`
+  - `TimelineOverviewSegment(... required TimelineOverviewMode mode ...)`
+  - `TimelineOverviewCard({required TimeBucket bucket, required TimelineOverviewMode mode, ...})`
+  - `DateTime resolveGroupingChangeAnchorDate({required DateTime topBucketDate, required TimelineOverviewMode previousMode, DateTime? remembered})`
+  - `Segment? findTimelineZoomAnchorSegment(List<Segment> segments, TimelineZoomAnchor anchor, TimelineOverviewMode mode)`
+  - `const timelineOverviewModeSelectorOrder = <TimelineOverviewMode>[years, months, all]`
+
+**Scenarios:** G-1…G-5, S-1…S-7, R-1…R-5, Z-1…Z-8, A-1…A-3, P-1…P-5, B-1…B-5.
+
+- [ ] **Step 1: Capture the pre-change baseline**
+
+```bash
+cd mobile && ~/.local/share/mise/installs/flutter/3.44.8/bin/flutter test 2>&1 | tail -3
+```
+
+Record the count. It must be matched or exceeded at Step 12.
+
+- [ ] **Step 2: Retype the drilldown provider**
+
+Replace the body of `mobile/lib/providers/timeline/overview_drilldown.provider.dart`:
+
+```dart
+typedef TimelineOverviewDrilldownHandler = Future<void> Function(TimeBucket bucket, TimelineOverviewMode mode);
+
+final timelineOverviewDrilldownProvider = Provider<TimelineOverviewDrilldownHandler?>((ref) => null);
+
+final sharedTimelineOverviewDrilldownProvider = Provider<TimelineOverviewDrilldownHandler>((ref) {
+  return (bucket, mode) async {
+    switch (mode) {
+      case TimelineOverviewMode.years:
+        ref.read(timelineZoomAnchorProvider.notifier).setYear(bucket.date.year);
+        await ref.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.months);
+      case TimelineOverviewMode.months:
+        ref.read(timelineZoomAnchorProvider.notifier).setMonth(year: bucket.date.year, month: bucket.date.month);
+        await ref.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.all);
+      case TimelineOverviewMode.all:
+        return;
+    }
+  };
+  // timelineOverviewModeProvider must be listed so a drilldown inside a TimelineRouteScope
+  // sets the ROUTE-LOCAL mode rather than the root one.
+}, dependencies: [timelineZoomAnchorProvider, timelineOverviewModeProvider]);
+
+final photosTimelineOverviewDrilldownProvider = sharedTimelineOverviewDrilldownProvider;
+```
+
+Note the three dead `day || auto || none` cases collapse to one honest `all` case.
+
+- [ ] **Step 3: Retype the representative cache key**
+
+`mobile/lib/providers/timeline/overview_representative_cache.provider.dart:24`:
+
+```dart
+  static String keyFor(TimelineOverviewMode mode, DateTime date) => '${mode.name}:${date.toIso8601String()}';
+```
+
+Add the `timeline_grouping.model.dart` import.
+
+- [ ] **Step 4: Retype the overview card**
+
+In `mobile/lib/presentation/widgets/timeline/overview/overview_card.dart`, rename the field and collapse each switch. The `all` branches keep the previous `day || auto || none` behaviour:
+
+```dart
+  final TimelineOverviewMode mode;
+
+  String _label(BuildContext context) {
+    final locale = context.locale.toLanguageTag();
+    return switch (mode) {
+      TimelineOverviewMode.years => DateFormat.y(locale).format(bucket.date),
+      TimelineOverviewMode.months => DateFormat.yMMM(locale).format(bucket.date),
+      TimelineOverviewMode.all => DateFormat.yMMMEd(locale).format(bucket.date),
+    };
+  }
+
+  String _semanticsPeriod(BuildContext context) {
+    final locale = context.locale.toLanguageTag();
+    return switch (mode) {
+      TimelineOverviewMode.years => DateFormat.y(locale).format(bucket.date),
+      TimelineOverviewMode.months => DateFormat.yMMMM(locale).format(bucket.date),
+      TimelineOverviewMode.all => DateFormat.yMMMMEEEEd(locale).format(bucket.date),
+    };
+  }
+```
+
+`_actionLabel()` gets the same treatment — `years => 'timeline_overview_show_months'`, `months => 'timeline_overview_show_days'`, `all => null` — in both the key switch and the fallback switch.
+
+Rename the constructor parameter `groupBy` → `mode`.
+
+- [ ] **Step 5: Retype the overview segment model**
+
+In `mobile/lib/presentation/widgets/timeline/overview/overview_segment.model.dart`: change `final GroupAssetsBy groupBy;` to `final TimelineOverviewMode mode;`, the constructor parameter to `required this.mode`, and in `_TimelineOverviewSegmentCard.build`:
+
+```dart
+    final onTap = drilldown != null && bucket.assetCount > 0
+        ? () => unawaited(drilldown(bucket, segment.mode))
+        : null;
+
+    final key = TimelineOverviewRepresentativeCacheNotifier.keyFor(segment.mode, bucket.date);
+```
+
+and the card construction:
+
+```dart
+    return TimelineOverviewCard(
+      bucket: bucket,
+      mode: segment.mode,
+      representativeAsset: cachedAsset,
+      onTap: onTap,
+    );
+```
+
+- [ ] **Step 6: Retype the overview segment builder**
+
+`mobile/lib/presentation/widgets/timeline/overview/overview_segment_builder.dart`. It extends the upstream `SegmentBuilder`, whose `groupBy` field defaults to `GroupAssetsBy.day` and is unused here — leave it at its default and carry the mode as this class's own field:
+
+```dart
+class TimelineOverviewSegmentBuilder extends SegmentBuilder {
+  const TimelineOverviewSegmentBuilder({required super.buckets, required this.mode});
+
+  /// The zoom level these cards represent. The inherited [SegmentBuilder.groupBy] is
+  /// unused for overview segments and stays at its upstream default.
+  final TimelineOverviewMode mode;
+
+  List<Segment> generate() {
+    if (mode == TimelineOverviewMode.all) {
+      throw ArgumentError.value(mode, 'mode', 'Overview segments support only years and months');
+    }
+    ...
+        TimelineOverviewSegment(
+          ...
+          mode: mode,
+          header: mode == TimelineOverviewMode.years ? HeaderType.year : HeaderType.month,
+        ),
+```
+
+Keep the rest of `generate()` byte-identical.
+
+- [ ] **Step 7: Retype the selector widget**
+
+In `mobile/lib/presentation/widgets/timeline/timeline_grouping_selector.widget.dart`:
+
+```dart
+const timelineOverviewModeSelectorOrder = <TimelineOverviewMode>[
+  TimelineOverviewMode.years,
+  TimelineOverviewMode.months,
+  TimelineOverviewMode.all,
+];
+```
+
+Replace `ref.watch(timelineGroupingProvider)` with `ref.watch(timelineOverviewModeProvider)` and both `ref.read(timelineGroupingProvider.notifier).set(...)` calls with `ref.read(timelineOverviewModeProvider.notifier).set(...)`. Change `final Future<void> Function(GroupAssetsBy groupBy) onSelected;` to take `TimelineOverviewMode mode`.
+
+`_selectNext` becomes:
+
+```dart
+    final TimelineOverviewMode next;
+    switch (selected) {
+      case TimelineOverviewMode.years:
+        next = TimelineOverviewMode.months;
+        direction.state = true; // continue zooming in toward All
+      case TimelineOverviewMode.months:
+        if (direction.state) {
+          next = TimelineOverviewMode.all;
+          direction.state = false; // reached the zoom-in extreme (All); bounce back up next
+        } else {
+          next = TimelineOverviewMode.years;
+          direction.state = true; // reached the zoom-out extreme (Years); bounce back down next
+        }
+      case TimelineOverviewMode.all:
+        next = TimelineOverviewMode.months;
+        direction.state = false; // continue zooming out toward Years
+    }
+```
+
+`_label` becomes:
+
+```dart
+String _label(BuildContext context, TimelineOverviewMode mode) {
+  return switch (mode) {
+    TimelineOverviewMode.years => _translated('timeline_grouping_years', 'Years'),
+    TimelineOverviewMode.months => _translated('timeline_grouping_months', 'Months'),
+    TimelineOverviewMode.all => _translated('timeline_grouping_all', 'All'),
+  };
+}
+```
+
+Rename any remaining local `groupBy` identifiers in this file to `mode`. Do not rename `timelineGroupingZoomingInProvider` — it is a direction flag, not a grouping.
+
+- [ ] **Step 8: Retype the anchor helpers**
+
+`mobile/lib/presentation/widgets/timeline/timeline_grouping_anchor.dart`:
+
+```dart
+DateTime resolveGroupingChangeAnchorDate({
+  required DateTime topBucketDate,
+  required TimelineOverviewMode previousMode,
+  DateTime? remembered,
+}) {
+  if (remembered == null) {
+    return topBucketDate;
+  }
+  final within = switch (previousMode) {
+    TimelineOverviewMode.years => remembered.year == topBucketDate.year,
+    TimelineOverviewMode.months =>
+      remembered.year == topBucketDate.year && remembered.month == topBucketDate.month,
+    TimelineOverviewMode.all => false,
+  };
+  return within ? remembered : topBucketDate;
+}
+```
+
+`mobile/lib/presentation/widgets/timeline/timeline_scroll_target.dart:29` — this is the payoff:
+
+```dart
+Segment? findTimelineZoomAnchorSegment(
+  List<Segment> segments,
+  TimelineZoomAnchor anchor,
+  TimelineOverviewMode mode,
+) {
+  return switch (anchor) {
+    TimelineZoomAnchorNone() => null,
+    TimelineZoomYearAnchor(:final year) when mode == TimelineOverviewMode.months => segments.firstWhereOrNull(
+      (segment) => _matchesDate(segment, (segmentDate) => segmentDate.year == year),
+    ),
+    TimelineZoomMonthAnchor(:final year, :final month) when mode == TimelineOverviewMode.all =>
+      segments.firstWhereOrNull(
+        (segment) => _matchesDate(segment, (segmentDate) => segmentDate.year == year && segmentDate.month == month),
+      ),
+    // A date anchor preserves the visible position across mode changes, so it
+    // resolves to the closest matching segment (day -> month -> year) in any mode.
+    TimelineZoomDateAnchor(:final date) => findTimelineScrollTargetSegment(segments, date),
+    _ => null,
+  };
+}
+```
+
+- [ ] **Step 9: Update `timeline.widget.dart` — four sites**
+
+Line 223:
+
+```dart
+    ref.listenManual(timelineOverviewModeProvider, _onGroupingChanged);
+```
+
+Line 292 signature and its `resolveGroupingChangeAnchorDate` call:
+
+```dart
+  void _onGroupingChanged(TimelineOverviewMode? previous, TimelineOverviewMode next) {
+```
+
+```dart
+    final resolved = resolveGroupingChangeAnchorDate(
+      topBucketDate: topBucketDate,
+      previousMode: previous,
+      remembered: anchorNotifier.lastPositionDate,
+    );
+```
+
+Line 472 — the anchor takes the **mode**, and a pinned `groupByArg` means "All":
+
+```dart
+    final TimelineOverviewMode activeMode = ref.read(timelineArgsProvider).groupBy != null
+        ? TimelineOverviewMode.all
+        : ref.read(timelineOverviewModeProvider);
+    if (activeMode != mode) {
+      return;
+    }
+
+    final targetSegment = findTimelineZoomAnchorSegment(segments, anchor, mode);
+```
+
+Rename the method's `required GroupAssetsBy groupBy` parameter to `required TimelineOverviewMode mode` on both `_scheduleZoomAnchorResolution` and `_resolveZoomAnchor`.
+
+Line 611 — split: the anchor gets the mode, the scrubber gets the granularity:
+
+```dart
+              final spec = ref.watch(timelineGroupingSpecProvider);
+              final pinnedGroupBy = ref.watch(timelineArgsProvider).groupBy;
+              final TimelineOverviewMode activeMode = pinnedGroupBy != null ? TimelineOverviewMode.all : spec.mode;
+              final GroupAssetsBy activeGroupBy = pinnedGroupBy ?? spec.groupBy;
+              final zoomAnchor = ref.watch(timelineZoomAnchorProvider);
+              _scheduleZoomAnchorResolution(anchor: zoomAnchor, mode: activeMode, segments: segments);
+```
+
+`Scrubber(groupBy: activeGroupBy, ...)` at line ~674 is unchanged — it keeps receiving a `GroupAssetsBy`.
+
+- [ ] **Step 10: Rewrite `timeline.state.dart` to upstream's shape**
+
+Replace the whole `timelineSegmentProvider` declaration with the single-provider form. Keep upstream's indentation — do **not** let the argument list go multi-line:
+
+```dart
+final timelineSegmentProvider = StreamProvider.autoDispose<List<Segment>>((ref) async* {
+  // maxHeight is left out on purpose, a height-only change must not restart the bucket stream
+  final (maxWidth, columnCount, spacing, groupByArg) = ref.watch(
+    timelineArgsProvider.select((args) => (args.maxWidth, args.columnCount, args.spacing, args.groupBy)),
+  );
+  final availableTileWidth = maxWidth - (spacing * (columnCount - 1));
+  final tileExtent = math.max(0, availableTileWidth) / columnCount;
+
+  // A pinned groupBy (the cleanup preview) always means the flat grid at that granularity.
+  final spec = groupByArg != null
+      ? (mode: TimelineOverviewMode.all, groupBy: groupByArg)
+      : ref.watch(timelineGroupingSpecProvider);
+
+  final timelineService = ref.watch(timelineServiceProvider);
+  yield* timelineService.watchBuckets().map((buckets) {
+    // A date-less bucket source (relevance-sorted search, or a `fromAssets` timeline) has no
+    // dates to group by — fall back to the flat grid regardless of the mode.
+    final isDateless = buckets.isNotEmpty && buckets.first is! TimeBucket;
+    if (spec.mode != TimelineOverviewMode.all && !isDateless) {
+      return TimelineOverviewSegmentBuilder(buckets: buckets, mode: spec.mode).generate();
+    }
+
+    return FixedSegmentBuilder(
+      buckets: buckets,
+      tileHeight: tileExtent,
+      columnCount: columnCount,
+      spacing: spacing,
+      groupBy: isDateless ? GroupAssetsBy.day : spec.groupBy,
+    ).generate();
+  });
+  // timelineGroupingSpecProvider must be listed so the auto-scoped copy of this provider
+  // inside a TimelineRouteScope resolves the ROUTE-LOCAL mode rather than the root one.
+}, dependencies: [timelineServiceProvider, timelineArgsProvider, timelineGroupingSpecProvider]);
+```
+
+That final line is 96 characters — under the 120 limit, so `dart format` leaves it alone.
+
+- [ ] **Step 11: Update the route scope and delete the old providers**
+
+`mobile/lib/presentation/widgets/timeline/timeline_route_scope.dart`:
+
+```dart
+        if (!sharedGrouping) timelineOverviewModeProvider.overrideWith(TimelineOverviewModeNotifier.new),
+```
+
+```dart
+            // The bucket granularity, not the zoom level: on "All" the query must group by the
+            // persisted "Group by" setting so month-only headers get month buckets.
+            final groupBy = ref.watch(timelineGroupingSpecProvider).groupBy;
+```
+
+Then delete from `timeline_grouping.provider.dart`: `normalizeTimelineGrouping`, `TimelineGroupingNotifier`, `timelineGroupingProvider`, `timelineBucketGroupingProvider`.
+
+- [ ] **Step 12: Make it compile**
+
+```bash
+cd mobile && ~/.local/share/mise/installs/flutter/3.44.8/bin/dart analyze --fatal-infos lib
+```
+
+Fix every remaining reference the compiler names. Expected final: `No issues found!`
+
+- [ ] **Step 13: Migrate the test suite**
+
+```bash
+~/.local/share/mise/installs/flutter/3.44.8/bin/dart analyze --fatal-infos test
+```
+
+Apply **renames only**, per this mapping:
+
+| Old, as a pill position          | New                                              |
+| -------------------------------- | ------------------------------------------------ |
+| `GroupAssetsBy.year`             | `TimelineOverviewMode.years`                     |
+| `GroupAssetsBy.month`            | `TimelineOverviewMode.months`                    |
+| `GroupAssetsBy.day`              | `TimelineOverviewMode.all`                       |
+| `timelineGroupingProvider`       | `timelineOverviewModeProvider`                   |
+| `timelineBucketGroupingProvider` | `timelineGroupingSpecProvider` (then `.groupBy`) |
+
+Where the same literal meant **header granularity**, it stays `GroupAssetsBy`. Two files must keep `GroupAssetsBy` throughout — `scrubber_segments_test.dart` and `timeline_query_provider_test.dart`. A rename applied there means the boundary has been crossed.
+
+In `main_timeline_zoom_test.dart`, the mock timeline-service factories must keep honouring the `groupBy` the production code passes rather than re-reading the setting. #911 fixed this; do not reintroduce it.
+
+**If any test needs its assertions changed rather than its identifiers, stop and escalate.**
+
+- [ ] **Step 14: Run the full suite**
+
+```bash
+~/.local/share/mise/installs/flutter/3.44.8/bin/flutter test
+```
+
+Expected: at least the Step 1 baseline, 0 failures.
+
+- [ ] **Step 15: Mutation-check the six highest-risk guards**
+
+For each row: apply the mutation, run the named test file, confirm the expected red, then **revert**.
+
+| Mutation                                                                              | Must break                                  |
+| ------------------------------------------------------------------------------------- | ------------------------------------------- |
+| `timelineGroupingSpecProvider`: make `all` return `GroupAssetsBy.day` unconditionally | `timeline_grouping_spec_test.dart` (M-4)    |
+| `timelineGroupingSpecProvider`: make `months` read `timelineGridGroupingProvider`     | `timeline_grouping_spec_test.dart` (M-5)    |
+| Drop `dependencies: [timelineOverviewModeProvider]` from the spec provider            | `timeline_route_scope_test.dart` (R-4)      |
+| `TimelineRouteScope`: stop overriding the mode provider                               | `timeline_route_scope_test.dart` (R-1, R-2) |
+| `timeline.state.dart`: drop `&& !isDateless` from the overview condition              | `timeline_segment_provider_test.dart` (S-2) |
+| `timeline.widget.dart:472`: pass `spec.groupBy` where the mode is expected            | compile error — that is the guarantee       |
+
+If a mutation stays green, the guard is missing. Write it before continuing.
+
+- [ ] **Step 16: Gates and commit**
+
+```bash
+~/.local/share/mise/installs/flutter/3.44.8/bin/dart analyze --fatal-infos lib test
+~/.local/share/mise/installs/flutter/3.44.8/bin/dart format lib
+```
+
+```bash
+git add mobile/lib mobile/test
+git commit -m "refactor(mobile): give the timeline overview selector its own type
+
+The Years/Months/All selector and the Photo Grid \"Group by\" setting both spoke
+GroupAssetsBy, so nothing distinguished \"month cards\" from \"month headers\" — the
+ambiguity behind #903. The selector now uses a fork-only TimelineOverviewMode and a
+single derived spec provider resolves the granularity to query and render.
+
+Also restores timeline.state.dart to upstream's shape: one provider in the
+dependencies list keeps the line under the formatter's width, so the whole body
+stops showing as reindented against upstream."
+```
+
+---
+
+## Task 5: Fill the remaining scenario gaps
+
+Everything compiles and the retype is done. This task adds the scenarios the existing suite never covered.
+
+**Files:**
+
+- Modify: `mobile/test/presentation/widgets/timeline/timeline_segment_provider_test.dart`
+- Modify: `mobile/test/presentation/widgets/timeline/timeline_zoom_anchor_resolution_test.dart`
+- Modify: `mobile/test/presentation/widgets/timeline/scrubber_segments_test.dart`
+- Modify: `mobile/test/widgets/settings/asset_list_group_settings_test.dart`
+- Create: `mobile/test/domain/services/timeline_factory_grouping_test.dart`
+
+**Interfaces:**
+
+- Consumes: everything from Tasks 1, 3 and 4.
+- Produces: nothing. Coverage only.
+
+**Scenarios:** S-4, S-5, S-6, S-7, Z-6, B-4, B-5, L-3, F-1…F-4.
+
+- [ ] **Step 1: Write the failing empty-bucket tests (S-4, S-5)**
+
+Add to `timeline_segment_provider_test.dart`. `isDateless` is `buckets.isNotEmpty && buckets.first is! TimeBucket`, so an **empty** list is _not_ dateless and an overview-mode timeline reaches `TimelineOverviewSegmentBuilder` with no buckets:
+
+```dart
+    test('S-4: empty buckets in Months mode produce no segments and do not throw', () async {
+      await setMode(TimelineOverviewMode.months);
+      bucketController.add(<Bucket>[]);
+      final segments = await readSegments();
+      expect(segments, isEmpty);
+    });
+
+    test('S-5: empty buckets in All mode with the month setting produce no segments', () async {
+      await setGridSetting(GroupAssetsBy.month);
+      await setMode(TimelineOverviewMode.all);
+      bucketController.add(<Bucket>[]);
+      final segments = await readSegments();
+      expect(segments, isEmpty);
+    });
+```
+
+Reuse the file's existing harness names for the bucket stream and segment read.
+
+- [ ] **Step 2: Run them**
+
+```bash
+~/.local/share/mise/installs/flutter/3.44.8/bin/flutter test test/presentation/widgets/timeline/timeline_segment_provider_test.dart
+```
+
+Expected: PASS — the loop in `generate()` never runs on an empty list.
+
+**If either throws**, that is a real pre-existing bug on `main`. Fix it here by returning early from `TimelineOverviewSegmentBuilder.generate()` on empty input, and say so in the commit message.
+
+- [ ] **Step 3: Write the pinned-grouping tests (S-6, S-7)**
+
+```dart
+    test('S-6: a pinned groupBy never reaches the overview builder', () async {
+      await setMode(TimelineOverviewMode.months);
+      setPinnedGroupBy(GroupAssetsBy.day);
+      bucketController.add(timeBuckets);
+      final segments = await readSegments();
+      expect(segments.every((s) => s is! TimelineOverviewSegment), isTrue);
+    });
+
+    test('S-7: with a pinned groupBy, mode and setting changes leave the segments alone', () async {
+      setPinnedGroupBy(GroupAssetsBy.day);
+      bucketController.add(timeBuckets);
+      final before = await readSegments();
+
+      await setMode(TimelineOverviewMode.years);
+      await setGridSetting(GroupAssetsBy.month);
+      final after = await readSegments();
+
+      expect(after.length, before.length);
+      expect(after.every((s) => s is! TimelineOverviewSegment), isTrue);
+    });
+```
+
+- [ ] **Step 4: Write the critical anchor test (Z-6)**
+
+Add to `timeline_zoom_anchor_resolution_test.dart`:
+
+```dart
+    test('Z-6: a month anchor still resolves in All mode when Group by is Month', () async {
+      // Regression guard: if the anchor is fed spec.groupBy instead of spec.mode, the
+      // month setting makes the granularity `month`, the `all` guard stops matching, and
+      // drilling from Months into All silently fails to scroll.
+      await setGridSetting(GroupAssetsBy.month);
+      final segments = monthGranularitySegments;
+      final target = findTimelineZoomAnchorSegment(
+        segments,
+        const TimelineZoomMonthAnchor(year: 2026, month: 3),
+        TimelineOverviewMode.all,
+      );
+      expect(target, isNotNull);
+    });
+```
+
+- [ ] **Step 5: Run it, then mutate to prove it bites**
+
+```bash
+~/.local/share/mise/installs/flutter/3.44.8/bin/flutter test test/presentation/widgets/timeline/timeline_zoom_anchor_resolution_test.dart
+```
+
+Expected: PASS.
+
+Then temporarily change the test's third argument from `TimelineOverviewMode.all` to `TimelineOverviewMode.months` — simulating the anchor being handed the wrong concept. Re-run.
+
+Expected: FAIL — `Expected: not null; Actual: <null>`.
+
+**Revert** and confirm PASS.
+
+- [ ] **Step 6: Add the scrubber pins (B-4, B-5)**
+
+```dart
+    test('B-4: All mode with Month + day still labels month+year', () {
+      final segments = buildScrubberSegments(
+        layoutSegments: dayGranularitySegments,
+        timelineHeight: 800,
+        groupBy: GroupAssetsBy.day,
+      );
+      expect(segments.first.scrollLabel, matches(RegExp(r'^\w+ \d{4}$')));
+    });
+
+    test('B-5: date-less layout segments produce no scrubber segments', () {
+      final segments = buildScrubberSegments(
+        layoutSegments: datelessSegments,
+        timelineHeight: 800,
+        groupBy: GroupAssetsBy.day,
+      );
+      expect(segments, isEmpty);
+    });
+```
+
+- [ ] **Step 7: Add the legacy settings test (L-3)**
+
+Add to `asset_list_group_settings_test.dart`. Assert a radio is **selected** — "renders with nothing selected" is the actual failure mode:
+
+```dart
+    testWidgets('L-3: a stored year value falls back to Month + day selected', (tester) async {
+      await setGridSetting(GroupAssetsBy.year);
+      await pumpGroupSettings(tester);
+
+      final monthDayTile = tester.widget<RadioListTile<GroupAssetsBy>>(
+        find.byWidgetPredicate(
+          (w) => w is RadioListTile<GroupAssetsBy> && w.value == GroupAssetsBy.day,
+        ),
+      );
+      expect(monthDayTile.groupValue, GroupAssetsBy.day);
+    });
+```
+
+Match the widget type the settings screen actually renders — read `settings_radio_list_tile.dart` and assert against that type rather than assuming `RadioListTile`.
+
+- [ ] **Step 8: Create the factory fallback tests (F-1…F-4)**
+
+Create `mobile/test/domain/services/timeline_factory_grouping_test.dart`, modelled on the existing `timeline_factory_temporal_scope_test.dart` in the same directory:
+
+```dart
+    test('F-1: month is preserved', () {
+      when(() => settingsRepository.appConfig).thenReturn(configWith(GroupAssetsBy.month));
+      expect(factory.groupBy, GroupAssetsBy.month);
+    });
+
+    test('F-2: day is preserved', () {
+      when(() => settingsRepository.appConfig).thenReturn(configWith(GroupAssetsBy.day));
+      expect(factory.groupBy, GroupAssetsBy.day);
+    });
+
+    test('F-3: a stored year falls back to day', () {
+      when(() => settingsRepository.appConfig).thenReturn(configWith(GroupAssetsBy.year));
+      expect(factory.groupBy, GroupAssetsBy.day);
+    });
+
+    test('F-4: auto falls back to day', () {
+      when(() => settingsRepository.appConfig).thenReturn(configWith(GroupAssetsBy.auto));
+      expect(factory.groupBy, GroupAssetsBy.day);
+    });
+```
+
+- [ ] **Step 9: Run everything**
+
+```bash
+~/.local/share/mise/installs/flutter/3.44.8/bin/flutter test
+~/.local/share/mise/installs/flutter/3.44.8/bin/dart analyze --fatal-infos lib test
+~/.local/share/mise/installs/flutter/3.44.8/bin/dart format lib
+```
+
+Expected: all green, count up by ~12.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add mobile/test
+git commit -m "test(mobile): cover the empty-bucket, pinned-grouping and legacy-setting edges"
+```
+
+---
+
+## Task 6: Filter and integration scenarios, then verify the outcome
+
+**Files:**
+
+- Modify: `mobile/test/presentation/pages/dev/timeline_filter_grouping_integration_test.dart`
+- Modify: `mobile/test/providers/photos_filter/timeline_query_provider_test.dart`
+- Modify: `docs/superpowers/specs/2026-08-02-timeline-grouping-upstream-divergence-design.md`
+
+**Interfaces:**
+
+- Consumes: everything above.
+- Produces: nothing.
+
+**Scenarios:** Q-2…Q-7.
+
+- [ ] **Step 1: Confirm the existing integration coverage**
+
+`timeline_filter_grouping_integration_test.dart` already carries Q-4, Q-5 and Q-6 in substance:
+
+- `Filtered + Months → month TimelineOverviewSegments, asset counts sum to total` (Q-4)
+- `Filtered + All with the month Group by setting produces month buckets on the grid` (Q-5)
+- `Changing the grouping while a filter is active rebuilds service buckets at new granularity` (Q-6)
+
+Verify each still asserts the same thing after Task 4's rename, and that none needed an assertion change. If one did, that is the escalation signal.
+
+- [ ] **Step 2: Mutation-check Q-5**
+
+Q-5 is the #903 case under a filter and it must bite. Temporarily make `timelineGroupingSpecProvider`'s `all` branch return `GroupAssetsBy.day` unconditionally, run the file, confirm FAIL, then **revert**.
+
+- [ ] **Step 3: Add Q-2, Q-3 and Q-7 if absent**
+
+`timeline_query_provider_test.dart` already covers:
+
+- `smart filter with newest sort uses active grouping setting (not none)` (Q-2)
+- `non-smart filter uses active grouping setting and defaults to descending` (Q-3)
+- `empty filter → delegates to main-library service` (Q-7)
+
+Confirm each reads the **spec** grouping after the rename. Add any that is missing rather than assuming.
+
+- [ ] **Step 4: Verify the divergence targets were met**
+
+```bash
+cd /Users/pierre/dev/gallery/.claude/worktrees/fix-903-photo-grid-group-by
+for f in mobile/lib/presentation/widgets/timeline/timeline.state.dart \
+         mobile/lib/domain/models/timeline.model.dart \
+         mobile/lib/widgets/settings/asset_list_settings/asset_list_group_settings.dart; do
+  printf "%-60s " "$(basename $f)"
+  git diff --numstat "upstream/main:$f" -- "$f" | awk '{print $1"+/"$2"-"}'
+done
+```
+
+Expected, per the spec's outcome table:
+
+| File                             | Target                 |
+| -------------------------------- | ---------------------- |
+| `timeline.state.dart`            | ~12+/3- (from 48+/20-) |
+| `timeline.model.dart`            | 2+/2- (from 12+/2-)    |
+| `asset_list_group_settings.dart` | ~2+/1- (from 3+/1-)    |
+
+If `timeline.state.dart` is materially above target, check whether `dart format` re-wrapped the `dependencies:` line — that is the failure mode, and it means the line exceeded 120 characters.
+
+- [ ] **Step 5: Record the two files the spec missed**
+
+The spec's §4 list omits `overview_segment.model.dart` and `overview_representative_cache.provider.dart`, both of which this plan retypes. Add them to the §4 bullet list in the design doc, then:
+
+```bash
+export PATH="$HOME/.local/share/mise/shims:$PATH"
+npx prettier --write docs/superpowers/specs/2026-08-02-timeline-grouping-upstream-divergence-design.md
+npx prettier --check docs/superpowers/specs/2026-08-02-timeline-grouping-upstream-divergence-design.md
+```
+
+- [ ] **Step 6: Final gates**
+
+```bash
+cd mobile
+~/.local/share/mise/installs/flutter/3.44.8/bin/flutter test
+~/.local/share/mise/installs/flutter/3.44.8/bin/dart analyze --fatal-infos lib test
+~/.local/share/mise/installs/flutter/3.44.8/bin/dart format lib
+```
+
+Expected: 0 failures, `No issues found!`, no formatting changes.
+
+- [ ] **Step 7: Commit and push**
+
+```bash
+git add mobile/test docs/superpowers/specs
+git commit -m "test(mobile): confirm filter-backed timelines follow the grouping spec"
+git push
+```
+
+- [ ] **Step 8: Update the PR description**
+
+PR #911's body describes the original three-provider fix. Rewrite the "The fix" section to describe `TimelineOverviewMode` + `timelineGroupingSpecProvider`, and add a line noting the upstream-divergence reduction with the measured before/after numbers.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every design section maps to a task: §1 → Task 1; §2 → Task 3; §3 → Task 4 Step 10; §4 → Task 4 Steps 2-8; §5 → Task 4 Step 9; §6 → Task 2; §7 → Task 5 Step 7. All 63 scenarios are assigned: G-1…G-5, S-1…S-3 and R-1…R-5, Z-1…Z-5, Z-7…Z-8, A-1…A-4, P-1…P-5, B-1…B-3 are existing tests migrated in Task 4 Step 13; S-4…S-7, Z-6, B-4, B-5, L-3, F-1…F-4 are added in Task 5; L-1, L-2, L-4, L-5 in Task 1; M-1…M-7 in Task 3; Q-1 in Task 2; Q-2…Q-7 in Task 6.
+
+**Two spec gaps found and handled here:** `overview_segment.model.dart` and `overview_representative_cache.provider.dart` are in the retype blast radius but absent from the spec's §4 list. Both are retyped in Task 4 (Steps 5 and 3) and the spec is corrected in Task 6 Step 5.
+
+**Type consistency.** `TimelineOverviewMode` values are `years`/`months`/`all` everywhere — never `year`/`month`/`day`. `TimelineGroupingSpec` is a record with fields `mode` and `groupBy`; every read uses `spec.mode` or `spec.groupBy`. The drilldown handler's second parameter is `mode` in the typedef, the implementation and the call site. `TimelineOverviewSegmentBuilder` takes `mode`, not `groupBy` — its inherited `SegmentBuilder.groupBy` stays at the upstream default and is unused.
+
+**Known risk.** Task 4 leaves the tree uncompilable between Steps 2 and 12. That is inherent to a Dart type flip and cannot be avoided without a temporary shim that would itself be churn. The task ends green, `dart analyze` is the intermediate signal, and Step 1 records the baseline to return to.

--- a/docs/superpowers/plans/2026-08-02-timeline-grouping-upstream-divergence.md
+++ b/docs/superpowers/plans/2026-08-02-timeline-grouping-upstream-divergence.md
@@ -493,7 +493,7 @@ void main() {
       expect(container.read(timelineGroupingSpecProvider).groupBy, GroupAssetsBy.day);
 
       await setGridSetting(GroupAssetsBy.month);
-      await container.pump();
+      await Future<void>.delayed(const Duration(milliseconds: 5));
       expect(container.read(timelineGroupingSpecProvider).groupBy, GroupAssetsBy.month);
     });
 
@@ -503,7 +503,7 @@ void main() {
       expect(container.read(timelineGroupingSpecProvider).groupBy, GroupAssetsBy.month);
 
       await setGridSetting(GroupAssetsBy.month);
-      await container.pump();
+      await Future<void>.delayed(const Duration(milliseconds: 5));
       expect(container.read(timelineGroupingSpecProvider).groupBy, GroupAssetsBy.month);
     });
 
@@ -514,7 +514,15 @@ void main() {
 }
 ```
 
-If `container.pump()` is unavailable in this Riverpod version, use `await Future<void>.delayed(Duration.zero)` — match whatever the existing timeline provider tests already do.
+**On the awaits in M-6 and M-7:** those two assert live propagation of a setting change, which travels
+Drift stream → `appConfigProvider` → `timelineGridGroupingProvider` → the spec. `Duration.zero` is not
+always enough for the Drift stream to emit; 5 ms matches what `timeline_query_provider_test.dart` already
+uses for the same reason. `ProviderContainer.pump()` exists in Riverpod 2.6.1 but is used nowhere in this
+repo — stick to the delay idiom the suite already uses (see `overview_drilldown_provider_test.dart:64`).
+
+If M-6 or M-7 proves flaky, do **not** just lengthen the delay. Every other test in this file writes the
+setting _before_ creating the container, sidestepping propagation entirely; if live propagation cannot be
+asserted reliably, say so and drop to that pattern rather than shipping a timing-dependent test.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -1018,7 +1026,9 @@ In `main_timeline_zoom_test.dart`, the mock timeline-service factories must keep
 ~/.local/share/mise/installs/flutter/3.44.8/bin/flutter test
 ```
 
-Expected: at least the Step 1 baseline, 0 failures.
+Expected: **the Step 1 baseline minus 2**, 0 failures. The drop is expected and accounted for: the `day:`,
+`auto:` and `none:` tests in `timeline_grouping_anchor_test.dart` collapse into a single `all:` test (see
+the churn table). Any other movement in the count is unexplained — investigate before continuing.
 
 - [ ] **Step 15: Mutation-check the six highest-risk guards**
 
@@ -1342,7 +1352,8 @@ Check `TimelineFactory`'s constructor parameter names against `lib/domain/servic
 ~/.local/share/mise/installs/flutter/3.44.8/bin/dart format lib
 ```
 
-Expected: 0 failures, count up by 12 over the Task 4 total.
+Expected: 0 failures, count up by **13** over the Task 4 total — S-4, S-5, S-6, S-7, Z-6, B-3, B-4, L-3,
+F-1…F-4 and the extra `none` fallback case.
 
 - [ ] **Step 11: Commit**
 
@@ -1467,5 +1478,9 @@ PR #911's body describes the original three-provider fix. Rewrite the "The fix" 
 **Two spec gaps handled here:** `overview_segment.model.dart` and `overview_representative_cache.provider.dart` are in the retype blast radius but absent from the spec's §4 list. Both are retyped in Task 4 (Steps 5 and 3); the spec is corrected in Task 6 Step 5.
 
 **Type consistency.** `TimelineOverviewMode` values are `years`/`months`/`all` everywhere — never `year`/`month`/`day`. `TimelineGroupingSpec` is a record with fields `mode` and `groupBy`. The drilldown handler's second parameter is `mode` in the typedef, implementation and call site. `TimelineOverviewSegmentBuilder` takes `mode`; its inherited `SegmentBuilder.groupBy` stays at the upstream default, unused. `TimelineArgs.groupBy`, the scrubber chain and the query layer stay `GroupAssetsBy`.
+
+**Second audit (this pass) — five further corrections.** `ProviderContainer.pump()` is used nowhere in this repo, so M-6/M-7 now use the suite's own `await Future<void>.delayed(...)` idiom, with an explicit instruction not to paper over flakiness by lengthening it. Task 4's expected test count is the baseline **minus 2**, not "at least the baseline" — the anchor-test collapse removes two. Task 5 adds **13** tests, not 12. `drift_favorite_page_test.dart` references `TimelineOverviewCard` only as a type, so it likely needs no edit. `TimelineFactory(timelineRepository:, settingsRepository:)` was confirmed against `timeline_factory_temporal_scope_test.dart:32`, and `overview_representative_cache.provider.dart` confirmed fork-only.
+
+**Verified this pass and unchanged:** `SegmentBuilder`'s constructor allows `TimelineOverviewSegmentBuilder({required super.buckets, required this.mode})` because `groupBy` has a default; `Segment.header` exists and is what the existing segment tests assert on; `overview_segment_builder_test.dart:99` and `timeline_overview_card_test.dart` do pass `groupBy:` and so are correctly listed in the churn table; the Task 2 mutation leaves `verifyNever(() => factory.groupBy)` satisfied while failing the `capturedGroupBy` expectation, so it is a clean red.
 
 **Known risk.** Task 4 leaves the tree uncompilable between Steps 2 and 12. That is inherent to a Dart type flip and cannot be avoided without a temporary shim that would be its own churn. `dart analyze` is the intermediate signal, Step 1 records the baseline, and the task ends green.

--- a/docs/superpowers/specs/2026-08-02-timeline-grouping-upstream-divergence-design.md
+++ b/docs/superpowers/specs/2026-08-02-timeline-grouping-upstream-divergence-design.md
@@ -1,0 +1,401 @@
+# Timeline grouping: separate the fork's overview mode from upstream's grid grouping
+
+**Date:** 2026-08-02
+**Branch:** `worktree-fix-903-photo-grid-group-by` (PR #911)
+**Status:** design approved, pending implementation
+
+## Background
+
+PR #911 fixes [#903](https://github.com/open-noodle/gallery/discussions/903): choosing **Month** under
+Settings → Photo Grid → **Group by** produced the month-card overview instead of a month-headered photo
+grid. The cause was PR #625, which made the on-page Years / Months / All selector read and write
+`SettingsKey.timelineGroupAssetsBy` — the same key behind the settings picker. Any month/year value in
+that key routes the timeline to `TimelineOverviewSegmentBuilder`, so the setting became unusable.
+
+#911 separates the two at the provider level and ships the user-visible fix. A review of the diff against
+`upstream/main` found that the fix, as written, pays for that separation in the wrong currency: it adds
+fork concepts to upstream-owned files, and in one case triples a file's rebase surface for no behavioural
+reason. It also leaves the underlying type confusion in place.
+
+This design covers both: reducing the divergence #911 introduced, and removing the ambiguity that made
+#625's mistake possible.
+
+### Measured divergence from `upstream/main`
+
+| File                             | Owner          | Before #911 | After #911  |
+| -------------------------------- | -------------- | ----------- | ----------- |
+| `timeline.state.dart`            | upstream       | 17+/4-      | **48+/20-** |
+| `timeline.model.dart`            | upstream       | 2+/2-       | **12+/2-**  |
+| `asset_list_group_settings.dart` | upstream       | 4+/0-       | 3+/1-       |
+| `timeline.service.dart`          | already forked | 143+/44-    | 145+/48-    |
+| `main_timeline.page.dart`        | already forked | 94+/5-      | 95+/5-      |
+
+All 12 test files touched by #911 are fork-only and carry no rebase cost.
+
+### Ownership of the grouping call chain
+
+Everything that speaks the _selector's_ meaning is already fork-only, which is what makes this change
+contained.
+
+| Fork-only — free to change                                     | Upstream-owned — fork types must not leak in |
+| -------------------------------------------------------------- | -------------------------------------------- |
+| `timeline_grouping_selector.widget.dart`                       | `timeline.widget.dart` (280+/64-)            |
+| `overview_drilldown.provider.dart`                             | `timeline.repository.dart` (1083+/120-)      |
+| `timeline_grouping_anchor.dart`                                | `header.widget.dart` (20+/5-)                |
+| `timeline_scroll_target.dart`                                  | `fixed/segment_builder.dart` (1+/0-)         |
+| `overview_card.dart`, `overview_segment_builder.dart`          | `segment_builder.dart` (1+/0-)               |
+| `scrubber.dart`, `scrubber_segments.dart`                      | `timeline.state.dart`, `timeline.model.dart` |
+| `timeline_grouping.provider.dart`, `timeline_route_scope.dart` |                                              |
+
+## Problem statement
+
+One type, `GroupAssetsBy`, carries two unrelated meanings:
+
+- **Upstream's meaning** — how coarse the photo grid's date headers are. `month` = one header per month
+  instead of one per day. This is the persisted Group by setting.
+- **The fork's meaning** — which zoom level the timeline is at. `months` = render the month **cards**
+  overview instead of photos. This is the Years / Months / All pill.
+
+Both meanings inhabit the same enum, so no call site — and no compiler — can tell which one it is being
+handed. #903 is the direct consequence.
+
+#911 separates the providers but not the vocabulary. The ambiguity survives in live code, for example
+`timeline_scroll_target.dart:29`:
+
+```dart
+TimelineZoomMonthAnchor(...) when groupBy == GroupAssetsBy.day => ...
+```
+
+Here `day` means "the user has drilled down to All", not "day headers". Passing the header granularity
+instead compiles cleanly and silently scrolls to the wrong place.
+
+## Goals
+
+1. Return `timeline.state.dart` and `timeline.model.dart` to approximately their pre-#911 divergence.
+2. Make the two grouping concepts distinct types, so mixing them is a compile error.
+3. Keep the persisted setting's meaning defined in exactly one place.
+4. No user-visible behaviour change beyond the #903 fix #911 already ships.
+
+## Non-goals
+
+`GroupAssetsBy.year` and `HeaderType.year` stay in upstream's enums. The query layer genuinely needs year
+bucketing (`timeline.repository.dart` lines 1445, 1526, 1532, 1688, 1709) and `HeaderType.year` renders
+the overview's year headers. Two single-line divergences therefore remain, in `fixed/segment_builder.dart`
+and `segment_builder.dart`, both forced by Dart's exhaustive switches over those enums.
+
+Evicting `year` from `GroupAssetsBy` was considered and rejected: it would make
+`fixed/segment_builder.dart` byte-identical to upstream at a cost of 36 repository method signatures, 15
+`TimelineFactory` methods, 15 timeline-service builder call sites and five blocks of bucketing SQL — and
+would push a fork type into upstream's repository signatures, entangling the two more rather than less.
+
+## Design
+
+### 1. New fork-only vocabulary
+
+New file `mobile/lib/domain/models/timeline_grouping.model.dart`. Being a new fork-only file, it has zero
+rebase surface. Living in `domain/` lets `TimelineFactory` import it without the layering inversion that
+originally pushed `normalizeGridGrouping` into `timeline.model.dart`.
+
+```dart
+/// Which zoom level the timeline is at. Fork-only: upstream has no overview.
+/// Deliberately NOT GroupAssetsBy — that type means "how coarse are the grid's
+/// date headers", and conflating the two is what caused #903.
+enum TimelineOverviewMode { years, months, all }
+
+/// The persisted "Photo Grid" -> "Group by" setting, clamped to the two
+/// granularities the grid renders.
+GroupAssetsBy normalizeGridGrouping(GroupAssetsBy groupBy) =>
+    groupBy == GroupAssetsBy.month ? GroupAssetsBy.month : GroupAssetsBy.day;
+```
+
+`normalizeGridGrouping` moves here from `timeline.model.dart`, which reverts to 2+/2- — the two `year`
+enum values that predate this work.
+
+`normalizeTimelineGrouping` is **deleted**. It existed to clamp `GroupAssetsBy` down to the three selector
+positions; `TimelineOverviewMode` is already that closed set, so there is nothing to clamp. Two
+confusably-named normalize functions become one.
+
+### 2. Provider layer
+
+| Today                                              | After                                                                                   |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `timelineGroupingProvider` → `GroupAssetsBy`       | `timelineOverviewModeProvider` → `TimelineOverviewMode`, `build() => all`               |
+| `timelineGridGroupingProvider` → `GroupAssetsBy`   | unchanged — the persisted setting                                                       |
+| `timelineBucketGroupingProvider` → `GroupAssetsBy` | `timelineGroupingSpecProvider` → `({TimelineOverviewMode mode, GroupAssetsBy groupBy})` |
+
+```dart
+final timelineGroupingSpecProvider = Provider<TimelineGroupingSpec>((ref) {
+  final mode = ref.watch(timelineOverviewModeProvider);
+  return switch (mode) {
+    TimelineOverviewMode.years  => (mode: mode, groupBy: GroupAssetsBy.year),
+    TimelineOverviewMode.months => (mode: mode, groupBy: GroupAssetsBy.month),
+    TimelineOverviewMode.all    => (mode: mode, groupBy: ref.watch(timelineGridGroupingProvider)),
+  };
+}, dependencies: [timelineOverviewModeProvider]);
+```
+
+One provider answers both questions the timeline asks — _cards or grid?_ and _at what granularity?_ —
+which is what allows `timeline.state.dart` to watch a single provider.
+
+`timelineGroupingSpecProvider` must declare `dependencies: [timelineOverviewModeProvider]`, and
+`TimelineRouteScope` must keep overriding the mode provider, so that a detail route's auto-scoped copy
+resolves the route-local mode rather than the root one.
+
+### 3. `timeline.state.dart` returns to upstream's shape
+
+```dart
+  final spec = groupByArg != null
+      ? (mode: TimelineOverviewMode.all, groupBy: groupByArg)
+      : ref.watch(timelineGroupingSpecProvider);
+
+  final timelineService = ref.watch(timelineServiceProvider);
+  yield* timelineService.watchBuckets().map((buckets) {
+    // A date-less bucket source (relevance-sorted search, `fromAssets`) has no dates
+    // to group by — fall back to the flat grid.
+    final isDateless = buckets.isNotEmpty && buckets.first is! TimeBucket;
+    if (spec.mode != TimelineOverviewMode.all && !isDateless) {
+      return TimelineOverviewSegmentBuilder(buckets: buckets, mode: spec.mode).generate();
+    }
+    return FixedSegmentBuilder(
+      buckets: buckets,
+      tileHeight: tileExtent,
+      columnCount: columnCount,
+      spacing: spacing,
+      groupBy: isDateless ? GroupAssetsBy.day : spec.groupBy,
+    ).generate();
+  });
+}, dependencies: [timelineServiceProvider, timelineArgsProvider, timelineGroupingSpecProvider]);
+```
+
+The single-provider dependency list is 96 characters against the 120 limit set by `analysis_options.yaml`,
+so `dart format` leaves the one-line trailing form alone and the whole provider body keeps upstream's
+indentation. This is the mechanism behind the 48+/20- → ~12+/3- reduction: the current four-entry list is
+124 characters, which forces the multi-line argument form and reindents ~25 otherwise-untouched upstream
+lines.
+
+The `groupByArg != null` short-circuit is preserved, so the one caller that pins a grouping
+(`cleanup_preview.page.dart:38`, `GroupAssetsBy.day`) does not begin watching a provider it never needed.
+
+### 4. Retyping the fork-only chain
+
+Mechanical, no behaviour change:
+
+- `timeline_grouping_selector.widget.dart` — the pill's three positions and labels
+- `overview_drilldown.provider.dart` — `.set(months)` / `.set(all)` replace `.set(month)` / `.set(day)`
+- `overview_card.dart`, `overview_segment_builder.dart` — take the mode; the builder maps it to
+  `HeaderType`
+- `scrubber.dart`, `scrubber_segments.dart` — take the mode
+- `timeline_grouping_anchor.dart` — `previousGroupBy` → `previousMode`
+- `timeline_route_scope.dart` — overrides `timelineOverviewModeProvider`, reads the spec
+- `timeline_scroll_target.dart` — the guards become `when mode == TimelineOverviewMode.all` / `.months`
+
+The last one is the payoff: the guard finally states what it means, and passing a header granularity there
+stops compiling.
+
+### 5. Upstream files touched by item 4
+
+Only `timeline.widget.dart`, at three lines (223 `listenManual`, 472, 611), in a file already 280+/64-
+diverged. Those sites split: the **mode** feeds the zoom anchor, `spec.groupBy` feeds the scrubber.
+
+That split is a small correctness improvement in its own right. Today the scrubber receives the selector
+position while rendering segments built at the _bucket_ granularity. It is harmless at present because
+`day` and `month` take the same branch in `scrubber_segments.dart` — only `year` is special-cased — but it
+is wrong on paper, and the retype fixes it at no extra cost.
+
+### 6. Settings screen
+
+`asset_list_group_settings.dart` watches `timelineGridGroupingProvider` rather than re-normalizing
+`appConfigProvider` itself. The line count barely moves; the point is that the definition of what the
+setting means lives in exactly one place instead of two.
+
+## Test strategy
+
+### TDD discipline
+
+This is a refactor of working code, so the usual TDD ordering needs one adjustment: **the behaviour is
+already specified by the existing suite.** The rule for this work is therefore:
+
+1. **Characterise before you change.** For each behaviour below that is not already asserted, write the
+   test against the _current_ implementation and watch it pass. That is the safety net. Only then retype.
+2. **RED first for anything genuinely new.** The `timelineGroupingSpecProvider` mapping, the pinned-grouping
+   path and the legacy-value cases are new behaviour with no existing coverage. Write those tests first,
+   run them, and confirm they fail for the stated reason before writing the provider.
+3. **One behaviour per test.** No test asserts both "which builder ran" and "at what granularity" unless
+   the scenario is specifically about their interaction.
+4. **Mutation-check every test not written RED-first.** A characterisation test that passes against the
+   old code proves nothing until you have seen it fail. Revert the specific line it guards, confirm the
+   red, restore. This is not optional — it is the only evidence a characterisation test is load-bearing.
+   Two tests in #911 were caught this way.
+5. **No assertion that cannot fail.** Watch for the usual shapes: asserting a setting nothing writes any
+   more, substring matches that collide with other numbers on screen, and querying a widget that is absent
+   in both the pass and fail case.
+6. **A behavioural rewrite of an existing test is a red flag.** Nothing in this design changes what the app
+   does. If a test needs its _assertions_ changed rather than just its _names_, stop: the retype has
+   changed semantics somewhere it should not have.
+
+### BDD scenarios
+
+Written Given/When/Then. Each maps to one test; the file column names where it belongs.
+
+#### The #903 guard — the setting and the pill are independent
+
+| #   | Given                                        | When                             | Then                                                          | File                                   |
+| --- | -------------------------------------------- | -------------------------------- | ------------------------------------------------------------- | -------------------------------------- |
+| G-1 | Group by = **Month**, pill = **All**         | the timeline builds segments     | `FixedSegmentBuilder` runs with `GroupAssetsBy.month`         | `timeline_segment_provider_test.dart`  |
+| G-2 | Group by = **Month + day**, pill = **All**   | the timeline builds segments     | `FixedSegmentBuilder` runs with `GroupAssetsBy.day`           | `timeline_segment_provider_test.dart`  |
+| G-3 | Group by = **Month**, pill = **Months**      | the timeline builds segments     | `TimelineOverviewSegmentBuilder` runs; the setting is ignored | `timeline_segment_provider_test.dart`  |
+| G-4 | Group by = **Month + day**, pill = **Years** | the timeline builds segments     | `TimelineOverviewSegmentBuilder` runs at year granularity     | `timeline_segment_provider_test.dart`  |
+| G-5 | any Group by value                           | the pill is moved to **Months**  | `SettingsKey.timelineGroupAssetsBy` is **not** written        | `timeline_grouping_selector_test.dart` |
+| G-6 | pill = **Months**                            | Group by is changed to **Month** | the pill stays on **Months**                                  | `asset_list_group_settings_test.dart`  |
+
+G-1 and G-5 are the two that would have caught #903. Both must be present and both must have been seen to
+fail.
+
+#### Mode → spec mapping
+
+| #   | Given                             | When                | Then                                  | File                               |
+| --- | --------------------------------- | ------------------- | ------------------------------------- | ---------------------------------- |
+| M-1 | mode = `years`                    | the spec is read    | `(years, GroupAssetsBy.year)`         | `timeline_grouping_spec_test.dart` |
+| M-2 | mode = `months`                   | the spec is read    | `(months, GroupAssetsBy.month)`       | `timeline_grouping_spec_test.dart` |
+| M-3 | mode = `all`, setting = `day`     | the spec is read    | `(all, GroupAssetsBy.day)`            | `timeline_grouping_spec_test.dart` |
+| M-4 | mode = `all`, setting = `month`   | the spec is read    | `(all, GroupAssetsBy.month)`          | `timeline_grouping_spec_test.dart` |
+| M-5 | mode = `years`, setting = `month` | the spec is read    | `groupBy` is `year` — setting ignored | `timeline_grouping_spec_test.dart` |
+| M-6 | mode = `all`                      | the setting changes | the spec's `groupBy` follows it       | `timeline_grouping_spec_test.dart` |
+| M-7 | mode = `months`                   | the setting changes | the spec is unchanged                 | `timeline_grouping_spec_test.dart` |
+
+#### Legacy and out-of-range persisted values
+
+The Year radio shipped in a fork build, so `year` can be sitting in a real user's store. `auto` and `none`
+are upstream legacy values. None of them are reachable through the UI any more.
+
+| #   | Given stored `timelineGroupAssetsBy` | Then `normalizeGridGrouping` | And the settings screen shows | File                                  |
+| --- | ------------------------------------ | ---------------------------- | ----------------------------- | ------------------------------------- |
+| L-1 | `day`                                | `day`                        | **Month + day** selected      | `timeline_grouping_model_test.dart`   |
+| L-2 | `month`                              | `month`                      | **Month** selected            | `timeline_grouping_model_test.dart`   |
+| L-3 | `year` (removed option)              | `day`                        | **Month + day** selected      | `asset_list_group_settings_test.dart` |
+| L-4 | `auto` (upstream legacy)             | `day`                        | **Month + day** selected      | `timeline_grouping_model_test.dart`   |
+| L-5 | `none` (upstream legacy)             | `day`                        | **Month + day** selected      | `timeline_grouping_model_test.dart`   |
+
+L-3 is the one with a real user behind it. It must assert a radio is _selected_, not merely that the
+screen renders — "renders without a selection" is exactly the failure mode.
+
+#### Route scoping
+
+| #   | Given                                   | When                            | Then                                                   | File                             |
+| --- | --------------------------------------- | ------------------------------- | ------------------------------------------------------ | -------------------------------- |
+| R-1 | main timeline pill = **Years**          | an album route opens            | the album opens at **All**                             | `timeline_route_scope_test.dart` |
+| R-2 | inside an album                         | the pill is moved to **Months** | the main timeline's pill is unchanged                  | `timeline_route_scope_test.dart` |
+| R-3 | main timeline pill = **Months**         | navigate away and back          | the pill is still **Months** (`sharedGrouping: true`)  | `timeline_route_scope_test.dart` |
+| R-4 | inside an album with a route-local mode | the segment provider is read    | it resolves the **route-local** mode, not the root one | `timeline_route_scope_test.dart` |
+| R-5 | app cold start                          | the main timeline opens         | the pill is **All** regardless of the stored setting   | `timeline_route_scope_test.dart` |
+
+R-4 is the `dependencies:` correctness test. It is the one that silently regresses if a provider is added
+to the chain without being declared, and it must fail if `timelineGroupingSpecProvider` drops its
+`dependencies: [timelineOverviewModeProvider]`.
+
+#### Segment builder selection and its edge cases
+
+| #   | Given                                                   | Then                                                           | File                                  |
+| --- | ------------------------------------------------------- | -------------------------------------------------------------- | ------------------------------------- |
+| S-1 | date-less buckets (relevance search), mode = **All**    | `FixedSegmentBuilder` with `day`                               | `timeline_segment_provider_test.dart` |
+| S-2 | date-less buckets, mode = **Months**                    | `FixedSegmentBuilder` with `day` — **never** the overview      | `timeline_segment_provider_test.dart` |
+| S-3 | date-less buckets, mode = **Years**                     | `FixedSegmentBuilder` with `day`                               | `timeline_segment_provider_test.dart` |
+| S-4 | **empty** bucket list, mode = **Months**                | no crash; segments are empty                                   | `timeline_segment_provider_test.dart` |
+| S-5 | empty bucket list, mode = **All**, Group by = **Month** | no crash; segments are empty                                   | `timeline_segment_provider_test.dart` |
+| S-6 | `groupByArg` pinned to `day`, mode = **Months**         | `FixedSegmentBuilder` with `day`; the overview is never chosen | `timeline_segment_provider_test.dart` |
+| S-7 | `groupByArg` pinned                                     | the spec provider is not watched                               | `timeline_segment_provider_test.dart` |
+
+S-4 deserves emphasis. `isDateless` is computed as `buckets.isNotEmpty && buckets.first is! TimeBucket`,
+so an **empty** list yields `isDateless == false` and an overview-mode timeline will call
+`TimelineOverviewSegmentBuilder` with no buckets. That path exists today and is untested. Characterise it
+before touching anything; if it turns out to throw, that is a pre-existing bug to fix in this PR, not to
+introduce.
+
+S-7 guards the short-circuit described in §3 — a pinned grouping must not create a subscription.
+
+#### Zoom anchor and drill-down
+
+This is the highest-risk area of the retype, because the anchor guards are exactly the call sites where
+the two meanings were previously indistinguishable.
+
+| #   | Given                                                            | When                   | Then                                           | File                                        |
+| --- | ---------------------------------------------------------------- | ---------------------- | ---------------------------------------------- | ------------------------------------------- |
+| Z-1 | mode = **Years**                                                 | a year card is tapped  | mode becomes **Months**, anchored on that year | `overview_drilldown_provider_test.dart`     |
+| Z-2 | mode = **Months**                                                | a month card is tapped | mode becomes **All**, anchored on that month   | `overview_drilldown_provider_test.dart`     |
+| Z-3 | a `YearAnchor` is pending                                        | mode = **Months**      | it resolves to the matching year segment       | `timeline_zoom_anchor_resolution_test.dart` |
+| Z-4 | a `MonthAnchor` is pending                                       | mode = **All**         | it resolves to the matching month segment      | `timeline_zoom_anchor_resolution_test.dart` |
+| Z-5 | a `MonthAnchor` is pending                                       | mode = **Months**      | it does **not** resolve                        | `timeline_zoom_anchor_resolution_test.dart` |
+| Z-6 | a `MonthAnchor` is pending, **Group by = Month**, mode = **All** | resolution runs        | it **still** resolves                          | `timeline_zoom_anchor_resolution_test.dart` |
+| Z-7 | an anchor was scheduled for one mode                             | the mode changes first | resolution bails out                           | `main_timeline_zoom_test.dart`              |
+| Z-8 | no anchor set                                                    | segments render        | nothing scrolls                                | `main_timeline_zoom_test.dart`              |
+
+**Z-6 is the critical one.** It is the test that fails if someone "helpfully" feeds `spec.groupBy` to the
+anchor instead of `spec.mode`: with Group by = Month the bucket grouping is `month`, so a `MonthAnchor`
+would stop matching an `all`-mode guard and drilling from Months into All would silently fail to scroll.
+This scenario did not exist before this design and must be written RED against a deliberately wrong
+implementation first.
+
+#### Scrubber labels
+
+| #   | Given                                | Then                                      | File                          |
+| --- | ------------------------------------ | ----------------------------------------- | ----------------------------- |
+| B-1 | mode = **Years**                     | labels are year-only (`DateFormat.y`)     | `scrubber_segments_test.dart` |
+| B-2 | mode = **Months**                    | labels are month+year (`DateFormat.yMMM`) | `scrubber_segments_test.dart` |
+| B-3 | mode = **All**, Group by = **Month** | labels are month+year                     | `scrubber_segments_test.dart` |
+
+B-3 pins the behaviour that makes the §5 scrubber change safe.
+
+#### `TimelineFactory.groupBy` fallback
+
+Reached only by routes that do not pass an explicit grouping.
+
+| #   | Given stored setting | Then `TimelineFactory.groupBy` | File                         |
+| --- | -------------------- | ------------------------------ | ---------------------------- |
+| F-1 | `month`              | `month`                        | `timeline_service_test.dart` |
+| F-2 | `day`                | `day`                          | `timeline_service_test.dart` |
+| F-3 | `year`               | `day`                          | `timeline_service_test.dart` |
+| F-4 | `auto`               | `day`                          | `timeline_service_test.dart` |
+
+### Migrating the existing suite
+
+All 12 fork-only test files touched by #911 need the rename applied. Rules:
+
+- Renames only. `GroupAssetsBy.day` as a _pill position_ becomes `TimelineOverviewMode.all`;
+  `GroupAssetsBy.month` as a _pill position_ becomes `TimelineOverviewMode.months`. Where the same literal
+  meant header granularity, it stays `GroupAssetsBy`.
+- The mock timeline-service factories in `main_timeline_zoom_test.dart` must keep honouring the `groupBy`
+  the production code passes them rather than re-reading the setting. #911 already fixed this; do not let
+  the retype reintroduce it, or the tests will shadow the wiring instead of exercising it.
+- Any test whose _assertions_ change is escalated, not edited. See TDD rule 6.
+
+### Gates
+
+From `mobile/`, with the pinned Flutter 3.44.8 (`mobile/mise.toml`):
+
+```
+flutter test
+dart analyze --fatal-infos lib test
+dart format lib
+```
+
+`dart analyze --fatal-infos` and `dart format` are separate CI gates and both are blocking. `dart analyze`
+alone is not a substitute for `flutter test`: generated-code compile errors only surface when a test
+actually compiles.
+
+Baseline to beat: 2902 passing, 0 failures.
+
+## Expected outcome
+
+| File                             | After #911 | After this work |
+| -------------------------------- | ---------- | --------------- |
+| `timeline.state.dart`            | 48+/20-    | ~12+/3-         |
+| `timeline.model.dart`            | 12+/2-     | 2+/2-           |
+| `asset_list_group_settings.dart` | 3+/1-      | ~2+/1-          |
+| `timeline.widget.dart`           | 280+/64-   | ~283+/67-       |
+
+Plus one new fork-only file and a fork-only chain that can no longer be confused with upstream's.
+
+## Delivery
+
+All four items land in PR #911, per Pierre's decision. The PR therefore carries the #903 fix, the
+divergence reduction, and the type separation together.

--- a/docs/superpowers/specs/2026-08-02-timeline-grouping-upstream-divergence-design.md
+++ b/docs/superpowers/specs/2026-08-02-timeline-grouping-upstream-divergence-design.md
@@ -102,6 +102,10 @@ originally pushed `normalizeGridGrouping` into `timeline.model.dart`.
 /// date headers", and conflating the two is what caused #903.
 enum TimelineOverviewMode { years, months, all }
 
+/// What the timeline should render for the current scope: which zoom level, and
+/// the bucket/header granularity that goes with it.
+typedef TimelineGroupingSpec = ({TimelineOverviewMode mode, GroupAssetsBy groupBy});
+
 /// The persisted "Photo Grid" -> "Group by" setting, clamped to the two
 /// granularities the grid renders.
 GroupAssetsBy normalizeGridGrouping(GroupAssetsBy groupBy) =>
@@ -235,7 +239,11 @@ already specified by the existing suite.** The rule for this work is therefore:
 
 ### BDD scenarios
 
-Written Given/When/Then. Each maps to one test; the file column names where it belongs.
+Written Given/When/Then. Each maps to one test; the file column names where it belongs. A **†** marks a
+file that does not exist yet — `timeline_grouping_spec_test.dart` and `timeline_grouping_model_test.dart`
+alongside the other timeline provider/model tests, and `timeline_factory_grouping_test.dart` next to the
+existing `test/domain/services/timeline_factory_temporal_scope_test.dart`. Everything else is an existing
+fork-only file.
 
 #### The #903 guard — the setting and the pill are independent
 
@@ -253,15 +261,15 @@ fail.
 
 #### Mode → spec mapping
 
-| #   | Given                             | When                | Then                                  | File                               |
-| --- | --------------------------------- | ------------------- | ------------------------------------- | ---------------------------------- |
-| M-1 | mode = `years`                    | the spec is read    | `(years, GroupAssetsBy.year)`         | `timeline_grouping_spec_test.dart` |
-| M-2 | mode = `months`                   | the spec is read    | `(months, GroupAssetsBy.month)`       | `timeline_grouping_spec_test.dart` |
-| M-3 | mode = `all`, setting = `day`     | the spec is read    | `(all, GroupAssetsBy.day)`            | `timeline_grouping_spec_test.dart` |
-| M-4 | mode = `all`, setting = `month`   | the spec is read    | `(all, GroupAssetsBy.month)`          | `timeline_grouping_spec_test.dart` |
-| M-5 | mode = `years`, setting = `month` | the spec is read    | `groupBy` is `year` — setting ignored | `timeline_grouping_spec_test.dart` |
-| M-6 | mode = `all`                      | the setting changes | the spec's `groupBy` follows it       | `timeline_grouping_spec_test.dart` |
-| M-7 | mode = `months`                   | the setting changes | the spec is unchanged                 | `timeline_grouping_spec_test.dart` |
+| #   | Given                             | When                | Then                                  | File                                 |
+| --- | --------------------------------- | ------------------- | ------------------------------------- | ------------------------------------ |
+| M-1 | mode = `years`                    | the spec is read    | `(years, GroupAssetsBy.year)`         | `timeline_grouping_spec_test.dart` † |
+| M-2 | mode = `months`                   | the spec is read    | `(months, GroupAssetsBy.month)`       | `timeline_grouping_spec_test.dart` † |
+| M-3 | mode = `all`, setting = `day`     | the spec is read    | `(all, GroupAssetsBy.day)`            | `timeline_grouping_spec_test.dart` † |
+| M-4 | mode = `all`, setting = `month`   | the spec is read    | `(all, GroupAssetsBy.month)`          | `timeline_grouping_spec_test.dart` † |
+| M-5 | mode = `years`, setting = `month` | the spec is read    | `groupBy` is `year` — setting ignored | `timeline_grouping_spec_test.dart` † |
+| M-6 | mode = `all`                      | the setting changes | the spec's `groupBy` follows it       | `timeline_grouping_spec_test.dart` † |
+| M-7 | mode = `months`                   | the setting changes | the spec is unchanged                 | `timeline_grouping_spec_test.dart` † |
 
 #### Legacy and out-of-range persisted values
 
@@ -270,11 +278,11 @@ are upstream legacy values. None of them are reachable through the UI any more.
 
 | #   | Given stored `timelineGroupAssetsBy` | Then `normalizeGridGrouping` | And the settings screen shows | File                                  |
 | --- | ------------------------------------ | ---------------------------- | ----------------------------- | ------------------------------------- |
-| L-1 | `day`                                | `day`                        | **Month + day** selected      | `timeline_grouping_model_test.dart`   |
-| L-2 | `month`                              | `month`                      | **Month** selected            | `timeline_grouping_model_test.dart`   |
+| L-1 | `day`                                | `day`                        | **Month + day** selected      | `timeline_grouping_model_test.dart` † |
+| L-2 | `month`                              | `month`                      | **Month** selected            | `timeline_grouping_model_test.dart` † |
 | L-3 | `year` (removed option)              | `day`                        | **Month + day** selected      | `asset_list_group_settings_test.dart` |
-| L-4 | `auto` (upstream legacy)             | `day`                        | **Month + day** selected      | `timeline_grouping_model_test.dart`   |
-| L-5 | `none` (upstream legacy)             | `day`                        | **Month + day** selected      | `timeline_grouping_model_test.dart`   |
+| L-4 | `auto` (upstream legacy)             | `day`                        | **Month + day** selected      | `timeline_grouping_model_test.dart` † |
+| L-5 | `none` (upstream legacy)             | `day`                        | **Month + day** selected      | `timeline_grouping_model_test.dart` † |
 
 L-3 is the one with a real user behind it. It must assert a radio is _selected_, not merely that the
 screen renders — "renders without a selection" is exactly the failure mode.
@@ -303,7 +311,7 @@ to the chain without being declared, and it must fail if `timelineGroupingSpecPr
 | S-4 | **empty** bucket list, mode = **Months**                | no crash; segments are empty                                   | `timeline_segment_provider_test.dart` |
 | S-5 | empty bucket list, mode = **All**, Group by = **Month** | no crash; segments are empty                                   | `timeline_segment_provider_test.dart` |
 | S-6 | `groupByArg` pinned to `day`, mode = **Months**         | `FixedSegmentBuilder` with `day`; the overview is never chosen | `timeline_segment_provider_test.dart` |
-| S-7 | `groupByArg` pinned                                     | the spec provider is not watched                               | `timeline_segment_provider_test.dart` |
+| S-7 | `groupByArg` pinned to `day`                            | moving the pill and changing Group by leave the segments alone | `timeline_segment_provider_test.dart` |
 
 S-4 deserves emphasis. `isDateless` is computed as `buckets.isNotEmpty && buckets.first is! TimeBucket`,
 so an **empty** list yields `isDateless == false` and an overview-mode timeline will call
@@ -311,7 +319,9 @@ so an **empty** list yields `isDateless == false` and an overview-mode timeline 
 before touching anything; if it turns out to throw, that is a pre-existing bug to fix in this PR, not to
 introduce.
 
-S-7 guards the short-circuit described in §3 — a pinned grouping must not create a subscription.
+S-7 guards the short-circuit described in §3. Assert it observably rather than by inspecting Riverpod's
+subscription graph: with `groupByArg` pinned, move the pill and change Group by, and the emitted segments
+must not change.
 
 #### Zoom anchor and drill-down
 
@@ -349,12 +359,12 @@ B-3 pins the behaviour that makes the §5 scrubber change safe.
 
 Reached only by routes that do not pass an explicit grouping.
 
-| #   | Given stored setting | Then `TimelineFactory.groupBy` | File                         |
-| --- | -------------------- | ------------------------------ | ---------------------------- |
-| F-1 | `month`              | `month`                        | `timeline_service_test.dart` |
-| F-2 | `day`                | `day`                          | `timeline_service_test.dart` |
-| F-3 | `year`               | `day`                          | `timeline_service_test.dart` |
-| F-4 | `auto`               | `day`                          | `timeline_service_test.dart` |
+| #   | Given stored setting | Then `TimelineFactory.groupBy` | File                                    |
+| --- | -------------------- | ------------------------------ | --------------------------------------- |
+| F-1 | `month`              | `month`                        | `timeline_factory_grouping_test.dart` † |
+| F-2 | `day`                | `day`                          | `timeline_factory_grouping_test.dart` † |
+| F-3 | `year`               | `day`                          | `timeline_factory_grouping_test.dart` † |
+| F-4 | `auto`               | `day`                          | `timeline_factory_grouping_test.dart` † |
 
 ### Migrating the existing suite
 

--- a/docs/superpowers/specs/2026-08-02-timeline-grouping-upstream-divergence-design.md
+++ b/docs/superpowers/specs/2026-08-02-timeline-grouping-upstream-divergence-design.md
@@ -188,6 +188,10 @@ Mechanical, no behaviour change:
 - `overview_drilldown.provider.dart` — `.set(months)` / `.set(all)` replace `.set(month)` / `.set(day)`
 - `overview_card.dart`, `overview_segment_builder.dart` — take the mode; the builder maps it to
   `HeaderType`
+- `overview_segment.model.dart` — `TimelineOverviewSegment.mode` is `TimelineOverviewMode`, passed through
+  to the drilldown call and the representative-cache key
+- `overview_representative_cache.provider.dart` — `TimelineOverviewRepresentativeCacheNotifier.keyFor`
+  takes `TimelineOverviewMode`, not `GroupAssetsBy`
 - `timeline_grouping_anchor.dart` — `previousGroupBy` → `previousMode`
 - `timeline_route_scope.dart` — overrides `timelineOverviewModeProvider`, reads the spec
 - `timeline_scroll_target.dart` — the guards become `when mode == TimelineOverviewMode.all` / `.months`

--- a/docs/superpowers/specs/2026-08-02-timeline-grouping-upstream-divergence-design.md
+++ b/docs/superpowers/specs/2026-08-02-timeline-grouping-upstream-divergence-design.md
@@ -44,8 +44,8 @@ contained.
 | `timeline_grouping_anchor.dart`                                | `header.widget.dart` (20+/5-)                |
 | `timeline_scroll_target.dart`                                  | `fixed/segment_builder.dart` (1+/0-)         |
 | `overview_card.dart`, `overview_segment_builder.dart`          | `segment_builder.dart` (1+/0-)               |
-| `scrubber.dart`, `scrubber_segments.dart`                      | `timeline.state.dart`, `timeline.model.dart` |
-| `timeline_grouping.provider.dart`, `timeline_route_scope.dart` |                                              |
+| `scrubber_segments.dart`                                       | `scrubber.widget.dart` (45+/82-)             |
+| `timeline_grouping.provider.dart`, `timeline_route_scope.dart` | `timeline.state.dart`, `timeline.model.dart` |
 
 ## Problem statement
 
@@ -188,7 +188,6 @@ Mechanical, no behaviour change:
 - `overview_drilldown.provider.dart` — `.set(months)` / `.set(all)` replace `.set(month)` / `.set(day)`
 - `overview_card.dart`, `overview_segment_builder.dart` — take the mode; the builder maps it to
   `HeaderType`
-- `scrubber.dart`, `scrubber_segments.dart` — take the mode
 - `timeline_grouping_anchor.dart` — `previousGroupBy` → `previousMode`
 - `timeline_route_scope.dart` — overrides `timelineOverviewModeProvider`, reads the spec
 - `timeline_scroll_target.dart` — the guards become `when mode == TimelineOverviewMode.all` / `.months`
@@ -196,17 +195,40 @@ Mechanical, no behaviour change:
 The last one is the payoff: the guard finally states what it means, and passing a header granularity there
 stops compiling.
 
+**The scrubber chain is deliberately excluded.** `scrubber.widget.dart` is upstream-owned (45+/82-) and
+its `groupBy` parameter feeds `buildScrubberSegments`, `countScrubberSnapSegments` and
+`findScrubberLayoutSegmentIndex` in `scrubber_segments.dart`, all of which use it as a pure
+_granularity_ — `scrubber_segments.dart:45` special-cases only `GroupAssetsBy.year`. That is upstream's
+meaning of the type, so the whole chain stays on `GroupAssetsBy` and simply receives `spec.groupBy`.
+Retyping it would push a fork type into an upstream constructor for no benefit.
+
 ### 5. Upstream files touched by item 4
 
 Only `timeline.widget.dart`, at three lines (223 `listenManual`, 472, 611), in a file already 280+/64-
-diverged. Those sites split: the **mode** feeds the zoom anchor, `spec.groupBy` feeds the scrubber.
+diverged. Those sites split: the **mode** feeds the zoom anchor and `_onGroupingChanged`, while
+`spec.groupBy` feeds the scrubber. `_onGroupingChanged(GroupAssetsBy? previous, GroupAssetsBy next)` at
+line 292 changes signature to take the mode.
 
 That split is a small correctness improvement in its own right. Today the scrubber receives the selector
 position while rendering segments built at the _bucket_ granularity. It is harmless at present because
 `day` and `month` take the same branch in `scrubber_segments.dart` — only `year` is special-cased — but it
 is wrong on paper, and the retype fixes it at no extra cost.
 
-### 6. Settings screen
+### 6. Invariant: `normalizeGridGrouping` applies to the persisted setting only
+
+`GroupAssetsBy.none` is **not** a dead legacy value. `timeline_query.provider.dart:54` passes it
+deliberately:
+
+```dart
+final effectiveGroupBy = isRelevance ? GroupAssetsBy.none : (groupBy ?? factory.groupBy);
+```
+
+A relevance-sorted smart search has no meaningful date order, so it queries flat. `normalizeGridGrouping`
+must therefore be applied **only** where the persisted setting is read — `timelineGridGroupingProvider`,
+`TimelineFactory.groupBy` and the settings screen — and never to a grouping a caller passed explicitly.
+Normalizing an explicit `none` to `day` would silently re-introduce date bucketing into relevance search.
+
+### 7. Settings screen
 
 `asset_list_group_settings.dart` watches `timelineGridGroupingProvider` rather than re-normalizing
 `appConfigProvider` itself. The line count barely moves; the point is that the definition of what the
@@ -216,26 +238,65 @@ setting means lives in exactly one place instead of two.
 
 ### TDD discipline
 
-This is a refactor of working code, so the usual TDD ordering needs one adjustment: **the behaviour is
-already specified by the existing suite.** The rule for this work is therefore:
+**The governing rule: no scenario in this spec is done until it has been observed failing.** A test that
+has only ever been green is an untested test. Refactoring is where that bites hardest, because a test can
+pass for reasons entirely unrelated to the thing it claims to guard.
 
-1. **Characterise before you change.** For each behaviour below that is not already asserted, write the
-   test against the _current_ implementation and watch it pass. That is the safety net. Only then retype.
-2. **RED first for anything genuinely new.** The `timelineGroupingSpecProvider` mapping, the pinned-grouping
-   path and the legacy-value cases are new behaviour with no existing coverage. Write those tests first,
-   run them, and confirm they fail for the stated reason before writing the provider.
-3. **One behaviour per test.** No test asserts both "which builder ran" and "at what granularity" unless
-   the scenario is specifically about their interaction.
-4. **Mutation-check every test not written RED-first.** A characterisation test that passes against the
-   old code proves nothing until you have seen it fail. Revert the specific line it guards, confirm the
-   red, restore. This is not optional — it is the only evidence a characterisation test is load-bearing.
-   Two tests in #911 were caught this way.
-5. **No assertion that cannot fail.** Watch for the usual shapes: asserting a setting nothing writes any
-   more, substring matches that collide with other numbers on screen, and querying a widget that is absent
-   in both the pass and fail case.
-6. **A behavioural rewrite of an existing test is a red flag.** Nothing in this design changes what the app
-   does. If a test needs its _assertions_ changed rather than just its _names_, stop: the retype has
-   changed semantics somewhere it should not have.
+Each scenario reaches red by exactly one of two routes, and the route is not the implementer's choice —
+it follows from whether the behaviour exists today:
+
+- **Route A — write-first (new behaviour).** No production code exists yet. Write the test, run it, watch
+  it fail with the expected message, then write the minimum code to pass. Applies to the
+  `timelineGroupingSpecProvider` mapping (M-1…M-7), the pinned-grouping path (S-6, S-7), the empty-bucket
+  cases (S-4, S-5) and Z-6.
+- **Route B — characterise, then mutate (existing behaviour).** Write the test against the _current_
+  implementation and watch it pass. Then break the specific line it claims to guard, re-run, and confirm
+  it goes red for the right reason. Restore. **The mutation step is the test.** Skipping it leaves a test
+  that would survive the very regression it was written to catch — two such tests were caught this way in
+  #911.
+
+The full loop per slice:
+
+1. Pick one scenario. Determine its route.
+2. Get it red — write-first, or characterise-then-mutate.
+3. Write the minimum production code to get it green.
+4. Refactor with the test green.
+5. Run the whole file, then the whole suite. A green scenario that broke a neighbour is not done.
+
+Additional rules that hold throughout:
+
+- **No production line before a failing test names it.** If you find yourself editing `lib/` with nothing
+  red, stop and go back to step 1.
+- **One behaviour per test.** No test asserts both "which builder ran" and "at what granularity" unless
+  the scenario is specifically about their interaction.
+- **No assertion that cannot fail.** Watch for the usual shapes: asserting a setting nothing writes any
+  more, substring matches that collide with other numbers on screen, and querying a widget that is absent
+  in both the pass and fail case.
+- **A behavioural rewrite of an existing test is a red flag.** Nothing in this design changes what the app
+  does. If a test needs its _assertions_ changed rather than just its _names_, stop: the retype has
+  changed semantics somewhere it should not have.
+
+### Mutation matrix
+
+Route B scenarios are only as good as the mutation used to prove them. These are the mutations that must
+produce a red, and the scenario that must catch each. If a mutation stays green, the guard is missing.
+
+| Mutation                                                                           | Must break                                                                   |
+| ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `timelineGroupingSpecProvider`: make `all` return a hard-coded `day`               | G-1, M-4                                                                     |
+| `timelineGroupingSpecProvider`: make `months` read the grid setting                | G-3, M-5                                                                     |
+| Drop `dependencies: [timelineOverviewModeProvider]` from the spec provider         | R-4                                                                          |
+| `TimelineRouteScope`: stop overriding the mode provider                            | R-1, R-2                                                                     |
+| `TimelineRouteScope`: pass `sharedGrouping: true` to a detail route                | R-1                                                                          |
+| Restore the selector's write to `SettingsKey.timelineGroupAssetsBy`                | G-5                                                                          |
+| `timeline.state.dart`: feed the overview builder on `isDateless`                   | S-2, S-3                                                                     |
+| `timeline.widget.dart`: feed the zoom anchor `spec.groupBy` instead of `spec.mode` | **Z-6**                                                                      |
+| `timeline.widget.dart`: feed the scrubber `spec.mode` instead of `spec.groupBy`    | compile error — the scrubber stays typed `GroupAssetsBy`, which is the point |
+| `normalizeGridGrouping`: return the input unchanged                                | L-3, F-3                                                                     |
+| Apply `normalizeGridGrouping` to the explicit groupBy in `timeline_query.provider` | **Q-1**                                                                      |
+
+The two bolded rows are the mutations most likely to happen by accident during this refactor, because both
+look like tidy-ups. Neither is caught by any test that exists today.
 
 ### BDD scenarios
 
@@ -274,7 +335,10 @@ fail.
 #### Legacy and out-of-range persisted values
 
 The Year radio shipped in a fork build, so `year` can be sitting in a real user's store. `auto` and `none`
-are upstream legacy values. None of them are reachable through the UI any more.
+are upstream legacy values. None of the three is reachable through the settings UI any more.
+
+These rows are about the value **as a persisted setting**. They say nothing about `GroupAssetsBy.none` as
+an explicitly passed query grouping, which is live — see §6 and Q-1.
 
 | #   | Given stored `timelineGroupAssetsBy` | Then `normalizeGridGrouping` | And the settings screen shows | File                                  |
 | --- | ------------------------------------ | ---------------------------- | ----------------------------- | ------------------------------------- |
@@ -345,15 +409,74 @@ would stop matching an `all`-mode guard and drilling from Months into All would 
 This scenario did not exist before this design and must be written RED against a deliberately wrong
 implementation first.
 
+#### Filtered and search-backed timelines
+
+The Photos timeline is frequently search-backed, and that path chooses its own grouping. These guard the
+§6 invariant and the filter/grouping interaction.
+
+| #   | Given                                                    | When                  | Then                                                         | File                                             |
+| --- | -------------------------------------------------------- | --------------------- | ------------------------------------------------------------ | ------------------------------------------------ |
+| Q-1 | a smart filter sorted by **relevance**                   | the service is built  | `groupBy` is `GroupAssetsBy.none` — mode and setting ignored | `timeline_query_provider_test.dart`              |
+| Q-2 | a smart filter sorted by **newest**                      | the service is built  | `groupBy` is the spec grouping, not `none`                   | `timeline_query_provider_test.dart`              |
+| Q-3 | a non-smart filter                                       | the service is built  | `groupBy` is the spec grouping; descending                   | `timeline_query_provider_test.dart`              |
+| Q-4 | a filter is active, mode = **Months**                    | segments are built    | month overview segments; asset counts sum to the total       | `timeline_filter_grouping_integration_test.dart` |
+| Q-5 | a filter is active, mode = **All**, Group by = **Month** | segments are built    | month buckets on the grid — #903 under a filter              | `timeline_filter_grouping_integration_test.dart` |
+| Q-6 | a filter is active                                       | the mode changes      | the service is rebuilt at the new granularity                | `timeline_filter_grouping_integration_test.dart` |
+| Q-7 | no filter                                                | the timeline is built | it delegates to the main-library service                     | `timeline_query_provider_test.dart`              |
+
+**Q-1 is the guard for the `none` invariant** and has no equivalent today. Route A: write it before
+touching `normalizeGridGrouping`'s call sites, and confirm it goes red if the explicit grouping is
+normalized.
+
+#### The grouping pill
+
+| #   | Given                      | When                    | Then                                         | File                                      |
+| --- | -------------------------- | ----------------------- | -------------------------------------------- | ----------------------------------------- |
+| P-1 | the pill is rendered       | —                       | three segments: Years, Months, All           | `timeline_grouping_bottom_pill_test.dart` |
+| P-2 | no surrounding route scope | a segment is tapped     | the root mode updates                        | `timeline_grouping_bottom_pill_test.dart` |
+| P-3 | RTL locale                 | a segment is tapped     | the mode still updates                       | `timeline_grouping_bottom_pill_test.dart` |
+| P-4 | multiselect is enabled     | —                       | the pill hides, and reappears when it ends   | `timeline_grouping_bottom_pill_test.dart` |
+| P-5 | the pill is rendered       | semantics are inspected | exactly the three selector buttons, no extra | `timeline_grouping_bottom_pill_test.dart` |
+
+P-4 and P-5 are pure Route B carry-overs — they do not touch grouping semantics, but they live in a file
+the rename edits, so they must be re-run and must not need assertion changes.
+
+#### Photos-filter overview activation
+
+The pill is not the only writer of the mode. Activating a year or month card from the Photos filter drives
+the same `overview_drilldown.provider.dart`.
+
+| #   | Given                     | When                          | Then                                                             | File                                      |
+| --- | ------------------------- | ----------------------------- | ---------------------------------------------------------------- | ----------------------------------------- |
+| A-1 | the Photos filter         | a **year** card is activated  | mode becomes **Months** with a year anchor, nothing else changes | `photos_overview_zoom_provider_test.dart` |
+| A-2 | the Photos filter         | a **month** card is activated | mode becomes **All** with a month anchor                         | `photos_overview_zoom_provider_test.dart` |
+| A-3 | the Photos filter         | an unrecognised value arrives | it is ignored; the mode is unchanged                             | `photos_overview_zoom_provider_test.dart` |
+| A-4 | a year card was activated | the filter subheader renders  | no temporal chip is added                                        | `filter_subheader_test.dart`              |
+
+A-1 and A-2 assert "nothing else changes" — specifically that no filter chip and no temporal scope is
+written as a side effect. That is the behaviour A-4 checks from the other side.
+
 #### Scrubber labels
 
-| #   | Given                                | Then                                      | File                          |
-| --- | ------------------------------------ | ----------------------------------------- | ----------------------------- |
-| B-1 | mode = **Years**                     | labels are year-only (`DateFormat.y`)     | `scrubber_segments_test.dart` |
-| B-2 | mode = **Months**                    | labels are month+year (`DateFormat.yMMM`) | `scrubber_segments_test.dart` |
-| B-3 | mode = **All**, Group by = **Month** | labels are month+year                     | `scrubber_segments_test.dart` |
+The scrubber chain stays on `GroupAssetsBy` (§4) and receives `spec.groupBy`, so these are expressed in
+terms of what the user sets, with the resolved grouping named for clarity.
 
-B-3 pins the behaviour that makes the §5 scrubber change safe.
+| #   | Given                                        | Then                                      | File                          |
+| --- | -------------------------------------------- | ----------------------------------------- | ----------------------------- |
+| B-1 | mode = **Years** (`spec.groupBy` = `year`)   | labels are year-only (`DateFormat.y`)     | `scrubber_segments_test.dart` |
+| B-2 | mode = **Months** (`spec.groupBy` = `month`) | labels are month+year (`DateFormat.yMMM`) | `scrubber_segments_test.dart` |
+| B-3 | mode = **All**, Group by = **Month**         | labels are month+year                     | `scrubber_segments_test.dart` |
+| B-4 | mode = **All**, Group by = **Month + day**   | labels are month+year                     | `scrubber_segments_test.dart` |
+| B-5 | date-less segments                           | no scrubber segments are produced         | `scrubber_segments_test.dart` |
+
+B-3 is the one that fails if the scrubber is handed `spec.mode` instead of `spec.groupBy`: with mode =
+**All** the mode-based call would pass `all`, which is not `year`, so the labels happen to come out the
+same — B-3 alone therefore cannot distinguish them. **B-1 is the discriminating case**: passing a mode
+where `GroupAssetsBy` is expected would not compile at all after the retype, which is the real guarantee.
+Keep B-3 and B-4 as behaviour pins, and rely on the type for the rest.
+
+B-5 pins the existing early return at `scrubber_segments.dart:41`, which is the scrubber's own date-less
+guard and is independent of grouping.
 
 #### `TimelineFactory.groupBy` fallback
 
@@ -376,7 +499,16 @@ All 12 fork-only test files touched by #911 need the rename applied. Rules:
 - The mock timeline-service factories in `main_timeline_zoom_test.dart` must keep honouring the `groupBy`
   the production code passes them rather than re-reading the setting. #911 already fixed this; do not let
   the retype reintroduce it, or the tests will shadow the wiring instead of exercising it.
-- Any test whose _assertions_ change is escalated, not edited. See TDD rule 6.
+- `scrubber_segments_test.dart` and `timeline_query_provider_test.dart` keep using `GroupAssetsBy`
+  throughout — neither the scrubber chain (§4) nor the explicit query grouping (§6) is retyped. A rename
+  applied there is a sign the boundary has been crossed.
+- Any test whose _assertions_ change is escalated, not edited. See the last rule under TDD discipline.
+
+All 12 files must be re-run after the rename even where no scenario in this spec names them, because the
+rename touches shared fixtures. The five that carry no new scenarios of their own —
+`filter_subheader_test.dart` beyond A-4, and the untouched cases in
+`timeline_grouping_bottom_pill_test.dart` and `timeline_query_provider_test.dart` — are Route B
+carry-overs: they must pass unchanged.
 
 ### Gates
 

--- a/mobile/lib/domain/models/timeline.model.dart
+++ b/mobile/lib/domain/models/timeline.model.dart
@@ -2,6 +2,16 @@ enum GroupAssetsBy { day, month, auto, none, year }
 
 enum HeaderType { none, month, day, monthAndDay, year }
 
+/// Clamps a value to the two granularities the photo grid renders: month + day headers
+/// ([GroupAssetsBy.day]) or month-only headers ([GroupAssetsBy.month]).
+///
+/// This is the meaning of the persisted `Setting.groupAssetsBy` ("Photo Grid" → "Group by"),
+/// which is a header-granularity choice and NOT the Years/Months/All overview selector.
+/// Legacy `auto`/`none` values, and `year` left behind by the removed Year option, all fall
+/// back to day.
+GroupAssetsBy normalizeGridGrouping(GroupAssetsBy groupBy) =>
+    groupBy == GroupAssetsBy.month ? GroupAssetsBy.month : GroupAssetsBy.day;
+
 enum SortAssetsBy { taken, uploaded }
 
 class Bucket {

--- a/mobile/lib/domain/models/timeline.model.dart
+++ b/mobile/lib/domain/models/timeline.model.dart
@@ -2,16 +2,6 @@ enum GroupAssetsBy { day, month, auto, none, year }
 
 enum HeaderType { none, month, day, monthAndDay, year }
 
-/// Clamps a value to the two granularities the photo grid renders: month + day headers
-/// ([GroupAssetsBy.day]) or month-only headers ([GroupAssetsBy.month]).
-///
-/// This is the meaning of the persisted `Setting.groupAssetsBy` ("Photo Grid" → "Group by"),
-/// which is a header-granularity choice and NOT the Years/Months/All overview selector.
-/// Legacy `auto`/`none` values, and `year` left behind by the removed Year option, all fall
-/// back to day.
-GroupAssetsBy normalizeGridGrouping(GroupAssetsBy groupBy) =>
-    groupBy == GroupAssetsBy.month ? GroupAssetsBy.month : GroupAssetsBy.day;
-
 enum SortAssetsBy { taken, uploaded }
 
 class Bucket {

--- a/mobile/lib/domain/models/timeline_grouping.model.dart
+++ b/mobile/lib/domain/models/timeline_grouping.model.dart
@@ -1,0 +1,26 @@
+import 'package:immich_mobile/domain/models/timeline.model.dart';
+
+/// Which zoom level the timeline is at. Fork-only: upstream has no overview.
+///
+/// Deliberately NOT [GroupAssetsBy]. That type means "how coarse are the photo
+/// grid's date headers"; this one means "which zoom level is the timeline at".
+/// Storing the second in the first is what caused #903.
+enum TimelineOverviewMode { years, months, all }
+
+/// What the timeline should render for the current scope: which zoom level, and
+/// the bucket/header granularity that goes with it.
+typedef TimelineGroupingSpec = ({TimelineOverviewMode mode, GroupAssetsBy groupBy});
+
+/// Clamps the persisted "Photo Grid" -> "Group by" setting to the two granularities
+/// the grid renders: month + day headers ([GroupAssetsBy.day]) or month-only headers
+/// ([GroupAssetsBy.month]).
+///
+/// Legacy `auto`/`none`, and `year` left behind by the removed Year option, all fall
+/// back to day.
+///
+/// Apply this ONLY where the persisted setting is read. Never apply it to a grouping a
+/// caller passed explicitly: `timeline_query.provider.dart` passes [GroupAssetsBy.none]
+/// deliberately for relevance-sorted search, and normalizing it to day would silently
+/// re-introduce date bucketing there.
+GroupAssetsBy normalizeGridGrouping(GroupAssetsBy groupBy) =>
+    groupBy == GroupAssetsBy.month ? GroupAssetsBy.month : GroupAssetsBy.day;

--- a/mobile/lib/domain/services/timeline.service.dart
+++ b/mobile/lib/domain/services/timeline.service.dart
@@ -45,13 +45,11 @@ class TimelineFactory {
 
   const TimelineFactory({required this._timelineRepository, required this._settingsRepository});
 
-  GroupAssetsBy get groupBy {
-    final group = _settingsRepository.appConfig.timeline.groupAssetsBy;
-    // We do not support auto grouping in the new timeline yet, fallback to day grouping.
-    // Fallback only: timeline routes pass groupBy explicitly from timelineGroupingProvider,
-    // which is the canonical normalization (it additionally maps `none` to day).
-    return group == GroupAssetsBy.auto ? GroupAssetsBy.day : group;
-  }
+  /// Fallback only: timeline routes pass groupBy explicitly from
+  /// `timelineBucketGroupingProvider`. The persisted setting is a grid header granularity, so
+  /// anything other than month (legacy `auto`/`none`, or `year` from the removed Year option)
+  /// falls back to day.
+  GroupAssetsBy get groupBy => normalizeGridGrouping(_settingsRepository.appConfig.timeline.groupAssetsBy);
 
   TimelineService main(
     List<String> timelineUsers,

--- a/mobile/lib/domain/services/timeline.service.dart
+++ b/mobile/lib/domain/services/timeline.service.dart
@@ -6,6 +6,7 @@ import 'package:immich_mobile/constants/constants.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/events.model.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/domain/models/timeline_temporal_scope.model.dart';
 import 'package:immich_mobile/domain/utils/event_stream.dart';
 import 'package:immich_mobile/infrastructure/repositories/settings.repository.dart';

--- a/mobile/lib/domain/services/timeline.service.dart
+++ b/mobile/lib/domain/services/timeline.service.dart
@@ -47,7 +47,7 @@ class TimelineFactory {
   const TimelineFactory({required this._timelineRepository, required this._settingsRepository});
 
   /// Fallback only: timeline routes pass groupBy explicitly from
-  /// `timelineBucketGroupingProvider`. The persisted setting is a grid header granularity, so
+  /// `timelineGroupingSpecProvider`. The persisted setting is a grid header granularity, so
   /// anything other than month (legacy `auto`/`none`, or `year` from the removed Year option)
   /// falls back to day.
   GroupAssetsBy get groupBy => normalizeGridGrouping(_settingsRepository.appConfig.timeline.groupAssetsBy);

--- a/mobile/lib/presentation/pages/dev/main_timeline.page.dart
+++ b/mobile/lib/presentation/pages/dev/main_timeline.page.dart
@@ -55,10 +55,11 @@ class _MainTimelinePageState extends ConsumerState<MainTimelinePage> {
     final hasMemories = ref.watch(driftMemoryFutureProvider.select((state) => state.value?.isNotEmpty ?? false));
     return TimelineRouteScope(
       timelineServiceBuilder: buildPhotosTimelineRouteService,
-      // The main Photos timeline is the only route whose grouping follows and writes
-      // the persisted Setting.groupAssetsBy; detail routes open at "All" and keep
-      // grouping changes route-local.
-      persistGrouping: true,
+      // The main Photos timeline is the only route on the app-level grouping, so its
+      // Years / Months / All choice survives navigating away and back; detail routes get
+      // their own and keep grouping changes route-local. Neither is persisted — the
+      // "Photo Grid" -> "Group by" setting is a separate header-granularity choice.
+      sharedGrouping: true,
       child: Stack(
         children: [
           // Read photosFilterSearchProvider from inside the TimelineRouteScope so the

--- a/mobile/lib/presentation/widgets/timeline/overview/overview_card.dart
+++ b/mobile/lib/presentation/widgets/timeline/overview/overview_card.dart
@@ -2,6 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
 
@@ -14,33 +15,31 @@ class TimelineOverviewCard extends StatelessWidget {
   const TimelineOverviewCard({
     super.key,
     required this.bucket,
-    required this.groupBy,
+    required this.mode,
     this.representativeAsset,
     this.onTap,
   });
 
   final TimeBucket bucket;
-  final GroupAssetsBy groupBy;
+  final TimelineOverviewMode mode;
   final BaseAsset? representativeAsset;
   final VoidCallback? onTap;
 
   String _label(BuildContext context) {
     final locale = context.locale.toLanguageTag();
-    return switch (groupBy) {
-      GroupAssetsBy.year => DateFormat.y(locale).format(bucket.date),
-      GroupAssetsBy.month => DateFormat.yMMM(locale).format(bucket.date),
-      GroupAssetsBy.day || GroupAssetsBy.auto || GroupAssetsBy.none => DateFormat.yMMMEd(locale).format(bucket.date),
+    return switch (mode) {
+      TimelineOverviewMode.years => DateFormat.y(locale).format(bucket.date),
+      TimelineOverviewMode.months => DateFormat.yMMM(locale).format(bucket.date),
+      TimelineOverviewMode.all => DateFormat.yMMMEd(locale).format(bucket.date),
     };
   }
 
   String _semanticsPeriod(BuildContext context) {
     final locale = context.locale.toLanguageTag();
-    return switch (groupBy) {
-      GroupAssetsBy.year => DateFormat.y(locale).format(bucket.date),
-      GroupAssetsBy.month => DateFormat.yMMMM(locale).format(bucket.date),
-      GroupAssetsBy.day ||
-      GroupAssetsBy.auto ||
-      GroupAssetsBy.none => DateFormat.yMMMMEEEEd(locale).format(bucket.date),
+    return switch (mode) {
+      TimelineOverviewMode.years => DateFormat.y(locale).format(bucket.date),
+      TimelineOverviewMode.months => DateFormat.yMMMM(locale).format(bucket.date),
+      TimelineOverviewMode.all => DateFormat.yMMMMEEEEd(locale).format(bucket.date),
     };
   }
 
@@ -55,10 +54,10 @@ class TimelineOverviewCard extends StatelessWidget {
   }
 
   String? _actionLabel() {
-    final key = switch (groupBy) {
-      GroupAssetsBy.year => 'timeline_overview_show_months',
-      GroupAssetsBy.month => 'timeline_overview_show_days',
-      GroupAssetsBy.day || GroupAssetsBy.auto || GroupAssetsBy.none => null,
+    final key = switch (mode) {
+      TimelineOverviewMode.years => 'timeline_overview_show_months',
+      TimelineOverviewMode.months => 'timeline_overview_show_days',
+      TimelineOverviewMode.all => null,
     };
     if (key == null) {
       return null;
@@ -69,10 +68,10 @@ class TimelineOverviewCard extends StatelessWidget {
       return translated;
     }
 
-    return switch (groupBy) {
-      GroupAssetsBy.year => 'show months',
-      GroupAssetsBy.month => 'show days',
-      GroupAssetsBy.day || GroupAssetsBy.auto || GroupAssetsBy.none => null,
+    return switch (mode) {
+      TimelineOverviewMode.years => 'show months',
+      TimelineOverviewMode.months => 'show days',
+      TimelineOverviewMode.all => null,
     };
   }
 

--- a/mobile/lib/presentation/widgets/timeline/overview/overview_segment.model.dart
+++ b/mobile/lib/presentation/widgets/timeline/overview/overview_segment.model.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/widgets.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/overview/overview_card.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/segment.model.dart';
 import 'package:immich_mobile/providers/timeline/overview_drilldown.provider.dart';
@@ -16,13 +17,13 @@ class TimelineOverviewSegment extends Segment {
     required super.endOffset,
     required super.firstAssetIndex,
     required super.bucket,
-    required this.groupBy,
+    required this.mode,
     super.headerExtent = 0,
     super.spacing = 0,
     required super.header,
   });
 
-  final GroupAssetsBy groupBy;
+  final TimelineOverviewMode mode;
 
   @override
   int getMinChildIndexForScrollOffset(double scrollOffset) => firstIndex;
@@ -52,11 +53,9 @@ class _TimelineOverviewSegmentCard extends ConsumerWidget {
     }
 
     final drilldown = ref.read(timelineOverviewDrilldownProvider);
-    final onTap = drilldown != null && bucket.assetCount > 0
-        ? () => unawaited(drilldown(bucket, segment.groupBy))
-        : null;
+    final onTap = drilldown != null && bucket.assetCount > 0 ? () => unawaited(drilldown(bucket, segment.mode)) : null;
 
-    final key = TimelineOverviewRepresentativeCacheNotifier.keyFor(segment.groupBy, bucket.date);
+    final key = TimelineOverviewRepresentativeCacheNotifier.keyFor(segment.mode, bucket.date);
 
     // Read the cached representative (null if not resolved yet).
     final cachedAsset = ref.watch(timelineOverviewRepresentativeCacheProvider.select((m) => m[key]?.asset));
@@ -72,11 +71,6 @@ class _TimelineOverviewSegmentCard extends ConsumerWidget {
       });
     }
 
-    return TimelineOverviewCard(
-      bucket: bucket,
-      groupBy: segment.groupBy,
-      representativeAsset: cachedAsset,
-      onTap: onTap,
-    );
+    return TimelineOverviewCard(bucket: bucket, mode: segment.mode, representativeAsset: cachedAsset, onTap: onTap);
   }
 }

--- a/mobile/lib/presentation/widgets/timeline/overview/overview_segment_builder.dart
+++ b/mobile/lib/presentation/widgets/timeline/overview/overview_segment_builder.dart
@@ -1,15 +1,20 @@
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/overview/overview_card.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/overview/overview_segment.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/segment.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/segment_builder.dart';
 
 class TimelineOverviewSegmentBuilder extends SegmentBuilder {
-  const TimelineOverviewSegmentBuilder({required super.buckets, required super.groupBy});
+  const TimelineOverviewSegmentBuilder({required super.buckets, required this.mode});
+
+  /// The zoom level these cards represent. The inherited [SegmentBuilder.groupBy] is
+  /// unused for overview segments and stays at its upstream default.
+  final TimelineOverviewMode mode;
 
   List<Segment> generate() {
-    if (groupBy != GroupAssetsBy.year && groupBy != GroupAssetsBy.month) {
-      throw ArgumentError.value(groupBy, 'groupBy', 'Overview segments support only year and month grouping');
+    if (mode == TimelineOverviewMode.all) {
+      throw ArgumentError.value(mode, 'mode', 'Overview segments support only years and months');
     }
 
     final segments = <Segment>[];
@@ -27,8 +32,8 @@ class TimelineOverviewSegmentBuilder extends SegmentBuilder {
           endOffset: endOffset,
           firstAssetIndex: assetIndex,
           bucket: bucket,
-          groupBy: groupBy,
-          header: groupBy == GroupAssetsBy.year ? HeaderType.year : HeaderType.month,
+          mode: mode,
+          header: mode == TimelineOverviewMode.years ? HeaderType.year : HeaderType.month,
         ),
       );
 

--- a/mobile/lib/presentation/widgets/timeline/timeline.state.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.state.dart
@@ -86,38 +86,53 @@ class TimelineStateNotifier extends Notifier<TimelineState> {
 
 // This provider watches the buckets from the timeline service & args and serves the segments.
 // It should be used only after the timeline service and timeline args provider is overridden
-final timelineSegmentProvider = StreamProvider.autoDispose<List<Segment>>((ref) async* {
-  // maxHeight is left out on purpose, a height-only change must not restart the bucket stream
-  final (maxWidth, columnCount, spacing, groupByArg) = ref.watch(
-    timelineArgsProvider.select((args) => (args.maxWidth, args.columnCount, args.spacing, args.groupBy)),
-  );
-  final availableTileWidth = maxWidth - (spacing * (columnCount - 1));
-  final tileExtent = math.max(0, availableTileWidth) / columnCount;
+final timelineSegmentProvider = StreamProvider.autoDispose<List<Segment>>(
+  (ref) async* {
+    // maxHeight is left out on purpose, a height-only change must not restart the bucket stream
+    final (maxWidth, columnCount, spacing, groupByArg) = ref.watch(
+      timelineArgsProvider.select((args) => (args.maxWidth, args.columnCount, args.spacing, args.groupBy)),
+    );
+    final availableTileWidth = maxWidth - (spacing * (columnCount - 1));
+    final tileExtent = math.max(0, availableTileWidth) / columnCount;
 
-  final GroupAssetsBy groupBy = groupByArg ?? ref.watch(timelineGroupingProvider);
+    // The view mode of the Years / Months / All selector decides between overview cards and the
+    // photo grid; the bucket grouping additionally folds in the persisted "Group by" setting, which
+    // sets the grid's header granularity while the selector sits on "All". An explicit `groupBy` arg
+    // pins both (e.g. the asset picker, which always wants the day grid).
+    final GroupAssetsBy grouping = groupByArg ?? ref.watch(timelineGroupingProvider);
+    final GroupAssetsBy groupBy = groupByArg ?? ref.watch(timelineBucketGroupingProvider);
 
-  final timelineService = ref.watch(timelineServiceProvider);
-  yield* timelineService.watchBuckets().map((buckets) {
-    // A date-less bucket source (e.g. relevance-sorted search, or a `fromAssets` timeline) cannot
-    // render the year/month overview — fall back to the flat grid regardless of the grouping setting.
-    final isDateless = buckets.isNotEmpty && buckets.first is! TimeBucket;
-    final effectiveGroupBy = isDateless ? GroupAssetsBy.day : groupBy;
-    if (effectiveGroupBy == GroupAssetsBy.year || effectiveGroupBy == GroupAssetsBy.month) {
-      return TimelineOverviewSegmentBuilder(buckets: buckets, groupBy: effectiveGroupBy).generate();
-    }
+    final timelineService = ref.watch(timelineServiceProvider);
+    yield* timelineService.watchBuckets().map((buckets) {
+      // A date-less bucket source (e.g. relevance-sorted search, or a `fromAssets` timeline) cannot
+      // render the year/month overview — fall back to the flat grid regardless of the grouping setting.
+      final isDateless = buckets.isNotEmpty && buckets.first is! TimeBucket;
+      final effectiveGroupBy = isDateless ? GroupAssetsBy.day : groupBy;
+      final isOverview = !isDateless && (grouping == GroupAssetsBy.year || grouping == GroupAssetsBy.month);
+      if (isOverview) {
+        return TimelineOverviewSegmentBuilder(buckets: buckets, groupBy: effectiveGroupBy).generate();
+      }
 
-    return FixedSegmentBuilder(
-      buckets: buckets,
-      tileHeight: tileExtent,
-      columnCount: columnCount,
-      spacing: spacing,
-      groupBy: effectiveGroupBy,
-    ).generate();
-  });
-  // timelineGroupingProvider must be listed so the auto-scoped copy of this provider
-  // inside a TimelineRouteScope resolves the ROUTE-LOCAL grouping override; without it
-  // the copy reads the root (persisted) grouping and detail routes silently render
-  // the persisted grouping instead of their own.
-}, dependencies: [timelineServiceProvider, timelineArgsProvider, timelineGroupingProvider]);
+      return FixedSegmentBuilder(
+        buckets: buckets,
+        tileHeight: tileExtent,
+        columnCount: columnCount,
+        spacing: spacing,
+        groupBy: effectiveGroupBy,
+      ).generate();
+    });
+    // timelineGroupingProvider must be listed so the auto-scoped copy of this provider
+    // inside a TimelineRouteScope resolves the ROUTE-LOCAL grouping override; without it
+    // the copy reads the root (app-level) grouping and detail routes silently render
+    // that grouping instead of their own. timelineBucketGroupingProvider derives from it,
+    // so it has to be scoped alongside.
+  },
+  dependencies: [
+    timelineServiceProvider,
+    timelineArgsProvider,
+    timelineGroupingProvider,
+    timelineBucketGroupingProvider,
+  ],
+);
 
 final timelineStateProvider = NotifierProvider<TimelineStateNotifier, TimelineState>(TimelineStateNotifier.new);

--- a/mobile/lib/presentation/widgets/timeline/timeline.state.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.state.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/constants.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/fixed/segment_builder.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/overview/overview_segment_builder.dart';
@@ -86,53 +87,38 @@ class TimelineStateNotifier extends Notifier<TimelineState> {
 
 // This provider watches the buckets from the timeline service & args and serves the segments.
 // It should be used only after the timeline service and timeline args provider is overridden
-final timelineSegmentProvider = StreamProvider.autoDispose<List<Segment>>(
-  (ref) async* {
-    // maxHeight is left out on purpose, a height-only change must not restart the bucket stream
-    final (maxWidth, columnCount, spacing, groupByArg) = ref.watch(
-      timelineArgsProvider.select((args) => (args.maxWidth, args.columnCount, args.spacing, args.groupBy)),
-    );
-    final availableTileWidth = maxWidth - (spacing * (columnCount - 1));
-    final tileExtent = math.max(0, availableTileWidth) / columnCount;
+final timelineSegmentProvider = StreamProvider.autoDispose<List<Segment>>((ref) async* {
+  // maxHeight is left out on purpose, a height-only change must not restart the bucket stream
+  final (maxWidth, columnCount, spacing, groupByArg) = ref.watch(
+    timelineArgsProvider.select((args) => (args.maxWidth, args.columnCount, args.spacing, args.groupBy)),
+  );
+  final availableTileWidth = maxWidth - (spacing * (columnCount - 1));
+  final tileExtent = math.max(0, availableTileWidth) / columnCount;
 
-    // The view mode of the Years / Months / All selector decides between overview cards and the
-    // photo grid; the bucket grouping additionally folds in the persisted "Group by" setting, which
-    // sets the grid's header granularity while the selector sits on "All". An explicit `groupBy` arg
-    // pins both (e.g. the asset picker, which always wants the day grid).
-    final GroupAssetsBy grouping = groupByArg ?? ref.watch(timelineGroupingProvider);
-    final GroupAssetsBy groupBy = groupByArg ?? ref.watch(timelineBucketGroupingProvider);
+  // A pinned groupBy (the cleanup preview) always means the flat grid at that granularity.
+  final spec = groupByArg != null
+      ? (mode: TimelineOverviewMode.all, groupBy: groupByArg)
+      : ref.watch(timelineGroupingSpecProvider);
 
-    final timelineService = ref.watch(timelineServiceProvider);
-    yield* timelineService.watchBuckets().map((buckets) {
-      // A date-less bucket source (e.g. relevance-sorted search, or a `fromAssets` timeline) cannot
-      // render the year/month overview — fall back to the flat grid regardless of the grouping setting.
-      final isDateless = buckets.isNotEmpty && buckets.first is! TimeBucket;
-      final effectiveGroupBy = isDateless ? GroupAssetsBy.day : groupBy;
-      final isOverview = !isDateless && (grouping == GroupAssetsBy.year || grouping == GroupAssetsBy.month);
-      if (isOverview) {
-        return TimelineOverviewSegmentBuilder(buckets: buckets, groupBy: effectiveGroupBy).generate();
-      }
+  final timelineService = ref.watch(timelineServiceProvider);
+  yield* timelineService.watchBuckets().map((buckets) {
+    // A date-less bucket source (relevance-sorted search, or a `fromAssets` timeline) has no
+    // dates to group by — fall back to the flat grid regardless of the mode.
+    final isDateless = buckets.isNotEmpty && buckets.first is! TimeBucket;
+    if (spec.mode != TimelineOverviewMode.all && !isDateless) {
+      return TimelineOverviewSegmentBuilder(buckets: buckets, mode: spec.mode).generate();
+    }
 
-      return FixedSegmentBuilder(
-        buckets: buckets,
-        tileHeight: tileExtent,
-        columnCount: columnCount,
-        spacing: spacing,
-        groupBy: effectiveGroupBy,
-      ).generate();
-    });
-    // timelineGroupingProvider must be listed so the auto-scoped copy of this provider
-    // inside a TimelineRouteScope resolves the ROUTE-LOCAL grouping override; without it
-    // the copy reads the root (app-level) grouping and detail routes silently render
-    // that grouping instead of their own. timelineBucketGroupingProvider derives from it,
-    // so it has to be scoped alongside.
-  },
-  dependencies: [
-    timelineServiceProvider,
-    timelineArgsProvider,
-    timelineGroupingProvider,
-    timelineBucketGroupingProvider,
-  ],
-);
+    return FixedSegmentBuilder(
+      buckets: buckets,
+      tileHeight: tileExtent,
+      columnCount: columnCount,
+      spacing: spacing,
+      groupBy: isDateless ? GroupAssetsBy.day : spec.groupBy,
+    ).generate();
+  });
+  // timelineGroupingSpecProvider must be listed so the auto-scoped copy of this provider
+  // inside a TimelineRouteScope resolves the ROUTE-LOCAL mode rather than the root one.
+}, dependencies: [timelineServiceProvider, timelineArgsProvider, timelineGroupingSpecProvider]);
 
 final timelineStateProvider = NotifierProvider<TimelineStateNotifier, TimelineState>(TimelineStateNotifier.new);

--- a/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
@@ -12,6 +12,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/events.model.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/domain/models/timeline_zoom_anchor.model.dart';
 import 'package:immich_mobile/domain/utils/event_stream.dart';
 import 'package:immich_mobile/extensions/asyncvalue_extensions.dart';
@@ -220,7 +221,7 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> with WidgetsBi
       if (mounted) _requestScrollDrain();
     });
 
-    ref.listenManual(timelineGroupingProvider, _onGroupingChanged);
+    ref.listenManual(timelineOverviewModeProvider, _onGroupingChanged);
   }
 
   @override
@@ -286,15 +287,15 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> with WidgetsBi
     EventStream.shared.emit(MultiSelectToggleEvent(isEnabled));
   }
 
-  // When the grouping granularity changes (e.g. via the grouping selector),
-  // anchor the rebuilt timeline to the date currently at the top of the viewport
-  // so the user keeps their place instead of jumping to the most recent content.
-  void _onGroupingChanged(GroupAssetsBy? previous, GroupAssetsBy next) {
+  // When the zoom level changes (e.g. via the grouping selector), anchor the
+  // rebuilt timeline to the date currently at the top of the viewport so the
+  // user keeps their place instead of jumping to the most recent content.
+  void _onGroupingChanged(TimelineOverviewMode? previous, TimelineOverviewMode next) {
     if (previous == null || previous == next) {
       return;
     }
     // A card-tap drilldown sets an explicit year/month anchor right before it
-    // changes the grouping; don't overwrite it with a position-derived anchor.
+    // changes the mode; don't overwrite it with a position-derived anchor.
     if (!ref.read(timelineZoomAnchorProvider).isEmpty) {
       return;
     }
@@ -309,7 +310,7 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> with WidgetsBi
     final anchorNotifier = ref.read(timelineZoomAnchorProvider.notifier);
     final resolved = resolveGroupingChangeAnchorDate(
       topBucketDate: topBucketDate,
-      previousGroupBy: previous,
+      previousMode: previous,
       remembered: anchorNotifier.lastPositionDate,
     );
     anchorNotifier.setDate(resolved);
@@ -442,7 +443,7 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> with WidgetsBi
 
   void _scheduleZoomAnchorResolution({
     required TimelineZoomAnchor anchor,
-    required GroupAssetsBy groupBy,
+    required TimelineOverviewMode mode,
     required List<Segment> segments,
   }) {
     if (anchor.isEmpty || _scheduledZoomAnchor == anchor || _resolvingZoomAnchor == anchor) {
@@ -456,25 +457,27 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> with WidgetsBi
       }
 
       _scheduledZoomAnchor = null;
-      _resolveZoomAnchor(anchor: anchor, groupBy: groupBy, segments: segments);
+      _resolveZoomAnchor(anchor: anchor, mode: mode, segments: segments);
     });
   }
 
   void _resolveZoomAnchor({
     required TimelineZoomAnchor anchor,
-    required GroupAssetsBy groupBy,
+    required TimelineOverviewMode mode,
     required List<Segment> segments,
   }) {
     if (ref.read(timelineZoomAnchorProvider) != anchor || !_scrollController.hasClients) {
       return;
     }
 
-    final GroupAssetsBy activeGroupBy = ref.read(timelineArgsProvider).groupBy ?? ref.read(timelineGroupingProvider);
-    if (activeGroupBy != groupBy) {
+    final TimelineOverviewMode activeMode = ref.read(timelineArgsProvider).groupBy != null
+        ? TimelineOverviewMode.all
+        : ref.read(timelineOverviewModeProvider);
+    if (activeMode != mode) {
       return;
     }
 
-    final targetSegment = findTimelineZoomAnchorSegment(segments, anchor, groupBy);
+    final targetSegment = findTimelineZoomAnchorSegment(segments, anchor, mode);
     if (targetSegment == null) {
       return;
     }
@@ -607,10 +610,12 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> with WidgetsBi
                 ),
             onData: (segments) {
               _lastRenderedSegments = segments;
-              final GroupAssetsBy activeGroupBy =
-                  ref.watch(timelineArgsProvider).groupBy ?? ref.watch(timelineGroupingProvider);
+              final spec = ref.watch(timelineGroupingSpecProvider);
+              final pinnedGroupBy = ref.watch(timelineArgsProvider).groupBy;
+              final TimelineOverviewMode activeMode = pinnedGroupBy != null ? TimelineOverviewMode.all : spec.mode;
+              final GroupAssetsBy activeGroupBy = pinnedGroupBy ?? spec.groupBy;
               final zoomAnchor = ref.watch(timelineZoomAnchorProvider);
-              _scheduleZoomAnchorResolution(anchor: zoomAnchor, groupBy: activeGroupBy, segments: segments);
+              _scheduleZoomAnchorResolution(anchor: zoomAnchor, mode: activeMode, segments: segments);
               final childCount = (segments.lastOrNull?.lastIndex ?? -1) + 1;
 
               // Zero assets: render the caller's empty state (first-run / no-results)

--- a/mobile/lib/presentation/widgets/timeline/timeline_grouping_anchor.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline_grouping_anchor.dart
@@ -1,6 +1,6 @@
-import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 
-/// The date to anchor on when the grouping changes away from [previousGroupBy].
+/// The date to anchor on when the zoom level changes away from [previousMode].
 /// [topBucketDate] is the (granularity-truncated) date of the top-visible bucket.
 /// [remembered] is the last position-derived anchor date, if any.
 ///
@@ -8,16 +8,16 @@ import 'package:immich_mobile/domain/models/timeline.model.dart';
 /// period (the user didn't scroll); otherwise uses the bucket date.
 DateTime resolveGroupingChangeAnchorDate({
   required DateTime topBucketDate,
-  required GroupAssetsBy previousGroupBy,
+  required TimelineOverviewMode previousMode,
   DateTime? remembered,
 }) {
   if (remembered == null) {
     return topBucketDate;
   }
-  final within = switch (previousGroupBy) {
-    GroupAssetsBy.year => remembered.year == topBucketDate.year,
-    GroupAssetsBy.month => remembered.year == topBucketDate.year && remembered.month == topBucketDate.month,
-    GroupAssetsBy.day || GroupAssetsBy.auto || GroupAssetsBy.none => false,
+  final within = switch (previousMode) {
+    TimelineOverviewMode.years => remembered.year == topBucketDate.year,
+    TimelineOverviewMode.months => remembered.year == topBucketDate.year && remembered.month == topBucketDate.month,
+    TimelineOverviewMode.all => false,
   };
   return within ? remembered : topBucketDate;
 }

--- a/mobile/lib/presentation/widgets/timeline/timeline_grouping_selector.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline_grouping_selector.widget.dart
@@ -5,10 +5,14 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/providers/timeline/timeline_grouping.provider.dart';
 
-const timelineGroupingSelectorGroups = <GroupAssetsBy>[GroupAssetsBy.year, GroupAssetsBy.month, GroupAssetsBy.day];
+const timelineOverviewModeSelectorOrder = <TimelineOverviewMode>[
+  TimelineOverviewMode.years,
+  TimelineOverviewMode.months,
+  TimelineOverviewMode.all,
+];
 
 class TimelineGroupingSelector extends ConsumerWidget {
   const TimelineGroupingSelector({super.key, this.enabled = true, this.bare = false}) : compact = false;
@@ -38,7 +42,7 @@ class TimelineGroupingSelector extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final selected = ref.watch(timelineGroupingProvider);
+    final selected = ref.watch(timelineOverviewModeProvider);
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
 
@@ -46,9 +50,9 @@ class TimelineGroupingSelector extends ConsumerWidget {
       return _TimelineGroupingCompactSelector(
         selected: selected,
         enabled: enabled,
-        onSelected: (groupBy) async {
+        onSelected: (mode) async {
           unawaited(HapticFeedback.selectionClick());
-          await ref.read(timelineGroupingProvider.notifier).set(groupBy);
+          await ref.read(timelineOverviewModeProvider.notifier).set(mode);
         },
       );
     }
@@ -78,15 +82,15 @@ class TimelineGroupingSelector extends ConsumerWidget {
                 clipBehavior: Clip.antiAlias,
                 child: Row(
                   children: [
-                    for (final groupBy in timelineGroupingSelectorGroups)
+                    for (final mode in timelineOverviewModeSelectorOrder)
                       Expanded(
                         child: _TimelineGroupingSegment(
-                          groupBy: groupBy,
-                          selected: selected == groupBy,
+                          mode: mode,
+                          selected: selected == mode,
                           enabled: enabled,
                           onTap: () async {
                             unawaited(HapticFeedback.selectionClick());
-                            await ref.read(timelineGroupingProvider.notifier).set(groupBy);
+                            await ref.read(timelineOverviewModeProvider.notifier).set(mode);
                           },
                         ),
                       ),
@@ -113,27 +117,27 @@ final timelineGroupingZoomingInProvider = StateProvider<bool>((ref) => true);
 class _TimelineGroupingCompactSelector extends ConsumerWidget {
   const _TimelineGroupingCompactSelector({required this.selected, required this.enabled, required this.onSelected});
 
-  final GroupAssetsBy selected;
+  final TimelineOverviewMode selected;
   final bool enabled;
-  final Future<void> Function(GroupAssetsBy groupBy) onSelected;
+  final Future<void> Function(TimelineOverviewMode mode) onSelected;
 
   Future<void> _selectNext(WidgetRef ref) async {
     final direction = ref.read(timelineGroupingZoomingInProvider.notifier);
-    final GroupAssetsBy next;
+    final TimelineOverviewMode next;
     switch (selected) {
-      case GroupAssetsBy.year:
-        next = GroupAssetsBy.month;
+      case TimelineOverviewMode.years:
+        next = TimelineOverviewMode.months;
         direction.state = true; // continue zooming in toward All
-      case GroupAssetsBy.month:
+      case TimelineOverviewMode.months:
         if (direction.state) {
-          next = GroupAssetsBy.day;
+          next = TimelineOverviewMode.all;
           direction.state = false; // reached the zoom-in extreme (All); bounce back up next
         } else {
-          next = GroupAssetsBy.year;
+          next = TimelineOverviewMode.years;
           direction.state = true; // reached the zoom-out extreme (Years); bounce back down next
         }
-      case GroupAssetsBy.day || GroupAssetsBy.auto || GroupAssetsBy.none:
-        next = GroupAssetsBy.month;
+      case TimelineOverviewMode.all:
+        next = TimelineOverviewMode.months;
         direction.state = false; // continue zooming out toward Years
     }
     await onSelected(next);
@@ -144,21 +148,21 @@ class _TimelineGroupingCompactSelector extends ConsumerWidget {
     final overlay = Overlay.of(context).context.findRenderObject()! as RenderBox;
     final offset = renderBox.localToGlobal(Offset.zero, ancestor: overlay);
     final position = RelativeRect.fromRect(offset & renderBox.size, Offset.zero & overlay.size);
-    final selectedGroupBy = await showMenu<GroupAssetsBy>(
+    final selectedMode = await showMenu<TimelineOverviewMode>(
       context: context,
       position: position,
       items: [
-        for (final groupBy in timelineGroupingSelectorGroups)
-          PopupMenuItem<GroupAssetsBy>(
-            key: Key('timeline-grouping-menu-${groupBy.name}'),
-            value: groupBy,
-            child: Text(_label(context, groupBy)),
+        for (final mode in timelineOverviewModeSelectorOrder)
+          PopupMenuItem<TimelineOverviewMode>(
+            key: Key('timeline-grouping-menu-${mode.name}'),
+            value: mode,
+            child: Text(_label(context, mode)),
           ),
       ],
     );
 
-    if (selectedGroupBy != null && context.mounted) {
-      await onSelected(selectedGroupBy);
+    if (selectedMode != null && context.mounted) {
+      await onSelected(selectedMode);
     }
   }
 
@@ -223,13 +227,13 @@ class _TimelineGroupingCompactSelector extends ConsumerWidget {
 
 class _TimelineGroupingSegment extends StatelessWidget {
   const _TimelineGroupingSegment({
-    required this.groupBy,
+    required this.mode,
     required this.selected,
     required this.enabled,
     required this.onTap,
   });
 
-  final GroupAssetsBy groupBy;
+  final TimelineOverviewMode mode;
   final bool selected;
   final bool enabled;
   final Future<void> Function() onTap;
@@ -240,11 +244,11 @@ class _TimelineGroupingSegment extends StatelessWidget {
     final colors = theme.colorScheme;
     final foreground = selected ? colors.onPrimary : colors.onSurface.withValues(alpha: 0.86);
     final duration = MediaQuery.disableAnimationsOf(context) ? Duration.zero : Durations.short3;
-    final label = _label(context, groupBy);
+    final label = _label(context, mode);
     final canTap = enabled && !selected;
 
     return Semantics(
-      key: Key('timeline-grouping-${groupBy.name}'),
+      key: Key('timeline-grouping-${mode.name}'),
       button: true,
       selected: selected,
       enabled: enabled,
@@ -284,12 +288,11 @@ class _TimelineGroupingSegment extends StatelessWidget {
 // Labels mirror the web timeline grouping control (Years / Months / All) so the two
 // platforms read identically. Both the inline segments and the compact app-bar chip use
 // these; the chip is sized to fit the widest label ("Months") to avoid truncation.
-String _label(BuildContext context, GroupAssetsBy groupBy) {
-  return switch (groupBy) {
-    GroupAssetsBy.year => _translated('timeline_grouping_years', 'Years'),
-    GroupAssetsBy.month => _translated('timeline_grouping_months', 'Months'),
-    GroupAssetsBy.day => _translated('timeline_grouping_all', 'All'),
-    GroupAssetsBy.auto || GroupAssetsBy.none => _translated('timeline_grouping_all', 'All'),
+String _label(BuildContext context, TimelineOverviewMode mode) {
+  return switch (mode) {
+    TimelineOverviewMode.years => _translated('timeline_grouping_years', 'Years'),
+    TimelineOverviewMode.months => _translated('timeline_grouping_months', 'Months'),
+    TimelineOverviewMode.all => _translated('timeline_grouping_all', 'All'),
   };
 }
 

--- a/mobile/lib/presentation/widgets/timeline/timeline_route_scope.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline_route_scope.dart
@@ -40,15 +40,15 @@ class TimelineRouteScope extends StatelessWidget {
       overrides: [
         timelineTemporalScopeProvider.overrideWith(TimelineTemporalScopeNotifier.new),
         timelineZoomAnchorProvider.overrideWith(TimelineZoomAnchorNotifier.new),
-        if (!sharedGrouping) timelineGroupingProvider.overrideWith(TimelineGroupingNotifier.new),
+        if (!sharedGrouping) timelineOverviewModeProvider.overrideWith(TimelineOverviewModeNotifier.new),
         timelineOverviewDrilldownProvider.overrideWith((ref) => ref.watch(sharedTimelineOverviewDrilldownProvider)),
         timelineOverviewRepresentativeCacheProvider.overrideWith(TimelineOverviewRepresentativeCacheNotifier.new),
         if (timelineServiceBuilder != null)
           timelineServiceProvider.overrideWith((ref) {
             final temporalScope = ref.watch(timelineTemporalScopeProvider);
-            // The bucket granularity, not the selector's view mode: on "All" the query must
-            // group by the persisted "Group by" setting so month-only headers get month buckets.
-            final groupBy = ref.watch(timelineBucketGroupingProvider);
+            // The bucket granularity, not the zoom level: on "All" the query must group by the
+            // persisted "Group by" setting so month-only headers get month buckets.
+            final groupBy = ref.watch(timelineGroupingSpecProvider).groupBy;
             final service = timelineServiceBuilder!(ref, temporalScope, groupBy);
             ref.onDispose(service.dispose);
             return service;

--- a/mobile/lib/presentation/widgets/timeline/timeline_route_scope.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline_route_scope.dart
@@ -18,19 +18,20 @@ class TimelineRouteScope extends StatelessWidget {
     super.key,
     required this.child,
     this.timelineServiceBuilder,
-    this.persistGrouping = false,
+    this.sharedGrouping = false,
     this.overrides = const [],
   });
 
   final Widget child;
   final TimelineRouteServiceBuilder? timelineServiceBuilder;
 
-  /// Whether grouping inside this route follows and writes the persisted
-  /// `Setting.groupAssetsBy`. The main Photos timeline passes true so its grouping
-  /// keeps surviving restarts; detail routes (albums, spaces, favorites, ...) leave
-  /// this false so they open grouped at "All" and keep grouping changes local to
-  /// the route.
-  final bool persistGrouping;
+  /// Whether this route shares the app-level grouping. The main Photos timeline passes
+  /// true so its Years / Months / All choice survives navigating away and back; detail
+  /// routes (albums, spaces, favorites, ...) leave this false so they get their own
+  /// grouping and changes stay local to the route. Either way grouping starts at "All"
+  /// and is never persisted — the "Group by" setting is a separate, header-granularity
+  /// choice.
+  final bool sharedGrouping;
   final List<Override> overrides;
 
   @override
@@ -39,13 +40,15 @@ class TimelineRouteScope extends StatelessWidget {
       overrides: [
         timelineTemporalScopeProvider.overrideWith(TimelineTemporalScopeNotifier.new),
         timelineZoomAnchorProvider.overrideWith(TimelineZoomAnchorNotifier.new),
-        if (!persistGrouping) timelineGroupingProvider.overrideWith(RouteTimelineGroupingNotifier.new),
+        if (!sharedGrouping) timelineGroupingProvider.overrideWith(TimelineGroupingNotifier.new),
         timelineOverviewDrilldownProvider.overrideWith((ref) => ref.watch(sharedTimelineOverviewDrilldownProvider)),
         timelineOverviewRepresentativeCacheProvider.overrideWith(TimelineOverviewRepresentativeCacheNotifier.new),
         if (timelineServiceBuilder != null)
           timelineServiceProvider.overrideWith((ref) {
             final temporalScope = ref.watch(timelineTemporalScopeProvider);
-            final groupBy = ref.watch(timelineGroupingProvider);
+            // The bucket granularity, not the selector's view mode: on "All" the query must
+            // group by the persisted "Group by" setting so month-only headers get month buckets.
+            final groupBy = ref.watch(timelineBucketGroupingProvider);
             final service = timelineServiceBuilder!(ref, temporalScope, groupBy);
             ref.onDispose(service.dispose);
             return service;

--- a/mobile/lib/presentation/widgets/timeline/timeline_scroll_target.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline_scroll_target.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/domain/models/timeline_zoom_anchor.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/segment.model.dart';
 
@@ -26,17 +27,18 @@ Segment? findTimelineScrollTargetSegment(List<Segment> segments, DateTime date) 
       segments.firstWhereOrNull((segment) => _matchesDate(segment, (segmentDate) => segmentDate.year == date.year));
 }
 
-Segment? findTimelineZoomAnchorSegment(List<Segment> segments, TimelineZoomAnchor anchor, GroupAssetsBy groupBy) {
+Segment? findTimelineZoomAnchorSegment(List<Segment> segments, TimelineZoomAnchor anchor, TimelineOverviewMode mode) {
   return switch (anchor) {
     TimelineZoomAnchorNone() => null,
-    TimelineZoomYearAnchor(:final year) when groupBy == GroupAssetsBy.month => segments.firstWhereOrNull(
+    TimelineZoomYearAnchor(:final year) when mode == TimelineOverviewMode.months => segments.firstWhereOrNull(
       (segment) => _matchesDate(segment, (segmentDate) => segmentDate.year == year),
     ),
-    TimelineZoomMonthAnchor(:final year, :final month) when groupBy == GroupAssetsBy.day => segments.firstWhereOrNull(
-      (segment) => _matchesDate(segment, (segmentDate) => segmentDate.year == year && segmentDate.month == month),
-    ),
-    // A date anchor preserves the visible position across grouping changes, so it
-    // resolves to the closest matching segment (day -> month -> year) in any grouping.
+    TimelineZoomMonthAnchor(:final year, :final month) when mode == TimelineOverviewMode.all =>
+      segments.firstWhereOrNull(
+        (segment) => _matchesDate(segment, (segmentDate) => segmentDate.year == year && segmentDate.month == month),
+      ),
+    // A date anchor preserves the visible position across mode changes, so it
+    // resolves to the closest matching segment (day -> month -> year) in any mode.
     TimelineZoomDateAnchor(:final date) => findTimelineScrollTargetSegment(segments, date),
     _ => null,
   };

--- a/mobile/lib/providers/timeline/overview_drilldown.provider.dart
+++ b/mobile/lib/providers/timeline/overview_drilldown.provider.dart
@@ -1,30 +1,28 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/providers/timeline/timeline_grouping.provider.dart';
 import 'package:immich_mobile/providers/timeline/zoom_anchor.provider.dart';
 
-typedef TimelineOverviewDrilldownHandler = Future<void> Function(TimeBucket bucket, GroupAssetsBy groupBy);
+typedef TimelineOverviewDrilldownHandler = Future<void> Function(TimeBucket bucket, TimelineOverviewMode mode);
 
 final timelineOverviewDrilldownProvider = Provider<TimelineOverviewDrilldownHandler?>((ref) => null);
 
 final sharedTimelineOverviewDrilldownProvider = Provider<TimelineOverviewDrilldownHandler>((ref) {
-  return (bucket, groupBy) async {
-    switch (groupBy) {
-      case GroupAssetsBy.year:
+  return (bucket, mode) async {
+    switch (mode) {
+      case TimelineOverviewMode.years:
         ref.read(timelineZoomAnchorProvider.notifier).setYear(bucket.date.year);
-        await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
-      case GroupAssetsBy.month:
+        await ref.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.months);
+      case TimelineOverviewMode.months:
         ref.read(timelineZoomAnchorProvider.notifier).setMonth(year: bucket.date.year, month: bucket.date.month);
-        await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.day);
-      case GroupAssetsBy.day:
-      case GroupAssetsBy.auto:
-      case GroupAssetsBy.none:
+        await ref.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.all);
+      case TimelineOverviewMode.all:
         return;
     }
   };
-  // timelineGroupingProvider must be listed so a drilldown inside a TimelineRouteScope
-  // sets the ROUTE-LOCAL grouping; on the main Photos timeline (where grouping is not
-  // overridden) it resolves the root provider and persists, same as before.
-}, dependencies: [timelineZoomAnchorProvider, timelineGroupingProvider]);
+  // timelineOverviewModeProvider must be listed so a drilldown inside a TimelineRouteScope
+  // sets the ROUTE-LOCAL mode rather than the root one.
+}, dependencies: [timelineZoomAnchorProvider, timelineOverviewModeProvider]);
 
 final photosTimelineOverviewDrilldownProvider = sharedTimelineOverviewDrilldownProvider;

--- a/mobile/lib/providers/timeline/overview_representative_cache.provider.dart
+++ b/mobile/lib/providers/timeline/overview_representative_cache.provider.dart
@@ -1,7 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
-import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 
 class TimelineOverviewRepresentative {
@@ -19,9 +19,9 @@ class TimelineOverviewRepresentativeCacheNotifier extends Notifier<Map<String, T
   /// against a previous service can never write an entry under the new one.
   int _generation = 0;
 
-  /// Cache key for a bucket. `groupBy` is part of the key so a year and a month bucket that share
+  /// Cache key for a bucket. `mode` is part of the key so a year and a month bucket that share
   /// the same date (e.g. 2024-01-01) don't collide. Shared with the card and tests to avoid drift.
-  static String keyFor(GroupAssetsBy groupBy, DateTime date) => '${groupBy.name}:${date.toIso8601String()}';
+  static String keyFor(TimelineOverviewMode mode, DateTime date) => '${mode.name}:${date.toIso8601String()}';
 
   @override
   Map<String, TimelineOverviewRepresentative> build() {

--- a/mobile/lib/providers/timeline/timeline_grouping.provider.dart
+++ b/mobile/lib/providers/timeline/timeline_grouping.provider.dart
@@ -1,6 +1,7 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/settings_key.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/providers/infrastructure/settings.provider.dart';
 
 /// Clamps a grouping value to the three options the timeline grouping selector

--- a/mobile/lib/providers/timeline/timeline_grouping.provider.dart
+++ b/mobile/lib/providers/timeline/timeline_grouping.provider.dart
@@ -13,6 +13,45 @@ GroupAssetsBy normalizeTimelineGrouping(GroupAssetsBy groupBy) {
   };
 }
 
+/// The active zoom level of the Years / Months / All selector.
+///
+/// View state only: it always starts at "All" and is never written to
+/// [SettingsKey.timelineGroupAssetsBy]. Persisting it there is what made the
+/// "Photo Grid" -> "Group by" setting flip the timeline into the overview cards (#903).
+class TimelineOverviewModeNotifier extends Notifier<TimelineOverviewMode> {
+  @override
+  TimelineOverviewMode build() => TimelineOverviewMode.all;
+
+  Future<void> set(TimelineOverviewMode mode) async {
+    state = mode;
+  }
+}
+
+/// The active zoom level for the current scope.
+///
+/// Scoped per-route by `TimelineRouteScope` (unless the route opts into `sharedGrouping`),
+/// so a change inside an album does not leak into the main Photos timeline. Widgets resolve
+/// the nearest scope automatically, but any PROVIDER that reads this must list it in its own
+/// `dependencies:` — otherwise its auto-scoped copy silently resolves the root mode.
+final timelineOverviewModeProvider = NotifierProvider<TimelineOverviewModeNotifier, TimelineOverviewMode>(
+  TimelineOverviewModeNotifier.new,
+);
+
+/// What to render for the current scope, and at what granularity.
+///
+/// Years / Months render the overview cards at that granularity. All renders the photo
+/// grid, whose header granularity is the persisted Group by setting.
+final timelineGroupingSpecProvider = Provider<TimelineGroupingSpec>((ref) {
+  final mode = ref.watch(timelineOverviewModeProvider);
+  return switch (mode) {
+    TimelineOverviewMode.years => (mode: mode, groupBy: GroupAssetsBy.year),
+    TimelineOverviewMode.months => (mode: mode, groupBy: GroupAssetsBy.month),
+    TimelineOverviewMode.all => (mode: mode, groupBy: ref.watch(timelineGridGroupingProvider)),
+  };
+  // timelineOverviewModeProvider must be listed so the auto-scoped copy of this provider
+  // inside a TimelineRouteScope resolves the ROUTE-LOCAL mode rather than the root one.
+}, dependencies: [timelineOverviewModeProvider]);
+
 /// The active view mode of the Years / Months / All selector.
 ///
 /// This is view state only: it always starts at "All" ([GroupAssetsBy.day]) and is never

--- a/mobile/lib/providers/timeline/timeline_grouping.provider.dart
+++ b/mobile/lib/providers/timeline/timeline_grouping.provider.dart
@@ -4,15 +4,6 @@ import 'package:immich_mobile/domain/models/timeline.model.dart';
 import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/providers/infrastructure/settings.provider.dart';
 
-/// Clamps a grouping value to the three options the timeline grouping selector
-/// exposes (Years / Months / All). Legacy `auto`/`none` values map to All.
-GroupAssetsBy normalizeTimelineGrouping(GroupAssetsBy groupBy) {
-  return switch (groupBy) {
-    GroupAssetsBy.year || GroupAssetsBy.month || GroupAssetsBy.day => groupBy,
-    GroupAssetsBy.auto || GroupAssetsBy.none => GroupAssetsBy.day,
-  };
-}
-
 /// The active zoom level of the Years / Months / All selector.
 ///
 /// View state only: it always starts at "All" and is never written to
@@ -52,46 +43,9 @@ final timelineGroupingSpecProvider = Provider<TimelineGroupingSpec>((ref) {
   // inside a TimelineRouteScope resolves the ROUTE-LOCAL mode rather than the root one.
 }, dependencies: [timelineOverviewModeProvider]);
 
-/// The active view mode of the Years / Months / All selector.
-///
-/// This is view state only: it always starts at "All" ([GroupAssetsBy.day]) and is never
-/// written to [SettingsKey.timelineGroupAssetsBy]. Persisting it there used to make the
-/// "Photo Grid" -> "Group by" setting flip the timeline into the overview cards (#903);
-/// the two are independent — see [timelineGridGroupingProvider].
-class TimelineGroupingNotifier extends Notifier<GroupAssetsBy> {
-  @override
-  GroupAssetsBy build() => GroupAssetsBy.day;
-
-  Future<void> set(GroupAssetsBy groupBy) async {
-    state = normalizeTimelineGrouping(groupBy);
-  }
-}
-
-/// The active timeline grouping for the current scope.
-///
-/// Scoped per-route by `TimelineRouteScope` (unless the route opts into `sharedGrouping`),
-/// so a grouping change inside an album does not leak into the main Photos timeline.
-/// Widgets resolve the nearest scope automatically, but any PROVIDER that reads this must
-/// list it in its own `dependencies:` — otherwise its auto-scoped copy silently resolves
-/// the root (app-level) grouping inside detail routes.
-final timelineGroupingProvider = NotifierProvider<TimelineGroupingNotifier, GroupAssetsBy>(
-  TimelineGroupingNotifier.new,
-);
-
 /// The persisted "Photo Grid" -> "Group by" setting: how coarse the headers on the photo
 /// grid are. Only [GroupAssetsBy.day] (month + day headers) and [GroupAssetsBy.month]
 /// (month-only headers) are reachable; everything else falls back to day.
 final timelineGridGroupingProvider = Provider<GroupAssetsBy>(
   (ref) => normalizeGridGrouping(ref.watch(appConfigProvider.select((config) => config.timeline.groupAssetsBy))),
 );
-
-/// The bucket granularity to query and render for the current scope.
-///
-/// Years / Months group the timeline into the overview cards at that granularity. "All"
-/// renders the photo grid, whose header granularity is the persisted Group by setting.
-final timelineBucketGroupingProvider = Provider<GroupAssetsBy>((ref) {
-  final grouping = ref.watch(timelineGroupingProvider);
-  return grouping == GroupAssetsBy.day ? ref.watch(timelineGridGroupingProvider) : grouping;
-  // timelineGroupingProvider must be listed so the auto-scoped copy of this provider inside
-  // a TimelineRouteScope resolves the ROUTE-LOCAL grouping rather than the root one.
-}, dependencies: [timelineGroupingProvider]);

--- a/mobile/lib/providers/timeline/timeline_grouping.provider.dart
+++ b/mobile/lib/providers/timeline/timeline_grouping.provider.dart
@@ -12,29 +12,16 @@ GroupAssetsBy normalizeTimelineGrouping(GroupAssetsBy groupBy) {
   };
 }
 
-/// Root behavior — used by the main Photos timeline: the active grouping follows
-/// the persisted [SettingsKey.timelineGroupAssetsBy] and [set] writes it back, so
-/// the choice survives restarts and stays in sync with the settings screen.
+/// The active view mode of the Years / Months / All selector.
+///
+/// This is view state only: it always starts at "All" ([GroupAssetsBy.day]) and is never
+/// written to [SettingsKey.timelineGroupAssetsBy]. Persisting it there used to make the
+/// "Photo Grid" -> "Group by" setting flip the timeline into the overview cards (#903);
+/// the two are independent — see [timelineGridGroupingProvider].
 class TimelineGroupingNotifier extends Notifier<GroupAssetsBy> {
-  @override
-  GroupAssetsBy build() =>
-      normalizeTimelineGrouping(ref.watch(appConfigProvider.select((config) => config.timeline.groupAssetsBy)));
-
-  Future<void> set(GroupAssetsBy groupBy) async {
-    await ref.read(settingsProvider).write(.timelineGroupAssetsBy, groupBy);
-  }
-}
-
-/// Route-local override — used by detail timelines (albums, spaces, favorites, ...):
-/// every route opens grouped at "All" ([GroupAssetsBy.day]) regardless of the
-/// persisted setting, and grouping changes stay local to that route. This keeps a
-/// persisted Years/Months grouping on the main Photos timeline from leaking into
-/// albums (and album grouping changes from leaking back out).
-class RouteTimelineGroupingNotifier extends TimelineGroupingNotifier {
   @override
   GroupAssetsBy build() => GroupAssetsBy.day;
 
-  @override
   Future<void> set(GroupAssetsBy groupBy) async {
     state = normalizeTimelineGrouping(groupBy);
   }
@@ -42,11 +29,29 @@ class RouteTimelineGroupingNotifier extends TimelineGroupingNotifier {
 
 /// The active timeline grouping for the current scope.
 ///
-/// Overridden per-route by `TimelineRouteScope` (with [RouteTimelineGroupingNotifier])
-/// unless the route opts into `persistGrouping`. Widgets resolve the nearest scope
-/// automatically, but any PROVIDER that reads this must list it in its own
-/// `dependencies:` — otherwise its auto-scoped copy silently resolves the root
-/// (persisted) grouping inside detail routes.
+/// Scoped per-route by `TimelineRouteScope` (unless the route opts into `sharedGrouping`),
+/// so a grouping change inside an album does not leak into the main Photos timeline.
+/// Widgets resolve the nearest scope automatically, but any PROVIDER that reads this must
+/// list it in its own `dependencies:` — otherwise its auto-scoped copy silently resolves
+/// the root (app-level) grouping inside detail routes.
 final timelineGroupingProvider = NotifierProvider<TimelineGroupingNotifier, GroupAssetsBy>(
   TimelineGroupingNotifier.new,
 );
+
+/// The persisted "Photo Grid" -> "Group by" setting: how coarse the headers on the photo
+/// grid are. Only [GroupAssetsBy.day] (month + day headers) and [GroupAssetsBy.month]
+/// (month-only headers) are reachable; everything else falls back to day.
+final timelineGridGroupingProvider = Provider<GroupAssetsBy>(
+  (ref) => normalizeGridGrouping(ref.watch(appConfigProvider.select((config) => config.timeline.groupAssetsBy))),
+);
+
+/// The bucket granularity to query and render for the current scope.
+///
+/// Years / Months group the timeline into the overview cards at that granularity. "All"
+/// renders the photo grid, whose header granularity is the persisted Group by setting.
+final timelineBucketGroupingProvider = Provider<GroupAssetsBy>((ref) {
+  final grouping = ref.watch(timelineGroupingProvider);
+  return grouping == GroupAssetsBy.day ? ref.watch(timelineGridGroupingProvider) : grouping;
+  // timelineGroupingProvider must be listed so the auto-scoped copy of this provider inside
+  // a TimelineRouteScope resolves the ROUTE-LOCAL grouping rather than the root one.
+}, dependencies: [timelineGroupingProvider]);

--- a/mobile/lib/widgets/settings/asset_list_settings/asset_list_group_settings.dart
+++ b/mobile/lib/widgets/settings/asset_list_settings/asset_list_group_settings.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/providers/app_settings.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/settings.provider.dart';

--- a/mobile/lib/widgets/settings/asset_list_settings/asset_list_group_settings.dart
+++ b/mobile/lib/widgets/settings/asset_list_settings/asset_list_group_settings.dart
@@ -4,11 +4,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
-import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/providers/app_settings.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/settings.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
+import 'package:immich_mobile/providers/timeline/timeline_grouping.provider.dart';
 import 'package:immich_mobile/widgets/settings/setting_group_title.dart';
 import 'package:immich_mobile/widgets/settings/settings_radio_list_tile.dart';
 
@@ -17,9 +17,7 @@ class GroupSettings extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final groupBy = useValueNotifier(
-      normalizeGridGrouping(ref.watch(appConfigProvider.select((s) => s.timeline.groupAssetsBy))),
-    );
+    final groupBy = useValueNotifier(ref.watch(timelineGridGroupingProvider));
 
     Future<void> updateAppSettings(GroupAssetsBy groupBy) async {
       await ref.read(settingsProvider).write(.timelineGroupAssetsBy, groupBy);

--- a/mobile/lib/widgets/settings/asset_list_settings/asset_list_group_settings.dart
+++ b/mobile/lib/widgets/settings/asset_list_settings/asset_list_group_settings.dart
@@ -16,7 +16,9 @@ class GroupSettings extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final groupBy = useValueNotifier(ref.watch(appConfigProvider.select((s) => s.timeline.groupAssetsBy)));
+    final groupBy = useValueNotifier(
+      normalizeGridGrouping(ref.watch(appConfigProvider.select((s) => s.timeline.groupAssetsBy))),
+    );
 
     Future<void> updateAppSettings(GroupAssetsBy groupBy) async {
       await ref.read(settingsProvider).write(.timelineGroupAssetsBy, groupBy);
@@ -43,10 +45,6 @@ class GroupSettings extends HookConsumerWidget {
             SettingsRadioGroup(
               title: 'asset_list_layout_settings_group_by_month_day'.t(context: context),
               value: GroupAssetsBy.day,
-            ),
-            SettingsRadioGroup(
-              title: 'year'.t(context: context),
-              value: GroupAssetsBy.year,
             ),
             SettingsRadioGroup(
               title: 'month'.t(context: context),

--- a/mobile/test/domain/models/timeline_grouping_model_test.dart
+++ b/mobile/test/domain/models/timeline_grouping_model_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
+
+void main() {
+  group('normalizeGridGrouping', () {
+    test('L-1: day stays day', () {
+      expect(normalizeGridGrouping(GroupAssetsBy.day), GroupAssetsBy.day);
+    });
+
+    test('L-2: month stays month', () {
+      expect(normalizeGridGrouping(GroupAssetsBy.month), GroupAssetsBy.month);
+    });
+
+    test('L-4: auto falls back to day', () {
+      expect(normalizeGridGrouping(GroupAssetsBy.auto), GroupAssetsBy.day);
+    });
+
+    test('L-5: none falls back to day as a persisted setting value', () {
+      expect(normalizeGridGrouping(GroupAssetsBy.none), GroupAssetsBy.day);
+    });
+
+    test('year, left behind by the removed Year option, falls back to day', () {
+      expect(normalizeGridGrouping(GroupAssetsBy.year), GroupAssetsBy.day);
+    });
+  });
+
+  group('TimelineOverviewMode', () {
+    test('has exactly the three selector positions', () {
+      expect(TimelineOverviewMode.values, [
+        TimelineOverviewMode.years,
+        TimelineOverviewMode.months,
+        TimelineOverviewMode.all,
+      ]);
+    });
+  });
+}

--- a/mobile/test/domain/services/timeline_factory_grouping_test.dart
+++ b/mobile/test/domain/services/timeline_factory_grouping_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/domain/models/config/app_config.dart';
+import 'package:immich_mobile/domain/models/config/timeline_config.dart';
+import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/services/timeline.service.dart';
+import 'package:immich_mobile/infrastructure/repositories/settings.repository.dart';
+import 'package:immich_mobile/infrastructure/repositories/timeline.repository.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockTimelineRepository extends Mock implements DriftTimelineRepository {}
+
+class _MockSettingsRepository extends Mock implements SettingsRepository {}
+
+void main() {
+  late _MockSettingsRepository settingsRepo;
+  late TimelineFactory factory;
+
+  setUp(() {
+    settingsRepo = _MockSettingsRepository();
+    factory = TimelineFactory(timelineRepository: _MockTimelineRepository(), settingsRepository: settingsRepo);
+  });
+
+  void storedSetting(GroupAssetsBy value) {
+    when(() => settingsRepo.appConfig).thenReturn(AppConfig(timeline: TimelineConfig(groupAssetsBy: value)));
+  }
+
+  test('F-1: month is preserved', () {
+    storedSetting(GroupAssetsBy.month);
+    expect(factory.groupBy, GroupAssetsBy.month);
+  });
+
+  test('F-2: day is preserved', () {
+    storedSetting(GroupAssetsBy.day);
+    expect(factory.groupBy, GroupAssetsBy.day);
+  });
+
+  test('F-3: a leftover year falls back to day', () {
+    storedSetting(GroupAssetsBy.year);
+    expect(factory.groupBy, GroupAssetsBy.day);
+  });
+
+  test('F-4: auto falls back to day', () {
+    storedSetting(GroupAssetsBy.auto);
+    expect(factory.groupBy, GroupAssetsBy.day);
+  });
+
+  test('none falls back to day as a persisted value', () {
+    storedSetting(GroupAssetsBy.none);
+    expect(factory.groupBy, GroupAssetsBy.day);
+  });
+}

--- a/mobile/test/presentation/pages/dev/main_timeline_zoom_test.dart
+++ b/mobile/test/presentation/pages/dev/main_timeline_zoom_test.dart
@@ -8,6 +8,7 @@ import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/domain/models/settings_key.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/domain/models/timeline_temporal_scope.model.dart';
 import 'package:immich_mobile/domain/models/timeline_zoom_anchor.model.dart';
 import 'package:immich_mobile/domain/models/user.model.dart';
@@ -96,7 +97,7 @@ void main() {
 
     await _pumpPhotosTimeline(tester, factory);
     final ref = ProviderScope.containerOf(tester.element(find.byType(Timeline)));
-    await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.year);
+    await ref.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.years);
     await tester.pumpAndSettle();
 
     await tester.tap(find.bySemanticsLabel('2025, 8 photos, show months'));
@@ -104,7 +105,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 600));
     await tester.pumpAndSettle();
 
-    expect(ref.read(timelineGroupingProvider), GroupAssetsBy.month);
+    expect(ref.read(timelineOverviewModeProvider), TimelineOverviewMode.months);
     expect(ref.read(timelineTemporalScopeProvider), const TimelineTemporalScope.none());
     expect(ref.read(timelineZoomAnchorProvider), const TimelineZoomAnchor.none());
     expect(_scrollPixels(tester), greaterThan(0));
@@ -130,7 +131,7 @@ void main() {
 
     await _pumpPhotosTimeline(tester, factory);
     final ref = ProviderScope.containerOf(tester.element(find.byType(Timeline)));
-    await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
+    await ref.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.months);
     await tester.pumpAndSettle();
 
     await tester.tap(find.bySemanticsLabel('March 2025, 9 photos, show days'));
@@ -138,7 +139,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 600));
     await tester.pumpAndSettle();
 
-    expect(ref.read(timelineGroupingProvider), GroupAssetsBy.day);
+    expect(ref.read(timelineOverviewModeProvider), TimelineOverviewMode.all);
     expect(ref.read(timelineTemporalScopeProvider), const TimelineTemporalScope.none());
     expect(ref.read(timelineZoomAnchorProvider), const TimelineZoomAnchor.none());
     expect(_scrollPixels(tester), greaterThan(0));
@@ -167,7 +168,7 @@ void main() {
 
     await _pumpPhotosTimeline(tester, factory);
     final ref = ProviderScope.containerOf(tester.element(find.byType(Timeline)));
-    await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.year);
+    await ref.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.years);
     await tester.pumpAndSettle();
 
     await tester.tap(find.bySemanticsLabel('2025, 8 photos, show months'));
@@ -175,7 +176,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 600));
     await tester.pumpAndSettle();
 
-    expect(ref.read(timelineGroupingProvider), GroupAssetsBy.month);
+    expect(ref.read(timelineOverviewModeProvider), TimelineOverviewMode.months);
     expect(find.bySemanticsLabel('December 2024, 8 photos, show days'), findsOneWidget);
     expect(find.bySemanticsLabel('June 2025, 8 photos, show days'), findsOneWidget);
     expect(find.bySemanticsLabel('February 2026, 8 photos, show days'), findsOneWidget);
@@ -220,13 +221,13 @@ void main() {
     final scrolledOffset = _scrollPixels(tester);
     expect(scrolledOffset, greaterThan(0));
 
-    // Switch grouping the same way the selector does.
-    await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
+    // Switch the zoom level the same way the selector does.
+    await ref.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.months);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
     await tester.pumpAndSettle();
 
-    expect(ref.read(timelineGroupingProvider), GroupAssetsBy.month);
+    expect(ref.read(timelineOverviewModeProvider), TimelineOverviewMode.months);
     // Position preserved: not reset to the most recent content at the top.
     expect(_scrollPixels(tester), greaterThan(0));
     // Landed on the old content: the previously visible month is rendered while
@@ -265,20 +266,20 @@ void main() {
 
     // At this point the day timeline is loaded at the top — Jun 9 is visible.
     // Step 1: switch to Months (no card tap — simulates the grouping selector).
-    await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
+    await ref.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.months);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
     await tester.pumpAndSettle();
 
-    expect(ref.read(timelineGroupingProvider), GroupAssetsBy.month);
+    expect(ref.read(timelineOverviewModeProvider), TimelineOverviewMode.months);
 
     // Step 2: switch back to All without tapping any card.
-    await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.day);
+    await ref.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.all);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
     await tester.pumpAndSettle();
 
-    expect(ref.read(timelineGroupingProvider), GroupAssetsBy.day);
+    expect(ref.read(timelineOverviewModeProvider), TimelineOverviewMode.all);
 
     // The timeline must have resolved back to the Jun 9 segment (not Jun 1).
     // Both segments are in the day timeline, so the anchor date drives which one
@@ -322,7 +323,7 @@ void main() {
     final ref = ProviderScope.containerOf(tester.element(find.byType(Timeline)));
 
     // Switch to Months — Jun 9 remembered.
-    await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
+    await ref.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.months);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
     await tester.pumpAndSettle();
@@ -338,12 +339,12 @@ void main() {
     // Switch back to All. The top-visible month is no longer June (user scrolled
     // past it), so the remembered Jun 9 is outside the top bucket's period and
     // must be dropped in favour of the bucket's truncated date.
-    await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.day);
+    await ref.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.all);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
     await tester.pumpAndSettle();
 
-    expect(ref.read(timelineGroupingProvider), GroupAssetsBy.day);
+    expect(ref.read(timelineOverviewModeProvider), TimelineOverviewMode.all);
     // lastPositionDate was overwritten with the top-visible month's bucket date
     // (NOT Jun 9, since the user scrolled away from June). A negative assertion is used
     // deliberately: the exact top-visible month depends on viewport/card-extent layout math,

--- a/mobile/test/presentation/pages/dev/main_timeline_zoom_test.dart
+++ b/mobile/test/presentation/pages/dev/main_timeline_zoom_test.dart
@@ -20,11 +20,11 @@ import 'package:immich_mobile/infrastructure/repositories/settings.repository.da
 import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline_route_scope.dart';
-import 'package:immich_mobile/providers/infrastructure/settings.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/user.provider.dart' as infra;
 import 'package:immich_mobile/providers/photos_filter/timeline_query.provider.dart';
 import 'package:immich_mobile/providers/timeline/temporal_scope.provider.dart';
+import 'package:immich_mobile/providers/timeline/timeline_grouping.provider.dart';
 import 'package:immich_mobile/providers/timeline/zoom_anchor.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:intl/date_symbol_data_local.dart';
@@ -77,7 +77,6 @@ void main() {
   });
 
   testWidgets('Photos year card tap switches to months and scrolls to the tapped year', (tester) async {
-    await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.year);
     final factory = _factoryForServices(
       yearService: _service([
         TimeBucket(date: DateTime(2026), assetCount: 8),
@@ -97,20 +96,21 @@ void main() {
 
     await _pumpPhotosTimeline(tester, factory);
     final ref = ProviderScope.containerOf(tester.element(find.byType(Timeline)));
+    await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.year);
+    await tester.pumpAndSettle();
 
     await tester.tap(find.bySemanticsLabel('2025, 8 photos, show months'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
     await tester.pumpAndSettle();
 
-    expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
+    expect(ref.read(timelineGroupingProvider), GroupAssetsBy.month);
     expect(ref.read(timelineTemporalScopeProvider), const TimelineTemporalScope.none());
     expect(ref.read(timelineZoomAnchorProvider), const TimelineZoomAnchor.none());
     expect(_scrollPixels(tester), greaterThan(0));
   });
 
   testWidgets('Photos month card tap switches to detailed mode and scrolls to the tapped month', (tester) async {
-    await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
     final factory = _factoryForServices(
       yearService: _service([TimeBucket(date: DateTime(2025), assetCount: 9)]),
       monthService: _service([
@@ -130,13 +130,15 @@ void main() {
 
     await _pumpPhotosTimeline(tester, factory);
     final ref = ProviderScope.containerOf(tester.element(find.byType(Timeline)));
+    await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
+    await tester.pumpAndSettle();
 
     await tester.tap(find.bySemanticsLabel('March 2025, 9 photos, show days'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
     await tester.pumpAndSettle();
 
-    expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
+    expect(ref.read(timelineGroupingProvider), GroupAssetsBy.day);
     expect(ref.read(timelineTemporalScopeProvider), const TimelineTemporalScope.none());
     expect(ref.read(timelineZoomAnchorProvider), const TimelineZoomAnchor.none());
     expect(_scrollPixels(tester), greaterThan(0));
@@ -148,7 +150,6 @@ void main() {
   // The mock factory honours the temporal scope like the real DB query, so if
   // the year drilldown ever scopes the query again this test fails.
   testWidgets('Photos year card tap keeps months from other years reachable', (tester) async {
-    await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.year);
     final factory = _scopeAwareFactory(
       yearBuckets: [
         TimeBucket(date: DateTime(2026), assetCount: 8),
@@ -165,13 +166,16 @@ void main() {
     addTearDown(factory.disposeServices);
 
     await _pumpPhotosTimeline(tester, factory);
+    final ref = ProviderScope.containerOf(tester.element(find.byType(Timeline)));
+    await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.year);
+    await tester.pumpAndSettle();
 
     await tester.tap(find.bySemanticsLabel('2025, 8 photos, show months'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
     await tester.pumpAndSettle();
 
-    expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
+    expect(ref.read(timelineGroupingProvider), GroupAssetsBy.month);
     expect(find.bySemanticsLabel('December 2024, 8 photos, show days'), findsOneWidget);
     expect(find.bySemanticsLabel('June 2025, 8 photos, show days'), findsOneWidget);
     expect(find.bySemanticsLabel('February 2026, 8 photos, show days'), findsOneWidget);
@@ -180,7 +184,6 @@ void main() {
   // Regression for Hagen bug 2: switching grouping via the selector must keep the
   // current position instead of jumping to the most recent content at the top.
   testWidgets('Switching All -> Months keeps the scrolled position instead of resetting to the top', (tester) async {
-    await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.day);
     final factory = _factoryForServices(
       yearService: _service([
         TimeBucket(date: DateTime(2026), assetCount: 30),
@@ -218,12 +221,12 @@ void main() {
     expect(scrolledOffset, greaterThan(0));
 
     // Switch grouping the same way the selector does.
-    await ref.read(settingsProvider).write(.timelineGroupAssetsBy, GroupAssetsBy.month);
+    await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
     await tester.pumpAndSettle();
 
-    expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
+    expect(ref.read(timelineGroupingProvider), GroupAssetsBy.month);
     // Position preserved: not reset to the most recent content at the top.
     expect(_scrollPixels(tester), greaterThan(0));
     // Landed on the old content: the previously visible month is rendered while
@@ -238,8 +241,6 @@ void main() {
   testWidgets('Round-trip All → Months → All without card tap returns to the same day (not 1st of month)', (
     tester,
   ) async {
-    await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.day);
-
     // Two day buckets for June: the 9th is the most-recent (top), the 1st is
     // further down. We put older content below so there is room to scroll.
     final factory = _factoryForServices(
@@ -264,20 +265,20 @@ void main() {
 
     // At this point the day timeline is loaded at the top — Jun 9 is visible.
     // Step 1: switch to Months (no card tap — simulates the grouping selector).
-    await ref.read(settingsProvider).write(.timelineGroupAssetsBy, GroupAssetsBy.month);
+    await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
     await tester.pumpAndSettle();
 
-    expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
+    expect(ref.read(timelineGroupingProvider), GroupAssetsBy.month);
 
     // Step 2: switch back to All without tapping any card.
-    await ref.read(settingsProvider).write(.timelineGroupAssetsBy, GroupAssetsBy.day);
+    await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.day);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
     await tester.pumpAndSettle();
 
-    expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
+    expect(ref.read(timelineGroupingProvider), GroupAssetsBy.day);
 
     // The timeline must have resolved back to the Jun 9 segment (not Jun 1).
     // Both segments are in the day timeline, so the anchor date drives which one
@@ -295,8 +296,6 @@ void main() {
   // scrolling to maxScrollExtent actually moves the scroll position.
   // Each overview card is 144 + 12 vertical padding (6 top + 6 bottom) = 156px; 5 cards = 780px > 600px.
   testWidgets('Round-trip with scroll in month view uses the scrolled-to month', (tester) async {
-    await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.day);
-
     final factory = _factoryForServices(
       yearService: _service([
         TimeBucket(date: DateTime(2026), assetCount: 9),
@@ -323,7 +322,7 @@ void main() {
     final ref = ProviderScope.containerOf(tester.element(find.byType(Timeline)));
 
     // Switch to Months — Jun 9 remembered.
-    await ref.read(settingsProvider).write(.timelineGroupAssetsBy, GroupAssetsBy.month);
+    await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
     await tester.pumpAndSettle();
@@ -339,12 +338,12 @@ void main() {
     // Switch back to All. The top-visible month is no longer June (user scrolled
     // past it), so the remembered Jun 9 is outside the top bucket's period and
     // must be dropped in favour of the bucket's truncated date.
-    await ref.read(settingsProvider).write(.timelineGroupAssetsBy, GroupAssetsBy.day);
+    await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.day);
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
     await tester.pumpAndSettle();
 
-    expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
+    expect(ref.read(timelineGroupingProvider), GroupAssetsBy.day);
     // lastPositionDate was overwritten with the top-visible month's bucket date
     // (NOT Jun 9, since the user scrolled away from June). A negative assertion is used
     // deliberately: the exact top-visible month depends on viewport/card-extent layout math,
@@ -367,8 +366,8 @@ void main() {
       groupBy: any(named: 'groupBy'),
       temporalScope: any(named: 'temporalScope'),
     ),
-  ).thenAnswer((_) {
-    final groupBy = SettingsRepository.instance.appConfig.timeline.groupAssetsBy;
+  ).thenAnswer((invocation) {
+    final groupBy = invocation.namedArguments[const Symbol('groupBy')] as GroupAssetsBy? ?? GroupAssetsBy.day;
     return switch (groupBy) {
       GroupAssetsBy.year => yearService,
       GroupAssetsBy.month => monthService,
@@ -415,7 +414,7 @@ void main() {
     final scope =
         invocation.namedArguments[const Symbol('temporalScope')] as TimelineTemporalScope? ??
         const TimelineTemporalScope.none();
-    final groupBy = SettingsRepository.instance.appConfig.timeline.groupAssetsBy;
+    final groupBy = invocation.namedArguments[const Symbol('groupBy')] as GroupAssetsBy? ?? GroupAssetsBy.day;
     return switch (groupBy) {
       GroupAssetsBy.year => build(yearBuckets),
       GroupAssetsBy.month => build(_filterBucketsByScope(monthBuckets, scope)),
@@ -490,9 +489,9 @@ Future<void> _pumpPhotosTimeline(
         child: const MaterialApp(
           home: TimelineRouteScope(
             timelineServiceBuilder: buildPhotosTimelineRouteService,
-            // These tests pin the MAIN Photos page contract: grouping follows and
-            // writes the persisted setting.
-            persistGrouping: true,
+            // These tests pin the MAIN Photos page contract: the app-level grouping,
+            // shared across the page rather than scoped per route.
+            sharedGrouping: true,
             child: Timeline(appBar: null, bottomSheet: null, withScrubber: false),
           ),
         ),

--- a/mobile/test/presentation/pages/dev/timeline_filter_grouping_integration_test.dart
+++ b/mobile/test/presentation/pages/dev/timeline_filter_grouping_integration_test.dart
@@ -21,6 +21,7 @@ import 'package:immich_mobile/domain/models/search_result.model.dart';
 import 'package:immich_mobile/domain/models/settings_key.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/domain/services/search.service.dart';
 import 'package:immich_mobile/domain/services/store.service.dart';
@@ -101,13 +102,13 @@ ProviderContainer _makeContainer({required SearchService search, required Drift 
       // can be read without a widget tree.
       timelineArgsProvider.overrideWith((_) => const TimelineArgs(maxWidth: 375, maxHeight: 812, columnCount: 3)),
       // Mirrors the Photos page's TimelineRouteScope wiring: the service is rebuilt from the
-      // temporal scope and the bucket grouping (selector view mode, or the persisted
+      // temporal scope and the bucket granularity (the zoom level, or the persisted
       // "Group by" setting while the selector is on All).
       timelineServiceProvider.overrideWith((ref) {
         final service = buildPhotosTimelineRouteService(
           ref,
           ref.watch(timelineTemporalScopeProvider),
-          ref.watch(timelineBucketGroupingProvider),
+          ref.watch(timelineGroupingSpecProvider).groupBy,
         );
         ref.onDispose(service.dispose);
         return service;
@@ -159,7 +160,7 @@ void main() {
 
     // Set a non-smart, non-empty filter (notInAlbum=true → no context → non-smart).
     container.read(photosFilterProvider.notifier).setNotInAlbum(true);
-    await container.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
+    await container.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.months);
 
     // Keep `photosFilterSearchProvider` (autoDispose) alive for the duration of
     // this test by subscribing a listener.  Without a listener the autoDispose
@@ -229,7 +230,7 @@ void main() {
     addTearDown(sub.close);
 
     // Selecting Months groups the filtered results by month.
-    await container.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
+    await container.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.months);
     await container.read(photosFilterSearchProvider.notifier).firstLoad;
 
     final monthBuckets = await container.read(timelineServiceProvider).watchBuckets().first;
@@ -237,7 +238,7 @@ void main() {
     expect(monthBuckets.length, 2, reason: 'Month grouping: 2024-03 + 2024-01');
 
     // Back to All: with the default "Month + day" setting the service regroups by day.
-    await container.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.day);
+    await container.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.all);
     await container.read(photosFilterSearchProvider.notifier).firstLoad;
 
     final dayBuckets = await container.read(timelineServiceProvider).watchBuckets().first;
@@ -268,7 +269,7 @@ void main() {
     }
 
     // Selecting Years groups the filtered results by year.
-    await container.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.year);
+    await container.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.years);
     await container.read(photosFilterSearchProvider.notifier).firstLoad;
 
     final yearBuckets = await container.read(timelineServiceProvider).watchBuckets().first;
@@ -297,7 +298,7 @@ void main() {
     final sub = container.listen(photosFilterSearchProvider, (_, __) {});
     addTearDown(sub.close);
 
-    expect(container.read(timelineGroupingProvider), GroupAssetsBy.day, reason: 'Selector opens on All');
+    expect(container.read(timelineOverviewModeProvider), TimelineOverviewMode.all, reason: 'Selector opens on All');
     await container.read(photosFilterSearchProvider.notifier).firstLoad;
 
     final buckets = await container.read(timelineServiceProvider).watchBuckets().first;
@@ -315,8 +316,8 @@ void main() {
   //
   // The drill-down handler lives in `sharedTimelineOverviewDrilldownProvider`
   // and is fully tested by `overview_drilldown_provider_test.dart`.  The handler
-  // calls `timelineGroupingProvider.notifier.set(...)` (persisted via the root
-  // notifier on the Photos page; route-local elsewhere) and sets a
+  // calls `timelineOverviewModeProvider.notifier.set(...)` (the root notifier on the
+  // Photos page; route-local elsewhere) and sets a
   // zoom anchor — it does NOT inspect the timeline service at all, so the
   // filtered vs unfiltered distinction makes no difference to the handler logic.
   //
@@ -324,7 +325,7 @@ void main() {
   // `TimelineOverviewCard` would require a full `EasyLocalization` + Flutter
   // widget tree (the card uses `Semantics` labels via localized month names), and
   // the value added would be duplicating what the zoom test already covers (it
-  // exercises the exact same tap → GroupAssetsBy.day + anchor path on the same
+  // exercises the exact same tap → TimelineOverviewMode.all + anchor path on the same
   // handler).  The load-bearing acceptance is fully covered by tests 1 and 2.
   // ---------------------------------------------------------------------------
 }

--- a/mobile/test/presentation/pages/dev/timeline_filter_grouping_integration_test.dart
+++ b/mobile/test/presentation/pages/dev/timeline_filter_grouping_integration_test.dart
@@ -35,13 +35,14 @@ import 'package:immich_mobile/presentation/widgets/timeline/overview/overview_se
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.state.dart';
 import 'package:immich_mobile/providers/infrastructure/db.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/search.provider.dart';
-import 'package:immich_mobile/providers/infrastructure/settings.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/user.provider.dart' as infra;
 import 'package:immich_mobile/providers/photos_filter/filter_count.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/photos_filter_search.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/timeline_query.provider.dart';
+import 'package:immich_mobile/providers/timeline/temporal_scope.provider.dart';
+import 'package:immich_mobile/providers/timeline/timeline_grouping.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -99,6 +100,18 @@ ProviderContainer _makeContainer({required SearchService search, required Drift 
       // Override timelineArgsProvider so timelineSegmentProvider (autoDispose)
       // can be read without a widget tree.
       timelineArgsProvider.overrideWith((_) => const TimelineArgs(maxWidth: 375, maxHeight: 812, columnCount: 3)),
+      // Mirrors the Photos page's TimelineRouteScope wiring: the service is rebuilt from the
+      // temporal scope and the bucket grouping (selector view mode, or the persisted
+      // "Group by" setting while the selector is on All).
+      timelineServiceProvider.overrideWith((ref) {
+        final service = buildPhotosTimelineRouteService(
+          ref,
+          ref.watch(timelineTemporalScopeProvider),
+          ref.watch(timelineBucketGroupingProvider),
+        );
+        ref.onDispose(service.dispose);
+        return service;
+      }),
     ],
   );
 }
@@ -141,13 +154,12 @@ void main() {
     final assets = _assets();
     when(() => search.search(any(), 1)).thenAnswer((_) async => SearchResult(assets: assets, nextPage: null));
 
-    await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
-
     final container = _makeContainer(search: search, db: db);
     addTearDown(container.dispose);
 
     // Set a non-smart, non-empty filter (notInAlbum=true → no context → non-smart).
     container.read(photosFilterProvider.notifier).setNotInAlbum(true);
+    await container.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
 
     // Keep `photosFilterSearchProvider` (autoDispose) alive for the duration of
     // this test by subscribing a listener.  Without a listener the autoDispose
@@ -158,7 +170,7 @@ void main() {
 
     // Read the photos timeline query provider — this builds the search-backed
     // TimelineService backed by the REAL TimelineFactory / DriftTimelineRepository.
-    final svc = container.read(photosTimelineQueryProvider);
+    final svc = container.read(timelineServiceProvider);
     expect(svc.origin, TimelineOrigin.search);
 
     // Wait for the page-1 search load to settle deterministically.
@@ -186,16 +198,7 @@ void main() {
     expect(countSum, assets.length, reason: 'No assets should be dropped during month-grouping');
 
     // Verify the segment provider too: TimelineOverviewSegments, not FixedSegments.
-    // Override timelineServiceProvider in a child scope to point at the real svc
-    // (timelineSegmentProvider depends on timelineServiceProvider).
-    final routeScope = ProviderContainer(
-      parent: container,
-      overrides: [timelineServiceProvider.overrideWithValue(svc)],
-    );
-    addTearDown(routeScope.dispose);
-
-    final segStream = routeScope.read(timelineSegmentProvider.future);
-    final segments = await segStream;
+    final segments = await container.read(timelineSegmentProvider.future);
 
     expect(segments, everyElement(isA<TimelineOverviewSegment>()));
     expect(segments.length, 2, reason: 'One overview card per month');
@@ -211,12 +214,10 @@ void main() {
   // month → day:  TimeBuckets (still dated) grouped at day granularity.
   // month → year: TimeBuckets grouped at year granularity (1 bucket).
   // ---------------------------------------------------------------------------
-  test('Changing groupAssetsBy while filter is active rebuilds service buckets at new granularity', () async {
+  test('Changing the grouping while a filter is active rebuilds service buckets at new granularity', () async {
     final search = _MockSearch();
     final assets = _assets();
     when(() => search.search(any(), 1)).thenAnswer((_) async => SearchResult(assets: assets, nextPage: null));
-
-    await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
 
     final container = _makeContainer(search: search, db: db);
     addTearDown(container.dispose);
@@ -227,28 +228,19 @@ void main() {
     final sub = container.listen(photosFilterSearchProvider, (_, __) {});
     addTearDown(sub.close);
 
-    // Read the month-grouped service.
-    final svcMonth = container.read(photosTimelineQueryProvider);
+    // Selecting Months groups the filtered results by month.
+    await container.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
     await container.read(photosFilterSearchProvider.notifier).firstLoad;
 
-    final monthBuckets = await svcMonth.watchBuckets().first;
+    final monthBuckets = await container.read(timelineServiceProvider).watchBuckets().first;
     expect(monthBuckets, everyElement(isA<TimeBucket>()));
     expect(monthBuckets.length, 2, reason: 'Month grouping: 2024-03 + 2024-01');
 
-    // Switch to day grouping via the settings provider (same mechanism as the UI selector).
-    await container.read(settingsProvider).write(.timelineGroupAssetsBy, GroupAssetsBy.day);
-
-    // On this branch settingsProvider exposes the SettingsRepository singleton (its
-    // identity never changes), so a grouping write does not invalidate
-    // timelineFactoryProvider. In the app the rebuild comes from
-    // timeline_route_scope.dart watching appConfigProvider; model that rebuild here.
-    container.invalidate(photosTimelineQueryProvider);
-    final svcDay = container.read(photosTimelineQueryProvider);
-
-    // A grouping change rebuilds only the service (not the notifier); firstLoad is already resolved.
+    // Back to All: with the default "Month + day" setting the service regroups by day.
+    await container.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.day);
     await container.read(photosFilterSearchProvider.notifier).firstLoad;
 
-    final dayBuckets = await svcDay.watchBuckets().first;
+    final dayBuckets = await container.read(timelineServiceProvider).watchBuckets().first;
     // Day grouping: the 2 March assets share the same date (2024-03-15), so
     // there are 2 distinct day buckets: 2024-03-15 and 2024-01-10.
     expect(dayBuckets, everyElement(isA<TimeBucket>()));
@@ -265,30 +257,8 @@ void main() {
     final dayCountSum = dayBuckets.fold<int>(0, (acc, b) => acc + b.assetCount);
     expect(dayCountSum, assets.length, reason: 'No assets dropped after regrouping to day');
 
-    // Switch to year grouping (route-scope rebuild modeled as above).
-    await container.read(settingsProvider).write(.timelineGroupAssetsBy, GroupAssetsBy.year);
-    container.invalidate(photosTimelineQueryProvider);
-    final svcYear = container.read(photosTimelineQueryProvider);
-    await container.read(photosFilterSearchProvider.notifier).firstLoad;
-
-    final yearBuckets = await svcYear.watchBuckets().first;
-    expect(yearBuckets, everyElement(isA<TimeBucket>()));
-    expect(yearBuckets.length, 1, reason: 'Year grouping: all 3 assets are in 2024');
-    expect((yearBuckets[0] as TimeBucket).date.year, 2024);
-    expect(yearBuckets[0].assetCount, assets.length);
-
-    // Segment provider emits FixedSegments for the day service in its route scope.
-    final dayRouteScope = ProviderContainer(
-      parent: container,
-      overrides: [timelineServiceProvider.overrideWithValue(svcDay)],
-    );
-    addTearDown(dayRouteScope.dispose);
-
-    // Restore day grouping (same mechanism as the UI selector) so the segment provider reads day.
-    await container.read(settingsProvider).write(.timelineGroupAssetsBy, GroupAssetsBy.day);
-
-    final daySegments = await dayRouteScope.read(timelineSegmentProvider.future);
-    // With day grouping + TimeBuckets the segment provider uses FixedSegmentBuilder.
+    // Segment provider emits FixedSegments for the day service.
+    final daySegments = await container.read(timelineSegmentProvider.future);
     for (final seg in daySegments) {
       expect(
         seg,
@@ -296,6 +266,48 @@ void main() {
         reason: 'Day grouping produces FixedSegments, not overview cards',
       );
     }
+
+    // Selecting Years groups the filtered results by year.
+    await container.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.year);
+    await container.read(photosFilterSearchProvider.notifier).firstLoad;
+
+    final yearBuckets = await container.read(timelineServiceProvider).watchBuckets().first;
+    expect(yearBuckets, everyElement(isA<TimeBucket>()));
+    expect(yearBuckets.length, 1, reason: 'Year grouping: all 3 assets are in 2024');
+    expect((yearBuckets[0] as TimeBucket).date.year, 2024);
+    expect(yearBuckets[0].assetCount, assets.length);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 2b (#903) — the "Group by" setting is a header granularity, so under an
+  // active filter "All" + Month must still be a photo grid, just with month buckets.
+  // ---------------------------------------------------------------------------
+  test('Filtered + All with the month Group by setting produces month buckets on the grid', () async {
+    final search = _MockSearch();
+    final assets = _assets();
+    when(() => search.search(any(), 1)).thenAnswer((_) async => SearchResult(assets: assets, nextPage: null));
+
+    await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
+
+    final container = _makeContainer(search: search, db: db);
+    addTearDown(container.dispose);
+
+    container.read(photosFilterProvider.notifier).setNotInAlbum(true);
+
+    final sub = container.listen(photosFilterSearchProvider, (_, __) {});
+    addTearDown(sub.close);
+
+    expect(container.read(timelineGroupingProvider), GroupAssetsBy.day, reason: 'Selector opens on All');
+    await container.read(photosFilterSearchProvider.notifier).firstLoad;
+
+    final buckets = await container.read(timelineServiceProvider).watchBuckets().first;
+    expect(buckets.length, 2, reason: 'Month granularity: 2024-03 + 2024-01');
+    expect((buckets[0] as TimeBucket).date.month, 3);
+    expect((buckets[0] as TimeBucket).date.day, 1, reason: 'Month buckets are truncated to the 1st');
+
+    final segments = await container.read(timelineSegmentProvider.future);
+    expect(segments, everyElement(isNot(isA<TimelineOverviewSegment>())), reason: 'Still a grid, not cards');
+    expect(segments.map((segment) => segment.header), everyElement(HeaderType.month));
   });
 
   // ---------------------------------------------------------------------------

--- a/mobile/test/presentation/pages/drift_favorite_page_test.dart
+++ b/mobile/test/presentation/pages/drift_favorite_page_test.dart
@@ -214,7 +214,7 @@ void main() {
     await pumpFavoritePage(tester, factoryHarness);
 
     // Switch to Months THROUGH THE PILL (the user-facing path, not the provider shortcut).
-    await tester.tap(find.byKey(const Key('timeline-grouping-month')));
+    await tester.tap(find.byKey(const Key('timeline-grouping-months')));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
     await tester.pump(const Duration(milliseconds: 600));

--- a/mobile/test/presentation/pages/timeline_route_adoption_test.dart
+++ b/mobile/test/presentation/pages/timeline_route_adoption_test.dart
@@ -6,6 +6,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/settings_key.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/domain/models/timeline_temporal_scope.model.dart';
 import 'package:immich_mobile/domain/models/timeline_zoom_anchor.model.dart';
 import 'package:immich_mobile/domain/services/store.service.dart';
@@ -126,7 +127,7 @@ void main() {
     await tester.runAsync(
       () async => ref
           .read(timelineOverviewDrilldownProvider)
-          ?.call(TimeBucket(date: DateTime(2025), assetCount: 3), GroupAssetsBy.year),
+          ?.call(TimeBucket(date: DateTime(2025), assetCount: 3), TimelineOverviewMode.years),
     );
     ref.invalidate(timelineServiceProvider);
     ref.read(timelineServiceProvider);
@@ -200,7 +201,7 @@ void main() {
 
         // Drive the route to Years through the selector (route-local, never persisted).
         calls.clear();
-        await tester.tap(find.byKey(const Key('timeline-grouping-year')));
+        await tester.tap(find.byKey(const Key('timeline-grouping-years')));
         await tester.pump();
         ref.read(timelineServiceProvider);
 
@@ -212,7 +213,7 @@ void main() {
         await tester.runAsync(
           () async => ref
               .read(timelineOverviewDrilldownProvider)
-              ?.call(TimeBucket(date: DateTime(2025), assetCount: 3), GroupAssetsBy.year),
+              ?.call(TimeBucket(date: DateTime(2025), assetCount: 3), TimelineOverviewMode.years),
         );
         // The drilldown persists the new grouping to SettingsRepository synchronously, but the
         // reactive rebuild now flows through appConfigProvider's drift watch stream, which does
@@ -232,7 +233,7 @@ void main() {
         await tester.runAsync(
           () async => ref
               .read(timelineOverviewDrilldownProvider)
-              ?.call(TimeBucket(date: DateTime(2025, 3), assetCount: 3), GroupAssetsBy.month),
+              ?.call(TimeBucket(date: DateTime(2025, 3), assetCount: 3), TimelineOverviewMode.months),
         );
         ref.invalidate(timelineServiceProvider);
         ref.read(timelineServiceProvider);

--- a/mobile/test/presentation/widgets/bottom_sheet/map_bottom_sheet_timeline_test.dart
+++ b/mobile/test/presentation/widgets/bottom_sheet/map_bottom_sheet_timeline_test.dart
@@ -168,7 +168,7 @@ void main() {
   testWidgets('tapping Months regroups the map timeline without persisting the setting', (tester) async {
     final harness = await _pumpMapTimeline(tester);
 
-    await tester.tap(find.byKey(const Key('timeline-grouping-month')));
+    await tester.tap(find.byKey(const Key('timeline-grouping-months')));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
 
@@ -213,7 +213,7 @@ void main() {
   testWidgets('grouping selection survives a map move', (tester) async {
     final harness = await _pumpMapTimeline(tester);
 
-    await tester.tap(find.byKey(const Key('timeline-grouping-month')));
+    await tester.tap(find.byKey(const Key('timeline-grouping-months')));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 600));
     verify(

--- a/mobile/test/presentation/widgets/photos_filter/filter_subheader_test.dart
+++ b/mobile/test/presentation/widgets/photos_filter/filter_subheader_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/settings_key.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/domain/models/timeline_temporal_scope.model.dart';
 import 'package:immich_mobile/domain/models/timeline_zoom_anchor.model.dart';
 import 'package:immich_mobile/domain/services/store.service.dart';
@@ -103,20 +104,20 @@ void main() {
       expect(find.text('clear_all'.tr()), findsOneWidget);
     });
 
-    testWidgets('does not render a temporal chip from Photos year activation', (tester) async {
+    testWidgets('does not render a temporal chip from Photos years activation', (tester) async {
       await tester.pumpConsumerWidget(_scroll(const PhotosFilterSubheader()));
       await tester.pumpAndSettle();
       final container = ProviderScope.containerOf(tester.element(find.byType(CustomScrollView)));
 
       await container.read(photosTimelineOverviewDrilldownProvider)(
         TimeBucket(date: DateTime(2025), assetCount: 4),
-        GroupAssetsBy.year,
+        TimelineOverviewMode.years,
       );
       await tester.pumpAndSettle();
 
       expect(container.read(timelineTemporalScopeProvider), const TimelineTemporalScope.none());
       expect(container.read(timelineZoomAnchorProvider), const TimelineZoomAnchor.year(2025));
-      expect(container.read(timelineGroupingProvider), GroupAssetsBy.month);
+      expect(container.read(timelineOverviewModeProvider), TimelineOverviewMode.months);
       expect(find.byKey(const Key('photos-filter-subheader')), findsNothing);
       expect(find.text('2025'), findsNothing);
       expect(find.text('Mar 2025'), findsNothing);
@@ -131,7 +132,7 @@ void main() {
 
       await container.read(photosTimelineOverviewDrilldownProvider)(
         TimeBucket(date: DateTime(2025), assetCount: 4),
-        GroupAssetsBy.year,
+        TimelineOverviewMode.years,
       );
       await tester.pumpAndSettle();
 
@@ -153,14 +154,14 @@ void main() {
 
       await container.read(photosTimelineOverviewDrilldownProvider)(
         TimeBucket(date: DateTime(2025), assetCount: 4),
-        GroupAssetsBy.year,
+        TimelineOverviewMode.years,
       );
       await tester.pumpAndSettle();
 
       expect(find.text('Mar 2025'), findsOneWidget);
       expect(container.read(timelineTemporalScopeProvider), const TimelineTemporalScope.none());
       expect(container.read(photosFilterProvider).date.takenAfter, DateTime(2025, 3));
-      expect(container.read(timelineGroupingProvider), GroupAssetsBy.month);
+      expect(container.read(timelineOverviewModeProvider), TimelineOverviewMode.months);
 
       await tester.drag(find.byType(Scrollable).last, const Offset(-120, 0));
       await tester.pumpAndSettle();
@@ -171,7 +172,7 @@ void main() {
       expect(container.read(photosFilterProvider).date.takenAfter, isNull);
       expect(container.read(photosFilterProvider).date.takenBefore, isNull);
       expect(container.read(timelineTemporalScopeProvider), const TimelineTemporalScope.none());
-      expect(container.read(timelineGroupingProvider), GroupAssetsBy.month);
+      expect(container.read(timelineOverviewModeProvider), TimelineOverviewMode.months);
     });
 
     testWidgets('temporal scope alone does not render as a filter chip', (tester) async {

--- a/mobile/test/presentation/widgets/photos_filter/filter_subheader_test.dart
+++ b/mobile/test/presentation/widgets/photos_filter/filter_subheader_test.dart
@@ -19,6 +19,7 @@ import 'package:immich_mobile/presentation/widgets/photos_filter/filter_subheade
 import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
 import 'package:immich_mobile/providers/timeline/overview_drilldown.provider.dart';
 import 'package:immich_mobile/providers/timeline/temporal_scope.provider.dart';
+import 'package:immich_mobile/providers/timeline/timeline_grouping.provider.dart';
 import 'package:immich_mobile/providers/timeline/zoom_anchor.provider.dart';
 
 import '../../../widget_tester_extensions.dart';
@@ -115,7 +116,7 @@ void main() {
 
       expect(container.read(timelineTemporalScopeProvider), const TimelineTemporalScope.none());
       expect(container.read(timelineZoomAnchorProvider), const TimelineZoomAnchor.year(2025));
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
+      expect(container.read(timelineGroupingProvider), GroupAssetsBy.month);
       expect(find.byKey(const Key('photos-filter-subheader')), findsNothing);
       expect(find.text('2025'), findsNothing);
       expect(find.text('Mar 2025'), findsNothing);
@@ -142,7 +143,6 @@ void main() {
     });
 
     testWidgets('explicit Photos date chips remain clearable after card activation', (tester) async {
-      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.year);
       await tester.pumpConsumerWidget(_scroll(const PhotosFilterSubheader()));
       await tester.pumpAndSettle();
       final container = ProviderScope.containerOf(tester.element(find.byType(CustomScrollView)));
@@ -160,7 +160,7 @@ void main() {
       expect(find.text('Mar 2025'), findsOneWidget);
       expect(container.read(timelineTemporalScopeProvider), const TimelineTemporalScope.none());
       expect(container.read(photosFilterProvider).date.takenAfter, DateTime(2025, 3));
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
+      expect(container.read(timelineGroupingProvider), GroupAssetsBy.month);
 
       await tester.drag(find.byType(Scrollable).last, const Offset(-120, 0));
       await tester.pumpAndSettle();
@@ -171,7 +171,7 @@ void main() {
       expect(container.read(photosFilterProvider).date.takenAfter, isNull);
       expect(container.read(photosFilterProvider).date.takenBefore, isNull);
       expect(container.read(timelineTemporalScopeProvider), const TimelineTemporalScope.none());
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
+      expect(container.read(timelineGroupingProvider), GroupAssetsBy.month);
     });
 
     testWidgets('temporal scope alone does not render as a filter chip', (tester) async {

--- a/mobile/test/presentation/widgets/timeline/overview/overview_segment_builder_test.dart
+++ b/mobile/test/presentation/widgets/timeline/overview/overview_segment_builder_test.dart
@@ -10,6 +10,7 @@ import 'package:immich_mobile/constants/constants.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/domain/services/store.service.dart';
 import 'package:immich_mobile/domain/services/timeline.service.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
@@ -59,7 +60,7 @@ void main() {
         TimeBucket(date: DateTime(2025), assetCount: 5),
         TimeBucket(date: DateTime(2024), assetCount: 2),
       ],
-      groupBy: GroupAssetsBy.year,
+      mode: TimelineOverviewMode.years,
     ).generate();
 
     expect(segments, hasLength(2));
@@ -80,7 +81,7 @@ void main() {
   test('month overview uses month headers and keeps one child per bucket', () {
     final segments = TimelineOverviewSegmentBuilder(
       buckets: [TimeBucket(date: DateTime(2025, 3), assetCount: 4)],
-      groupBy: GroupAssetsBy.month,
+      mode: TimelineOverviewMode.months,
     ).generate();
 
     expect(segments.single.firstIndex, 0);
@@ -92,11 +93,11 @@ void main() {
     expect(segments.single.indexToLayoutOffset(segments.single.lastIndex + 1), segments.single.endOffset);
   });
 
-  test('builder rejects non-overview grouping modes', () {
+  test('builder rejects the all mode', () {
     expect(
       () => TimelineOverviewSegmentBuilder(
         buckets: [TimeBucket(date: DateTime(2025), assetCount: 1)],
-        groupBy: GroupAssetsBy.day,
+        mode: TimelineOverviewMode.all,
       ).generate(),
       throwsArgumentError,
     );
@@ -126,7 +127,7 @@ void main() {
       endOffset: kTimelineOverviewSegmentExtent * 2,
       firstAssetIndex: 5,
       bucket: TimeBucket(date: DateTime(2024), assetCount: 1),
-      groupBy: GroupAssetsBy.year,
+      mode: TimelineOverviewMode.years,
       header: HeaderType.year,
     );
 
@@ -163,7 +164,7 @@ void main() {
   });
 
   testWidgets('passes overview drilldown handler to rendered card when override exists', (tester) async {
-    final tapped = <({DateTime date, GroupAssetsBy groupBy})>[];
+    final tapped = <({DateTime date, TimelineOverviewMode mode})>[];
     final representativeAsset = TestUtils.createRemoteAsset(id: 'asset-0');
     final timelineService = TimelineService((
       bucketSource: () => Stream.value([TimeBucket(date: DateTime(2025), assetCount: 1)]),
@@ -179,7 +180,7 @@ void main() {
       endOffset: kTimelineOverviewSegmentExtent,
       firstAssetIndex: 0,
       bucket: TimeBucket(date: DateTime(2025), assetCount: 1),
-      groupBy: GroupAssetsBy.year,
+      mode: TimelineOverviewMode.years,
       header: HeaderType.year,
     );
 
@@ -191,8 +192,8 @@ void main() {
         child: ProviderScope(
           overrides: [
             timelineServiceProvider.overrideWithValue(timelineService),
-            timelineOverviewDrilldownProvider.overrideWithValue((bucket, groupBy) async {
-              tapped.add((date: bucket.date, groupBy: groupBy));
+            timelineOverviewDrilldownProvider.overrideWithValue((bucket, mode) async {
+              tapped.add((date: bucket.date, mode: mode));
             }),
           ],
           child: MaterialApp(
@@ -206,7 +207,7 @@ void main() {
     await tester.tap(find.byType(TimelineOverviewCard));
     await tester.pump();
 
-    expect(tapped, [(date: DateTime(2025), groupBy: GroupAssetsBy.year)]);
+    expect(tapped, [(date: DateTime(2025), mode: TimelineOverviewMode.years)]);
   });
 
   testWidgets('leaves rendered card onTap null without overview drilldown handler', (tester) async {
@@ -225,7 +226,7 @@ void main() {
       endOffset: kTimelineOverviewSegmentExtent,
       firstAssetIndex: 0,
       bucket: TimeBucket(date: DateTime(2025), assetCount: 1),
-      groupBy: GroupAssetsBy.year,
+      mode: TimelineOverviewMode.years,
       header: HeaderType.year,
     );
 
@@ -250,7 +251,7 @@ void main() {
   });
 
   testWidgets('leaves zero-count overview card onTap null even with drilldown handler override', (tester) async {
-    final tapped = <({DateTime date, GroupAssetsBy groupBy})>[];
+    final tapped = <({DateTime date, TimelineOverviewMode mode})>[];
     final timelineService = TimelineService((
       bucketSource: () => Stream.value([TimeBucket(date: DateTime(2025), assetCount: 0)]),
       assetSource: (_, _) async => const <BaseAsset>[],
@@ -265,7 +266,7 @@ void main() {
       endOffset: kTimelineOverviewSegmentExtent,
       firstAssetIndex: 0,
       bucket: TimeBucket(date: DateTime(2025), assetCount: 0),
-      groupBy: GroupAssetsBy.year,
+      mode: TimelineOverviewMode.years,
       header: HeaderType.year,
     );
 
@@ -277,8 +278,8 @@ void main() {
         child: ProviderScope(
           overrides: [
             timelineServiceProvider.overrideWithValue(timelineService),
-            timelineOverviewDrilldownProvider.overrideWithValue((bucket, groupBy) async {
-              tapped.add((date: bucket.date, groupBy: groupBy));
+            timelineOverviewDrilldownProvider.overrideWithValue((bucket, mode) async {
+              tapped.add((date: bucket.date, mode: mode));
             }),
           ],
           child: MaterialApp(
@@ -353,7 +354,7 @@ void main() {
       endOffset: kTimelineOverviewSegmentExtent,
       firstAssetIndex: 0,
       bucket: TimeBucket(date: DateTime(2025), assetCount: pool.length),
-      groupBy: GroupAssetsBy.year,
+      mode: TimelineOverviewMode.years,
       header: HeaderType.year,
     );
 
@@ -409,7 +410,7 @@ void main() {
       endOffset: kTimelineOverviewSegmentExtent,
       firstAssetIndex: 0,
       bucket: TimeBucket(date: DateTime(2025), assetCount: 1),
-      groupBy: GroupAssetsBy.year,
+      mode: TimelineOverviewMode.years,
       header: HeaderType.year,
     );
 
@@ -452,7 +453,7 @@ void main() {
       endOffset: kTimelineOverviewSegmentExtent,
       firstAssetIndex: 0,
       bucket: TimeBucket(date: DateTime(2025), assetCount: 0),
-      groupBy: GroupAssetsBy.year,
+      mode: TimelineOverviewMode.years,
       header: HeaderType.year,
     );
 

--- a/mobile/test/presentation/widgets/timeline/overview/timeline_overview_card_test.dart
+++ b/mobile/test/presentation/widgets/timeline/overview/timeline_overview_card_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/domain/services/store.service.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
@@ -77,7 +78,7 @@ void main() {
       wrap(
         TimelineOverviewCard(
           bucket: TimeBucket(date: DateTime(2025), assetCount: 1),
-          groupBy: GroupAssetsBy.year,
+          mode: TimelineOverviewMode.years,
           representativeAsset: asset,
         ),
       ),
@@ -97,7 +98,7 @@ void main() {
       wrap(
         TimelineOverviewCard(
           bucket: TimeBucket(date: DateTime(2025, 3), assetCount: 4),
-          groupBy: GroupAssetsBy.month,
+          mode: TimelineOverviewMode.months,
         ),
       ),
     );
@@ -112,7 +113,7 @@ void main() {
       wrap(
         TimelineOverviewCard(
           bucket: TimeBucket(date: DateTime(2024), assetCount: 2),
-          groupBy: GroupAssetsBy.year,
+          mode: TimelineOverviewMode.years,
         ),
       ),
     );
@@ -131,7 +132,7 @@ void main() {
       wrap(
         TimelineOverviewCard(
           bucket: TimeBucket(date: DateTime(2025), assetCount: 1),
-          groupBy: GroupAssetsBy.year,
+          mode: TimelineOverviewMode.years,
           onTap: () => taps++,
         ),
       ),
@@ -157,7 +158,7 @@ void main() {
       wrap(
         TimelineOverviewCard(
           bucket: TimeBucket(date: DateTime(2025, 3), assetCount: 4),
-          groupBy: GroupAssetsBy.month,
+          mode: TimelineOverviewMode.months,
           onTap: () {},
         ),
       ),
@@ -179,7 +180,7 @@ void main() {
       wrap(
         TimelineOverviewCard(
           bucket: TimeBucket(date: DateTime(2025), assetCount: 0),
-          groupBy: GroupAssetsBy.year,
+          mode: TimelineOverviewMode.years,
         ),
       ),
     );
@@ -198,7 +199,7 @@ void main() {
       wrap(
         TimelineOverviewCard(
           bucket: TimeBucket(date: DateTime(2025, 3), assetCount: 2),
-          groupBy: GroupAssetsBy.month,
+          mode: TimelineOverviewMode.months,
           onTap: () {},
         ),
       ),
@@ -221,7 +222,7 @@ void main() {
       wrap(
         TimelineOverviewCard(
           bucket: TimeBucket(date: DateTime(2025, 3), assetCount: 3),
-          groupBy: GroupAssetsBy.month,
+          mode: TimelineOverviewMode.months,
           onTap: () {},
         ),
         supportedLocales: const [Locale('de'), Locale('en')],
@@ -244,7 +245,7 @@ void main() {
       wrap(
         TimelineOverviewCard(
           bucket: TimeBucket(date: DateTime(2025, 3), assetCount: 5),
-          groupBy: GroupAssetsBy.month,
+          mode: TimelineOverviewMode.months,
           onTap: () => taps++,
         ),
         supportedLocales: const [Locale('ar'), Locale('en')],
@@ -269,7 +270,7 @@ void main() {
           width: 320,
           child: TimelineOverviewCard(
             bucket: TimeBucket(date: DateTime(2025), assetCount: 1),
-            groupBy: GroupAssetsBy.year,
+            mode: TimelineOverviewMode.years,
             onTap: () {},
           ),
         ),
@@ -293,7 +294,7 @@ void main() {
           width: 240,
           child: TimelineOverviewCard(
             bucket: TimeBucket(date: DateTime(2025, 9), assetCount: 10),
-            groupBy: GroupAssetsBy.month,
+            mode: TimelineOverviewMode.months,
             onTap: () {},
           ),
         ),
@@ -314,7 +315,7 @@ void main() {
       wrap(
         TimelineOverviewCard(
           bucket: TimeBucket(date: DateTime(2025), assetCount: 1),
-          groupBy: GroupAssetsBy.year,
+          mode: TimelineOverviewMode.years,
         ),
         mediaQuery: const MediaQueryData(highContrast: true),
         theme: ThemeData.dark(),
@@ -334,7 +335,7 @@ void main() {
       wrap(
         TimelineOverviewCard(
           bucket: TimeBucket(date: DateTime(2025), assetCount: 1),
-          groupBy: GroupAssetsBy.year,
+          mode: TimelineOverviewMode.years,
           onTap: () {},
         ),
         mediaQuery: const MediaQueryData(disableAnimations: true, accessibleNavigation: true),
@@ -350,7 +351,7 @@ void main() {
       wrap(
         TimelineOverviewCard(
           bucket: TimeBucket(date: DateTime(2025), assetCount: 1),
-          groupBy: GroupAssetsBy.year,
+          mode: TimelineOverviewMode.years,
           onTap: () {},
         ),
       ),
@@ -371,12 +372,12 @@ void main() {
           children: [
             TimelineOverviewCard(
               bucket: TimeBucket(date: DateTime(2025), assetCount: 2),
-              groupBy: GroupAssetsBy.year,
+              mode: TimelineOverviewMode.years,
               onTap: () {},
             ),
             TimelineOverviewCard(
               bucket: TimeBucket(date: DateTime(2024), assetCount: 3),
-              groupBy: GroupAssetsBy.year,
+              mode: TimelineOverviewMode.years,
               onTap: () {},
             ),
           ],
@@ -398,12 +399,12 @@ void main() {
           children: [
             TimelineOverviewCard(
               bucket: TimeBucket(date: DateTime(2025), assetCount: 2),
-              groupBy: GroupAssetsBy.year,
+              mode: TimelineOverviewMode.years,
               onTap: () {},
             ),
             TimelineOverviewCard(
               bucket: TimeBucket(date: DateTime(2024), assetCount: 3),
-              groupBy: GroupAssetsBy.year,
+              mode: TimelineOverviewMode.years,
               onTap: () {},
             ),
           ],

--- a/mobile/test/presentation/widgets/timeline/scrubber_segments_test.dart
+++ b/mobile/test/presentation/widgets/timeline/scrubber_segments_test.dart
@@ -68,6 +68,30 @@ void main() {
     expect(countScrubberSnapSegments(segments, GroupAssetsBy.day), 2);
   });
 
+  test('B-3: month granularity labels month+year', () {
+    final segments = [_segment(DateTime(2026, 4), 0, 100), _segment(DateTime(2026, 3), 100, 200)];
+
+    final scrubberSegments = buildScrubberSegments(
+      layoutSegments: segments,
+      timelineHeight: 300,
+      groupBy: GroupAssetsBy.month,
+    );
+
+    expect(scrubberSegments.first.scrollLabel, isNot(matches(RegExp(r'^\d{4}$'))));
+  });
+
+  test('B-4: day granularity labels month+year, same as month', () {
+    final segments = [_segment(DateTime(2026, 4), 0, 100), _segment(DateTime(2026, 3), 100, 200)];
+
+    final scrubberSegments = buildScrubberSegments(
+      layoutSegments: segments,
+      timelineHeight: 300,
+      groupBy: GroupAssetsBy.day,
+    );
+
+    expect(scrubberSegments.first.scrollLabel, isNot(matches(RegExp(r'^\d{4}$'))));
+  });
+
   test('empty layout returns empty scrubber segments', () {
     expect(buildScrubberSegments(layoutSegments: [], timelineHeight: 300, groupBy: GroupAssetsBy.year), isEmpty);
   });

--- a/mobile/test/presentation/widgets/timeline/scrubber_segments_test.dart
+++ b/mobile/test/presentation/widgets/timeline/scrubber_segments_test.dart
@@ -68,29 +68,11 @@ void main() {
     expect(countScrubberSnapSegments(segments, GroupAssetsBy.day), 2);
   });
 
-  test('B-3: month granularity labels month+year', () {
-    final segments = [_segment(DateTime(2026, 4), 0, 100), _segment(DateTime(2026, 3), 100, 200)];
-
-    final scrubberSegments = buildScrubberSegments(
-      layoutSegments: segments,
-      timelineHeight: 300,
-      groupBy: GroupAssetsBy.month,
-    );
-
-    expect(scrubberSegments.first.scrollLabel, isNot(matches(RegExp(r'^\d{4}$'))));
-  });
-
-  test('B-4: day granularity labels month+year, same as month', () {
-    final segments = [_segment(DateTime(2026, 4), 0, 100), _segment(DateTime(2026, 3), 100, 200)];
-
-    final scrubberSegments = buildScrubberSegments(
-      layoutSegments: segments,
-      timelineHeight: 300,
-      groupBy: GroupAssetsBy.day,
-    );
-
-    expect(scrubberSegments.first.scrollLabel, isNot(matches(RegExp(r'^\d{4}$'))));
-  });
+  // B-3 ("month granularity labels month+year") and B-4 ("day granularity labels month+year, same
+  // as month") are not added here: the two tests above already assert the exact scrollLabel
+  // strings (['Apr 2026', 'Apr 2026', 'Mar 2026']) for month and day grouping — strictly stronger
+  // than a "not a bare year" regex, over the same segments. No mutation can fail B-3/B-4 while
+  // those keep passing. Do not re-add them.
 
   test('empty layout returns empty scrubber segments', () {
     expect(buildScrubberSegments(layoutSegments: [], timelineHeight: 300, groupBy: GroupAssetsBy.year), isEmpty);

--- a/mobile/test/presentation/widgets/timeline/timeline_grouping_anchor_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_grouping_anchor_test.dart
@@ -1,32 +1,32 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline_grouping_anchor.dart';
 
 void main() {
   // ---- month-granularity cases ----
 
-  test('month: remembered date within same month is kept', () {
-    // Day view at 9 Jun → switch to Months → bucket is 1 Jun → should keep 9 Jun
+  test('months: remembered date within same month is kept', () {
+    // All view at 9 Jun → switch to Months → bucket is 1 Jun → should keep 9 Jun
     final remembered = DateTime(2026, 6, 9);
     final topBucketDate = DateTime(2026, 6, 1);
     expect(
       resolveGroupingChangeAnchorDate(
         topBucketDate: topBucketDate,
-        previousGroupBy: GroupAssetsBy.month,
+        previousMode: TimelineOverviewMode.months,
         remembered: remembered,
       ),
       remembered,
     );
   });
 
-  test('month: remembered date in a different month is dropped', () {
+  test('months: remembered date in a different month is dropped', () {
     // User scrolled to March while in month view → should use March 1st
     final remembered = DateTime(2026, 6, 9);
     final topBucketDate = DateTime(2026, 3, 1);
     expect(
       resolveGroupingChangeAnchorDate(
         topBucketDate: topBucketDate,
-        previousGroupBy: GroupAssetsBy.month,
+        previousMode: TimelineOverviewMode.months,
         remembered: remembered,
       ),
       topBucketDate,
@@ -35,67 +35,41 @@ void main() {
 
   // ---- year-granularity cases ----
 
-  test('year: remembered date within same year is kept', () {
+  test('years: remembered date within same year is kept', () {
     final remembered = DateTime(2026, 6, 9);
     final topBucketDate = DateTime(2026, 1, 1);
     expect(
       resolveGroupingChangeAnchorDate(
         topBucketDate: topBucketDate,
-        previousGroupBy: GroupAssetsBy.year,
+        previousMode: TimelineOverviewMode.years,
         remembered: remembered,
       ),
       remembered,
     );
   });
 
-  test('year: remembered date in a different year is dropped', () {
+  test('years: remembered date in a different year is dropped', () {
     final remembered = DateTime(2025, 6, 9);
     final topBucketDate = DateTime(2026, 1, 1);
     expect(
       resolveGroupingChangeAnchorDate(
         topBucketDate: topBucketDate,
-        previousGroupBy: GroupAssetsBy.year,
+        previousMode: TimelineOverviewMode.years,
         remembered: remembered,
       ),
       topBucketDate,
     );
   });
 
-  // ---- day/auto/none: always return bucket date (already full precision) ----
+  // ---- all: always return bucket date (already full precision) ----
 
-  test('day: always returns bucket date even when remembered is present', () {
+  test('all: always returns bucket date even when remembered is present', () {
     final remembered = DateTime(2026, 6, 9);
     final topBucketDate = DateTime(2026, 6, 9);
     expect(
       resolveGroupingChangeAnchorDate(
         topBucketDate: topBucketDate,
-        previousGroupBy: GroupAssetsBy.day,
-        remembered: remembered,
-      ),
-      topBucketDate,
-    );
-  });
-
-  test('auto: always returns bucket date', () {
-    final remembered = DateTime(2026, 6, 9);
-    final topBucketDate = DateTime(2026, 6, 5);
-    expect(
-      resolveGroupingChangeAnchorDate(
-        topBucketDate: topBucketDate,
-        previousGroupBy: GroupAssetsBy.auto,
-        remembered: remembered,
-      ),
-      topBucketDate,
-    );
-  });
-
-  test('none: always returns bucket date', () {
-    final remembered = DateTime(2026, 6, 9);
-    final topBucketDate = DateTime(2026, 6, 5);
-    expect(
-      resolveGroupingChangeAnchorDate(
-        topBucketDate: topBucketDate,
-        previousGroupBy: GroupAssetsBy.none,
+        previousMode: TimelineOverviewMode.all,
         remembered: remembered,
       ),
       topBucketDate,
@@ -109,7 +83,7 @@ void main() {
     expect(
       resolveGroupingChangeAnchorDate(
         topBucketDate: topBucketDate,
-        previousGroupBy: GroupAssetsBy.month,
+        previousMode: TimelineOverviewMode.months,
         remembered: null,
       ),
       topBucketDate,

--- a/mobile/test/presentation/widgets/timeline/timeline_grouping_bottom_pill_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_grouping_bottom_pill_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/domain/models/settings_key.dart';
 import 'package:immich_mobile/domain/services/store.service.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
@@ -61,9 +62,9 @@ void main() {
       expect(find.byKey(const Key('timeline-grouping-bottom-pill')), findsOneWidget);
       expect(find.byType(TimelineGroupingSelector), findsOneWidget);
       // Full selector, not the compact chip: all three segments are present.
-      expect(find.byKey(const Key('timeline-grouping-year')), findsOneWidget);
-      expect(find.byKey(const Key('timeline-grouping-month')), findsOneWidget);
-      expect(find.byKey(const Key('timeline-grouping-day')), findsOneWidget);
+      expect(find.byKey(const Key('timeline-grouping-years')), findsOneWidget);
+      expect(find.byKey(const Key('timeline-grouping-months')), findsOneWidget);
+      expect(find.byKey(const Key('timeline-grouping-all')), findsOneWidget);
       expect(find.byKey(const Key('timeline-grouping-compact-selector')), findsNothing);
       // The pill surface hugs the selector (218 self-cap + 2×8 padding) instead of
       // spanning the screen — keeps the scrubber's right-edge margin clear.
@@ -83,17 +84,17 @@ void main() {
       expect((selectorMaterial.shape! as StadiumBorder).side, BorderSide.none);
     });
 
-    // Hosted at root (no TimelineRouteScope): pins the ROOT grouping fallback. The pill's
+    // Hosted at root (no TimelineRouteScope): pins the ROOT mode fallback. The pill's
     // route-local contract is covered by the route-scope and favorites page tests.
-    testWidgets('tapping a segment outside a route scope updates the root grouping', (tester) async {
+    testWidgets('tapping a segment outside a route scope updates the root mode', (tester) async {
       await tester.pumpConsumerWidget(host());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byKey(const Key('timeline-grouping-month')));
+      await tester.tap(find.byKey(const Key('timeline-grouping-months')));
       await tester.pumpAndSettle();
 
       final container = ProviderScope.containerOf(tester.element(find.byType(TimelineGroupingSelector)));
-      expect(container.read(timelineGroupingProvider), GroupAssetsBy.month);
+      expect(container.read(timelineOverviewModeProvider), TimelineOverviewMode.months);
       // The "Photo Grid" -> "Group by" setting is independent of the selector (#903).
       expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
     });
@@ -214,10 +215,10 @@ void main() {
       await tester.pumpConsumerWidget(Directionality(textDirection: TextDirection.rtl, child: host()));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byKey(const Key('timeline-grouping-year')));
+      await tester.tap(find.byKey(const Key('timeline-grouping-years')));
       await tester.pumpAndSettle();
       final container = ProviderScope.containerOf(tester.element(find.byType(TimelineGroupingSelector)));
-      expect(container.read(timelineGroupingProvider), GroupAssetsBy.year);
+      expect(container.read(timelineOverviewModeProvider), TimelineOverviewMode.years);
     });
   });
 }

--- a/mobile/test/presentation/widgets/timeline/timeline_grouping_bottom_pill_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_grouping_bottom_pill_test.dart
@@ -3,6 +3,7 @@ import 'package:drift/native.dart';
 import 'package:easy_localization/easy_localization.dart' hide TextDirection;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
 import 'package:immich_mobile/domain/models/settings_key.dart';
 import 'package:immich_mobile/domain/services/store.service.dart';
@@ -12,6 +13,7 @@ import 'package:immich_mobile/infrastructure/repositories/settings.repository.da
 import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline_grouping_bottom_pill.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline_grouping_selector.widget.dart';
+import 'package:immich_mobile/providers/timeline/timeline_grouping.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
 // easy_localization initializes shared_preferences internally; tests need the mock initializer.
 // ignore: depend_on_referenced_packages
@@ -81,17 +83,19 @@ void main() {
       expect((selectorMaterial.shape! as StadiumBorder).side, BorderSide.none);
     });
 
-    // Hosted at root (no TimelineRouteScope): pins the ROOT grouping fallback, where segment
-    // taps persist the setting. The pill's production contract (route-local, store untouched)
-    // is covered by the route-scope and favorites page tests.
-    testWidgets('tapping a segment outside a route scope writes Setting.groupAssetsBy', (tester) async {
+    // Hosted at root (no TimelineRouteScope): pins the ROOT grouping fallback. The pill's
+    // route-local contract is covered by the route-scope and favorites page tests.
+    testWidgets('tapping a segment outside a route scope updates the root grouping', (tester) async {
       await tester.pumpConsumerWidget(host());
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const Key('timeline-grouping-month')));
       await tester.pumpAndSettle();
 
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
+      final container = ProviderScope.containerOf(tester.element(find.byType(TimelineGroupingSelector)));
+      expect(container.read(timelineGroupingProvider), GroupAssetsBy.month);
+      // The "Photo Grid" -> "Group by" setting is independent of the selector (#903).
+      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
     });
 
     testWidgets('hides while multiselect is enabled and reappears after', (tester) async {
@@ -212,7 +216,8 @@ void main() {
 
       await tester.tap(find.byKey(const Key('timeline-grouping-year')));
       await tester.pumpAndSettle();
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.year);
+      final container = ProviderScope.containerOf(tester.element(find.byType(TimelineGroupingSelector)));
+      expect(container.read(timelineGroupingProvider), GroupAssetsBy.year);
     });
   });
 }

--- a/mobile/test/presentation/widgets/timeline/timeline_grouping_selector_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_grouping_selector_test.dart
@@ -13,7 +13,7 @@ import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/settings.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline_grouping_selector.widget.dart';
-import 'package:immich_mobile/providers/infrastructure/settings.provider.dart';
+import 'package:immich_mobile/providers/timeline/timeline_grouping.provider.dart';
 import 'package:immich_mobile/widgets/settings/asset_list_settings/asset_list_group_settings.dart';
 
 import '../../../test_utils.dart';
@@ -47,6 +47,19 @@ void main() {
   bool selected(WidgetTester tester, GroupAssetsBy groupBy) {
     return segment(tester, groupBy).properties.selected ?? false;
   }
+
+  ProviderContainer containerOf(WidgetTester tester) {
+    return ProviderScope.containerOf(tester.element(find.byType(TimelineGroupingSelector)));
+  }
+
+  // The selector is view state, so drive it through its own provider rather than through
+  // Setting.groupAssetsBy — that setting is the independent "Photo Grid" -> "Group by" choice.
+  Future<void> setGrouping(WidgetTester tester, GroupAssetsBy groupBy) async {
+    await containerOf(tester).read(timelineGroupingProvider.notifier).set(groupBy);
+    await tester.pumpAndSettle();
+  }
+
+  GroupAssetsBy grouping(WidgetTester tester) => containerOf(tester).read(timelineGroupingProvider);
 
   group('TimelineGroupingSelector', () {
     testWidgets('renders years, months, and days segments in an app-bar action slot', (tester) async {
@@ -88,23 +101,32 @@ void main() {
       expect((material.shape! as StadiumBorder).side.style, BorderStyle.solid);
     });
 
-    testWidgets('initializes selected segment from Setting.groupAssetsBy', (tester) async {
-      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
-
+    testWidgets('selects the segment matching the active grouping', (tester) async {
       await tester.pumpConsumerWidget(const TimelineGroupingSelector());
       await tester.pumpAndSettle();
+      await setGrouping(tester, GroupAssetsBy.month);
 
       expect(selected(tester, GroupAssetsBy.month), isTrue);
       expect(selected(tester, GroupAssetsBy.day), isFalse);
       expect(selected(tester, GroupAssetsBy.year), isFalse);
     });
 
-    testWidgets('selected segment exposes button semantics without duplicate child text', (tester) async {
+    testWidgets('opens on the All segment regardless of the Group by setting', (tester) async {
       await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
+
+      await tester.pumpConsumerWidget(const TimelineGroupingSelector());
+      await tester.pumpAndSettle();
+
+      expect(selected(tester, GroupAssetsBy.day), isTrue);
+      expect(selected(tester, GroupAssetsBy.month), isFalse);
+    });
+
+    testWidgets('selected segment exposes button semantics without duplicate child text', (tester) async {
       final semantics = tester.ensureSemantics();
       try {
         await tester.pumpConsumerWidget(const TimelineGroupingSelector());
         await tester.pumpAndSettle();
+        await setGrouping(tester, GroupAssetsBy.month);
 
         expect(tester.getSemantics(find.byKey(const Key('timeline-grouping-selector'))).label, 'Timeline grouping');
         expect(find.bySemanticsLabel('Years'), findsOneWidget);
@@ -132,65 +154,67 @@ void main() {
     });
 
     testWidgets('normalizes unsupported auto and none values to the All segment visually', (tester) async {
-      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.auto);
       await tester.pumpConsumerWidget(const TimelineGroupingSelector());
       await tester.pumpAndSettle();
+
+      await setGrouping(tester, GroupAssetsBy.auto);
       expect(selected(tester, GroupAssetsBy.day), isTrue);
 
-      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.none);
-      final container = ProviderScope.containerOf(tester.element(find.byType(TimelineGroupingSelector)));
-      container.invalidate(settingsProvider);
-      await tester.pumpAndSettle();
+      await setGrouping(tester, GroupAssetsBy.none);
       expect(selected(tester, GroupAssetsBy.day), isTrue);
     });
 
-    testWidgets('tapping each segment writes the matching GroupAssetsBy setting', (tester) async {
+    testWidgets('tapping each segment changes the grouping without writing the Group by setting', (tester) async {
       await tester.pumpConsumerWidget(const TimelineGroupingSelector());
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const Key('timeline-grouping-year')));
       await tester.pumpAndSettle();
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.year);
+      expect(grouping(tester), GroupAssetsBy.year);
       expect(selected(tester, GroupAssetsBy.year), isTrue);
 
       await tester.tap(find.byKey(const Key('timeline-grouping-month')));
       await tester.pumpAndSettle();
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
+      expect(grouping(tester), GroupAssetsBy.month);
       expect(selected(tester, GroupAssetsBy.month), isTrue);
 
       await tester.tap(find.byKey(const Key('timeline-grouping-day')));
       await tester.pumpAndSettle();
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
+      expect(grouping(tester), GroupAssetsBy.day);
       expect(selected(tester, GroupAssetsBy.day), isTrue);
+
+      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
     });
 
-    testWidgets('settings picker changes update the selector', (tester) async {
+    // #903: picking "Month" under Photo Grid must group the photo grid's headers, not flip the
+    // timeline into the Months overview cards. The selector has to stay where it was.
+    testWidgets('settings picker changes leave the selector alone', (tester) async {
       await tester.pumpConsumerWidget(
         const SingleChildScrollView(child: Column(children: [TimelineGroupingSelector(), GroupSettings()])),
       );
       await tester.pumpAndSettle();
 
-      await tester.tap(find.descendant(of: find.byType(GroupSettings), matching: find.text('year'.tr())));
+      await tester.tap(find.descendant(of: find.byType(GroupSettings), matching: find.text('month'.tr())));
       await tester.pumpAndSettle();
 
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.year);
-      expect(selected(tester, GroupAssetsBy.year), isTrue);
+      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
+      expect(grouping(tester), GroupAssetsBy.day);
+      expect(selected(tester, GroupAssetsBy.day), isTrue);
+      expect(selected(tester, GroupAssetsBy.month), isFalse);
     });
 
-    testWidgets('disabled selector does not write settings', (tester) async {
-      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.day);
+    testWidgets('disabled selector does not change the grouping', (tester) async {
       await tester.pumpConsumerWidget(const TimelineGroupingSelector(enabled: false));
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const Key('timeline-grouping-year')), warnIfMissed: false);
       await tester.pumpAndSettle();
 
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
+      expect(grouping(tester), GroupAssetsBy.day);
       expect(selected(tester, GroupAssetsBy.day), isTrue);
     });
 
-    testWidgets('disabled selector removes actionable semantics and does not write settings', (tester) async {
-      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.day);
+    testWidgets('disabled selector removes actionable semantics and does not change the grouping', (tester) async {
       final semantics = tester.ensureSemantics();
       try {
         await tester.pumpConsumerWidget(const TimelineGroupingSelector(enabled: false));
@@ -212,7 +236,7 @@ void main() {
         await tester.tap(find.byKey(const Key('timeline-grouping-year')), warnIfMissed: false);
         await tester.pumpAndSettle();
 
-        expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
+        expect(grouping(tester), GroupAssetsBy.day);
       } finally {
         semantics.dispose();
       }
@@ -282,12 +306,11 @@ void main() {
     });
 
     testWidgets('rtl layout preserves tap behavior and directional visual order', (tester) async {
-      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
-
       await tester.pumpConsumerWidget(
         const Directionality(textDirection: TextDirection.rtl, child: TimelineGroupingSelector()),
       );
       await tester.pumpAndSettle();
+      await setGrouping(tester, GroupAssetsBy.month);
 
       final years = tester.getCenter(find.byKey(const Key('timeline-grouping-year')));
       final months = tester.getCenter(find.byKey(const Key('timeline-grouping-month')));
@@ -299,12 +322,10 @@ void main() {
       await tester.tap(find.byKey(const Key('timeline-grouping-day')));
       await tester.pumpAndSettle();
 
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
+      expect(grouping(tester), GroupAssetsBy.day);
     });
 
     testWidgets('compact mode renders only the current grouping in a small app-bar chip', (tester) async {
-      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.day);
-
       await tester.pumpConsumerWidget(
         const CustomScrollView(
           slivers: [
@@ -327,40 +348,38 @@ void main() {
     });
 
     testWidgets('compact mode tapping Day zooms out to Month', (tester) async {
-      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.day);
-
       await tester.pumpConsumerWidget(const TimelineGroupingSelector.compact());
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const Key('timeline-grouping-compact-selector')));
       await tester.pumpAndSettle();
 
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
+      expect(grouping(tester), GroupAssetsBy.month);
       expect(find.text('Months'), findsOneWidget);
     });
 
     testWidgets('compact mode bounces between extremes', (tester) async {
-      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.year);
       await tester.pumpConsumerWidget(const TimelineGroupingSelector.compact());
       await tester.pumpAndSettle();
+      await setGrouping(tester, GroupAssetsBy.year);
 
       final selector = find.byKey(const Key('timeline-grouping-compact-selector'));
 
       // Year -> Month -> Day (heading down)
       await tester.tap(selector);
       await tester.pumpAndSettle();
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
+      expect(grouping(tester), GroupAssetsBy.month);
       await tester.tap(selector);
       await tester.pumpAndSettle();
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
+      expect(grouping(tester), GroupAssetsBy.day);
 
       // Day -> Month -> Year (direction inverted at Day; preserved through Month)
       await tester.tap(selector);
       await tester.pumpAndSettle();
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
+      expect(grouping(tester), GroupAssetsBy.month);
       await tester.tap(selector);
       await tester.pumpAndSettle();
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.year);
+      expect(grouping(tester), GroupAssetsBy.year);
     });
 
     testWidgets('compact mode keeps bouncing back to Years when the chip is recreated between taps', (tester) async {
@@ -368,8 +387,6 @@ void main() {
       // (every grouping change flashes the timelineSegmentProvider loading state). The bounce
       // direction must survive that recreation, otherwise the chip gets stuck oscillating
       // Months <-> All and never returns to Years.
-      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.year);
-
       var generation = 0;
       late StateSetter setOuter;
       await tester.pumpConsumerWidget(
@@ -383,6 +400,7 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
+      await setGrouping(tester, GroupAssetsBy.year);
 
       final selector = find.byKey(const Key('timeline-grouping-compact-selector'));
 
@@ -394,21 +412,16 @@ void main() {
       }
 
       await tapAndRecreate();
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month); // Years -> Months
+      expect(grouping(tester), GroupAssetsBy.month); // Years -> Months
       await tapAndRecreate();
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day); // Months -> All
+      expect(grouping(tester), GroupAssetsBy.day); // Months -> All
       await tapAndRecreate();
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month); // All -> Months
+      expect(grouping(tester), GroupAssetsBy.month); // All -> Months
       await tapAndRecreate();
-      expect(
-        SettingsRepository.instance.appConfig.timeline.groupAssetsBy,
-        GroupAssetsBy.year,
-      ); // Months -> Years (the bug)
+      expect(grouping(tester), GroupAssetsBy.year); // Months -> Years (the bug)
     });
 
     testWidgets('compact mode opens a direct selection menu on long press', (tester) async {
-      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.day);
-
       await tester.pumpConsumerWidget(const TimelineGroupingSelector.compact());
       await tester.pumpAndSettle();
 
@@ -417,13 +430,12 @@ void main() {
       await tester.tap(find.byKey(const Key('timeline-grouping-menu-month')));
       await tester.pumpAndSettle();
 
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
+      expect(grouping(tester), GroupAssetsBy.month);
       expect(find.text('Months'), findsOneWidget);
       expect(find.text('Month'), findsNothing);
     });
 
     testWidgets('compact mode resumes bouncing after a long-press menu selection', (tester) async {
-      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.day);
       await tester.pumpConsumerWidget(const TimelineGroupingSelector.compact());
       await tester.pumpAndSettle();
 
@@ -434,15 +446,15 @@ void main() {
       await tester.pumpAndSettle();
       await tester.tap(find.byKey(const Key('timeline-grouping-menu-year')));
       await tester.pumpAndSettle();
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.year);
+      expect(grouping(tester), GroupAssetsBy.year);
 
       // Subsequent taps bounce down: Year -> Month -> Day.
       await tester.tap(selector);
       await tester.pumpAndSettle();
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
+      expect(grouping(tester), GroupAssetsBy.month);
       await tester.tap(selector);
       await tester.pumpAndSettle();
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
+      expect(grouping(tester), GroupAssetsBy.day);
     });
 
     testWidgets('compact mode shows the full "Months" label at normal size and never clips when enlarged', (
@@ -451,8 +463,6 @@ void main() {
       // "Months" is the widest grouping label. At the default text scale it must render at full
       // size inside the compact chip; when the OS enlarges text it may scale down to fit but must
       // never clip (the old "Mo..." truncation).
-      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
-
       Future<void> pumpAt(double scale) async {
         await tester.pumpConsumerWidget(
           MediaQuery(
@@ -465,6 +475,7 @@ void main() {
           ),
         );
         await tester.pumpAndSettle();
+        await setGrouping(tester, GroupAssetsBy.month);
       }
 
       // Default scale: the glyphs are painted at their full intrinsic width (not shrunk, not clipped).

--- a/mobile/test/presentation/widgets/timeline/timeline_grouping_selector_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_grouping_selector_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/settings_key.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/domain/services/store.service.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
@@ -40,12 +41,12 @@ void main() {
     await db.close();
   });
 
-  Semantics segment(WidgetTester tester, GroupAssetsBy groupBy) {
-    return tester.widget<Semantics>(find.byKey(Key('timeline-grouping-${groupBy.name}')));
+  Semantics segment(WidgetTester tester, TimelineOverviewMode mode) {
+    return tester.widget<Semantics>(find.byKey(Key('timeline-grouping-${mode.name}')));
   }
 
-  bool selected(WidgetTester tester, GroupAssetsBy groupBy) {
-    return segment(tester, groupBy).properties.selected ?? false;
+  bool selected(WidgetTester tester, TimelineOverviewMode mode) {
+    return segment(tester, mode).properties.selected ?? false;
   }
 
   ProviderContainer containerOf(WidgetTester tester) {
@@ -54,12 +55,12 @@ void main() {
 
   // The selector is view state, so drive it through its own provider rather than through
   // Setting.groupAssetsBy — that setting is the independent "Photo Grid" -> "Group by" choice.
-  Future<void> setGrouping(WidgetTester tester, GroupAssetsBy groupBy) async {
-    await containerOf(tester).read(timelineGroupingProvider.notifier).set(groupBy);
+  Future<void> setGrouping(WidgetTester tester, TimelineOverviewMode mode) async {
+    await containerOf(tester).read(timelineOverviewModeProvider.notifier).set(mode);
     await tester.pumpAndSettle();
   }
 
-  GroupAssetsBy grouping(WidgetTester tester) => containerOf(tester).read(timelineGroupingProvider);
+  TimelineOverviewMode grouping(WidgetTester tester) => containerOf(tester).read(timelineOverviewModeProvider);
 
   group('TimelineGroupingSelector', () {
     testWidgets('renders years, months, and days segments in an app-bar action slot', (tester) async {
@@ -73,10 +74,10 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('timeline-grouping-selector')), findsOneWidget);
-      expect(find.byKey(const Key('timeline-grouping-year')), findsOneWidget);
-      expect(find.byKey(const Key('timeline-grouping-month')), findsOneWidget);
-      expect(find.byKey(const Key('timeline-grouping-day')), findsOneWidget);
-      expect(selected(tester, GroupAssetsBy.day), isTrue);
+      expect(find.byKey(const Key('timeline-grouping-years')), findsOneWidget);
+      expect(find.byKey(const Key('timeline-grouping-months')), findsOneWidget);
+      expect(find.byKey(const Key('timeline-grouping-all')), findsOneWidget);
+      expect(selected(tester, TimelineOverviewMode.all), isTrue);
     });
 
     testWidgets('bare variant draws no surface or border of its own (for hosts that paint the pill)', (tester) async {
@@ -104,11 +105,11 @@ void main() {
     testWidgets('selects the segment matching the active grouping', (tester) async {
       await tester.pumpConsumerWidget(const TimelineGroupingSelector());
       await tester.pumpAndSettle();
-      await setGrouping(tester, GroupAssetsBy.month);
+      await setGrouping(tester, TimelineOverviewMode.months);
 
-      expect(selected(tester, GroupAssetsBy.month), isTrue);
-      expect(selected(tester, GroupAssetsBy.day), isFalse);
-      expect(selected(tester, GroupAssetsBy.year), isFalse);
+      expect(selected(tester, TimelineOverviewMode.months), isTrue);
+      expect(selected(tester, TimelineOverviewMode.all), isFalse);
+      expect(selected(tester, TimelineOverviewMode.years), isFalse);
     });
 
     testWidgets('opens on the All segment regardless of the Group by setting', (tester) async {
@@ -117,8 +118,8 @@ void main() {
       await tester.pumpConsumerWidget(const TimelineGroupingSelector());
       await tester.pumpAndSettle();
 
-      expect(selected(tester, GroupAssetsBy.day), isTrue);
-      expect(selected(tester, GroupAssetsBy.month), isFalse);
+      expect(selected(tester, TimelineOverviewMode.all), isTrue);
+      expect(selected(tester, TimelineOverviewMode.months), isFalse);
     });
 
     testWidgets('selected segment exposes button semantics without duplicate child text', (tester) async {
@@ -126,16 +127,16 @@ void main() {
       try {
         await tester.pumpConsumerWidget(const TimelineGroupingSelector());
         await tester.pumpAndSettle();
-        await setGrouping(tester, GroupAssetsBy.month);
+        await setGrouping(tester, TimelineOverviewMode.months);
 
         expect(tester.getSemantics(find.byKey(const Key('timeline-grouping-selector'))).label, 'Timeline grouping');
         expect(find.bySemanticsLabel('Years'), findsOneWidget);
         expect(find.bySemanticsLabel('Months'), findsOneWidget);
         expect(find.bySemanticsLabel('All'), findsOneWidget);
 
-        final years = tester.getSemantics(find.byKey(const Key('timeline-grouping-year')));
-        final months = tester.getSemantics(find.byKey(const Key('timeline-grouping-month')));
-        final days = tester.getSemantics(find.byKey(const Key('timeline-grouping-day')));
+        final years = tester.getSemantics(find.byKey(const Key('timeline-grouping-years')));
+        final months = tester.getSemantics(find.byKey(const Key('timeline-grouping-months')));
+        final days = tester.getSemantics(find.byKey(const Key('timeline-grouping-all')));
 
         expect(years.flagsCollection.isButton, isTrue);
         expect(years.flagsCollection.toStrings(), contains('hasSelectedState'));
@@ -153,35 +154,24 @@ void main() {
       }
     });
 
-    testWidgets('normalizes unsupported auto and none values to the All segment visually', (tester) async {
-      await tester.pumpConsumerWidget(const TimelineGroupingSelector());
-      await tester.pumpAndSettle();
-
-      await setGrouping(tester, GroupAssetsBy.auto);
-      expect(selected(tester, GroupAssetsBy.day), isTrue);
-
-      await setGrouping(tester, GroupAssetsBy.none);
-      expect(selected(tester, GroupAssetsBy.day), isTrue);
-    });
-
     testWidgets('tapping each segment changes the grouping without writing the Group by setting', (tester) async {
       await tester.pumpConsumerWidget(const TimelineGroupingSelector());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byKey(const Key('timeline-grouping-year')));
+      await tester.tap(find.byKey(const Key('timeline-grouping-years')));
       await tester.pumpAndSettle();
-      expect(grouping(tester), GroupAssetsBy.year);
-      expect(selected(tester, GroupAssetsBy.year), isTrue);
+      expect(grouping(tester), TimelineOverviewMode.years);
+      expect(selected(tester, TimelineOverviewMode.years), isTrue);
 
-      await tester.tap(find.byKey(const Key('timeline-grouping-month')));
+      await tester.tap(find.byKey(const Key('timeline-grouping-months')));
       await tester.pumpAndSettle();
-      expect(grouping(tester), GroupAssetsBy.month);
-      expect(selected(tester, GroupAssetsBy.month), isTrue);
+      expect(grouping(tester), TimelineOverviewMode.months);
+      expect(selected(tester, TimelineOverviewMode.months), isTrue);
 
-      await tester.tap(find.byKey(const Key('timeline-grouping-day')));
+      await tester.tap(find.byKey(const Key('timeline-grouping-all')));
       await tester.pumpAndSettle();
-      expect(grouping(tester), GroupAssetsBy.day);
-      expect(selected(tester, GroupAssetsBy.day), isTrue);
+      expect(grouping(tester), TimelineOverviewMode.all);
+      expect(selected(tester, TimelineOverviewMode.all), isTrue);
 
       expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
     });
@@ -198,20 +188,20 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
-      expect(grouping(tester), GroupAssetsBy.day);
-      expect(selected(tester, GroupAssetsBy.day), isTrue);
-      expect(selected(tester, GroupAssetsBy.month), isFalse);
+      expect(grouping(tester), TimelineOverviewMode.all);
+      expect(selected(tester, TimelineOverviewMode.all), isTrue);
+      expect(selected(tester, TimelineOverviewMode.months), isFalse);
     });
 
     testWidgets('disabled selector does not change the grouping', (tester) async {
       await tester.pumpConsumerWidget(const TimelineGroupingSelector(enabled: false));
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byKey(const Key('timeline-grouping-year')), warnIfMissed: false);
+      await tester.tap(find.byKey(const Key('timeline-grouping-years')), warnIfMissed: false);
       await tester.pumpAndSettle();
 
-      expect(grouping(tester), GroupAssetsBy.day);
-      expect(selected(tester, GroupAssetsBy.day), isTrue);
+      expect(grouping(tester), TimelineOverviewMode.all);
+      expect(selected(tester, TimelineOverviewMode.all), isTrue);
     });
 
     testWidgets('disabled selector removes actionable semantics and does not change the grouping', (tester) async {
@@ -220,23 +210,22 @@ void main() {
         await tester.pumpConsumerWidget(const TimelineGroupingSelector(enabled: false));
         await tester.pumpAndSettle();
 
-        for (final groupBy in timelineGroupingSelectorGroups) {
-          final label = switch (groupBy) {
-            GroupAssetsBy.year => 'Years',
-            GroupAssetsBy.month => 'Months',
-            GroupAssetsBy.day => 'All',
-            GroupAssetsBy.auto || GroupAssetsBy.none => 'All',
+        for (final mode in timelineOverviewModeSelectorOrder) {
+          final label = switch (mode) {
+            TimelineOverviewMode.years => 'Years',
+            TimelineOverviewMode.months => 'Months',
+            TimelineOverviewMode.all => 'All',
           };
-          final node = tester.getSemantics(find.byKey(Key('timeline-grouping-${groupBy.name}')));
+          final node = tester.getSemantics(find.byKey(Key('timeline-grouping-${mode.name}')));
           expect(node.getSemanticsData().hasAction(SemanticsAction.tap), isFalse, reason: label);
           expect(node.flagsCollection.toStrings(), contains('hasEnabledState'), reason: label);
           expect(node.flagsCollection.toStrings(), isNot(contains('isEnabled')), reason: label);
         }
 
-        await tester.tap(find.byKey(const Key('timeline-grouping-year')), warnIfMissed: false);
+        await tester.tap(find.byKey(const Key('timeline-grouping-years')), warnIfMissed: false);
         await tester.pumpAndSettle();
 
-        expect(grouping(tester), GroupAssetsBy.day);
+        expect(grouping(tester), TimelineOverviewMode.all);
       } finally {
         semantics.dispose();
       }
@@ -253,8 +242,8 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(tester.getSize(find.byKey(const Key('timeline-grouping-selector'))).height, greaterThanOrEqualTo(48));
-      for (final groupBy in timelineGroupingSelectorGroups) {
-        expect(tester.getSize(find.byKey(Key('timeline-grouping-${groupBy.name}'))).height, greaterThanOrEqualTo(48));
+      for (final mode in timelineOverviewModeSelectorOrder) {
+        expect(tester.getSize(find.byKey(Key('timeline-grouping-${mode.name}'))).height, greaterThanOrEqualTo(48));
       }
     });
 
@@ -275,9 +264,9 @@ void main() {
 
       expect(tester.takeException(), isNull);
       expect(tester.getSize(find.byKey(const Key('timeline-grouping-selector'))).width, lessThanOrEqualTo(150));
-      expect(find.byKey(const Key('timeline-grouping-year')), findsOneWidget);
-      expect(find.byKey(const Key('timeline-grouping-month')), findsOneWidget);
-      expect(find.byKey(const Key('timeline-grouping-day')), findsOneWidget);
+      expect(find.byKey(const Key('timeline-grouping-years')), findsOneWidget);
+      expect(find.byKey(const Key('timeline-grouping-months')), findsOneWidget);
+      expect(find.byKey(const Key('timeline-grouping-all')), findsOneWidget);
     });
 
     testWidgets('reduced motion removes nonessential selector animation', (tester) async {
@@ -310,19 +299,19 @@ void main() {
         const Directionality(textDirection: TextDirection.rtl, child: TimelineGroupingSelector()),
       );
       await tester.pumpAndSettle();
-      await setGrouping(tester, GroupAssetsBy.month);
+      await setGrouping(tester, TimelineOverviewMode.months);
 
-      final years = tester.getCenter(find.byKey(const Key('timeline-grouping-year')));
-      final months = tester.getCenter(find.byKey(const Key('timeline-grouping-month')));
-      final days = tester.getCenter(find.byKey(const Key('timeline-grouping-day')));
+      final years = tester.getCenter(find.byKey(const Key('timeline-grouping-years')));
+      final months = tester.getCenter(find.byKey(const Key('timeline-grouping-months')));
+      final days = tester.getCenter(find.byKey(const Key('timeline-grouping-all')));
 
       expect(years.dx, greaterThan(months.dx));
       expect(months.dx, greaterThan(days.dx));
 
-      await tester.tap(find.byKey(const Key('timeline-grouping-day')));
+      await tester.tap(find.byKey(const Key('timeline-grouping-all')));
       await tester.pumpAndSettle();
 
-      expect(grouping(tester), GroupAssetsBy.day);
+      expect(grouping(tester), TimelineOverviewMode.all);
     });
 
     testWidgets('compact mode renders only the current grouping in a small app-bar chip', (tester) async {
@@ -337,9 +326,9 @@ void main() {
 
       expect(find.byKey(const Key('timeline-grouping-compact-selector')), findsOneWidget);
       expect(find.byKey(const Key('timeline-grouping-selector')), findsNothing);
-      expect(find.byKey(const Key('timeline-grouping-year')), findsNothing);
-      expect(find.byKey(const Key('timeline-grouping-month')), findsNothing);
-      expect(find.byKey(const Key('timeline-grouping-day')), findsNothing);
+      expect(find.byKey(const Key('timeline-grouping-years')), findsNothing);
+      expect(find.byKey(const Key('timeline-grouping-months')), findsNothing);
+      expect(find.byKey(const Key('timeline-grouping-all')), findsNothing);
       expect(find.text('All'), findsOneWidget);
       expect(find.text('Day'), findsNothing);
       expect(find.text('Days'), findsNothing);
@@ -354,32 +343,32 @@ void main() {
       await tester.tap(find.byKey(const Key('timeline-grouping-compact-selector')));
       await tester.pumpAndSettle();
 
-      expect(grouping(tester), GroupAssetsBy.month);
+      expect(grouping(tester), TimelineOverviewMode.months);
       expect(find.text('Months'), findsOneWidget);
     });
 
     testWidgets('compact mode bounces between extremes', (tester) async {
       await tester.pumpConsumerWidget(const TimelineGroupingSelector.compact());
       await tester.pumpAndSettle();
-      await setGrouping(tester, GroupAssetsBy.year);
+      await setGrouping(tester, TimelineOverviewMode.years);
 
       final selector = find.byKey(const Key('timeline-grouping-compact-selector'));
 
       // Year -> Month -> Day (heading down)
       await tester.tap(selector);
       await tester.pumpAndSettle();
-      expect(grouping(tester), GroupAssetsBy.month);
+      expect(grouping(tester), TimelineOverviewMode.months);
       await tester.tap(selector);
       await tester.pumpAndSettle();
-      expect(grouping(tester), GroupAssetsBy.day);
+      expect(grouping(tester), TimelineOverviewMode.all);
 
       // Day -> Month -> Year (direction inverted at Day; preserved through Month)
       await tester.tap(selector);
       await tester.pumpAndSettle();
-      expect(grouping(tester), GroupAssetsBy.month);
+      expect(grouping(tester), TimelineOverviewMode.months);
       await tester.tap(selector);
       await tester.pumpAndSettle();
-      expect(grouping(tester), GroupAssetsBy.year);
+      expect(grouping(tester), TimelineOverviewMode.years);
     });
 
     testWidgets('compact mode keeps bouncing back to Years when the chip is recreated between taps', (tester) async {
@@ -400,7 +389,7 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
-      await setGrouping(tester, GroupAssetsBy.year);
+      await setGrouping(tester, TimelineOverviewMode.years);
 
       final selector = find.byKey(const Key('timeline-grouping-compact-selector'));
 
@@ -412,13 +401,13 @@ void main() {
       }
 
       await tapAndRecreate();
-      expect(grouping(tester), GroupAssetsBy.month); // Years -> Months
+      expect(grouping(tester), TimelineOverviewMode.months); // Years -> Months
       await tapAndRecreate();
-      expect(grouping(tester), GroupAssetsBy.day); // Months -> All
+      expect(grouping(tester), TimelineOverviewMode.all); // Months -> All
       await tapAndRecreate();
-      expect(grouping(tester), GroupAssetsBy.month); // All -> Months
+      expect(grouping(tester), TimelineOverviewMode.months); // All -> Months
       await tapAndRecreate();
-      expect(grouping(tester), GroupAssetsBy.year); // Months -> Years (the bug)
+      expect(grouping(tester), TimelineOverviewMode.years); // Months -> Years (the bug)
     });
 
     testWidgets('compact mode opens a direct selection menu on long press', (tester) async {
@@ -427,10 +416,10 @@ void main() {
 
       await tester.longPress(find.byKey(const Key('timeline-grouping-compact-selector')));
       await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const Key('timeline-grouping-menu-month')));
+      await tester.tap(find.byKey(const Key('timeline-grouping-menu-months')));
       await tester.pumpAndSettle();
 
-      expect(grouping(tester), GroupAssetsBy.month);
+      expect(grouping(tester), TimelineOverviewMode.months);
       expect(find.text('Months'), findsOneWidget);
       expect(find.text('Month'), findsNothing);
     });
@@ -444,17 +433,17 @@ void main() {
       // Pick Year directly via the long-press menu.
       await tester.longPress(selector);
       await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const Key('timeline-grouping-menu-year')));
+      await tester.tap(find.byKey(const Key('timeline-grouping-menu-years')));
       await tester.pumpAndSettle();
-      expect(grouping(tester), GroupAssetsBy.year);
+      expect(grouping(tester), TimelineOverviewMode.years);
 
       // Subsequent taps bounce down: Year -> Month -> Day.
       await tester.tap(selector);
       await tester.pumpAndSettle();
-      expect(grouping(tester), GroupAssetsBy.month);
+      expect(grouping(tester), TimelineOverviewMode.months);
       await tester.tap(selector);
       await tester.pumpAndSettle();
-      expect(grouping(tester), GroupAssetsBy.day);
+      expect(grouping(tester), TimelineOverviewMode.all);
     });
 
     testWidgets('compact mode shows the full "Months" label at normal size and never clips when enlarged', (
@@ -475,7 +464,7 @@ void main() {
           ),
         );
         await tester.pumpAndSettle();
-        await setGrouping(tester, GroupAssetsBy.month);
+        await setGrouping(tester, TimelineOverviewMode.months);
       }
 
       // Default scale: the glyphs are painted at their full intrinsic width (not shrunk, not clipped).

--- a/mobile/test/presentation/widgets/timeline/timeline_route_scope_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_route_scope_test.dart
@@ -8,6 +8,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/settings_key.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/domain/models/timeline_temporal_scope.model.dart';
 import 'package:immich_mobile/domain/models/timeline_zoom_anchor.model.dart';
 import 'package:immich_mobile/domain/services/store.service.dart';
@@ -174,10 +175,10 @@ void main() {
                       key: const Key('left-drilldown'),
                       onPressed: () {
                         final handler = ref.read(timelineOverviewDrilldownProvider);
-                        handler?.call(TimeBucket(date: DateTime(2025), assetCount: 4), GroupAssetsBy.year);
+                        handler?.call(TimeBucket(date: DateTime(2025), assetCount: 4), TimelineOverviewMode.years);
                       },
                       child: Text(
-                        'left:${ref.watch(timelineTemporalScopeProvider).kind.name}:${_anchorLabel(ref.watch(timelineZoomAnchorProvider))}:${ref.watch(timelineGroupingProvider).name}',
+                        'left:${ref.watch(timelineTemporalScopeProvider).kind.name}:${_anchorLabel(ref.watch(timelineZoomAnchorProvider))}:${ref.watch(timelineOverviewModeProvider).name}',
                       ),
                     ),
                   ),
@@ -187,7 +188,7 @@ void main() {
                 child: TimelineRouteScope(
                   child: Consumer(
                     builder: (context, ref, child) => Text(
-                      'right:${ref.watch(timelineTemporalScopeProvider).kind.name}:${_anchorLabel(ref.watch(timelineZoomAnchorProvider))}:${ref.watch(timelineGroupingProvider).name}',
+                      'right:${ref.watch(timelineTemporalScopeProvider).kind.name}:${_anchorLabel(ref.watch(timelineZoomAnchorProvider))}:${ref.watch(timelineOverviewModeProvider).name}',
                       key: const Key('right-drilldown'),
                     ),
                   ),
@@ -199,20 +200,20 @@ void main() {
       ),
     );
 
-    expect(find.text('left:none:none:day'), findsOneWidget);
-    expect(find.text('right:none:none:day'), findsOneWidget);
+    expect(find.text('left:none:none:all'), findsOneWidget);
+    expect(find.text('right:none:none:all'), findsOneWidget);
 
     await tester.tap(find.byKey(const Key('left-drilldown')));
     await tester.pumpAndSettle();
 
-    expect(find.text('left:none:year:2025:month'), findsOneWidget);
-    expect(find.text('right:none:none:day'), findsOneWidget);
-    // Drilldown inside a route changes only the route-local grouping; the persisted
+    expect(find.text('left:none:year:2025:months'), findsOneWidget);
+    expect(find.text('right:none:none:all'), findsOneWidget);
+    // Drilldown inside a route changes only the route-local mode; the persisted
     // setting is never written.
     expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
   });
 
-  testWidgets('route grouping opens at All regardless of the persisted setting', (tester) async {
+  testWidgets('route mode opens at All regardless of the persisted setting', (tester) async {
     await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
 
     await tester.pumpWidget(
@@ -220,18 +221,18 @@ void main() {
         child: MaterialApp(
           home: TimelineRouteScope(
             child: Consumer(
-              builder: (context, ref, child) => Text('grouping:${ref.watch(timelineGroupingProvider).name}'),
+              builder: (context, ref, child) => Text('grouping:${ref.watch(timelineOverviewModeProvider).name}'),
             ),
           ),
         ),
       ),
     );
 
-    expect(find.text('grouping:day'), findsOneWidget);
+    expect(find.text('grouping:all'), findsOneWidget);
     expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
   });
 
-  testWidgets('grouping changes stay local to the invoking route', (tester) async {
+  testWidgets('mode changes stay local to the invoking route', (tester) async {
     await tester.pumpWidget(
       ProviderScope(
         child: MaterialApp(
@@ -241,15 +242,15 @@ void main() {
                 child: Consumer(
                   builder: (context, ref, child) => TextButton(
                     key: const Key('left-grouping'),
-                    onPressed: () => unawaited(ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month)),
-                    child: Text('left:${ref.watch(timelineGroupingProvider).name}'),
+                    onPressed: () => unawaited(ref.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.months)),
+                    child: Text('left:${ref.watch(timelineOverviewModeProvider).name}'),
                   ),
                 ),
               ),
               TimelineRouteScope(
                 child: Consumer(
                   builder: (context, ref, child) =>
-                      Text('right:${ref.watch(timelineGroupingProvider).name}', key: const Key('right-grouping')),
+                      Text('right:${ref.watch(timelineOverviewModeProvider).name}', key: const Key('right-grouping')),
                 ),
               ),
             ],
@@ -258,14 +259,14 @@ void main() {
       ),
     );
 
-    expect(find.text('left:day'), findsOneWidget);
-    expect(find.text('right:day'), findsOneWidget);
+    expect(find.text('left:all'), findsOneWidget);
+    expect(find.text('right:all'), findsOneWidget);
 
     await tester.tap(find.byKey(const Key('left-grouping')));
     await tester.pump();
 
-    expect(find.text('left:month'), findsOneWidget);
-    expect(find.text('right:day'), findsOneWidget);
+    expect(find.text('left:months'), findsOneWidget);
+    expect(find.text('right:all'), findsOneWidget);
     expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
   });
 
@@ -279,20 +280,20 @@ void main() {
             sharedGrouping: true,
             child: Consumer(
               builder: (context, ref, child) =>
-                  Text('grouping:${ref.watch(timelineGroupingProvider).name}', key: const Key('shared-probe')),
+                  Text('grouping:${ref.watch(timelineOverviewModeProvider).name}', key: const Key('shared-probe')),
             ),
           ),
         ),
       ),
     );
 
-    expect(find.text('grouping:day'), findsOneWidget);
+    expect(find.text('grouping:all'), findsOneWidget);
 
     final ref = ProviderScope.containerOf(tester.element(find.byKey(const Key('shared-probe'))));
-    await tester.runAsync(() => ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.year));
+    await tester.runAsync(() => ref.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.years));
     await tester.pump();
 
-    expect(find.text('grouping:year'), findsOneWidget);
+    expect(find.text('grouping:years'), findsOneWidget);
     expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
   });
 
@@ -311,7 +312,7 @@ void main() {
             child: Consumer(
               builder: (context, ref, child) {
                 ref.watch(timelineServiceProvider);
-                return Text('grouping:${ref.watch(timelineGroupingProvider).name}');
+                return Text('grouping:${ref.watch(timelineOverviewModeProvider).name}');
               },
             ),
           ),
@@ -319,11 +320,11 @@ void main() {
       ),
     );
 
-    expect(find.text('grouping:day'), findsOneWidget);
+    expect(find.text('grouping:all'), findsOneWidget);
     expect(groupings, [GroupAssetsBy.month]);
   });
 
-  testWidgets('timelineServiceProvider rebuilds with the route-local grouping', (tester) async {
+  testWidgets('timelineServiceProvider rebuilds with the route-local mode', (tester) async {
     final groupings = <GroupAssetsBy>[];
 
     await tester.pumpWidget(
@@ -339,8 +340,8 @@ void main() {
                 ref.watch(timelineServiceProvider);
                 return TextButton(
                   key: const Key('grouping-service'),
-                  onPressed: () => unawaited(ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month)),
-                  child: Text('grouping:${ref.watch(timelineGroupingProvider).name}'),
+                  onPressed: () => unawaited(ref.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.months)),
+                  child: Text('grouping:${ref.watch(timelineOverviewModeProvider).name}'),
                 );
               },
             ),
@@ -368,11 +369,11 @@ void main() {
       ),
     );
 
-    await tester.tap(find.byKey(const Key('timeline-grouping-month')));
+    await tester.tap(find.byKey(const Key('timeline-grouping-months')));
     await tester.pump();
 
     final ref = ProviderScope.containerOf(tester.element(find.byType(TimelineGroupingSelector)));
-    expect(ref.read(timelineGroupingProvider), GroupAssetsBy.month);
+    expect(ref.read(timelineOverviewModeProvider), TimelineOverviewMode.months);
     expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
   });
 

--- a/mobile/test/presentation/widgets/timeline/timeline_route_scope_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_route_scope_test.dart
@@ -269,31 +269,58 @@ void main() {
     expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
   });
 
-  testWidgets('persistGrouping: true follows and writes the persisted setting', (tester) async {
+  testWidgets('sharedGrouping: true opens at All and never writes the Group by setting', (tester) async {
     await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
 
     await tester.pumpWidget(
       ProviderScope(
         child: MaterialApp(
           home: TimelineRouteScope(
-            persistGrouping: true,
+            sharedGrouping: true,
             child: Consumer(
               builder: (context, ref, child) =>
-                  Text('grouping:${ref.watch(timelineGroupingProvider).name}', key: const Key('persist-probe')),
+                  Text('grouping:${ref.watch(timelineGroupingProvider).name}', key: const Key('shared-probe')),
             ),
           ),
         ),
       ),
     );
 
-    expect(find.text('grouping:month'), findsOneWidget);
+    expect(find.text('grouping:day'), findsOneWidget);
 
-    final ref = ProviderScope.containerOf(tester.element(find.byKey(const Key('persist-probe'))));
+    final ref = ProviderScope.containerOf(tester.element(find.byKey(const Key('shared-probe'))));
     await tester.runAsync(() => ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.year));
     await tester.pump();
 
-    expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.year);
     expect(find.text('grouping:year'), findsOneWidget);
+    expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
+  });
+
+  testWidgets('route service buckets by the Group by setting while the selector shows All', (tester) async {
+    await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
+    final groupings = <GroupAssetsBy>[];
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: TimelineRouteScope(
+            timelineServiceBuilder: (ref, temporalScope, groupBy) {
+              groupings.add(groupBy);
+              return _emptyService(TimelineOrigin.main);
+            },
+            child: Consumer(
+              builder: (context, ref, child) {
+                ref.watch(timelineServiceProvider);
+                return Text('grouping:${ref.watch(timelineGroupingProvider).name}');
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('grouping:day'), findsOneWidget);
+    expect(groupings, [GroupAssetsBy.month]);
   });
 
   testWidgets('timelineServiceProvider rebuilds with the route-local grouping', (tester) async {

--- a/mobile/test/presentation/widgets/timeline/timeline_scroll_target_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_scroll_target_test.dart
@@ -117,21 +117,12 @@ void main() {
     );
   });
 
-  test('Z-6: findTimelineZoomAnchorSegment resolves a month anchor in All mode over month-granularity segments', () {
-    // Regression guard: if the anchor is handed spec.groupBy instead of spec.mode, a
-    // Group by = Month library makes the granularity `month`, the `all` guard stops
-    // matching, and drilling from Months into All silently fails to scroll.
-    final segments = [_segment(DateTime(2026, 4), 0, 100), _segment(DateTime(2026, 3), 100, 200)];
-
-    final target = findTimelineZoomAnchorSegment(
-      segments,
-      TimelineZoomAnchor.month(year: 2026, month: 3),
-      TimelineOverviewMode.all,
-    );
-
-    expect(target, isNotNull);
-    expect((target!.bucket as TimeBucket).date, DateTime(2026, 3));
-  });
+  // Z-6 ("resolves a month anchor in All mode over month-granularity segments") is not added
+  // here: it exercises the identical guard as 'resolves a month anchor in all mode' above.
+  // findTimelineZoomAnchorSegment never inspects day-of-month, so "month-granularity segments"
+  // is not a distinct code path, and findTimelineZoomAnchorSegment's third parameter is a typed
+  // TimelineOverviewMode — a spec.mode/spec.groupBy mix-up at the call site is now a compile
+  // error, not something this pure-function test could ever catch. Do not re-add it.
 
   test('findTimelineZoomAnchorSegment ignores non-time bucket segments', () {
     final segments = [_nonTimeSegment(0, 100), _segment(DateTime(2025, 3), 100, 200)];

--- a/mobile/test/presentation/widgets/timeline/timeline_scroll_target_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_scroll_target_test.dart
@@ -117,6 +117,22 @@ void main() {
     );
   });
 
+  test('Z-6: findTimelineZoomAnchorSegment resolves a month anchor in All mode over month-granularity segments', () {
+    // Regression guard: if the anchor is handed spec.groupBy instead of spec.mode, a
+    // Group by = Month library makes the granularity `month`, the `all` guard stops
+    // matching, and drilling from Months into All silently fails to scroll.
+    final segments = [_segment(DateTime(2026, 4), 0, 100), _segment(DateTime(2026, 3), 100, 200)];
+
+    final target = findTimelineZoomAnchorSegment(
+      segments,
+      TimelineZoomAnchor.month(year: 2026, month: 3),
+      TimelineOverviewMode.all,
+    );
+
+    expect(target, isNotNull);
+    expect((target!.bucket as TimeBucket).date, DateTime(2026, 3));
+  });
+
   test('findTimelineZoomAnchorSegment ignores non-time bucket segments', () {
     final segments = [_nonTimeSegment(0, 100), _segment(DateTime(2025, 3), 100, 200)];
 

--- a/mobile/test/presentation/widgets/timeline/timeline_scroll_target_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_scroll_target_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/domain/models/timeline_zoom_anchor.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/fixed/segment.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline_scroll_target.dart';
@@ -40,7 +41,7 @@ void main() {
     expect(findTimelineScrollTargetSegment([_nonTimeSegment(0, 100)], DateTime(2026, 4, 3)), isNull);
   });
 
-  test('findTimelineZoomAnchorSegment resolves a year anchor in month grouping', () {
+  test('findTimelineZoomAnchorSegment resolves a year anchor in months mode', () {
     final segments = [
       _segment(DateTime(2026, 1), 0, 100),
       _segment(DateTime(2025, 12), 100, 200),
@@ -48,12 +49,12 @@ void main() {
     ];
 
     expect(
-      findTimelineZoomAnchorSegment(segments, const TimelineZoomAnchor.year(2025), GroupAssetsBy.month),
+      findTimelineZoomAnchorSegment(segments, const TimelineZoomAnchor.year(2025), TimelineOverviewMode.months),
       segments[1],
     );
   });
 
-  test('findTimelineZoomAnchorSegment resolves a month anchor in day grouping', () {
+  test('findTimelineZoomAnchorSegment resolves a month anchor in all mode', () {
     final segments = [
       _segment(DateTime(2025, 4, 1), 0, 100),
       _segment(DateTime(2025, 3, 20), 100, 200),
@@ -61,7 +62,7 @@ void main() {
     ];
 
     expect(
-      findTimelineZoomAnchorSegment(segments, TimelineZoomAnchor.month(year: 2025, month: 3), GroupAssetsBy.day),
+      findTimelineZoomAnchorSegment(segments, TimelineZoomAnchor.month(year: 2025, month: 3), TimelineOverviewMode.all),
       segments[1],
     );
   });
@@ -69,28 +70,28 @@ void main() {
   test('findTimelineZoomAnchorSegment does not fall back to nearby years or months', () {
     final segments = [_segment(DateTime(2026, 1), 0, 100), _segment(DateTime(2024, 12), 100, 200)];
 
-    expect(findTimelineZoomAnchorSegment(segments, const TimelineZoomAnchor.year(2025), GroupAssetsBy.month), isNull);
+    expect(findTimelineZoomAnchorSegment(segments, const TimelineZoomAnchor.year(2025), TimelineOverviewMode.months), isNull);
     expect(
       findTimelineZoomAnchorSegment(
         [_segment(DateTime(2025, 2), 0, 100), _segment(DateTime(2025, 4), 100, 200)],
         TimelineZoomAnchor.month(year: 2025, month: 3),
-        GroupAssetsBy.day,
+        TimelineOverviewMode.all,
       ),
       isNull,
     );
   });
 
-  test('findTimelineZoomAnchorSegment ignores anchors in stale grouping modes', () {
+  test('findTimelineZoomAnchorSegment ignores anchors in stale modes', () {
     final segments = [_segment(DateTime(2025, 3), 0, 100)];
 
-    expect(findTimelineZoomAnchorSegment(segments, const TimelineZoomAnchor.year(2025), GroupAssetsBy.day), isNull);
+    expect(findTimelineZoomAnchorSegment(segments, const TimelineZoomAnchor.year(2025), TimelineOverviewMode.all), isNull);
     expect(
-      findTimelineZoomAnchorSegment(segments, TimelineZoomAnchor.month(year: 2025, month: 3), GroupAssetsBy.month),
+      findTimelineZoomAnchorSegment(segments, TimelineZoomAnchor.month(year: 2025, month: 3), TimelineOverviewMode.months),
       isNull,
     );
   });
 
-  test('findTimelineZoomAnchorSegment resolves a date anchor by month fallback in month grouping', () {
+  test('findTimelineZoomAnchorSegment resolves a date anchor by month fallback in months mode', () {
     final segments = [
       _segment(DateTime(2026, 1), 0, 100),
       _segment(DateTime(2017, 11), 100, 200),
@@ -98,12 +99,12 @@ void main() {
     ];
 
     expect(
-      findTimelineZoomAnchorSegment(segments, TimelineZoomAnchor.date(DateTime(2017, 11, 15)), GroupAssetsBy.month),
+      findTimelineZoomAnchorSegment(segments, TimelineZoomAnchor.date(DateTime(2017, 11, 15)), TimelineOverviewMode.months),
       segments[1],
     );
   });
 
-  test('findTimelineZoomAnchorSegment resolves a date anchor by year fallback in year grouping', () {
+  test('findTimelineZoomAnchorSegment resolves a date anchor by year fallback in years mode', () {
     final segments = [
       _segment(DateTime(2026), 0, 100),
       _segment(DateTime(2020), 100, 200),
@@ -111,7 +112,7 @@ void main() {
     ];
 
     expect(
-      findTimelineZoomAnchorSegment(segments, TimelineZoomAnchor.date(DateTime(2020, 8, 1)), GroupAssetsBy.year),
+      findTimelineZoomAnchorSegment(segments, TimelineZoomAnchor.date(DateTime(2020, 8, 1)), TimelineOverviewMode.years),
       segments[1],
     );
   });
@@ -120,14 +121,14 @@ void main() {
     final segments = [_nonTimeSegment(0, 100), _segment(DateTime(2025, 3), 100, 200)];
 
     expect(
-      findTimelineZoomAnchorSegment(segments, TimelineZoomAnchor.month(year: 2025, month: 3), GroupAssetsBy.day),
+      findTimelineZoomAnchorSegment(segments, TimelineZoomAnchor.month(year: 2025, month: 3), TimelineOverviewMode.all),
       segments[1],
     );
     expect(
       findTimelineZoomAnchorSegment(
         [_nonTimeSegment(0, 100)],
         const TimelineZoomAnchor.year(2025),
-        GroupAssetsBy.month,
+        TimelineOverviewMode.months,
       ),
       isNull,
     );

--- a/mobile/test/presentation/widgets/timeline/timeline_segment_provider_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_segment_provider_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/settings_key.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/domain/services/timeline.service.dart';
 import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/settings.repository.dart';
@@ -13,8 +14,20 @@ import 'package:immich_mobile/presentation/widgets/timeline/timeline.state.dart'
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
 import 'package:immich_mobile/providers/timeline/timeline_grouping.provider.dart';
 
+/// Seeds [timelineOverviewModeProvider] so a test can start at a given zoom level.
+class _SeededOverviewMode extends TimelineOverviewModeNotifier {
+  _SeededOverviewMode(this._seed);
+
+  final TimelineOverviewMode _seed;
+
+  @override
+  TimelineOverviewMode build() => _seed;
+}
+
 void main() {
-  ProviderContainer containerFor(GroupAssetsBy groupBy, {bool dateless = false}) {
+  /// [pinnedGroupBy] pins `TimelineArgs.groupBy` (the cleanup preview), which always means the
+  /// flat grid at that granularity; otherwise the zoom level comes from [mode].
+  ProviderContainer containerFor(TimelineOverviewMode mode, {bool dateless = false, GroupAssetsBy? pinnedGroupBy}) {
     final service = TimelineService((
       assetSource: (offset, count) async => const [],
       bucketSource: dateless
@@ -30,8 +43,9 @@ void main() {
       overrides: [
         timelineServiceProvider.overrideWithValue(service),
         timelineArgsProvider.overrideWithValue(
-          TimelineArgs(maxWidth: 390, maxHeight: 800, columnCount: 3, groupBy: groupBy),
+          TimelineArgs(maxWidth: 390, maxHeight: 800, columnCount: 3, groupBy: pinnedGroupBy),
         ),
+        timelineOverviewModeProvider.overrideWith(() => _SeededOverviewMode(mode)),
       ],
     );
     addTearDown(() async {
@@ -41,8 +55,8 @@ void main() {
     return container;
   }
 
-  test('year grouping uses overview segments', () async {
-    final container = containerFor(GroupAssetsBy.year);
+  test('years mode uses overview segments', () async {
+    final container = containerFor(TimelineOverviewMode.years);
 
     final segments = await container.read(timelineSegmentProvider.future);
 
@@ -51,16 +65,16 @@ void main() {
     expect(segments.last.firstAssetIndex, 2);
   });
 
-  test('month grouping uses overview segments', () async {
-    final container = containerFor(GroupAssetsBy.month);
+  test('months mode uses overview segments', () async {
+    final container = containerFor(TimelineOverviewMode.months);
 
     final segments = await container.read(timelineSegmentProvider.future);
 
     expect(segments, everyElement(isA<TimelineOverviewSegment>()));
   });
 
-  test('day grouping stays on fixed grid segments', () async {
-    final container = containerFor(GroupAssetsBy.day);
+  test('a pinned day groupBy stays on fixed grid segments', () async {
+    final container = containerFor(TimelineOverviewMode.all, pinnedGroupBy: GroupAssetsBy.day);
 
     final segments = await container.read(timelineSegmentProvider.future);
 
@@ -69,31 +83,31 @@ void main() {
 
   // Slice 3: date-less bucket fallback tests
 
-  test('date-less buckets with month setting fall back to fixed grid segments', () async {
-    final container = containerFor(GroupAssetsBy.month, dateless: true);
+  test('date-less buckets in months mode fall back to fixed grid segments', () async {
+    final container = containerFor(TimelineOverviewMode.months, dateless: true);
 
     final segments = await container.read(timelineSegmentProvider.future);
 
     expect(segments, everyElement(isA<FixedSegment>()));
   });
 
-  test('date-less buckets with year setting fall back to fixed grid segments', () async {
-    final container = containerFor(GroupAssetsBy.year, dateless: true);
+  test('date-less buckets in years mode fall back to fixed grid segments', () async {
+    final container = containerFor(TimelineOverviewMode.years, dateless: true);
 
     final segments = await container.read(timelineSegmentProvider.future);
 
     expect(segments, everyElement(isA<FixedSegment>()));
   });
 
-  test('TimeBuckets with month setting still use overview segments', () async {
-    final container = containerFor(GroupAssetsBy.month);
+  test('TimeBuckets in months mode still use overview segments', () async {
+    final container = containerFor(TimelineOverviewMode.months);
 
     final segments = await container.read(timelineSegmentProvider.future);
 
     expect(segments, everyElement(isA<TimelineOverviewSegment>()));
   });
 
-  test('empty bucket list with month setting produces no segments and no throw', () async {
+  test('empty bucket list in months mode produces no segments and no throw', () async {
     final service = TimelineService((
       assetSource: (offset, count) async => const [],
       bucketSource: () => Stream.value(const <Bucket>[]),
@@ -103,9 +117,8 @@ void main() {
     final container = ProviderContainer(
       overrides: [
         timelineServiceProvider.overrideWithValue(service),
-        timelineArgsProvider.overrideWithValue(
-          const TimelineArgs(maxWidth: 390, maxHeight: 800, columnCount: 3, groupBy: GroupAssetsBy.month),
-        ),
+        timelineArgsProvider.overrideWithValue(const TimelineArgs(maxWidth: 390, maxHeight: 800, columnCount: 3)),
+        timelineOverviewModeProvider.overrideWith(() => _SeededOverviewMode(TimelineOverviewMode.months)),
       ],
     );
     addTearDown(() async {
@@ -196,7 +209,7 @@ void main() {
     test('selecting Months still renders the overview cards', () async {
       await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
       final container = settingsBackedContainer();
-      await container.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
+      await container.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.months);
 
       final segments = await container.read(timelineSegmentProvider.future);
 
@@ -206,7 +219,7 @@ void main() {
     test('selecting Years still renders the overview cards', () async {
       await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
       final container = settingsBackedContainer();
-      await container.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.year);
+      await container.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.years);
 
       final segments = await container.read(timelineSegmentProvider.future);
 

--- a/mobile/test/presentation/widgets/timeline/timeline_segment_provider_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_segment_provider_test.dart
@@ -81,6 +81,21 @@ void main() {
     expect(segments, everyElement(isA<FixedSegment>()));
   });
 
+  // The one behaviour this refactor deliberately changed: a pinned `TimelineArgs.groupBy` (the
+  // cleanup preview) always means the FLAT GRID at that granularity, even when the zoom level
+  // would otherwise render overview cards. Mode and pinned grouping disagree on purpose here —
+  // years would mean year cards, but the pinned month must win and produce a month-header grid.
+  // Without the pinned short-circuit in `timeline.state.dart` this renders overview cards.
+  test('a pinned groupBy wins over the zoom level and renders the grid, not overview cards', () async {
+    final container = containerFor(TimelineOverviewMode.years, pinnedGroupBy: GroupAssetsBy.month);
+
+    final segments = await container.read(timelineSegmentProvider.future);
+
+    expect(segments, everyElement(isA<FixedSegment>()));
+    expect(segments, everyElement(isNot(isA<TimelineOverviewSegment>())));
+    expect(segments.map((segment) => segment.header), everyElement(HeaderType.month));
+  });
+
   // Slice 3: date-less bucket fallback tests
 
   test('date-less buckets in months mode fall back to fixed grid segments', () async {

--- a/mobile/test/presentation/widgets/timeline/timeline_segment_provider_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_segment_provider_test.dart
@@ -96,6 +96,21 @@ void main() {
     expect(segments.map((segment) => segment.header), everyElement(HeaderType.month));
   });
 
+  // S-6 ("a pinned groupBy renders the flat grid and never the overview") is not added here:
+  // once `pinnedGroupBy` is set, `timeline.state.dart` forces `spec.mode` to `all` internally and
+  // never evaluates `timelineGroupingSpecProvider`, so the container's seeded `mode` argument is
+  // unobservable. The two tests above already prove FixedSegment-only rendering for a pinned
+  // `day` and `month` groupBy (including the not-TimelineOverviewSegment and header assertions) —
+  // a third case only varying the (irrelevant) seeded mode would be a duplicate.
+  test('S-7: with a pinned groupBy, changing the mode afterwards is ignored', () async {
+    final container = containerFor(TimelineOverviewMode.all, pinnedGroupBy: GroupAssetsBy.day);
+    await container.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.years);
+
+    final segments = await container.read(timelineSegmentProvider.future);
+
+    expect(segments, everyElement(isA<FixedSegment>()));
+  });
+
   // Slice 3: date-less bucket fallback tests
 
   test('date-less buckets in months mode fall back to fixed grid segments', () async {
@@ -190,6 +205,44 @@ void main() {
       });
       return container;
     }
+
+    ProviderContainer emptyBucketContainer() {
+      final service = TimelineService((
+        assetSource: (offset, count) async => const [],
+        bucketSource: () => Stream.value(const <Bucket>[]),
+        origin: TimelineOrigin.main,
+      ));
+
+      final container = ProviderContainer(
+        overrides: [
+          timelineServiceProvider.overrideWithValue(service),
+          timelineArgsProvider.overrideWithValue(const TimelineArgs(maxWidth: 390, maxHeight: 800, columnCount: 3)),
+        ],
+      );
+      addTearDown(() async {
+        container.dispose();
+        await service.dispose();
+      });
+      return container;
+    }
+
+    test('S-4: empty buckets in Months mode produce no segments and do not throw', () async {
+      final container = emptyBucketContainer();
+      await container.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.months);
+
+      final segments = await container.read(timelineSegmentProvider.future);
+
+      expect(segments, isEmpty);
+    });
+
+    test('S-5: empty buckets in All mode with the month setting produce no segments', () async {
+      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
+      final container = emptyBucketContainer();
+
+      final segments = await container.read(timelineSegmentProvider.future);
+
+      expect(segments, isEmpty);
+    });
 
     test('month setting renders a grid with month-only headers', () async {
       await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);

--- a/mobile/test/presentation/widgets/timeline/timeline_segment_provider_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_segment_provider_test.dart
@@ -1,11 +1,17 @@
+import 'package:drift/drift.dart' as drift;
+import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/settings_key.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
 import 'package:immich_mobile/domain/services/timeline.service.dart';
+import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
+import 'package:immich_mobile/infrastructure/repositories/settings.repository.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/fixed/segment.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/overview/overview_segment.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.state.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
+import 'package:immich_mobile/providers/timeline/timeline_grouping.provider.dart';
 
 void main() {
   ProviderContainer containerFor(GroupAssetsBy groupBy, {bool dateless = false}) {
@@ -110,5 +116,101 @@ void main() {
     final segments = await container.read(timelineSegmentProvider.future);
 
     expect(segments, isEmpty);
+  });
+
+  // The "Photo Grid" -> "Group by" setting is a header-granularity choice, not the
+  // Years/Months/All overview selector (#903). With the selector on "All" the grid must
+  // stay a grid, and only the header granularity follows the setting.
+  group('grid grouping follows the persisted Group by setting', () {
+    late Drift db;
+
+    setUpAll(() async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      db = Drift(drift.DatabaseConnection(NativeDatabase.memory(), closeStreamsSynchronously: true));
+      await SettingsRepository.ensureInitialized(db);
+    });
+
+    setUp(() async {
+      await SettingsRepository.instance.clear(SettingsKey.values);
+    });
+
+    tearDownAll(() async {
+      await SettingsRepository.instance.clear(SettingsKey.values);
+      await db.close();
+    });
+
+    ProviderContainer settingsBackedContainer() {
+      final service = TimelineService((
+        assetSource: (offset, count) async => const [],
+        bucketSource: () => Stream.value([
+          TimeBucket(date: DateTime(2025, 7), assetCount: 4),
+          TimeBucket(date: DateTime(2025, 6), assetCount: 2),
+        ]),
+        origin: TimelineOrigin.main,
+      ));
+
+      final container = ProviderContainer(
+        overrides: [
+          timelineServiceProvider.overrideWithValue(service),
+          // No groupBy: the provider must resolve it from the selector + the setting.
+          timelineArgsProvider.overrideWithValue(const TimelineArgs(maxWidth: 390, maxHeight: 800, columnCount: 3)),
+        ],
+      );
+      addTearDown(() async {
+        container.dispose();
+        await service.dispose();
+      });
+      return container;
+    }
+
+    test('month setting renders a grid with month-only headers', () async {
+      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
+      final container = settingsBackedContainer();
+
+      final segments = await container.read(timelineSegmentProvider.future);
+
+      expect(segments, everyElement(isA<FixedSegment>()));
+      expect(segments.map((segment) => segment.header), everyElement(HeaderType.month));
+    });
+
+    test('month + day setting renders a grid with day headers', () async {
+      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.day);
+      final container = settingsBackedContainer();
+
+      final segments = await container.read(timelineSegmentProvider.future);
+
+      expect(segments, everyElement(isA<FixedSegment>()));
+      expect(segments.map((segment) => segment.header), everyElement(HeaderType.monthAndDay));
+    });
+
+    test('a leftover year setting falls back to the month + day grid', () async {
+      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.year);
+      final container = settingsBackedContainer();
+
+      final segments = await container.read(timelineSegmentProvider.future);
+
+      expect(segments, everyElement(isA<FixedSegment>()));
+      expect(segments.map((segment) => segment.header), everyElement(HeaderType.monthAndDay));
+    });
+
+    test('selecting Months still renders the overview cards', () async {
+      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
+      final container = settingsBackedContainer();
+      await container.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
+
+      final segments = await container.read(timelineSegmentProvider.future);
+
+      expect(segments, everyElement(isA<TimelineOverviewSegment>()));
+    });
+
+    test('selecting Years still renders the overview cards', () async {
+      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
+      final container = settingsBackedContainer();
+      await container.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.year);
+
+      final segments = await container.read(timelineSegmentProvider.future);
+
+      expect(segments, everyElement(isA<TimelineOverviewSegment>()));
+    });
   });
 }

--- a/mobile/test/presentation/widgets/timeline/timeline_zoom_anchor_resolution_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_zoom_anchor_resolution_test.dart
@@ -17,6 +17,7 @@ import 'package:immich_mobile/infrastructure/repositories/settings.repository.da
 import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/timeline.provider.dart';
+import 'package:immich_mobile/providers/timeline/timeline_grouping.provider.dart';
 import 'package:immich_mobile/providers/timeline/zoom_anchor.provider.dart';
 import 'package:intl/date_symbol_data_local.dart';
 // easy_localization initializes shared_preferences internally; tests need the mock initializer.
@@ -54,7 +55,6 @@ void main() {
   });
 
   testWidgets('resolves a year anchor in month grouping and clears it after scrolling', (tester) async {
-    await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
     final service = _service([
       TimeBucket(date: DateTime(2026, 4), assetCount: 8),
       TimeBucket(date: DateTime(2026, 3), assetCount: 8),
@@ -69,6 +69,8 @@ void main() {
 
     await _pumpTimeline(tester, service);
     final ref = ProviderScope.containerOf(tester.element(find.byType(Timeline)));
+    await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
+    await tester.pumpAndSettle();
 
     ref.read(timelineZoomAnchorProvider.notifier).setYear(2025);
     await tester.pump();
@@ -80,7 +82,6 @@ void main() {
   });
 
   testWidgets('resolves a month anchor in day grouping and clears it after scrolling', (tester) async {
-    await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.day);
     final service = _service([
       TimeBucket(date: DateTime(2025, 5, 2), assetCount: 9),
       TimeBucket(date: DateTime(2025, 4, 2), assetCount: 9),
@@ -103,8 +104,35 @@ void main() {
     expect(_scrollPixels(tester), greaterThan(0));
   });
 
-  testWidgets('keeps a missing year anchor pending without scrolling', (tester) async {
+  // #903: with "Group by" set to Month, drilling a month card down to All lands on a photo
+  // grid of month buckets — the month anchor must still resolve against those buckets.
+  testWidgets('resolves a month anchor on a month-grouped grid and clears it after scrolling', (tester) async {
     await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
+    final service = _service([
+      TimeBucket(date: DateTime(2025, 6), assetCount: 9),
+      TimeBucket(date: DateTime(2025, 5), assetCount: 9),
+      TimeBucket(date: DateTime(2025, 4), assetCount: 9),
+      TimeBucket(date: DateTime(2025, 3), assetCount: 9),
+      TimeBucket(date: DateTime(2025, 2), assetCount: 9),
+      TimeBucket(date: DateTime(2025), assetCount: 9),
+    ]);
+    addTearDown(service.dispose);
+
+    await _pumpTimeline(tester, service);
+    final ref = ProviderScope.containerOf(tester.element(find.byType(Timeline)));
+    // The selector stays on All: the month grouping comes from the setting, not the selector.
+    expect(ref.read(timelineGroupingProvider), GroupAssetsBy.day);
+
+    ref.read(timelineZoomAnchorProvider.notifier).setMonth(year: 2025, month: 3);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 600));
+    await tester.pumpAndSettle();
+
+    expect(ref.read(timelineZoomAnchorProvider), const TimelineZoomAnchor.none());
+    expect(_scrollPixels(tester), greaterThan(0));
+  });
+
+  testWidgets('keeps a missing year anchor pending without scrolling', (tester) async {
     final service = _service([
       TimeBucket(date: DateTime(2026, 4), assetCount: 8),
       TimeBucket(date: DateTime(2026, 3), assetCount: 8),
@@ -115,6 +143,8 @@ void main() {
 
     await _pumpTimeline(tester, service);
     final ref = ProviderScope.containerOf(tester.element(find.byType(Timeline)));
+    await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
+    await tester.pumpAndSettle();
 
     ref.read(timelineZoomAnchorProvider.notifier).setYear(2025);
     await tester.pump();

--- a/mobile/test/presentation/widgets/timeline/timeline_zoom_anchor_resolution_test.dart
+++ b/mobile/test/presentation/widgets/timeline/timeline_zoom_anchor_resolution_test.dart
@@ -8,6 +8,7 @@ import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/domain/models/settings_key.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/domain/models/timeline_zoom_anchor.model.dart';
 import 'package:immich_mobile/domain/services/store.service.dart';
 import 'package:immich_mobile/domain/services/timeline.service.dart';
@@ -54,7 +55,7 @@ void main() {
     await db.close();
   });
 
-  testWidgets('resolves a year anchor in month grouping and clears it after scrolling', (tester) async {
+  testWidgets('resolves a year anchor in months mode and clears it after scrolling', (tester) async {
     final service = _service([
       TimeBucket(date: DateTime(2026, 4), assetCount: 8),
       TimeBucket(date: DateTime(2026, 3), assetCount: 8),
@@ -69,7 +70,7 @@ void main() {
 
     await _pumpTimeline(tester, service);
     final ref = ProviderScope.containerOf(tester.element(find.byType(Timeline)));
-    await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
+    await ref.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.months);
     await tester.pumpAndSettle();
 
     ref.read(timelineZoomAnchorProvider.notifier).setYear(2025);
@@ -81,7 +82,7 @@ void main() {
     expect(_scrollPixels(tester), greaterThan(0));
   });
 
-  testWidgets('resolves a month anchor in day grouping and clears it after scrolling', (tester) async {
+  testWidgets('resolves a month anchor in all mode and clears it after scrolling', (tester) async {
     final service = _service([
       TimeBucket(date: DateTime(2025, 5, 2), assetCount: 9),
       TimeBucket(date: DateTime(2025, 4, 2), assetCount: 9),
@@ -120,8 +121,8 @@ void main() {
 
     await _pumpTimeline(tester, service);
     final ref = ProviderScope.containerOf(tester.element(find.byType(Timeline)));
-    // The selector stays on All: the month grouping comes from the setting, not the selector.
-    expect(ref.read(timelineGroupingProvider), GroupAssetsBy.day);
+    // The selector stays on All: the month bucketing comes from the setting, not the selector.
+    expect(ref.read(timelineOverviewModeProvider), TimelineOverviewMode.all);
 
     ref.read(timelineZoomAnchorProvider.notifier).setMonth(year: 2025, month: 3);
     await tester.pump();
@@ -143,7 +144,7 @@ void main() {
 
     await _pumpTimeline(tester, service);
     final ref = ProviderScope.containerOf(tester.element(find.byType(Timeline)));
-    await ref.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
+    await ref.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.months);
     await tester.pumpAndSettle();
 
     ref.read(timelineZoomAnchorProvider.notifier).setYear(2025);

--- a/mobile/test/providers/photos_filter/timeline_query_provider_test.dart
+++ b/mobile/test/providers/photos_filter/timeline_query_provider_test.dart
@@ -408,7 +408,7 @@ void main() {
           child: TimelineRouteScope(
             timelineServiceBuilder: buildPhotosTimelineRouteService,
             // Mirrors MainTimelinePage: the Photos route follows the persisted grouping.
-            persistGrouping: true,
+            sharedGrouping: true,
             child: Directionality(
               textDirection: TextDirection.ltr,
               child: Consumer(builder: (context, ref, child) => Text(ref.watch(timelineServiceProvider).origin.name)),

--- a/mobile/test/providers/photos_filter/timeline_query_provider_test.dart
+++ b/mobile/test/providers/photos_filter/timeline_query_provider_test.dart
@@ -315,7 +315,7 @@ void main() {
           timelineTemporalScopeProvider.overrideWith(TimelineTemporalScopeNotifier.new),
           timelineServiceProvider.overrideWith((ref) {
             final temporalScope = ref.watch(timelineTemporalScopeProvider);
-            return buildPhotosTimelineRouteService(ref, temporalScope, ref.watch(timelineGroupingProvider));
+            return buildPhotosTimelineRouteService(ref, temporalScope, ref.watch(timelineGroupingSpecProvider).groupBy);
           }),
         ],
       );
@@ -363,7 +363,7 @@ void main() {
           timelineTemporalScopeProvider.overrideWith(TimelineTemporalScopeNotifier.new),
           timelineServiceProvider.overrideWith((ref) {
             final temporalScope = ref.watch(timelineTemporalScopeProvider);
-            return buildPhotosTimelineRouteService(ref, temporalScope, ref.watch(timelineGroupingProvider));
+            return buildPhotosTimelineRouteService(ref, temporalScope, ref.watch(timelineGroupingSpecProvider).groupBy);
           }),
         ],
       );

--- a/mobile/test/providers/timeline/overview_drilldown_provider_test.dart
+++ b/mobile/test/providers/timeline/overview_drilldown_provider_test.dart
@@ -16,6 +16,7 @@ import 'package:immich_mobile/infrastructure/repositories/store.repository.dart'
 import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
 import 'package:immich_mobile/providers/timeline/overview_drilldown.provider.dart';
 import 'package:immich_mobile/providers/timeline/temporal_scope.provider.dart';
+import 'package:immich_mobile/providers/timeline/timeline_grouping.provider.dart';
 import 'package:immich_mobile/providers/timeline/zoom_anchor.provider.dart';
 
 void main() {
@@ -56,13 +57,16 @@ void main() {
 
     expect(container.read(timelineTemporalScopeProvider), const TimelineTemporalScope.year(2024));
     expect(container.read(timelineZoomAnchorProvider), const TimelineZoomAnchor.year(2025));
-    expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
+    expect(container.read(timelineGroupingProvider), GroupAssetsBy.month);
+    // Drilldown is view state: the "Group by" setting must not move with it.
+    expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
     expect(container.read(photosFilterProvider).context, 'paris');
     await Future<void>.delayed(Duration.zero);
     expect(scrollEvents, 0);
   });
 
   test('month activation groups by day, stores a month anchor, and leaves temporal scope unchanged', () async {
+    await container.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
     container.read(timelineTemporalScopeProvider.notifier).setYear(2024);
     var scrollEvents = 0;
     final subscription = EventStream.shared.listen<ScrollToTopEvent>((_) => scrollEvents++);
@@ -75,21 +79,22 @@ void main() {
 
     expect(container.read(timelineTemporalScopeProvider), const TimelineTemporalScope.year(2024));
     expect(container.read(timelineZoomAnchorProvider), TimelineZoomAnchor.month(year: 2025, month: 3));
+    expect(container.read(timelineGroupingProvider), GroupAssetsBy.day);
     expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
     await Future<void>.delayed(Duration.zero);
     expect(scrollEvents, 0);
   });
 
-  test('year activation stores the anchor before publishing the grouping setting change', () async {
+  test('year activation stores the anchor before publishing the grouping change', () async {
     final anchorsSeenAtGroupingChange = <TimelineZoomAnchor>[];
-    // The drilldown sets the zoom anchor before writing the grouping setting; capture the
-    // anchor at the moment the published config flips to month grouping.
-    final subscription = SettingsRepository.instance.watchConfig().listen((config) {
-      if (config.timeline.groupAssetsBy == GroupAssetsBy.month) {
+    // The drilldown sets the zoom anchor before changing the grouping; capture the anchor at
+    // the moment the grouping flips to month.
+    final subscription = container.listen(timelineGroupingProvider, (previous, next) {
+      if (next == GroupAssetsBy.month) {
         anchorsSeenAtGroupingChange.add(container.read(timelineZoomAnchorProvider));
       }
     });
-    addTearDown(subscription.cancel);
+    addTearDown(subscription.close);
 
     await container.read(sharedTimelineOverviewDrilldownProvider)(
       TimeBucket(date: DateTime(2025), assetCount: 4),
@@ -101,8 +106,8 @@ void main() {
   });
 
   for (final groupBy in [GroupAssetsBy.day, GroupAssetsBy.auto, GroupAssetsBy.none]) {
-    test('$groupBy grouping is ignored and leaves anchors, scope, and settings unchanged', () async {
-      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.year);
+    test('$groupBy grouping is ignored and leaves anchors, scope, and grouping unchanged', () async {
+      await container.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.year);
       container.read(timelineTemporalScopeProvider.notifier).setYear(2024);
 
       await container.read(sharedTimelineOverviewDrilldownProvider)(
@@ -112,7 +117,7 @@ void main() {
 
       expect(container.read(timelineTemporalScopeProvider), const TimelineTemporalScope.year(2024));
       expect(container.read(timelineZoomAnchorProvider), const TimelineZoomAnchor.none());
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.year);
+      expect(container.read(timelineGroupingProvider), GroupAssetsBy.year);
     });
   }
 

--- a/mobile/test/providers/timeline/overview_drilldown_provider_test.dart
+++ b/mobile/test/providers/timeline/overview_drilldown_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/events.model.dart';
 import 'package:immich_mobile/domain/models/settings_key.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/domain/models/timeline_temporal_scope.model.dart';
 import 'package:immich_mobile/domain/models/timeline_zoom_anchor.model.dart';
 import 'package:immich_mobile/domain/services/store.service.dart';
@@ -43,7 +44,7 @@ void main() {
     await db.close();
   });
 
-  test('year activation groups by month, stores a year anchor, and preserves filters without changing scope', () async {
+  test('years activation zooms to months, stores a year anchor, and preserves filters without changing scope', () async {
     container.read(photosFilterProvider.notifier).setText('paris');
     container.read(timelineTemporalScopeProvider.notifier).setYear(2024);
     var scrollEvents = 0;
@@ -52,12 +53,12 @@ void main() {
 
     await container.read(sharedTimelineOverviewDrilldownProvider)(
       TimeBucket(date: DateTime(2025), assetCount: 4),
-      GroupAssetsBy.year,
+      TimelineOverviewMode.years,
     );
 
     expect(container.read(timelineTemporalScopeProvider), const TimelineTemporalScope.year(2024));
     expect(container.read(timelineZoomAnchorProvider), const TimelineZoomAnchor.year(2025));
-    expect(container.read(timelineGroupingProvider), GroupAssetsBy.month);
+    expect(container.read(timelineOverviewModeProvider), TimelineOverviewMode.months);
     // Drilldown is view state: the "Group by" setting must not move with it.
     expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
     expect(container.read(photosFilterProvider).context, 'paris');
@@ -65,8 +66,8 @@ void main() {
     expect(scrollEvents, 0);
   });
 
-  test('month activation groups by day, stores a month anchor, and leaves temporal scope unchanged', () async {
-    await container.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
+  test('months activation zooms to all, stores a month anchor, and leaves temporal scope unchanged', () async {
+    await container.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.months);
     container.read(timelineTemporalScopeProvider.notifier).setYear(2024);
     var scrollEvents = 0;
     final subscription = EventStream.shared.listen<ScrollToTopEvent>((_) => scrollEvents++);
@@ -74,23 +75,23 @@ void main() {
 
     await container.read(sharedTimelineOverviewDrilldownProvider)(
       TimeBucket(date: DateTime(2025, 3), assetCount: 4),
-      GroupAssetsBy.month,
+      TimelineOverviewMode.months,
     );
 
     expect(container.read(timelineTemporalScopeProvider), const TimelineTemporalScope.year(2024));
     expect(container.read(timelineZoomAnchorProvider), TimelineZoomAnchor.month(year: 2025, month: 3));
-    expect(container.read(timelineGroupingProvider), GroupAssetsBy.day);
+    expect(container.read(timelineOverviewModeProvider), TimelineOverviewMode.all);
     expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
     await Future<void>.delayed(Duration.zero);
     expect(scrollEvents, 0);
   });
 
-  test('year activation stores the anchor before publishing the grouping change', () async {
+  test('years activation stores the anchor before publishing the mode change', () async {
     final anchorsSeenAtGroupingChange = <TimelineZoomAnchor>[];
-    // The drilldown sets the zoom anchor before changing the grouping; capture the anchor at
-    // the moment the grouping flips to month.
-    final subscription = container.listen(timelineGroupingProvider, (previous, next) {
-      if (next == GroupAssetsBy.month) {
+    // The drilldown sets the zoom anchor before changing the mode; capture the anchor at
+    // the moment the mode flips to months.
+    final subscription = container.listen(timelineOverviewModeProvider, (previous, next) {
+      if (next == TimelineOverviewMode.months) {
         anchorsSeenAtGroupingChange.add(container.read(timelineZoomAnchorProvider));
       }
     });
@@ -98,28 +99,26 @@ void main() {
 
     await container.read(sharedTimelineOverviewDrilldownProvider)(
       TimeBucket(date: DateTime(2025), assetCount: 4),
-      GroupAssetsBy.year,
+      TimelineOverviewMode.years,
     );
     await Future<void>.delayed(Duration.zero);
 
     expect(anchorsSeenAtGroupingChange, [const TimelineZoomAnchor.year(2025)]);
   });
 
-  for (final groupBy in [GroupAssetsBy.day, GroupAssetsBy.auto, GroupAssetsBy.none]) {
-    test('$groupBy grouping is ignored and leaves anchors, scope, and grouping unchanged', () async {
-      await container.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.year);
-      container.read(timelineTemporalScopeProvider.notifier).setYear(2024);
+  test('all mode is ignored and leaves anchors, scope, and mode unchanged', () async {
+    await container.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.years);
+    container.read(timelineTemporalScopeProvider.notifier).setYear(2024);
 
-      await container.read(sharedTimelineOverviewDrilldownProvider)(
-        TimeBucket(date: DateTime(2025, 3), assetCount: 4),
-        groupBy,
-      );
+    await container.read(sharedTimelineOverviewDrilldownProvider)(
+      TimeBucket(date: DateTime(2025, 3), assetCount: 4),
+      TimelineOverviewMode.all,
+    );
 
-      expect(container.read(timelineTemporalScopeProvider), const TimelineTemporalScope.year(2024));
-      expect(container.read(timelineZoomAnchorProvider), const TimelineZoomAnchor.none());
-      expect(container.read(timelineGroupingProvider), GroupAssetsBy.year);
-    });
-  }
+    expect(container.read(timelineTemporalScopeProvider), const TimelineTemporalScope.year(2024));
+    expect(container.read(timelineZoomAnchorProvider), const TimelineZoomAnchor.none());
+    expect(container.read(timelineOverviewModeProvider), TimelineOverviewMode.years);
+  });
 
   test('photos drilldown provider aliases shared drilldown handler', () {
     expect(

--- a/mobile/test/providers/timeline/photos_overview_zoom_provider_test.dart
+++ b/mobile/test/providers/timeline/photos_overview_zoom_provider_test.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/settings_key.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/domain/models/timeline_temporal_scope.model.dart';
 import 'package:immich_mobile/domain/models/timeline_zoom_anchor.model.dart';
 import 'package:immich_mobile/domain/services/store.service.dart';
@@ -44,7 +45,7 @@ void main() {
     await db.close();
   });
 
-  test('Photos year activation changes grouping and anchor only', () async {
+  test('Photos years activation changes the mode and anchor only', () async {
     container.read(photosFilterProvider.notifier)
       ..setText('paris')
       ..toggleTag('tag-1')
@@ -55,10 +56,10 @@ void main() {
 
     await container.read(photosTimelineOverviewDrilldownProvider)(
       TimeBucket(date: DateTime(2025), assetCount: 4),
-      GroupAssetsBy.year,
+      TimelineOverviewMode.years,
     );
 
-    expect(container.read(timelineGroupingProvider), GroupAssetsBy.month);
+    expect(container.read(timelineOverviewModeProvider), TimelineOverviewMode.months);
     // Drilldown is view state: the "Group by" setting must not move with it.
     expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
     expect(container.read(timelineZoomAnchorProvider), const TimelineZoomAnchor.year(2025));
@@ -70,19 +71,19 @@ void main() {
     expect(container.read(photosFilterProvider).mediaType, AssetType.video);
   });
 
-  test('Photos month activation changes grouping and anchor only', () async {
+  test('Photos months activation changes the mode and anchor only', () async {
     container.read(photosFilterProvider.notifier)
       ..setLocation(SearchLocationFilter(country: 'France'))
       ..setRating(4);
     final beforeFilter = container.read(photosFilterProvider);
-    await container.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
+    await container.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.months);
 
     await container.read(photosTimelineOverviewDrilldownProvider)(
       TimeBucket(date: DateTime(2025, 3), assetCount: 4),
-      GroupAssetsBy.month,
+      TimelineOverviewMode.months,
     );
 
-    expect(container.read(timelineGroupingProvider), GroupAssetsBy.day);
+    expect(container.read(timelineOverviewModeProvider), TimelineOverviewMode.all);
     expect(container.read(timelineZoomAnchorProvider), TimelineZoomAnchor.month(year: 2025, month: 3));
     expect(container.read(timelineTemporalScopeProvider), const TimelineTemporalScope.none());
     expect(container.read(photosFilterProvider), beforeFilter);
@@ -90,21 +91,19 @@ void main() {
     expect(container.read(photosFilterProvider).rating.rating.unwrapOrNull, 4);
   });
 
-  for (final groupBy in [GroupAssetsBy.day, GroupAssetsBy.auto, GroupAssetsBy.none]) {
-    test('Photos $groupBy activation is ignored', () async {
-      await container.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.year);
-      container.read(photosFilterProvider.notifier).setText('paris');
-      final beforeFilter = container.read(photosFilterProvider);
+  test('Photos all activation is ignored', () async {
+    await container.read(timelineOverviewModeProvider.notifier).set(TimelineOverviewMode.years);
+    container.read(photosFilterProvider.notifier).setText('paris');
+    final beforeFilter = container.read(photosFilterProvider);
 
-      await container.read(photosTimelineOverviewDrilldownProvider)(
-        TimeBucket(date: DateTime(2025, 3), assetCount: 4),
-        groupBy,
-      );
+    await container.read(photosTimelineOverviewDrilldownProvider)(
+      TimeBucket(date: DateTime(2025, 3), assetCount: 4),
+      TimelineOverviewMode.all,
+    );
 
-      expect(container.read(timelineGroupingProvider), GroupAssetsBy.year);
-      expect(container.read(timelineZoomAnchorProvider), const TimelineZoomAnchor.none());
-      expect(container.read(timelineTemporalScopeProvider), const TimelineTemporalScope.none());
-      expect(container.read(photosFilterProvider), beforeFilter);
-    });
-  }
+    expect(container.read(timelineOverviewModeProvider), TimelineOverviewMode.years);
+    expect(container.read(timelineZoomAnchorProvider), const TimelineZoomAnchor.none());
+    expect(container.read(timelineTemporalScopeProvider), const TimelineTemporalScope.none());
+    expect(container.read(photosFilterProvider), beforeFilter);
+  });
 }

--- a/mobile/test/providers/timeline/photos_overview_zoom_provider_test.dart
+++ b/mobile/test/providers/timeline/photos_overview_zoom_provider_test.dart
@@ -16,6 +16,7 @@ import 'package:immich_mobile/models/search/search_filter.model.dart';
 import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
 import 'package:immich_mobile/providers/timeline/overview_drilldown.provider.dart';
 import 'package:immich_mobile/providers/timeline/temporal_scope.provider.dart';
+import 'package:immich_mobile/providers/timeline/timeline_grouping.provider.dart';
 import 'package:immich_mobile/providers/timeline/zoom_anchor.provider.dart';
 
 void main() {
@@ -57,7 +58,9 @@ void main() {
       GroupAssetsBy.year,
     );
 
-    expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
+    expect(container.read(timelineGroupingProvider), GroupAssetsBy.month);
+    // Drilldown is view state: the "Group by" setting must not move with it.
+    expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
     expect(container.read(timelineZoomAnchorProvider), const TimelineZoomAnchor.year(2025));
     expect(container.read(timelineTemporalScopeProvider), TimelineTemporalScope.month(year: 2024, month: 12));
     expect(container.read(photosFilterProvider), beforeFilter);
@@ -72,13 +75,14 @@ void main() {
       ..setLocation(SearchLocationFilter(country: 'France'))
       ..setRating(4);
     final beforeFilter = container.read(photosFilterProvider);
+    await container.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.month);
 
     await container.read(photosTimelineOverviewDrilldownProvider)(
       TimeBucket(date: DateTime(2025, 3), assetCount: 4),
       GroupAssetsBy.month,
     );
 
-    expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
+    expect(container.read(timelineGroupingProvider), GroupAssetsBy.day);
     expect(container.read(timelineZoomAnchorProvider), TimelineZoomAnchor.month(year: 2025, month: 3));
     expect(container.read(timelineTemporalScopeProvider), const TimelineTemporalScope.none());
     expect(container.read(photosFilterProvider), beforeFilter);
@@ -88,7 +92,7 @@ void main() {
 
   for (final groupBy in [GroupAssetsBy.day, GroupAssetsBy.auto, GroupAssetsBy.none]) {
     test('Photos $groupBy activation is ignored', () async {
-      await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.year);
+      await container.read(timelineGroupingProvider.notifier).set(GroupAssetsBy.year);
       container.read(photosFilterProvider.notifier).setText('paris');
       final beforeFilter = container.read(photosFilterProvider);
 
@@ -97,7 +101,7 @@ void main() {
         groupBy,
       );
 
-      expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.year);
+      expect(container.read(timelineGroupingProvider), GroupAssetsBy.year);
       expect(container.read(timelineZoomAnchorProvider), const TimelineZoomAnchor.none());
       expect(container.read(timelineTemporalScopeProvider), const TimelineTemporalScope.none());
       expect(container.read(photosFilterProvider), beforeFilter);

--- a/mobile/test/providers/timeline/timeline_grouping_spec_test.dart
+++ b/mobile/test/providers/timeline/timeline_grouping_spec_test.dart
@@ -1,0 +1,103 @@
+import 'package:drift/drift.dart' as drift;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/settings_key.dart';
+import 'package:immich_mobile/domain/models/timeline.model.dart';
+import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
+import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
+import 'package:immich_mobile/infrastructure/repositories/settings.repository.dart';
+import 'package:immich_mobile/providers/timeline/timeline_grouping.provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Drift db;
+  late ProviderContainer container;
+
+  setUpAll(() async {
+    db = Drift(drift.DatabaseConnection(NativeDatabase.memory(), closeStreamsSynchronously: true));
+    await SettingsRepository.ensureInitialized(db);
+  });
+
+  // SettingsRepository.instance is a process-wide singleton: without this clear, a value
+  // written by one test leaks into the next and the failures look like ordering flakes.
+  setUp(() async {
+    await SettingsRepository.instance.clear(SettingsKey.values);
+    container = ProviderContainer();
+  });
+
+  tearDown(() => container.dispose());
+
+  tearDownAll(() async {
+    await SettingsRepository.instance.clear(SettingsKey.values);
+    await db.close();
+  });
+
+  Future<void> setGridSetting(GroupAssetsBy value) =>
+      SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, value);
+
+  Future<void> setMode(TimelineOverviewMode mode) => container.read(timelineOverviewModeProvider.notifier).set(mode);
+
+  group('timelineGroupingSpecProvider', () {
+    test('M-1: years queries and renders at year granularity', () async {
+      await setMode(TimelineOverviewMode.years);
+      final spec = container.read(timelineGroupingSpecProvider);
+      expect(spec.mode, TimelineOverviewMode.years);
+      expect(spec.groupBy, GroupAssetsBy.year);
+    });
+
+    test('M-2: months queries and renders at month granularity', () async {
+      await setMode(TimelineOverviewMode.months);
+      final spec = container.read(timelineGroupingSpecProvider);
+      expect(spec.mode, TimelineOverviewMode.months);
+      expect(spec.groupBy, GroupAssetsBy.month);
+    });
+
+    test('M-3: all with Month + day selected renders day headers', () async {
+      await setGridSetting(GroupAssetsBy.day);
+      await setMode(TimelineOverviewMode.all);
+      final spec = container.read(timelineGroupingSpecProvider);
+      expect(spec.mode, TimelineOverviewMode.all);
+      expect(spec.groupBy, GroupAssetsBy.day);
+    });
+
+    test('M-4: all with Month selected renders month headers — the #903 case', () async {
+      await setGridSetting(GroupAssetsBy.month);
+      await setMode(TimelineOverviewMode.all);
+      final spec = container.read(timelineGroupingSpecProvider);
+      expect(spec.mode, TimelineOverviewMode.all);
+      expect(spec.groupBy, GroupAssetsBy.month);
+    });
+
+    test('M-5: years ignores the grid setting', () async {
+      await setGridSetting(GroupAssetsBy.month);
+      await setMode(TimelineOverviewMode.years);
+      expect(container.read(timelineGroupingSpecProvider).groupBy, GroupAssetsBy.year);
+    });
+
+    test('M-6: on all, the spec follows a setting change', () async {
+      await setGridSetting(GroupAssetsBy.day);
+      await setMode(TimelineOverviewMode.all);
+      expect(container.read(timelineGroupingSpecProvider).groupBy, GroupAssetsBy.day);
+
+      await setGridSetting(GroupAssetsBy.month);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      expect(container.read(timelineGroupingSpecProvider).groupBy, GroupAssetsBy.month);
+    });
+
+    test('M-7: on months, a setting change leaves the spec alone', () async {
+      await setGridSetting(GroupAssetsBy.day);
+      await setMode(TimelineOverviewMode.months);
+      expect(container.read(timelineGroupingSpecProvider).groupBy, GroupAssetsBy.month);
+
+      await setGridSetting(GroupAssetsBy.month);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      expect(container.read(timelineGroupingSpecProvider).groupBy, GroupAssetsBy.month);
+    });
+
+    test('the mode starts at all', () {
+      expect(container.read(timelineOverviewModeProvider), TimelineOverviewMode.all);
+    });
+  });
+}

--- a/mobile/test/widgets/settings/asset_list_group_settings_test.dart
+++ b/mobile/test/widgets/settings/asset_list_group_settings_test.dart
@@ -11,7 +11,6 @@ import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/settings.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
 import 'package:immich_mobile/widgets/settings/asset_list_settings/asset_list_group_settings.dart';
-import 'package:immich_mobile/widgets/settings/settings_radio_list_tile.dart';
 
 import '../../test_utils.dart';
 import '../../widget_tester_extensions.dart';
@@ -81,16 +80,9 @@ void main() {
     expect(radioGroup.groupValue, GroupAssetsBy.day);
   });
 
-  testWidgets('a stored year value falls back to Month + day selected', (tester) async {
-    // The Year option shipped in a fork build, so a real user can have `year` stored.
-    // It must resolve to a selected radio, not an empty selection.
-    await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.year);
-
-    await tester.pumpConsumerWidget(const GroupSettings());
-    await tester.pumpAndSettle();
-
-    final tile = tester.widget<SettingsRadioListTile<GroupAssetsBy>>(find.byType(SettingsRadioListTile<GroupAssetsBy>));
-
-    expect(tile.groupBy, GroupAssetsBy.day);
-  });
+  // L-3 ("a stored year value falls back to Month + day selected") is not added here: the test
+  // above already covers it end to end. `SettingsRadioListTile.groupBy` is the very same value
+  // `RadioGroup.groupValue` reads one line later inside the widget's own build() — any bug that
+  // breaks one breaks the other identically, so asserting via the inner widget too is a duplicate,
+  // not a distinct scenario. Do not re-add it.
 }

--- a/mobile/test/widgets/settings/asset_list_group_settings_test.dart
+++ b/mobile/test/widgets/settings/asset_list_group_settings_test.dart
@@ -1,6 +1,7 @@
 import 'package:easy_localization/easy_localization.dart' hide TextDirection;
 import 'package:drift/drift.dart' as drift;
 import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:immich_mobile/domain/models/settings_key.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
@@ -36,30 +37,18 @@ void main() {
     await db.close();
   });
 
-  testWidgets('renders grouping choices without none', (tester) async {
+  testWidgets('offers only the month + day and month choices', (tester) async {
     await tester.pumpConsumerWidget(const GroupSettings());
     await tester.pumpAndSettle();
 
-    expect(find.text('year'.tr()), findsOneWidget);
-    expect(find.text('month'.tr()), findsOneWidget);
     expect(find.text('asset_list_layout_settings_group_by_month_day'.tr()), findsOneWidget);
+    expect(find.text('month'.tr()), findsOneWidget);
+    expect(find.text('year'.tr()), findsNothing);
     expect(find.text('asset_list_layout_settings_group_automatically'.tr()), findsNothing);
     expect(find.text('none'.tr()), findsNothing);
   });
 
-  testWidgets('selecting year persists selected grouping', (tester) async {
-    await tester.pumpConsumerWidget(const GroupSettings());
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.text('year'.tr()));
-    await tester.pumpAndSettle();
-
-    expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.year);
-  });
-
-  testWidgets('selecting month from year persists selected grouping', (tester) async {
-    await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.year);
-
+  testWidgets('selecting month persists selected grouping', (tester) async {
     await tester.pumpConsumerWidget(const GroupSettings());
     await tester.pumpAndSettle();
 
@@ -67,5 +56,27 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.month);
+  });
+
+  testWidgets('selecting month + day from month persists selected grouping', (tester) async {
+    await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.month);
+
+    await tester.pumpConsumerWidget(const GroupSettings());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('asset_list_layout_settings_group_by_month_day'.tr()));
+    await tester.pumpAndSettle();
+
+    expect(SettingsRepository.instance.appConfig.timeline.groupAssetsBy, GroupAssetsBy.day);
+  });
+
+  testWidgets('a persisted year grouping shows month + day as the selected choice', (tester) async {
+    await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.year);
+
+    await tester.pumpConsumerWidget(const GroupSettings());
+    await tester.pumpAndSettle();
+
+    final radioGroup = tester.widget<RadioGroup<GroupAssetsBy>>(find.byType(RadioGroup<GroupAssetsBy>));
+    expect(radioGroup.groupValue, GroupAssetsBy.day);
   });
 }

--- a/mobile/test/widgets/settings/asset_list_group_settings_test.dart
+++ b/mobile/test/widgets/settings/asset_list_group_settings_test.dart
@@ -11,6 +11,7 @@ import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/settings.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
 import 'package:immich_mobile/widgets/settings/asset_list_settings/asset_list_group_settings.dart';
+import 'package:immich_mobile/widgets/settings/settings_radio_list_tile.dart';
 
 import '../../test_utils.dart';
 import '../../widget_tester_extensions.dart';
@@ -78,5 +79,18 @@ void main() {
 
     final radioGroup = tester.widget<RadioGroup<GroupAssetsBy>>(find.byType(RadioGroup<GroupAssetsBy>));
     expect(radioGroup.groupValue, GroupAssetsBy.day);
+  });
+
+  testWidgets('a stored year value falls back to Month + day selected', (tester) async {
+    // The Year option shipped in a fork build, so a real user can have `year` stored.
+    // It must resolve to a selected radio, not an empty selection.
+    await SettingsRepository.instance.write(SettingsKey.timelineGroupAssetsBy, GroupAssetsBy.year);
+
+    await tester.pumpConsumerWidget(const GroupSettings());
+    await tester.pumpAndSettle();
+
+    final tile = tester.widget<SettingsRadioListTile<GroupAssetsBy>>(find.byType(SettingsRadioListTile<GroupAssetsBy>));
+
+    expect(tile.groupBy, GroupAssetsBy.day);
   });
 }


### PR DESCRIPTION
Fixes [#903](https://github.com/open-noodle/gallery/discussions/903).

## The problem

Settings → Photo Grid → **Group by** offered `Month + day` / `Year` / `Month`, and both `Year` and `Month` produced the overview card grid instead of a timeline with month headers. Only `Month + day` matched upstream Immich.

Mobile-only — web's grouping is per-route `$state('day')` with no settings screen.

## Root cause

PR #625 made the on-page **Years / Months / All** selector read and write `SettingsKey.timelineGroupAssetsBy` — the same key behind the settings picker. Since any month/year value routes the timeline to `TimelineOverviewSegmentBuilder`, picking "Month" in settings produced card view. `FixedSegmentBuilder` already supported `HeaderType.month`; it had simply become unreachable.

## The fix

Split the two concepts that were sharing one key:

- `timelineGroupingProvider` — the selector's view mode. Pure view state now: always opens on **All**, never written to settings.
- `timelineGridGroupingProvider` — the persisted **Group by** setting, normalized to `day` (month + day headers) or `month` (month-only headers).
- `timelineBucketGroupingProvider` — the granularity actually queried and rendered: the overview grouping on Years/Months, otherwise the grid setting.

The setting has to reach the query, not just the builder — month-only headers need month buckets, or you get one month header per day.

Behaviour decisions:

- Settings now offers only **Month + day** and **Month**, matching Immich.
- The selector resets to **All** on each launch.
- The setting applies to every timeline (upstream behaviour).
- A leftover `year` value from before this change falls back to **Month + day**.
- `persistGrouping` renamed `sharedGrouping` since it no longer persists anything.

## Tests

2892 → 2902 passing, 0 failures.

22 existing tests used the settings write as a proxy for selector state — precisely the coupling being removed. Their setup and assertions moved onto `timelineGroupingProvider`, preserving each test's original intent; several were passing vacuously afterwards (asserting a setting nothing writes anymore) and were rewritten to assert real state. `settings picker changes update the selector` was inverted into a #903 regression guard.

Two tests written after the implementation (the route-scope service-builder test and the month-anchor test) couldn't be watched fail cleanly, so both were mutation-tested — reverting the route-scope line and pointing the anchor at the bucket grouping. Both were caught.

`dart analyze --fatal-infos lib test` and `dart format lib` are clean.
