### PR TITLE
fix(web): offer only reachable album targets for shared-space photos (#889)

### DIFF
--- a/web/src/lib/components/asset-viewer/AssetViewer.svelte
+++ b/web/src/lib/components/asset-viewer/AssetViewer.svelte
@@ -77,6 +77,8 @@
     onRemoveFromAlbum?: (assetIds: string[]) => void;
     onRandom?: () => Promise<{ id: string } | undefined>;
     spaceId?: string;
+    /** Shared-space surface + the caller's write capability on it — see `Timeline` (#889). */
+    space?: { id: string; canWrite: boolean };
   }
 
   let {
@@ -94,6 +96,7 @@
     onRemoveFromAlbum,
     onRandom,
     spaceId,
+    space,
   }: Props = $props();
 
   const {
@@ -522,6 +525,7 @@
         {onRemoveFromAlbum}
         {isPlayingOriginalVideo}
         {setPlayOriginalVideo}
+        {space}
       />
     </div>
   {/if}

--- a/web/src/lib/components/asset-viewer/AssetViewerNavBar.spec.ts
+++ b/web/src/lib/components/asset-viewer/AssetViewerNavBar.spec.ts
@@ -1,6 +1,9 @@
+import { modalManager } from '@immich/ui';
 import '@testing-library/jest-dom';
+import { fireEvent, screen } from '@testing-library/svelte';
 import { getResizeObserverMock } from '$lib/__mocks__/resize-observer.mock';
 import { authManager } from '$lib/managers/auth-manager.svelte';
+import AssetAddToCollectionModal from '$lib/modals/AssetAddToCollectionModal.svelte';
 import { renderWithTooltips } from '$tests/helpers';
 import { assetFactory } from '@test-data/factories/asset-factory';
 import { preferencesFactory } from '@test-data/factories/preferences-factory';
@@ -83,6 +86,38 @@ describe('AssetViewerNavBar component', () => {
 
       const { getByLabelText } = renderWithTooltips(AssetViewerNavBar, { asset, ...additionalProps });
       expect(getByLabelText('delete')).toBeInTheDocument();
+    });
+  });
+
+  // #889: viewing a shared-space photo owned by someone else, "add to album or space" used to
+  // list every personal album — all of which the server must reject.
+  describe('add to album on a shared-space photo the user does not own', () => {
+    const renderSpaceViewer = async (space: { id: string; canWrite: boolean }) => {
+      authManager.setUser(userAdminFactory.build({ id: 'space-member' }));
+      authManager.setPreferences(preferencesFactory.build({ cast: { gCastEnabled: false } }));
+      const asset = assetFactory.build({ id: 'space-photo', ownerId: 'space-owner', isTrashed: false });
+
+      renderWithTooltips(AssetViewerNavBar, { asset, space, ...additionalProps });
+      await fireEvent.click(screen.getByLabelText('more'));
+    };
+
+    it('narrows the picker to the space for an editor', async () => {
+      const show = vi.spyOn(modalManager, 'show').mockResolvedValue(undefined as never);
+
+      await renderSpaceViewer({ id: 'space-1', canWrite: true });
+      await fireEvent.click(screen.getByText('add_to_album_or_space'));
+
+      expect(show).toHaveBeenCalledWith(AssetAddToCollectionModal, {
+        assetIds: ['space-photo'],
+        restrictToSpaceId: 'space-1',
+      });
+      show.mockRestore();
+    });
+
+    it('does not offer the action to a viewer', async () => {
+      await renderSpaceViewer({ id: 'space-1', canWrite: false });
+
+      expect(screen.queryByText('add_to_album_or_space')).not.toBeInTheDocument();
     });
   });
 });

--- a/web/src/lib/components/asset-viewer/AssetViewerNavBar.svelte
+++ b/web/src/lib/components/asset-viewer/AssetViewerNavBar.svelte
@@ -48,6 +48,12 @@
     onRemoveFromAlbum?: (assetIds: string[]) => void;
     isPlayingOriginalVideo: boolean;
     setPlayOriginalVideo: (value: boolean) => void;
+    /**
+     * Present on shared-space surfaces (direct space, space album, space person). Gates and
+     * narrows the add-to-album action for assets the caller does not own — see
+     * `getAssetActions` (#889).
+     */
+    space?: { id: string; canWrite: boolean };
   }
 
   let {
@@ -62,6 +68,7 @@
     onRemoveFromAlbum,
     isPlayingOriginalVideo = false,
     setPlayOriginalVideo,
+    space,
   }: Props = $props();
 
   const isOwner = $derived(authManager.authenticated && asset.ownerId === authManager.user.id);
@@ -85,7 +92,7 @@
     onAction: () => setPlayOriginalVideo(!isPlayingOriginalVideo),
   });
 
-  const Actions = $derived(getAssetActions($t, { ...asset, stackPrimaryAssetId: stack?.primaryAssetId }));
+  const Actions = $derived(getAssetActions($t, { ...asset, stackPrimaryAssetId: stack?.primaryAssetId }, { space }));
   const sharedLink = getSharedLink();
 </script>
 

--- a/web/src/lib/components/search/smart-search-results.svelte
+++ b/web/src/lib/components/search/smart-search-results.svelte
@@ -9,6 +9,8 @@
     searchQuery: string;
     filters: FilterState;
     spaceId?: string;
+    /** Shared-space surface + the caller's write capability on it — see `Timeline` (#889). */
+    space?: { id: string; canWrite: boolean };
     withSharedSpaces?: boolean;
     language?: string;
     isShared: boolean;
@@ -30,6 +32,7 @@
     searchQuery,
     filters,
     spaceId,
+    space,
     withSharedSpaces,
     language,
     isShared,
@@ -146,6 +149,7 @@
   onLoadMore={handleLoadMore}
   onReload={handleReload}
   {spaceId}
+  {space}
   {isShared}
   sortMode={filters.sortOrder}
   {total}

--- a/web/src/lib/components/spaces/space-search-results.spec.ts
+++ b/web/src/lib/components/spaces/space-search-results.spec.ts
@@ -317,6 +317,31 @@ describe('SpaceSearchResults', () => {
       expect(props.isShared).toBe(false);
     });
 
+    // #889 — the viewer opened from space search results has to know it is on a space surface,
+    // or add-to-album offers personal albums the server cannot accept a non-owned photo into.
+    it('should forward the space capability to AssetViewer', async () => {
+      render(SpaceSearchResults, {
+        props: {
+          results: mockAssets,
+          isLoading: false,
+          hasMore: false,
+          totalLoaded: 3,
+          onLoadMore: vi.fn(),
+          sortMode: 'relevance',
+          spaceId: 'space-1',
+          space: { id: 'space-1', canWrite: true },
+          isShared: true,
+        },
+      });
+
+      await fireEvent.click(screen.getByTestId('gallery-asset-asset-1'));
+
+      await vi.waitFor(() => expect(assetViewerPropsCalls.length).toBeGreaterThan(0));
+
+      const props = assetViewerPropsCalls.at(-1)!;
+      expect(props.space).toEqual({ id: 'space-1', canWrite: true });
+    });
+
     it('should call getAssetInfo WITH spaceId when spaceId prop is set', async () => {
       render(SpaceSearchResults, {
         props: {

--- a/web/src/lib/components/spaces/space-search-results.svelte
+++ b/web/src/lib/components/spaces/space-search-results.svelte
@@ -20,6 +20,8 @@
     totalLoaded: number;
     onLoadMore: () => void;
     spaceId?: string;
+    /** Shared-space surface + the caller's write capability on it — see `Timeline` (#889). */
+    space?: { id: string; canWrite: boolean };
     isShared: boolean;
     sortMode: 'relevance' | 'asc' | 'desc';
     total?: number;
@@ -34,6 +36,7 @@
     totalLoaded,
     onLoadMore,
     spaceId,
+    space,
     isShared,
     sortMode,
     total,
@@ -177,7 +180,7 @@
   {#if isViewerOpen && cursor}
     {#if LazyAssetViewer.current}
       {@const AssetViewer = LazyAssetViewer.current}
-      <AssetViewer {cursor} {isShared} {spaceId} onClose={() => handlePromiseError(handleClose())} />
+      <AssetViewer {cursor} {isShared} {spaceId} {space} onClose={() => handlePromiseError(handleClose())} />
     {/if}
   {/if}
 </Portal>

--- a/web/src/lib/components/timeline/Timeline.svelte
+++ b/web/src/lib/components/timeline/Timeline.svelte
@@ -57,6 +57,12 @@
     albumUsers?: UserResponseDto[];
     person?: PersonResponseDto;
     spaceId?: string;
+    /**
+     * The shared space this timeline belongs to, mirroring what the surface hands
+     * `SelectionToolbar`. Forwarded to the asset viewer so single-photo actions can be gated the
+     * same way the multi-select bar gates them (#889).
+     */
+    space?: { id: string; canWrite: boolean };
     onSelect?: (asset: TimelineAsset) => void;
     onEscape?: () => void;
     onScroll?: (scrollTop: number) => void;
@@ -96,6 +102,7 @@
     albumUsers = [],
     person,
     spaceId,
+    space,
     onSelect = () => {},
     onEscape = () => {},
     onScroll,
@@ -883,6 +890,7 @@
       {album}
       {person}
       {spaceId}
+      {space}
     />
   {/if}
 </Portal>

--- a/web/src/lib/components/timeline/TimelineAssetViewer.svelte
+++ b/web/src/lib/components/timeline/TimelineAssetViewer.svelte
@@ -28,6 +28,8 @@
     person?: PersonResponseDto;
     removeAction?: AssetAction.UNARCHIVE | AssetAction.ARCHIVE | AssetAction.SET_VISIBILITY_TIMELINE | null;
     spaceId?: string;
+    /** Shared-space surface + the caller's write capability on it — see `Timeline` (#889). */
+    space?: { id: string; canWrite: boolean };
   }
 
   let {
@@ -40,6 +42,7 @@
     album,
     person,
     spaceId,
+    space,
   }: Props = $props();
 
   const getAsset = (id: string) => {
@@ -250,6 +253,7 @@
     {album}
     {person}
     {spaceId}
+    {space}
     onAssetChange={(asset) => {
       timelineManager?.upsertAssets([toTimelineAsset(asset)]);
     }}

--- a/web/src/lib/managers/selection-command-handlers.spec.ts
+++ b/web/src/lib/managers/selection-command-handlers.spec.ts
@@ -231,6 +231,39 @@ describe('add selected to album', () => {
     expect(modalManager.show).toHaveBeenCalledWith(AssetAddToCollectionModal, { assetIds: ['asset-1', 'asset-2'] });
     expect(selection.clearSelection).not.toHaveBeenCalled();
   });
+
+  // #889 — the ⌘K / "l" shortcut must narrow the picker exactly like the selection toolbar does,
+  // or a space editor is offered personal albums the server has to reject for non-owned assets.
+  it('narrows the picker to the space when the selection is not all-owned', async () => {
+    const assets = [makeAsset({ id: 'mine' }), makeAsset({ id: 'theirs' })];
+    const selection = makeSelection({
+      assets,
+      ownedAssets: [assets[0]],
+      isAllUserOwned: false,
+    });
+
+    await handleAddSelectedToAlbum(
+      makeCtx(selection, { routeId: '/(user)/spaces/[spaceId]', space: makeWritableSpaceContext() }),
+    );
+
+    expect(modalManager.show).toHaveBeenCalledWith(AssetAddToCollectionModal, {
+      assetIds: ['mine', 'theirs'],
+      restrictToSpaceId: 'space-1',
+    });
+  });
+
+  it('leaves the picker unrestricted when the space selection is all-owned', async () => {
+    const selection = makeSelection({ assets: [makeAsset({ id: 'mine' })] });
+
+    await handleAddSelectedToAlbum(
+      makeCtx(selection, { routeId: '/(user)/spaces/[spaceId]', space: makeWritableSpaceContext() }),
+    );
+
+    expect(modalManager.show).toHaveBeenCalledWith(AssetAddToCollectionModal, {
+      assetIds: ['mine'],
+      restrictToSpaceId: undefined,
+    });
+  });
 });
 
 describe('add selected to space', () => {

--- a/web/src/lib/managers/selection-command-handlers.ts
+++ b/web/src/lib/managers/selection-command-handlers.ts
@@ -59,7 +59,15 @@ export function handleAddSelectedToAlbum(ctx?: CommandContext) {
   if (!selection?.canAddToAlbum) {
     return;
   }
-  return modalManager.show(AssetAddToCollectionModal, { assetIds: selection.selectedAssetIds });
+  // #889: mirrors SelectionToolbar's `addToAlbumRestrictedToSpace`. Assets the caller does not own
+  // only reach an album as #764 contributions, which the server accepts solely for albums linked
+  // to a space where the caller is Owner/Editor — so the picker must offer nothing else.
+  const space = ctx?.space;
+  const restrictToSpaceId = !selection.isAllUserOwned && space?.canWrite ? space.id : undefined;
+  return modalManager.show(AssetAddToCollectionModal, {
+    assetIds: selection.selectedAssetIds,
+    restrictToSpaceId,
+  });
 }
 
 export function handleAddSelectedToSpace(ctx?: CommandContext) {

--- a/web/src/lib/services/asset.service.spec.ts
+++ b/web/src/lib/services/asset.service.spec.ts
@@ -284,4 +284,69 @@ describe('add to album/space entry points', () => {
     action.onAction(action);
     expect(modalManager.show).toHaveBeenCalledWith(AssetAddToCollectionModal, { assetIds: ['single-1'] });
   });
+
+  // #889: the viewer used to offer every personal album for a space photo the caller does not own.
+  // The server can only ever accept those as #764 contributions into an album linked to the space,
+  // so an unrestricted picker guaranteed "assets cannot be added to the album".
+  describe('single-photo viewer "+" on a space surface', () => {
+    // `authManager.authenticated` — and with it the ownership check — is false unless BOTH the
+    // user and the preferences are set, so setting only the user would make every case look
+    // non-owned and the assertions unfalsifiable.
+    beforeEach(() => authManager.setPreferences(preferencesFactory.build()));
+    afterEach(() => authManager.reset());
+
+    it('narrows the picker to the space when a space editor opens a photo they do not own', () => {
+      authManager.setUser(userAdminFactory.build({ id: 'editor-1' }));
+      const asset = assetFactory.build({ id: 'not-mine', ownerId: 'someone-else' });
+
+      const action = getAssetActions(() => '', asset, { space: { id: 'space-1', canWrite: true } }).AddToAlbum;
+      action.onAction(action);
+
+      expect(action.$if?.()).toBe(true);
+      expect(modalManager.show).toHaveBeenCalledWith(AssetAddToCollectionModal, {
+        assetIds: ['not-mine'],
+        restrictToSpaceId: 'space-1',
+      });
+    });
+
+    it('leaves the picker unrestricted for a photo the space editor owns', () => {
+      authManager.setUser(userAdminFactory.build({ id: 'editor-1' }));
+      const asset = assetFactory.build({ id: 'mine', ownerId: 'editor-1' });
+
+      const action = getAssetActions(() => '', asset, { space: { id: 'space-1', canWrite: true } }).AddToAlbum;
+      action.onAction(action);
+
+      expect(action.$if?.()).toBe(true);
+      expect(modalManager.show).toHaveBeenCalledWith(AssetAddToCollectionModal, {
+        assetIds: ['mine'],
+        restrictToSpaceId: undefined,
+      });
+    });
+
+    it('hides the action for a space viewer looking at a photo they do not own', () => {
+      authManager.setUser(userAdminFactory.build({ id: 'viewer-1' }));
+      const asset = assetFactory.build({ id: 'not-mine', ownerId: 'someone-else' });
+
+      const action = getAssetActions(() => '', asset, { space: { id: 'space-1', canWrite: false } }).AddToAlbum;
+
+      expect(action.$if?.()).toBe(false);
+    });
+
+    it('keeps the action off a space surface for a photo the user does not own', () => {
+      // Partner-shared assets legitimately reach the caller's own album through
+      // Permission.AssetShare, which the viewer cannot evaluate — so it must not gate on ownership
+      // outside a space.
+      authManager.setUser(userAdminFactory.build({ id: 'partner-of-owner' }));
+      const asset = assetFactory.build({ id: 'partners-photo', ownerId: 'the-partner' });
+
+      const action = getAssetActions(() => '', asset).AddToAlbum;
+      action.onAction(action);
+
+      expect(action.$if?.()).toBe(true);
+      expect(modalManager.show).toHaveBeenCalledWith(AssetAddToCollectionModal, {
+        assetIds: ['partners-photo'],
+        restrictToSpaceId: undefined,
+      });
+    });
+  });
 });

--- a/web/src/lib/services/asset.service.ts
+++ b/web/src/lib/services/asset.service.ts
@@ -122,7 +122,19 @@ export const getAssetBulkActions = (
   return { AddToAlbum, RefreshFacesJob, RefreshMetadataJob, RegenerateThumbnailJob, TranscodeVideoJob };
 };
 
-export const getAssetActions = ($t: MessageFormatter, asset: AssetResponseDto & { stackPrimaryAssetId?: string }) => {
+export const getAssetActions = (
+  $t: MessageFormatter,
+  asset: AssetResponseDto & { stackPrimaryAssetId?: string },
+  {
+    space,
+  }: {
+    /**
+     * The shared space this asset is being viewed through, when the viewer sits on a space
+     * surface. Drives the add-to-album gating below; absent everywhere else.
+     */
+    space?: { id: string; canWrite: boolean };
+  } = {},
+) => {
   const sharedLink = getSharedLink();
   const authUser = authManager.authenticated ? authManager.user : undefined;
   const isOwner = !!(authUser && authUser.id === asset.ownerId);
@@ -136,6 +148,17 @@ export const getAssetActions = ($t: MessageFormatter, asset: AssetResponseDto & 
   // omits `ownerId` altogether, so ownership is unknowable client-side there — treat unknown as
   // shareable rather than hiding the button from the owner of the asset they linked.
   const canShare = !!authUser && (isOwner || !asset.ownerId);
+
+  // #889: an asset the caller does not own reaches an album only through the #764 contribution
+  // path, which the server accepts solely for albums linked to a space where the caller is
+  // Owner/Editor. Offering the ordinary picker there lists nothing but targets the server must
+  // reject, so on a space surface the picker is narrowed to that space's albums — and dropped
+  // entirely for a space Viewer, who has no contribution path at all. Mirrors the multi-select
+  // rule in `getSelectionCapabilities`. Off a space surface `space` is undefined and nothing
+  // changes: partner-shared assets do land in the caller's own album (Permission.AssetShare),
+  // and the viewer cannot evaluate that from the DTO.
+  const canAddToAlbum = isOwner || space === undefined || space.canWrite;
+  const restrictToSpaceId = !isOwner && space?.canWrite ? space.id : undefined;
 
   const Share: ActionItem = {
     title: $t('share'),
@@ -209,8 +232,8 @@ export const getAssetActions = ($t: MessageFormatter, asset: AssetResponseDto & 
     title: $t('add_to_album_or_space'),
     icon: mdiPlus,
     shortcuts: [{ key: 'l' }],
-    $if: () => asset.visibility !== AssetVisibility.Locked && !asset.isTrashed,
-    onAction: () => modalManager.show(AssetAddToCollectionModal, { assetIds: [asset.id] }),
+    $if: () => canAddToAlbum && asset.visibility !== AssetVisibility.Locked && !asset.isTrashed,
+    onAction: () => modalManager.show(AssetAddToCollectionModal, { assetIds: [asset.id], restrictToSpaceId }),
   };
 
   const Offline: ActionItem = {

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -873,6 +873,7 @@
         {filters}
         language={$lang}
         spaceId={space.id}
+        space={{ id: space.id, canWrite: isEditor }}
         isShared={true}
         total={smartFacetTotal}
       />
@@ -896,6 +897,7 @@
           {isSelectionMode}
           onEscape={handleEscape}
           spaceId={space.id}
+          space={{ id: space.id, canWrite: isEditor }}
           onTimelineBucketActivate={handleTimelineBucketActivate}
           {temporalAnchor}
           onTemporalAnchorResolved={() => (temporalAnchor = undefined)}

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/mock-timeline.test-wrapper.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/mock-timeline.test-wrapper.svelte
@@ -13,6 +13,7 @@
     temporalAnchor?: { year: number; month?: number };
     onTemporalAnchorResolved?: () => void;
     withStacked?: boolean;
+    space?: { id: string; canWrite: boolean };
     children?: Snippet;
     [key: string]: unknown;
   }
@@ -27,6 +28,7 @@
     temporalAnchor,
     onTemporalAnchorResolved,
     withStacked = false,
+    space,
     ...rest
   }: Props = $props();
 
@@ -59,6 +61,7 @@
 <div {...rest} data-testid="timeline-stub" data-has-timeline={String(timelineManager !== undefined)}>
   <div data-testid="timeline-options">{JSON.stringify(options)}</div>
   <div data-testid="timeline-withstacked">{String(withStacked)}</div>
+  <div data-testid="timeline-space">{JSON.stringify(space ?? null)}</div>
   <button
     type="button"
     data-testid="activate-year-bucket"

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -972,4 +972,26 @@ describe('Spaces page search URL state', () => {
     // when withStacked is requested).
     expect(screen.getByTestId('timeline-options')).toHaveTextContent('"withStacked":true');
   });
+
+  // #889 — the asset viewer opened from this timeline has to know it is on a space surface and
+  // whether the viewer may contribute, or it offers "add to album" targets the server must reject.
+  it('passes the space capability into the space Timeline for an editor', async () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos');
+
+    renderPage({ members: [makeMember({ role: SharedSpaceRole.Editor })] });
+
+    expect(await screen.findByTestId('timeline-space')).toHaveTextContent(
+      JSON.stringify({ id: 'space-1', canWrite: true }),
+    );
+  });
+
+  it('passes the space capability into the space Timeline as read-only for a viewer', async () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos');
+
+    renderPage({ members: [makeMember({ role: SharedSpaceRole.Viewer })] });
+
+    expect(await screen.findByTestId('timeline-space')).toHaveTextContent(
+      JSON.stringify({ id: 'space-1', canWrite: false }),
+    );
+  });
 });

--- a/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -417,6 +417,7 @@
             assetInteraction={assetMultiSelectManager}
             isSelectionMode={false}
             singleSelect={false}
+            space={{ id: space.id, canWrite: isSpaceEditor }}
             grouping={timelineGrouping}
             onGroupingChange={handleTimelineGroupingChange}
             onTimelineBucketActivate={handleTimelineBucketActivate}

--- a/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/mock-timeline.test-wrapper.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/mock-timeline.test-wrapper.svelte
@@ -11,6 +11,7 @@
     singleSelect?: boolean;
     assetInteraction?: unknown;
     timelineManager?: Record<string, unknown>;
+    space?: { id: string; canWrite: boolean };
     grouping?: TimelineGrouping;
     onGroupingChange?: (grouping: TimelineGrouping) => void;
     onTimelineBucketActivate?: (bucket: ActivatableTimelineBucket) => void;
@@ -26,6 +27,7 @@
     singleSelect = false,
     assetInteraction,
     timelineManager = $bindable(),
+    space,
     grouping = 'day',
     empty,
     // remaining props accepted but not used in mock rendering
@@ -56,6 +58,7 @@
   data-single-select={String(singleSelect)}
   data-mode={derivedMode}
   data-grouping={grouping}
+  data-space={JSON.stringify(space ?? null)}
 >
   <div data-testid="timeline-options">{serializedOptions}</div>
   {@render empty?.()}

--- a/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/space-album-detail-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/space-album-detail-page.spec.ts
@@ -362,6 +362,25 @@ describe('Space album detail page', () => {
     expect(screen.getByTestId('space-album-timeline')).toHaveAttribute('data-enable-routing', 'true');
   });
 
+  // #889 — the in-place asset viewer gates add-to-album on the space capability, so the browse
+  // timeline has to carry it (an album linked to this space is the only target the server can
+  // accept another member's photo into).
+  it('browse timeline carries the space capability for an editor', () => {
+    renderPage();
+    expect(screen.getByTestId('space-album-timeline')).toHaveAttribute(
+      'data-space',
+      JSON.stringify({ id: 'space-1', canWrite: true }),
+    );
+  });
+
+  it('browse timeline carries the space capability as read-only for a viewer', () => {
+    renderPage({ members: [makeMember(SharedSpaceRole.Viewer)] });
+    expect(screen.getByTestId('space-album-timeline')).toHaveAttribute(
+      'data-space',
+      JSON.stringify({ id: 'space-1', canWrite: false }),
+    );
+  });
+
   it('in browse mode, the timeline-desktop-grouping-control renders', () => {
     renderPage();
     expect(screen.getByTestId('timeline-desktop-grouping-control')).toBeInTheDocument();

--- a/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -576,6 +576,7 @@
         assetInteraction={assetMultiSelectManager}
         onEscape={handleBack}
         spaceId={space.id}
+        space={{ id: space.id, canWrite: isEditor }}
         {temporalAnchor}
         onTimelineBucketActivate={handleTimelineBucketActivate}
         onTemporalAnchorResolved={() => (temporalAnchor = undefined)}

--- a/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/mock-space-person-timeline.test-wrapper.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/mock-space-person-timeline.test-wrapper.svelte
@@ -8,6 +8,7 @@
     options?: Record<string, unknown>;
     enableRouting?: boolean;
     spaceId?: string;
+    space?: { id: string; canWrite: boolean };
     grouping?: TimelineGrouping;
     onGroupingChange?: (grouping: TimelineGrouping) => void;
     onTimelineBucketActivate?: (bucket: ActivatableTimelineBucket) => void;
@@ -22,6 +23,7 @@
     options = {},
     enableRouting = false,
     spaceId,
+    space,
     grouping = 'day',
     onGroupingChange,
     onTimelineBucketActivate,
@@ -54,6 +56,7 @@
   data-testid="space-person-timeline"
   data-enable-routing={String(enableRouting)}
   data-space-id={spaceId}
+  data-space={JSON.stringify(space ?? null)}
   data-has-timeline-manager={String(timelineManager !== undefined)}
 >
   <div data-testid="timeline-stub" data-options={serializedOptions}></div>

--- a/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/space-person-detail-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/[personId]/[[photos=photos]]/[[assetId=id]]/space-person-detail-page.spec.ts
@@ -270,6 +270,25 @@ describe('Spaces person detail page', () => {
     expect(screen.queryByTestId('person-asset-asset-1')).not.toBeInTheDocument();
   });
 
+  // #889 — the asset viewer opened from this timeline gates add-to-album on the space capability.
+  it('passes the space capability into the timeline for an editor', () => {
+    renderPage();
+
+    expect(screen.getByTestId('space-person-timeline')).toHaveAttribute(
+      'data-space',
+      JSON.stringify({ id: 'space-1', canWrite: true }),
+    );
+  });
+
+  it('passes the space capability into the timeline as read-only for a viewer', () => {
+    renderPage({ members: [makeMember({ role: SharedSpaceRole.Viewer })] });
+
+    expect(screen.getByTestId('space-person-timeline')).toHaveAttribute(
+      'data-space',
+      JSON.stringify({ id: 'space-1', canWrite: false }),
+    );
+  });
+
   it('renders space person timeline grouping controls and passes mobile grouping props', async () => {
     renderPage();
 


### PR DESCRIPTION
Closes #889.

## Problem

A non-admin Space **Editor** opens a photo in a Shared Space (owned by another member), picks **⋮ → Add to album or space**, and always gets `Warning — assets cannot be added to the album`.

The asset viewer built that action via `getAssetActions()` with **no ownership gate and no space restriction**, so the picker listed every personal album of the caller. The server can only accept an asset the caller does not own through the #764 contribution path (`AlbumService.tryContributeDeniedAssets` → `getContributableAssetSpaces`), which requires the album to be **linked to a space where the caller is Owner/Editor**. Every target on offer was therefore guaranteed to come back `no_permission`.

The multi-select toolbar already handles this (`getSelectionCapabilities` → `addToAlbumRestrictedToSpace` → `restrictToSpaceId`); the single-photo viewer and the ⌘K / `l` handler both skipped it.

## Fix

`getAssetActions($t, asset, { space })` takes the space surface and applies the same rule as the toolbar:

| case | behaviour |
| --- | --- |
| owned asset | unchanged — full picker |
| not owned, space **editor** | picker narrowed to that space's linked albums (contribution) |
| not owned, space **viewer** | action hidden (no contribution path exists) |
| not owned, **no** space surface | unchanged — partner-shared assets still reach the caller's own album via `Permission.AssetShare`, which the client cannot evaluate |

`space={{ id, canWrite }}` — the same shape those pages already pass `SelectionToolbar` — is threaded from the three space surfaces (space photos, space album browse, space person) and space search results through `Timeline → TimelineAssetViewer → AssetViewer → AssetViewerNavBar`. `handleAddSelectedToAlbum` applies the restriction from `ctx.space`.

No server change: the RBAC behaviour is the intended #764 design, the UI just stops offering targets it forbids.

## Tests

Written first, each verified red before the fix:

- `asset.service.spec.ts` — the four gating cases above.
- `AssetViewerNavBar.spec.ts` — menu item narrows the picker for an editor, absent for a viewer.
- `selection-command-handlers.spec.ts` — ⌘K path restricts a not-all-owned space selection, leaves an all-owned one alone.
- `spaces-page` / `space-person-detail-page` / `space-album-detail-page` specs — each surface passes the capability into its timeline, editor and viewer.
- `space-search-results.spec.ts` — forwarded to the viewer.

`vitest run` 4027 passed · `check:typescript` clean · `check:svelte` 572 files 0 errors · `lint` 0 errors.

## Known gaps (deliberately out of scope)

- If a space has no linked albums the restricted picker shows *"This space has no albums yet"* with no create option — same as the existing toolbar behaviour. Letting the picker create a space-linked album would close the workflow fully but is a feature, not this fix.
- `/search`, `/tags` and `/map` pass `withSharedSpaces: true`, so another member's space photo can be opened there too with no space context and still fails. Fixing that needs `asset.resolvedSpaceId` plus an async role lookup, and restricting naively on `resolvedSpaceId` would regress the partner case. Worth its own issue.