### PR TITLE
fix(web): use the justified, selectable gallery for search results (#908)

### DIFF
--- a/web/src/lib/components/search/smart-search-results.svelte
+++ b/web/src/lib/components/search/smart-search-results.svelte
@@ -14,6 +14,16 @@
     isShared: boolean;
     isLoading?: boolean;
     total?: number;
+    /**
+     * Loaded results, exposed so the host page's multi-select toolbar can act on them
+     * (select-all, and removing/updating assets after a bulk action).
+     */
+    results?: AssetResponseDto[];
+    /**
+     * Bump to force a re-run of the current search — how a host page restores results after an
+     * undone delete, since undo hands back TimelineAssets rather than full AssetResponseDtos.
+     */
+    reloadToken?: number;
   }
 
   let {
@@ -25,9 +35,10 @@
     isShared,
     isLoading = $bindable(false),
     total,
+    results: searchResults = $bindable([]),
+    reloadToken = 0,
   }: Props = $props();
 
-  let searchResults = $state<AssetResponseDto[]>([]);
   let hasMoreResults = $state(false);
   let searchPage = $state(1);
   let searchAbortController: AbortController | undefined;
@@ -82,10 +93,18 @@
     void executeSearch(searchPage + 1, true);
   };
 
+  // Re-runs the current search from page 1. Used by GalleryViewer's own delete-with-undo path;
+  // a host page triggers the same thing by bumping `reloadToken`.
+  const handleReload = () => {
+    searchPage = 1;
+    void executeSearch(1, false);
+  };
+
   $effect(() => {
     // Track everything that should trigger a re-search
     const _ = [
       searchQuery,
+      reloadToken,
       filters.personIds,
       filters.city,
       filters.country,
@@ -120,11 +139,12 @@
 </script>
 
 <SpaceSearchResults
-  results={searchResults}
+  bind:results={searchResults}
   {isLoading}
   hasMore={hasMoreResults}
   totalLoaded={searchResults.length}
   onLoadMore={handleLoadMore}
+  onReload={handleReload}
   {spaceId}
   {isShared}
   sortMode={filters.sortOrder}

--- a/web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte
+++ b/web/src/lib/components/shared-components/gallery-viewer/GalleryViewer.svelte
@@ -58,6 +58,22 @@
     arrowNavigation?: boolean;
     allowDeletion?: boolean;
     enableGrouping?: boolean;
+    /**
+     * Element this gallery scrolls inside. Defaults to the document, which is what the
+     * full-page callers (search, folders, memory, shared link) use. Surfaces embedded in
+     * an inner `overflow-y-auto` pane — e.g. the smart search results inside
+     * `UserPageLayout` — must pass their scroll container, otherwise `document`'s
+     * scrollTop never moves and virtualization freezes on the first viewport.
+     */
+    scrollElement?: HTMLElement;
+    /**
+     * Overrides click-to-open. Defaults to route navigation (`navigateToAsset`). Callers
+     * that own their own asset viewer (and so need extra context such as `spaceId`) pass
+     * their own opener together with `withAssetViewer={false}`.
+     */
+    onAssetOpen?: (asset: AssetResponseDto) => void;
+    /** Set to `false` when the caller mounts its own `AssetViewer`. */
+    withAssetViewer?: boolean;
   };
 
   let {
@@ -75,6 +91,9 @@
     arrowNavigation = true,
     allowDeletion = true,
     enableGrouping = false,
+    scrollElement = undefined,
+    onAssetOpen = undefined,
+    withAssetViewer = true,
   }: Props = $props();
 
   let galleryGrouping = $state<TimelineGrouping>('day');
@@ -124,7 +143,27 @@
     assets[index] = asset;
   };
 
-  const updateSlidingWindow = () => (scrollTop = document.scrollingElement?.scrollTop ?? 0);
+  const updateSlidingWindow = () => (scrollTop = (scrollElement ?? document.scrollingElement)?.scrollTop ?? 0);
+
+  // `scroll` doesn't bubble, so the `svelte:document` handler below only ever sees
+  // document-level scrolling. Attach directly when we're virtualizing inside a container.
+  $effect(() => {
+    const element = scrollElement;
+    if (!element) {
+      return;
+    }
+    updateSlidingWindow();
+    element.addEventListener('scroll', updateSlidingWindow, { passive: true });
+    return () => element.removeEventListener('scroll', updateSlidingWindow);
+  });
+
+  const openAsset = (asset: AssetResponseDto) => {
+    if (onAssetOpen) {
+      onAssetOpen(asset);
+      return;
+    }
+    void navigateToAsset(asset);
+  };
 
   const debouncedOnEndReached = debounce(() => onEndReached?.(), 750, { maxWait: 100, leading: true });
 
@@ -386,7 +425,7 @@
   const scrollToGalleryAssetIndex = (index: number) => {
     const top = geometry.getTop(index);
     scrollTop = top;
-    document.scrollingElement?.scrollTo?.({ top });
+    (scrollElement ?? document.scrollingElement)?.scrollTo?.({ top });
   };
 
   $effect(() => {
@@ -520,10 +559,10 @@
                   handleSelectAssets(currentAsset);
                   return;
                 }
-                void navigateToAsset(asset);
+                openAsset(asset);
               }}
               onSelect={() => handleSelectAssets(currentAsset)}
-              onPreview={assetInteraction.selectionActive ? () => void navigateToAsset(asset) : undefined}
+              onPreview={assetInteraction.selectionActive ? () => openAsset(asset) : undefined}
               onMouseEvent={() => assetMouseEventHandler(currentAsset)}
               {showArchiveIcon}
               asset={currentAsset}
@@ -547,7 +586,7 @@
 </div>
 
 <!-- Overlay Asset Viewer -->
-{#if assetViewerManager.isViewing}
+{#if withAssetViewer && assetViewerManager.isViewing}
   <Portal target="body">
     {#if LazyAssetViewer.current}
       {@const AssetViewer = LazyAssetViewer.current}

--- a/web/src/lib/components/spaces/mock-gallery-viewer.test-wrapper.svelte
+++ b/web/src/lib/components/spaces/mock-gallery-viewer.test-wrapper.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import type { AssetMultiSelectManager } from '$lib/managers/asset-multi-select-manager.svelte';
+  import type { AssetResponseDto } from '@immich/sdk';
+
+  /**
+   * Stands in for GalleryViewer in space-search-results tests. The real component measures a
+   * justified layout against a scroll container, which happy-dom reports as 0x0 — so it would
+   * render no thumbnails at all. This records the props under test as data attributes and
+   * renders one clickable stub per asset.
+   */
+  interface Props {
+    assets?: AssetResponseDto[];
+    assetInteraction?: AssetMultiSelectManager;
+    scrollElement?: HTMLElement;
+    onAssetOpen?: (asset: AssetResponseDto) => void;
+    withAssetViewer?: boolean;
+    showArchiveIcon?: boolean;
+  }
+
+  let {
+    assets = [],
+    assetInteraction,
+    scrollElement,
+    onAssetOpen,
+    withAssetViewer = true,
+    showArchiveIcon = false,
+  }: Props = $props();
+</script>
+
+<div
+  data-testid="gallery-viewer"
+  data-with-asset-viewer={String(withAssetViewer)}
+  data-show-archive-icon={String(showArchiveIcon)}
+  data-has-scroll-element={String(!!scrollElement)}
+  data-has-asset-interaction={String(!!assetInteraction)}
+>
+  {#each assets as asset (asset.id)}
+    <button type="button" data-testid={`gallery-asset-${asset.id}`} onclick={() => onAssetOpen?.(asset)}>
+      {asset.id}
+    </button>
+  {/each}
+</div>

--- a/web/src/lib/components/spaces/space-search-results.spec.ts
+++ b/web/src/lib/components/spaces/space-search-results.spec.ts
@@ -10,6 +10,14 @@ vi.mock('@immich/sdk', async (importOriginal) => {
   return { ...actual, getAssetInfo: (...args: unknown[]) => getAssetInfoMock(...args) };
 });
 
+// The real GalleryViewer measures a justified layout against its scroll container, which
+// happy-dom reports as 0x0 — it would render zero thumbnails here. The stub records the props
+// under test and renders one clickable element per asset.
+vi.mock('$lib/components/shared-components/gallery-viewer/GalleryViewer.svelte', async () => {
+  const { default: MockComponent } = await import('./mock-gallery-viewer.test-wrapper.svelte');
+  return { default: MockComponent };
+});
+
 // Spy on the props forwarded to AssetViewer. The component dynamic-imports asset-viewer.svelte,
 // so we mock the module and record each invocation's props on this array. Tests assert against it.
 const assetViewerPropsCalls: Array<Record<string, unknown>> = [];
@@ -28,12 +36,6 @@ const mockAssets = [
   { id: 'asset-3', originalFileName: 'photo3.jpg' },
 ] as AssetResponseDto[];
 
-const mockAssetsWithDates = [
-  { id: 'a1', originalFileName: 'p1.jpg', fileCreatedAt: '2024-06-15T10:00:00.000Z' },
-  { id: 'a2', originalFileName: 'p2.jpg', fileCreatedAt: '2024-06-10T10:00:00.000Z' },
-  { id: 'a3', originalFileName: 'p3.jpg', fileCreatedAt: '2024-03-01T10:00:00.000Z' },
-] as AssetResponseDto[];
-
 describe('SpaceSearchResults', () => {
   beforeAll(async () => {
     register('en-US', () => import('$i18n/en.json'));
@@ -48,7 +50,7 @@ describe('SpaceSearchResults', () => {
     assetViewerPropsCalls.length = 0;
   });
 
-  it('should render thumbnail grid from search results', () => {
+  it('should render search results through the gallery viewer', () => {
     render(SpaceSearchResults, {
       props: {
         results: mockAssets,
@@ -59,8 +61,69 @@ describe('SpaceSearchResults', () => {
         sortMode: 'relevance',
       },
     });
-    const images = screen.getAllByRole('img');
-    expect(images).toHaveLength(3);
+    expect(screen.getByTestId('gallery-viewer')).toBeInTheDocument();
+    for (const asset of mockAssets) {
+      expect(screen.getByTestId(`gallery-asset-${asset.id}`)).toBeInTheDocument();
+    }
+  });
+
+  // The whole point of #908: results must use the justified, selectable gallery rather than the
+  // old fixed-aspect-ratio grid of bare <img> elements.
+  it('should hand the gallery viewer a selection manager so photos are selectable on hover', () => {
+    render(SpaceSearchResults, {
+      props: {
+        results: mockAssets,
+        isLoading: false,
+        hasMore: false,
+        totalLoaded: 3,
+        onLoadMore: vi.fn(),
+        sortMode: 'relevance',
+      },
+    });
+    expect(screen.getByTestId('gallery-viewer')).toHaveAttribute('data-has-asset-interaction', 'true');
+  });
+
+  it('should virtualize against its own scroll container rather than the document', () => {
+    render(SpaceSearchResults, {
+      props: {
+        results: mockAssets,
+        isLoading: false,
+        hasMore: false,
+        totalLoaded: 3,
+        onLoadMore: vi.fn(),
+        sortMode: 'relevance',
+      },
+    });
+    expect(screen.getByTestId('gallery-viewer')).toHaveAttribute('data-has-scroll-element', 'true');
+  });
+
+  it('should keep ownership of the asset viewer so space context is preserved', () => {
+    render(SpaceSearchResults, {
+      props: {
+        results: mockAssets,
+        isLoading: false,
+        hasMore: false,
+        totalLoaded: 3,
+        onLoadMore: vi.fn(),
+        sortMode: 'relevance',
+      },
+    });
+    expect(screen.getByTestId('gallery-viewer')).toHaveAttribute('data-with-asset-viewer', 'false');
+  });
+
+  it('should render the same justified gallery in date-sorted mode (no month headers)', () => {
+    render(SpaceSearchResults, {
+      props: {
+        results: mockAssets,
+        isLoading: false,
+        hasMore: false,
+        totalLoaded: 3,
+        onLoadMore: vi.fn(),
+        sortMode: 'desc',
+      },
+    });
+    expect(screen.getByTestId('gallery-viewer')).toBeInTheDocument();
+    expect(screen.queryByTestId('date-group-header-0')).not.toBeInTheDocument();
   });
 
   it('should show result count with + for relevance mode when more pages exist', () => {
@@ -165,39 +228,10 @@ describe('SpaceSearchResults', () => {
     expect(screen.getByTestId('search-empty')).toBeInTheDocument();
   });
 
-  it('should show date headers when sortMode is desc', () => {
-    render(SpaceSearchResults, {
-      props: {
-        results: mockAssetsWithDates,
-        isLoading: false,
-        hasMore: false,
-        totalLoaded: 3,
-        onLoadMore: vi.fn(),
-        sortMode: 'desc',
-      },
-    });
-    expect(screen.getByTestId('date-group-header-0')).toHaveTextContent('June 2024');
-    expect(screen.getByTestId('date-group-header-1')).toHaveTextContent('March 2024');
-  });
-
-  it('should not show date headers when sortMode is relevance', () => {
-    render(SpaceSearchResults, {
-      props: {
-        results: mockAssetsWithDates,
-        isLoading: false,
-        hasMore: false,
-        totalLoaded: 3,
-        onLoadMore: vi.fn(),
-        sortMode: 'relevance',
-      },
-    });
-    expect(screen.queryByTestId('date-group-header-0')).not.toBeInTheDocument();
-  });
-
   it('should show contextual result count for date-sorted mode', () => {
     render(SpaceSearchResults, {
       props: {
-        results: mockAssetsWithDates,
+        results: mockAssets,
         isLoading: false,
         hasMore: true,
         totalLoaded: 100,
@@ -208,48 +242,10 @@ describe('SpaceSearchResults', () => {
     expect(screen.getByTestId('result-count')).toHaveTextContent('100 of up to 500');
   });
 
-  it('should show date headers when sortMode is asc', () => {
-    render(SpaceSearchResults, {
-      props: {
-        results: mockAssetsWithDates,
-        isLoading: false,
-        hasMore: false,
-        totalLoaded: 3,
-        onLoadMore: vi.fn(),
-        sortMode: 'asc',
-      },
-    });
-    expect(screen.getByTestId('date-group-header-0')).toBeInTheDocument();
-    expect(screen.getByTestId('date-group-header-1')).toBeInTheDocument();
-  });
-
-  it('should merge assets with same month into one group', () => {
-    const assetsWithSameMonth = [
-      { id: 'b1', originalFileName: 'q1.jpg', fileCreatedAt: '2024-06-20T10:00:00.000Z' },
-      { id: 'b2', originalFileName: 'q2.jpg', fileCreatedAt: '2024-03-15T10:00:00.000Z' },
-      { id: 'b3', originalFileName: 'q3.jpg', fileCreatedAt: '2024-06-05T10:00:00.000Z' },
-    ] as AssetResponseDto[];
-
-    render(SpaceSearchResults, {
-      props: {
-        results: assetsWithSameMonth,
-        isLoading: false,
-        hasMore: false,
-        totalLoaded: 3,
-        onLoadMore: vi.fn(),
-        sortMode: 'desc',
-      },
-    });
-    // June 2024 appears twice in the data but should merge into one group
-    expect(screen.getByTestId('date-group-header-0')).toHaveTextContent('June 2024');
-    expect(screen.getByTestId('date-group-header-1')).toHaveTextContent('March 2024');
-    expect(screen.queryByTestId('date-group-header-2')).not.toBeInTheDocument();
-  });
-
   it('should show contextual result count for asc mode', () => {
     render(SpaceSearchResults, {
       props: {
-        results: mockAssetsWithDates,
+        results: mockAssets,
         isLoading: false,
         hasMore: true,
         totalLoaded: 50,
@@ -263,7 +259,7 @@ describe('SpaceSearchResults', () => {
   it('should show exact count in date mode when all loaded', () => {
     render(SpaceSearchResults, {
       props: {
-        results: mockAssetsWithDates,
+        results: mockAssets,
         isLoading: false,
         hasMore: false,
         totalLoaded: 35,
@@ -291,8 +287,7 @@ describe('SpaceSearchResults', () => {
         },
       });
 
-      const firstThumb = screen.getAllByRole('img')[0];
-      await fireEvent.click(firstThumb);
+      await fireEvent.click(screen.getByTestId('gallery-asset-asset-1'));
 
       // Wait for the dynamic-imported AssetViewer mock to be invoked with props.
       await vi.waitFor(() => expect(assetViewerPropsCalls.length).toBeGreaterThan(0));
@@ -314,10 +309,8 @@ describe('SpaceSearchResults', () => {
         },
       });
 
-      const firstThumb = screen.getAllByRole('img')[0];
-      await fireEvent.click(firstThumb);
+      await fireEvent.click(screen.getByTestId('gallery-asset-asset-1'));
 
-      // This test FAILS today because the component hardcodes isShared={true} in the AssetViewer render.
       await vi.waitFor(() => expect(assetViewerPropsCalls.length).toBeGreaterThan(0));
 
       const props = assetViewerPropsCalls.at(-1)!;
@@ -338,8 +331,7 @@ describe('SpaceSearchResults', () => {
         },
       });
 
-      const firstThumb = screen.getAllByRole('img')[0];
-      await fireEvent.click(firstThumb);
+      await fireEvent.click(screen.getByTestId('gallery-asset-asset-1'));
 
       await vi.waitFor(() => expect(getAssetInfoMock).toHaveBeenCalled());
 
@@ -359,14 +351,11 @@ describe('SpaceSearchResults', () => {
         },
       });
 
-      const firstThumb = screen.getAllByRole('img')[0];
-      await fireEvent.click(firstThumb);
+      await fireEvent.click(screen.getByTestId('gallery-asset-asset-1'));
 
       await vi.waitFor(() => expect(getAssetInfoMock).toHaveBeenCalled());
 
-      // Assert the spaceId key is ABSENT (not just undefined) from every call. The current
-      // implementation passes `{ ...authManager.params, id, spaceId }` which results in the
-      // key being present with an undefined value, so this test FAILS today.
+      // Assert the spaceId key is ABSENT (not just undefined) from every call.
       for (const call of getAssetInfoMock.mock.calls) {
         const arg = call[0] as Record<string, unknown>;
         expect(Object.prototype.hasOwnProperty.call(arg, 'spaceId')).toBe(false);

--- a/web/src/lib/components/spaces/space-search-results.svelte
+++ b/web/src/lib/components/spaces/space-search-results.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
   import { lazyComponent } from '$lib/utils/lazy-component.svelte';
   import { page } from '$app/state';
+  import GalleryViewer from '$lib/components/shared-components/gallery-viewer/GalleryViewer.svelte';
   import LoadingSpinner from '$lib/components/shared-components/LoadingSpinner.svelte';
   import Portal from '$lib/elements/Portal.svelte';
   import type { AssetCursor } from '$lib/components/asset-viewer/AssetViewer.svelte';
+  import { assetMultiSelectManager } from '$lib/managers/asset-multi-select-manager.svelte';
   import { authManager } from '$lib/managers/auth-manager.svelte';
+  import type { Viewport } from '$lib/managers/timeline-manager/types';
   import { handlePromiseError } from '$lib/utils';
   import { navigate } from '$lib/utils/navigation';
   import { type AssetResponseDto, getAssetInfo } from '@immich/sdk';
-  import { SvelteMap } from 'svelte/reactivity';
   import { t } from 'svelte-i18n';
 
   interface Props {
@@ -21,14 +23,28 @@
     isShared: boolean;
     sortMode: 'relevance' | 'asc' | 'desc';
     total?: number;
+    /** Re-runs the current search — used to restore results after an undone delete. */
+    onReload?: () => void;
   }
 
-  let { results, isLoading, hasMore, totalLoaded, onLoadMore, spaceId, isShared, sortMode, total }: Props = $props();
+  let {
+    results = $bindable(),
+    isLoading,
+    hasMore,
+    totalLoaded,
+    onLoadMore,
+    spaceId,
+    isShared,
+    sortMode,
+    total,
+    onReload,
+  }: Props = $props();
 
   let isViewerOpen = $state(false);
   let sentinelElement: HTMLElement | undefined = $state();
   let scrollContainer: HTMLElement | undefined = $state();
   let observer: IntersectionObserver | undefined;
+  const viewport: Viewport = $state({ width: 0, height: 0 });
 
   $effect(() => {
     if (!(sentinelElement && scrollContainer)) {
@@ -86,28 +102,6 @@
     await navigate({ targetRoute: 'current', assetId: null });
   };
 
-  // Date grouping for date-sorted modes
-  type DateGroup = { key: string; label: string; assets: AssetResponseDto[] };
-
-  const groupByMonth = (assets: AssetResponseDto[]): DateGroup[] => {
-    const map = new SvelteMap<string, DateGroup>();
-    for (const asset of assets) {
-      const date = asset.fileCreatedAt ? new Date(asset.fileCreatedAt) : undefined;
-      const key = date ? `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}` : 'unknown';
-      let group = map.get(key);
-      if (!group) {
-        const label = date
-          ? date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', timeZone: 'UTC' })
-          : $t('unknown_date');
-        group = { key, label, assets: [] };
-        map.set(key, group);
-      }
-      group.assets.push(asset);
-    }
-    return [...map.values()];
-  };
-
-  let dateGroups = $derived(sortMode === 'relevance' ? [] : groupByMonth(results));
   const resultCount = $derived(total ?? totalLoaded);
   const hasExactTotal = $derived(total !== undefined);
 
@@ -116,7 +110,14 @@
   const LazyAssetViewer = lazyComponent(() => import('$lib/components/asset-viewer/AssetViewer.svelte'));
 </script>
 
-<section bind:this={scrollContainer} class="flex-1 immich-scrollbar overflow-y-auto p-4">
+<!-- `viewport.height` is the *visible* height of the scroll container (what GalleryViewer
+     virtualizes against), while `viewport.width` is measured on the inner content div so it
+     excludes this section's padding. -->
+<section
+  bind:this={scrollContainer}
+  bind:clientHeight={viewport.height}
+  class="flex-1 immich-scrollbar overflow-y-auto p-4"
+>
   {#if isLoading && results.length === 0}
     <div class="flex justify-center py-8" data-testid="search-loading">
       <LoadingSpinner />
@@ -147,39 +148,20 @@
       {/if}
     </div>
 
-    {#if sortMode === 'relevance'}
-      <div class="grid grid-cols-[repeat(auto-fill,minmax(250px,1fr))] gap-3">
-        {#each results as asset (asset.id)}
-          <button
-            type="button"
-            class="aspect-square cursor-pointer overflow-hidden rounded-sm"
-            onclick={() => openAsset(asset)}
-          >
-            <img src="/api/assets/{asset.id}/thumbnail" alt={asset.originalFileName} class="size-full object-cover" />
-          </button>
-        {/each}
-      </div>
-    {:else}
-      {#each dateGroups as group, i (group.key)}
-        <h3
-          class="mt-4 mb-2 text-sm font-medium text-gray-500 first:mt-0 dark:text-gray-400"
-          data-testid="date-group-header-{i}"
-        >
-          {group.label}
-        </h3>
-        <div class="grid grid-cols-[repeat(auto-fill,minmax(250px,1fr))] gap-3">
-          {#each group.assets as asset (asset.id)}
-            <button
-              type="button"
-              class="aspect-square cursor-pointer overflow-hidden rounded-sm"
-              onclick={() => openAsset(asset)}
-            >
-              <img src="/api/assets/{asset.id}/thumbnail" alt={asset.originalFileName} class="size-full object-cover" />
-            </button>
-          {/each}
-        </div>
-      {/each}
-    {/if}
+    <!-- Justified (aspect-ratio preserving) layout with hover selection, matching the
+         timeline and the legacy /search page. See discussion #908. -->
+    <div bind:clientWidth={viewport.width}>
+      <GalleryViewer
+        bind:assets={results}
+        assetInteraction={assetMultiSelectManager}
+        scrollElement={scrollContainer}
+        onAssetOpen={(asset) => handlePromiseError(openAsset(asset))}
+        withAssetViewer={false}
+        showArchiveIcon={true}
+        {viewport}
+        {onReload}
+      />
+    </div>
 
     {#if hasMore}
       <div bind:this={sentinelElement} data-testid="scroll-sentinel" class="flex justify-center py-4">

--- a/web/src/lib/components/timeline/SelectionToolbar.svelte
+++ b/web/src/lib/components/timeline/SelectionToolbar.svelte
@@ -46,8 +46,11 @@
    * See `docs/superpowers/specs/2026-07-24-selection-toolbar-consistency-design.md`.
    */
   interface Props {
-    timelineManager: TimelineManager;
+    /** Absent on surfaces with no timeline behind them — e.g. smart search results. */
+    timelineManager?: TimelineManager;
     assetInteraction: AssetMultiSelectManager;
+    /** Overrides the timeline-wide select-all. Required when `timelineManager` is absent. */
+    onSelectAll?: () => void;
     /** Present on album surfaces (regular album OR space album). */
     album?: AlbumResponseDto;
     /** Present on space surfaces (direct space OR space album). */
@@ -67,6 +70,7 @@
   let {
     timelineManager,
     assetInteraction,
+    onSelectAll,
     album,
     space,
     downloadFilename,
@@ -184,7 +188,7 @@
       <CreateSharedLink />
     {/if}
     {#if caps.canSelectAll}
-      <SelectAllAssets {timelineManager} {assetInteraction} />
+      <SelectAllAssets {timelineManager} {assetInteraction} {onSelectAll} />
     {/if}
     {#if caps.canAddToAlbum}
       <ActionButton action={Actions.AddToAlbum} />

--- a/web/src/lib/components/timeline/actions/SelectAllAction.svelte
+++ b/web/src/lib/components/timeline/actions/SelectAllAction.svelte
@@ -7,12 +7,15 @@
   import { t } from 'svelte-i18n';
 
   type Props = {
-    timelineManager: TimelineManager;
+    /** Absent on surfaces with no timeline behind them (e.g. smart search results). */
+    timelineManager?: TimelineManager;
     assetInteraction: AssetMultiSelectManager;
     withText?: boolean;
+    /** Overrides the timeline-wide select-all — pass on non-timeline surfaces. */
+    onSelectAll?: () => void;
   };
 
-  let { timelineManager, assetInteraction, withText = false }: Props = $props();
+  let { timelineManager, assetInteraction, withText = false, onSelectAll }: Props = $props();
   const allAssetsSelected = $derived(assetInteraction.selectAll);
 
   const icon = $derived(allAssetsSelected ? mdiSelectRemove : mdiSelectAll);
@@ -20,7 +23,13 @@
   const onclick = async () => {
     if (allAssetsSelected) {
       assetInteraction.clear();
-    } else {
+      return;
+    }
+    if (onSelectAll) {
+      onSelectAll();
+      return;
+    }
+    if (timelineManager) {
       await selectAllAssets(timelineManager, assetInteraction);
     }
   };

--- a/web/src/lib/utils/search-result-selection.spec.ts
+++ b/web/src/lib/utils/search-result-selection.spec.ts
@@ -1,0 +1,89 @@
+import { AssetTypeEnum, AssetVisibility, type AssetResponseDto } from '@immich/sdk';
+import type { AssetMultiSelectManager } from '$lib/managers/asset-multi-select-manager.svelte';
+import { removeSearchResults, selectAllSearchResults, updateSearchResults } from '$lib/utils/search-result-selection';
+
+const asset = (id: string, overrides: Partial<AssetResponseDto> = {}): AssetResponseDto =>
+  ({
+    id,
+    ownerId: 'owner-1',
+    type: AssetTypeEnum.Image,
+    originalFileName: `${id}.jpg`,
+    fileCreatedAt: '2024-06-15T10:00:00.000Z',
+    localDateTime: '2024-06-15T10:00:00.000Z',
+    createdAt: '2024-06-15T10:00:00.000Z',
+    isFavorite: false,
+    isTrashed: false,
+    visibility: AssetVisibility.Timeline,
+    duration: null,
+    ...overrides,
+  }) as AssetResponseDto;
+
+describe('search-result-selection', () => {
+  describe('selectAllSearchResults', () => {
+    it('selects every loaded result and flags the selection as select-all', () => {
+      const selectAssets = vi.fn();
+      const assetInteraction = { selectAll: false, selectAssets } as unknown as AssetMultiSelectManager;
+
+      selectAllSearchResults([asset('a'), asset('b')], assetInteraction);
+
+      expect(assetInteraction.selectAll).toBe(true);
+      expect(selectAssets).toHaveBeenCalledTimes(1);
+      expect(selectAssets.mock.calls[0][0].map((a: { id: string }) => a.id)).toEqual(['a', 'b']);
+    });
+
+    it('converts results to timeline assets so the toolbar can read selection capabilities', () => {
+      const selectAssets = vi.fn();
+      const assetInteraction = { selectAll: false, selectAssets } as unknown as AssetMultiSelectManager;
+
+      selectAllSearchResults([asset('a', { isFavorite: true })], assetInteraction);
+
+      const [selected] = selectAssets.mock.calls[0][0];
+      expect(selected).toMatchObject({ id: 'a', isFavorite: true, isImage: true });
+    });
+  });
+
+  describe('removeSearchResults', () => {
+    it('removes every matching asset in place', () => {
+      const results = [asset('a'), asset('b'), asset('c')];
+
+      removeSearchResults(results, ['a', 'c']);
+
+      expect(results.map((a) => a.id)).toEqual(['b']);
+    });
+
+    it('leaves the array untouched when nothing matches', () => {
+      const results = [asset('a'), asset('b')];
+
+      removeSearchResults(results, ['zzz']);
+
+      expect(results.map((a) => a.id)).toEqual(['a', 'b']);
+    });
+
+    it('removes adjacent matches without skipping (reverse iteration)', () => {
+      const results = [asset('a'), asset('b'), asset('c'), asset('d')];
+
+      removeSearchResults(results, ['b', 'c']);
+
+      expect(results.map((a) => a.id)).toEqual(['a', 'd']);
+    });
+  });
+
+  describe('updateSearchResults', () => {
+    it('applies the edit only to the matching assets', () => {
+      const results = [asset('a'), asset('b')];
+
+      updateSearchResults(results, ['b'], (a) => (a.isFavorite = true));
+
+      expect(results[0].isFavorite).toBe(false);
+      expect(results[1].isFavorite).toBe(true);
+    });
+
+    it('can update visibility for archive toggles', () => {
+      const results = [asset('a'), asset('b')];
+
+      updateSearchResults(results, ['a', 'b'], (a) => (a.visibility = AssetVisibility.Archive));
+
+      expect(results.map((a) => a.visibility)).toEqual([AssetVisibility.Archive, AssetVisibility.Archive]);
+    });
+  });
+});

--- a/web/src/lib/utils/search-result-selection.ts
+++ b/web/src/lib/utils/search-result-selection.ts
@@ -1,0 +1,43 @@
+import type { AssetResponseDto } from '@immich/sdk';
+import type { AssetMultiSelectManager } from '$lib/managers/asset-multi-select-manager.svelte';
+import { toTimelineAsset } from '$lib/utils/timeline-util';
+
+/**
+ * Bulk-action helpers for the smart search results grid (discussion #908).
+ *
+ * The multi-select toolbars on /photos, /recently-added and /spaces/[id] normally mutate the
+ * page's `TimelineManager`. That manager isn't mounted while search results are showing — the
+ * results are a plain `AssetResponseDto[]` owned by `smart-search-results.svelte` — so the
+ * toolbars route through these helpers instead. All of them mutate the array in place, which
+ * is reactive because the host pages hold it in `$state`.
+ */
+
+/** Selects every loaded result. Mirrors `selectAllAssets`, minus the timeline paging. */
+export const selectAllSearchResults = (results: AssetResponseDto[], assetInteraction: AssetMultiSelectManager) => {
+  assetInteraction.selectAll = true;
+  assetInteraction.selectAssets(results.map((asset) => toTimelineAsset(asset)));
+};
+
+/** Drops assets from the results — for deletes, archives and visibility changes. */
+export const removeSearchResults = (results: AssetResponseDto[], assetIds: string[]) => {
+  const ids = new Set(assetIds);
+  for (let index = results.length - 1; index >= 0; index--) {
+    if (ids.has(results[index].id)) {
+      results.splice(index, 1);
+    }
+  }
+};
+
+/** Applies an in-place edit to the matching results — for favorite/archive toggles. */
+export const updateSearchResults = (
+  results: AssetResponseDto[],
+  assetIds: string[],
+  update: (asset: AssetResponseDto) => void,
+) => {
+  const ids = new Set(assetIds);
+  for (const asset of results) {
+    if (ids.has(asset.id)) {
+      update(asset);
+    }
+  }
+};

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -43,7 +43,8 @@
   import { globalSearchManager } from '$lib/managers/global-search-manager.svelte';
   import { memoryManager } from '$lib/managers/memory-manager.svelte';
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
-  import type { TimelineGrouping, TimelineTemporalAnchor } from '$lib/managers/timeline-manager/types';
+  import type { TimelineAsset, TimelineGrouping, TimelineTemporalAnchor } from '$lib/managers/timeline-manager/types';
+  import { removeSearchResults, selectAllSearchResults, updateSearchResults } from '$lib/utils/search-result-selection';
   import { Route } from '$lib/route';
   import { getAssetBulkActions } from '$lib/services/asset.service';
   import { lang } from '$lib/stores/preferences.store';
@@ -83,6 +84,7 @@
   import { getTimelineTopVisibleAnchor } from '$lib/managers/timeline-manager/timeline-anchor';
   import { toTimelineAsset } from '$lib/utils/timeline-util';
   import {
+    type AssetResponseDto,
     AssetTypeEnum,
     AssetVisibility,
     getFilterSuggestions,
@@ -132,6 +134,11 @@
   >();
   let isLoading = $state(false);
   const showSearchResults = $derived(committedQuery.trim().length > 0);
+  // Loaded smart search results. The timeline (and its TimelineManager) is unmounted while
+  // these are showing, so the multi-select toolbar acts on this array instead (#908).
+  let searchResults = $state<AssetResponseDto[]>([]);
+  // Bumped to force a re-run of the search (undo-delete restores the removed assets).
+  let searchReloadToken = $state(0);
   const options = $derived({
     ...buildPhotosTimelineOptions(filters),
     grouping: timelineGrouping,
@@ -406,8 +413,48 @@
   };
 
   const handleSetVisibility = (assetIds: string[]) => {
-    timelineManager.removeAssets(assetIds);
+    if (showSearchResults) {
+      removeSearchResults(searchResults, assetIds);
+    } else {
+      timelineManager.removeAssets(assetIds);
+    }
     assetMultiSelectManager.clear();
+  };
+
+  // While search results are showing, the timeline is unmounted — bulk actions have to mutate
+  // the result list instead of the TimelineManager (#908).
+  const handleFavorite = (ids: string[], isFavorite: boolean) => {
+    if (showSearchResults) {
+      updateSearchResults(searchResults, ids, (asset) => (asset.isFavorite = isFavorite));
+      return;
+    }
+    timelineManager.update(ids, (asset) => (asset.isFavorite = isFavorite));
+  };
+
+  const handleArchive = (ids: string[], visibility: AssetVisibility) => {
+    if (showSearchResults) {
+      updateSearchResults(searchResults, ids, (asset) => (asset.visibility = visibility));
+      return;
+    }
+    timelineManager.update(ids, (asset) => (asset.visibility = visibility));
+  };
+
+  const handleAssetDelete = (assetIds: string[]) => {
+    if (showSearchResults) {
+      removeSearchResults(searchResults, assetIds);
+      return;
+    }
+    timelineManager.removeAssets(assetIds);
+  };
+
+  const handleUndoDelete = (assets: TimelineAsset[]) => {
+    if (showSearchResults) {
+      // Undo hands back TimelineAssets; the results list holds full AssetResponseDtos, so
+      // re-running the search is how they come back.
+      searchReloadToken++;
+      return;
+    }
+    timelineManager.upsertAssets(assets);
   };
 
   registerSelectionContext({
@@ -415,16 +462,10 @@
     clearSelection: () => assetMultiSelectManager.clear(),
     canAddToAlbum: () => true,
     canAddToSpace: () => true,
-    getOnFavorite: () =>
-      timelineManager
-        ? (ids, isFavorite) => timelineManager.update(ids, (asset) => (asset.isFavorite = isFavorite))
-        : undefined,
-    getOnArchive: () =>
-      timelineManager
-        ? (ids, visibility) => timelineManager.update(ids, (asset) => (asset.visibility = visibility))
-        : undefined,
-    getOnDelete: () => (timelineManager ? (assetIds) => timelineManager.removeAssets(assetIds) : undefined),
-    getOnUndoDelete: () => (timelineManager ? (assets) => timelineManager.upsertAssets(assets) : undefined),
+    getOnFavorite: () => (showSearchResults || timelineManager ? handleFavorite : undefined),
+    getOnArchive: () => (showSearchResults || timelineManager ? handleArchive : undefined),
+    getOnDelete: () => (showSearchResults || timelineManager ? handleAssetDelete : undefined),
+    getOnUndoDelete: () => (showSearchResults || timelineManager ? handleUndoDelete : undefined),
   });
 
   function clearSearch() {
@@ -599,6 +640,8 @@
       {#if showSearchResults}
         <SmartSearchResults
           bind:isLoading
+          bind:results={searchResults}
+          reloadToken={searchReloadToken}
           searchQuery={committedQuery}
           {filters}
           language={$lang}
@@ -648,25 +691,29 @@
     <CommandPaletteDefaultProvider name={$t('assets')} actions={Object.values(Actions)} />
 
     <CreateSharedLink />
-    <SelectAllAssets {timelineManager} assetInteraction={assetMultiSelectManager} />
+    {#if showSearchResults}
+      <SelectAllAssets
+        assetInteraction={assetMultiSelectManager}
+        onSelectAll={() => selectAllSearchResults(searchResults, assetMultiSelectManager)}
+      />
+    {:else}
+      <SelectAllAssets {timelineManager} assetInteraction={assetMultiSelectManager} />
+    {/if}
     <ActionButton action={Actions.AddToAlbum} />
 
     {#if assetMultiSelectManager.isAllUserOwned}
-      <FavoriteAction
-        removeFavorite={assetMultiSelectManager.isAllFavorite}
-        onFavorite={(ids, isFavorite) => timelineManager.update(ids, (asset) => (asset.isFavorite = isFavorite))}
-      />
+      <FavoriteAction removeFavorite={assetMultiSelectManager.isAllFavorite} onFavorite={handleFavorite} />
 
       <ButtonContextMenu icon={mdiDotsVertical} title={$t('menu')}>
         <DownloadAction menuItem />
-        {#if assetMultiSelectManager.assets.length > 1 || isAssetStackSelected}
+        {#if !showSearchResults && (assetMultiSelectManager.assets.length > 1 || isAssetStackSelected)}
           <StackAction
             unstack={isAssetStackSelected}
             onStack={(result) => updateStackedAssetInTimeline(timelineManager, result)}
             onUnstack={(assets) => updateUnstackedAssetInTimeline(timelineManager, assets)}
           />
         {/if}
-        {#if isLinkActionAvailable}
+        {#if !showSearchResults && isLinkActionAvailable}
           <LinkLivePhotoAction
             menuItem
             unlink={assetMultiSelectManager.assets.length === 1}
@@ -678,18 +725,11 @@
         <ChangeDate menuItem />
         <ChangeDescription menuItem />
         <ChangeLocation menuItem />
-        <ArchiveAction
-          menuItem
-          onArchive={(ids, visibility) => timelineManager.update(ids, (asset) => (asset.visibility = visibility))}
-        />
+        <ArchiveAction menuItem onArchive={handleArchive} />
         {#if authManager.preferences.tags.enabled}
           <TagAction menuItem />
         {/if}
-        <DeleteAssets
-          menuItem
-          onAssetDelete={(assetIds) => timelineManager.removeAssets(assetIds)}
-          onUndoDelete={(assets) => timelineManager.upsertAssets(assets)}
-        />
+        <DeleteAssets menuItem onAssetDelete={handleAssetDelete} onUndoDelete={handleUndoDelete} />
         <SetVisibilityAction menuItem onVisibilitySet={handleSetVisibility} />
         <hr />
         <ActionMenuItem action={Actions.RegenerateThumbnailJob} />

--- a/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -39,7 +39,8 @@
   import { globalSearchManager } from '$lib/managers/global-search-manager.svelte';
   import { getTimelineTopVisibleAnchor } from '$lib/managers/timeline-manager/timeline-anchor';
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
-  import type { TimelineGrouping, TimelineTemporalAnchor } from '$lib/managers/timeline-manager/types';
+  import type { TimelineAsset, TimelineGrouping, TimelineTemporalAnchor } from '$lib/managers/timeline-manager/types';
+  import { removeSearchResults, selectAllSearchResults, updateSearchResults } from '$lib/utils/search-result-selection';
   import { getAssetBulkActions } from '$lib/services/asset.service';
   import { lang } from '$lib/stores/preferences.store';
   import {
@@ -71,7 +72,13 @@
   } from '$lib/utils/space-search';
   import { getTimelineBucketZoomTarget, type ActivatableTimelineBucket } from '$lib/utils/timeline-zoom-navigation';
   import { consumeTypedSearchNamesInto } from '$lib/utils/typed-search/typed-search-name-cache';
-  import { getTimeBuckets, searchSmartFacets, type SmartSearchFacetsResponseDto } from '@immich/sdk';
+  import {
+    type AssetResponseDto,
+    type AssetVisibility,
+    getTimeBuckets,
+    searchSmartFacets,
+    type SmartSearchFacetsResponseDto,
+  } from '@immich/sdk';
   import { ActionButton, CommandPaletteDefaultProvider } from '@immich/ui';
   import { mdiDotsVertical } from '@mdi/js';
   import { untrack } from 'svelte';
@@ -117,6 +124,11 @@
   >();
   let isLoading = $state(false);
   const showSearchResults = $derived(committedQuery.trim().length > 0);
+  // Loaded smart search results. The timeline (and its TimelineManager) is unmounted while
+  // these are showing, so the multi-select toolbar acts on this array instead (#908).
+  let searchResults = $state<AssetResponseDto[]>([]);
+  // Bumped to force a re-run of the search (undo-delete restores the removed assets).
+  let searchReloadToken = $state(0);
   const options = $derived({ ...buildRecentlyAddedTimelineOptions(filters), grouping: timelineGrouping });
   $effect(() => {
     filtersBeforePanelChange = filters;
@@ -310,8 +322,48 @@
   };
 
   const handleSetVisibility = (assetIds: string[]) => {
-    timelineManager.removeAssets(assetIds);
+    if (showSearchResults) {
+      removeSearchResults(searchResults, assetIds);
+    } else {
+      timelineManager.removeAssets(assetIds);
+    }
     assetMultiSelectManager.clear();
+  };
+
+  // While search results are showing, the timeline is unmounted — bulk actions have to mutate
+  // the result list instead of the TimelineManager (#908).
+  const handleFavorite = (ids: string[], isFavorite: boolean) => {
+    if (showSearchResults) {
+      updateSearchResults(searchResults, ids, (asset) => (asset.isFavorite = isFavorite));
+      return;
+    }
+    timelineManager.update(ids, (asset) => (asset.isFavorite = isFavorite));
+  };
+
+  const handleArchive = (ids: string[], visibility: AssetVisibility) => {
+    if (showSearchResults) {
+      updateSearchResults(searchResults, ids, (asset) => (asset.visibility = visibility));
+      return;
+    }
+    timelineManager.update(ids, (asset) => (asset.visibility = visibility));
+  };
+
+  const handleAssetDelete = (assetIds: string[]) => {
+    if (showSearchResults) {
+      removeSearchResults(searchResults, assetIds);
+      return;
+    }
+    timelineManager.removeAssets(assetIds);
+  };
+
+  const handleUndoDelete = (assets: TimelineAsset[]) => {
+    if (showSearchResults) {
+      // Undo hands back TimelineAssets; the results list holds full AssetResponseDtos, so
+      // re-running the search is how they come back.
+      searchReloadToken++;
+      return;
+    }
+    timelineManager.upsertAssets(assets);
   };
 
   function clearSearch() {
@@ -487,6 +539,8 @@
       {#if showSearchResults}
         <SmartSearchResults
           bind:isLoading
+          bind:results={searchResults}
+          reloadToken={searchReloadToken}
           searchQuery={committedQuery}
           {filters}
           language={$lang}
@@ -528,25 +582,29 @@
     <CommandPaletteDefaultProvider name={$t('assets')} actions={Object.values(Actions)} />
 
     <CreateSharedLink />
-    <SelectAllAssets {timelineManager} assetInteraction={assetMultiSelectManager} />
+    {#if showSearchResults}
+      <SelectAllAssets
+        assetInteraction={assetMultiSelectManager}
+        onSelectAll={() => selectAllSearchResults(searchResults, assetMultiSelectManager)}
+      />
+    {:else}
+      <SelectAllAssets {timelineManager} assetInteraction={assetMultiSelectManager} />
+    {/if}
     <ActionButton action={Actions.AddToAlbum} />
 
     {#if assetMultiSelectManager.isAllUserOwned}
-      <FavoriteAction
-        removeFavorite={assetMultiSelectManager.isAllFavorite}
-        onFavorite={(ids, isFavorite) => timelineManager.update(ids, (asset) => (asset.isFavorite = isFavorite))}
-      />
+      <FavoriteAction removeFavorite={assetMultiSelectManager.isAllFavorite} onFavorite={handleFavorite} />
 
       <ButtonContextMenu icon={mdiDotsVertical} title={$t('menu')}>
         <DownloadAction menuItem />
-        {#if assetMultiSelectManager.assets.length > 1 || isAssetStackSelected}
+        {#if !showSearchResults && (assetMultiSelectManager.assets.length > 1 || isAssetStackSelected)}
           <StackAction
             unstack={isAssetStackSelected}
             onStack={(result) => updateStackedAssetInTimeline(timelineManager, result)}
             onUnstack={(assets) => updateUnstackedAssetInTimeline(timelineManager, assets)}
           />
         {/if}
-        {#if isLinkActionAvailable}
+        {#if !showSearchResults && isLinkActionAvailable}
           <LinkLivePhotoAction
             menuItem
             unlink={assetMultiSelectManager.assets.length === 1}
@@ -557,18 +615,11 @@
         <ChangeDate menuItem />
         <ChangeDescription menuItem />
         <ChangeLocation menuItem />
-        <ArchiveAction
-          menuItem
-          onArchive={(ids, visibility) => timelineManager.update(ids, (asset) => (asset.visibility = visibility))}
-        />
+        <ArchiveAction menuItem onArchive={handleArchive} />
         {#if authManager.preferences.tags.enabled}
           <TagAction menuItem />
         {/if}
-        <DeleteAssets
-          menuItem
-          onAssetDelete={(assetIds) => timelineManager.removeAssets(assetIds)}
-          onUndoDelete={(assets) => timelineManager.upsertAssets(assets)}
-        />
+        <DeleteAssets menuItem onAssetDelete={handleAssetDelete} onUndoDelete={handleUndoDelete} />
         <SetVisibilityAction menuItem onVisibilitySet={handleSetVisibility} />
         <hr />
         <ActionMenuItem action={Actions.RegenerateThumbnailJob} />

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -24,6 +24,7 @@
   import Timeline from '$lib/components/timeline/Timeline.svelte';
   import { TimelineManager } from '$lib/managers/timeline-manager/timeline-manager.svelte';
   import type { TimelineAsset, TimelineGrouping, TimelineTemporalAnchor } from '$lib/managers/timeline-manager/types';
+  import { removeSearchResults, selectAllSearchResults, updateSearchResults } from '$lib/utils/search-result-selection';
   import { registerSelectionContext, registerSpaceContext } from '$lib/managers/command-context-manager.svelte';
   import { eventManager } from '$lib/managers/event-manager.svelte';
   import { globalSearchManager } from '$lib/managers/global-search-manager.svelte';
@@ -60,6 +61,7 @@
   import { getTimelineTopVisibleAnchor } from '$lib/managers/timeline-manager/timeline-anchor';
   import {
     addAssets,
+    type AssetResponseDto,
     AssetTypeEnum,
     AssetVisibility,
     getFilterSuggestions,
@@ -511,20 +513,18 @@
     getAssets: () => assetMultiSelectManager.assets,
     clearSelection: () => assetMultiSelectManager.clear(),
     canAddToAlbum: () => true,
-    getOnFavorite: () =>
-      viewMode === 'view' && timelineManager
-        ? (ids, isFavorite) => timelineManager.update(ids, (asset) => (asset.isFavorite = isFavorite))
-        : undefined,
-    getOnArchive: () =>
-      viewMode === 'view' && timelineManager
-        ? (ids, visibility) => timelineManager.update(ids, (asset) => (asset.visibility = visibility))
-        : undefined,
+    getOnFavorite: () => (viewMode === 'view' && (showSearchResults || timelineManager) ? handleFavorite : undefined),
+    getOnArchive: () => (viewMode === 'view' && (showSearchResults || timelineManager) ? handleArchive : undefined),
     getAddSelectedToCurrentSpace: () =>
       viewMode === 'select-assets' && isEditor ? addSelectedAssetsToCurrentSpace : undefined,
   });
 
   const handleRemoveAssets = async (assetIds: string[]) => {
-    timelineManager.removeAssets(assetIds);
+    if (showSearchResults) {
+      removeSearchResults(searchResults, assetIds);
+    } else {
+      timelineManager.removeAssets(assetIds);
+    }
     await refreshSpace();
     // Also revalidate layout data so the shell's Photos tab count badge updates.
     await invalidateAll();
@@ -534,8 +534,30 @@
   // takes them out of this (non-locked) timeline view. Unlike remove-from-space, this isn't a
   // space-membership change, so it doesn't touch the space's asset count.
   const handleSetVisibility = (assetIds: string[]) => {
-    timelineManager.removeAssets(assetIds);
+    if (showSearchResults) {
+      removeSearchResults(searchResults, assetIds);
+    } else {
+      timelineManager.removeAssets(assetIds);
+    }
     assetMultiSelectManager.clear();
+  };
+
+  // While search results are showing, the timeline is unmounted — bulk actions have to mutate
+  // the result list instead of the TimelineManager (#908).
+  const handleFavorite = (ids: string[], isFavorite: boolean) => {
+    if (showSearchResults) {
+      updateSearchResults(searchResults, ids, (asset) => (asset.isFavorite = isFavorite));
+      return;
+    }
+    timelineManager.update(ids, (asset) => (asset.isFavorite = isFavorite));
+  };
+
+  const handleArchive = (ids: string[], visibility: AssetVisibility) => {
+    if (showSearchResults) {
+      updateSearchResults(searchResults, ids, (asset) => (asset.visibility = visibility));
+      return;
+    }
+    timelineManager.update(ids, (asset) => (asset.visibility = visibility));
   };
 
   // DeleteAssets already performed the server-side trash before calling this — it's a
@@ -546,6 +568,10 @@
   // via the page's `<OnEvents onAssetsDelete={refreshSpace} />` (see below), so refreshing
   // again here would be redundant.
   const handleAssetDelete = (assetIds: string[]) => {
+    if (showSearchResults) {
+      removeSearchResults(searchResults, assetIds);
+      return;
+    }
     timelineManager.removeAssets(assetIds);
   };
 
@@ -553,6 +579,12 @@
   // so re-add the assets to the local view directly; no space-count refresh is needed since
   // undoing a delete doesn't change space membership either.
   const handleUndoAssetDelete = (assets: TimelineAsset[]) => {
+    if (showSearchResults) {
+      // Undo hands back TimelineAssets; the results list holds full AssetResponseDtos, so
+      // re-running the search is how they come back.
+      searchReloadToken++;
+      return;
+    }
     timelineManager.upsertAssets(assets);
   };
 
@@ -582,7 +614,11 @@
   };
 
   const onSpaceRemoveAssets = async ({ assetIds }: { assetIds: string[]; spaceId: string }) => {
-    timelineManager.removeAssets(assetIds);
+    if (showSearchResults) {
+      removeSearchResults(searchResults, assetIds);
+    } else {
+      timelineManager.removeAssets(assetIds);
+    }
     await refreshSpace();
     // Also revalidate layout data so the shell's Photos tab count badge updates.
     await invalidateAll();
@@ -595,6 +631,11 @@
   >();
   let isLoading = $state(false);
   const showSearchResults = $derived(committedSearchQuery.trim().length > 0);
+  // Loaded smart search results. The timeline (and its TimelineManager) is unmounted while
+  // these are showing, so the multi-select toolbar acts on this array instead (#908).
+  let searchResults = $state<AssetResponseDto[]>([]);
+  // Bumped to force a re-run of the search (undo-delete restores the removed assets).
+  let searchReloadToken = $state(0);
   // `isEmptyForOptions` (not a bare `totalAssetCount === 0`) so clearing a filter that had 0
   // results can't flip this true for a tick while the timeline reloads — that transient would
   // unmount the filter panel and drop focus from a text input mid-typing.
@@ -827,6 +868,8 @@
       <SmartSearchResults
         searchQuery={committedSearchQuery}
         bind:isLoading
+        bind:results={searchResults}
+        reloadToken={searchReloadToken}
         {filters}
         language={$lang}
         spaceId={space.id}
@@ -896,13 +939,14 @@
 {#if assetMultiSelectManager.selectionActive && viewMode === 'view'}
   <div class="fixed inset-s-0 top-0 z-2 w-full">
     <SelectionToolbar
-      {timelineManager}
+      timelineManager={showSearchResults ? undefined : timelineManager}
       assetInteraction={assetMultiSelectManager}
+      onSelectAll={showSearchResults ? () => selectAllSearchResults(searchResults, assetMultiSelectManager) : undefined}
       space={{ id: space.id, canWrite: isEditor }}
       onRemove={handleRemoveAssets}
       onSetCover={handleSetAsCover}
-      onFavorite={(ids, isFavorite) => timelineManager.update(ids, (asset) => (asset.isFavorite = isFavorite))}
-      onArchive={(ids, visibility) => timelineManager.update(ids, (asset) => (asset.visibility = visibility))}
+      onFavorite={handleFavorite}
+      onArchive={handleArchive}
       onVisibilitySet={handleSetVisibility}
       onAssetDelete={handleAssetDelete}
       onUndoDelete={handleUndoAssetDelete}


### PR DESCRIPTION
Closes #908 (discussion).

## Problem

On web, smart search results were drawn as a fixed-aspect-ratio grid of bare `<img>` elements: every photo was cropped to a square, and there was no way to select anything. The timeline and the legacy `/search` page both use the justified (masonry) layout with hover selection, so search was the odd one out.

## Change

`space-search-results.svelte` now renders results through `GalleryViewer` — the same component the legacy `/search` page uses. That gets aspect-ratio-preserving layout and, because `Thumbnail` is wired to `assetMultiSelectManager`, hover checkboxes, shift-range selection and ctrl+A for free.

Three additive props on `GalleryViewer` (its four existing full-page callers are untouched):

- **`scrollElement`** — the actual blocker. `GalleryViewer` virtualized off `document.scrollingElement`, which works on full-page surfaces but not for search results, which live inside `UserPageLayout`'s inner `overflow-y-auto` pane. Document scrollTop never moves there, so virtualization would freeze on the first viewport. `scroll` doesn't bubble, so the existing `svelte:document` handler can't cover this — it attaches to the container directly when given one.
- **`onAssetOpen` / `withAssetViewer`** — let the search surface keep its own `AssetViewer`, preserving the `spaceId` handling shared-space assets need.

### Bulk actions

The multi-select toolbars on `/photos`, `/recently-added` and `/spaces/[id]` mutate a `TimelineManager` that isn't mounted while search results are showing, so they'd have half-worked the moment selection became possible. Each now routes through `search-result-selection.ts` (select-all / remove / update) when results are showing. `SelectAllAction` and `SelectionToolbar` take an optional `timelineManager` plus an `onSelectAll` override. Stack and link-live-photo are hidden during search, both being timeline-only operations.

### Behaviour change

Date-sorted results lose their month headers and render as one continuous justified run, matching the legacy search page and upstream. Agreed up front rather than rendering one `GalleryViewer` per month group, which would register duplicate document shortcuts and viewer portals.

## Verification

- `check:typescript` clean, `check:svelte` 572 files / 0 errors / 0 warnings, `eslint` 0 errors, `pnpm test` 4010 passed.
- Rewrote `space-search-results.spec.ts` around a `GalleryViewer` stub — the real component measures against a scroll container that happy-dom reports as 0x0, so it renders nothing under test. Existing AssetViewer / `spaceId` coverage kept, plus assertions for the three things this PR is about. New unit spec for the selection helpers.
- Checked in a browser against a seeded dev library: search renders 52 thumbnails at genuine aspect ratios (1.33 landscape, 0.71 portrait — previously all 1.0), and hovering a tile reveals the selection control.