### PR TITLE
fix(mobile): keep the bottom nav inside the screen on narrow phones (#909)

### DIFF
--- a/mobile/lib/presentation/widgets/gallery_nav/gallery_bottom_nav.widget.dart
+++ b/mobile/lib/presentation/widgets/gallery_nav/gallery_bottom_nav.widget.dart
@@ -105,10 +105,17 @@ class _GalleryBottomNavState extends ConsumerState<GalleryBottomNav> {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                GalleryNavPill(
-                  activeTab: GalleryTabEnum.values[widget.tabsRouter.activeIndex],
-                  disabledTabs: isReadonly ? const {GalleryTabEnum.albums, GalleryTabEnum.library} : const {},
-                  onTabTap: _onTabTap,
+                // Flexible, not fixed: long localized labels (e.g. French
+                // "Bibliothèque") make the pill's natural width exceed a narrow
+                // phone, which used to push the search blob off-screen entirely
+                // (#909). The blob is laid out first and keeps its full size; the
+                // pill takes what is left and shrinks its tabs to fit.
+                Flexible(
+                  child: GalleryNavPill(
+                    activeTab: GalleryTabEnum.values[widget.tabsRouter.activeIndex],
+                    disabledTabs: isReadonly ? const {GalleryTabEnum.albums, GalleryTabEnum.library} : const {},
+                    onTabTap: _onTabTap,
+                  ),
                 ),
                 const SizedBox(width: 12),
                 GallerySearchBlob(enabled: !isReadonly, onTap: () => openGallerySearch(widget.tabsRouter, ref.read)),

--- a/mobile/lib/presentation/widgets/gallery_nav/gallery_nav_pill.widget.dart
+++ b/mobile/lib/presentation/widgets/gallery_nav/gallery_nav_pill.widget.dart
@@ -50,7 +50,6 @@ class _GalleryNavPillState extends State<GalleryNavPill> {
     if (!mounted) return;
     final pillBox = _pillKey.currentContext?.findRenderObject() as RenderBox?;
     if (pillBox == null) return;
-    final pillOrigin = pillBox.localToGlobal(Offset.zero);
 
     final rects = <GalleryTabEnum, Rect>{};
     for (final entry in _keys.entries) {
@@ -58,8 +57,11 @@ class _GalleryNavPillState extends State<GalleryNavPill> {
       if (ctx == null) continue;
       final box = ctx.findRenderObject() as RenderBox?;
       if (box == null) continue;
-      final origin = box.localToGlobal(Offset.zero) - pillOrigin;
-      rects[entry.key] = origin & box.size;
+      // Project through the full transform rather than diffing origins: the
+      // segments sit inside a `FittedBox` that may scale them down (#909), so
+      // their raw `size` is the pre-scale size and would leave the underlay
+      // wider than the segment it highlights.
+      rects[entry.key] = MatrixUtils.transformRect(box.getTransformTo(pillBox), Offset.zero & box.size);
     }
     if (rects.length == _keys.length && !_rectsEqual(rects, _segmentRects)) {
       setState(() => _segmentRects = rects);
@@ -151,28 +153,36 @@ class _GalleryNavPillState extends State<GalleryNavPill> {
               ),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: _edgeInset),
-                child: Row(
-                  // Google-Photos-style: cluster the tabs (content width) instead of
-                  // spreading them edge-to-edge; the pill sizes to this Row.
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    for (final tab in GalleryTabEnum.values)
-                      KeyedSubtree(
-                        key: _keys[tab],
-                        child: Opacity(
-                          opacity: widget.disabledTabs.contains(tab) ? 0.3 : 1.0,
-                          child: IgnorePointer(
-                            ignoring: widget.disabledTabs.contains(tab),
-                            child: GalleryNavSegment(
-                              key: Key('gallery-nav-segment-${tab.name}'),
-                              tab: tab,
-                              active: widget.activeTab == tab,
-                              onTap: () => widget.onTabTap(tab),
+                // Long localized labels can make the tab row wider than the space
+                // the pill was given, which used to clip the trailing tab out of
+                // the pill entirely (#909). Scale the cluster down to fit rather
+                // than truncating labels; `scaleDown` never enlarges, so the pill
+                // still sizes to its content whenever there is room.
+                child: FittedBox(
+                  fit: BoxFit.scaleDown,
+                  child: Row(
+                    // Google-Photos-style: cluster the tabs (content width) instead of
+                    // spreading them edge-to-edge; the pill sizes to this Row.
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      for (final tab in GalleryTabEnum.values)
+                        KeyedSubtree(
+                          key: _keys[tab],
+                          child: Opacity(
+                            opacity: widget.disabledTabs.contains(tab) ? 0.3 : 1.0,
+                            child: IgnorePointer(
+                              ignoring: widget.disabledTabs.contains(tab),
+                              child: GalleryNavSegment(
+                                key: Key('gallery-nav-segment-${tab.name}'),
+                                tab: tab,
+                                active: widget.activeTab == tab,
+                                onTap: () => widget.onTabTap(tab),
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ],

--- a/mobile/test/presentation/widgets/gallery_nav/gallery_bottom_nav_test.dart
+++ b/mobile/test/presentation/widgets/gallery_nav/gallery_bottom_nav_test.dart
@@ -13,6 +13,7 @@ import 'package:immich_mobile/providers/haptic_feedback.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/readonly_mode.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/remote_album.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/filter_sheet.provider.dart';
 
 import '../../../test_helpers/fake_tabs_router.dart';
 
@@ -256,6 +257,96 @@ void main() {
 
     expect(container.read(bottomNavHeightProvider), 86);
     expect(tester.getRect(find.byType(GalleryNavPill)).bottom, 932 - 34);
+  });
+
+  testWidgets('narrow phone: the whole cluster stays inside the screen (#909)', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(360, 800);
+    addTearDown(() {
+      tester.view.resetDevicePixelRatio();
+      tester.view.resetPhysicalSize();
+    });
+
+    final router = FakeTabsRouter();
+    await tester.pumpWidget(
+      _wrap(
+        GalleryBottomNav(tabsRouter: router),
+        mq: const MediaQueryData(size: Size(360, 800)),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final pill = tester.getRect(find.byType(GalleryNavPill));
+    final blob = tester.getRect(find.byType(GallerySearchBlob));
+
+    expect(pill.left, greaterThanOrEqualTo(0), reason: 'pill must not run off the left edge');
+    expect(blob.right, lessThanOrEqualTo(360), reason: 'search blob must not run off the right edge');
+    expect(pill.right, lessThanOrEqualTo(blob.left), reason: 'pill must not overlap the search blob');
+  });
+
+  testWidgets('roomy screen: pill stays content-sized and the cluster stays centred', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1024, 800);
+    addTearDown(() {
+      tester.view.resetDevicePixelRatio();
+      tester.view.resetPhysicalSize();
+    });
+
+    final router = FakeTabsRouter();
+    await tester.pumpWidget(
+      _wrap(
+        GalleryBottomNav(tabsRouter: router),
+        // Portrait MediaQuery so the pill branch is exercised, not the rail.
+        mq: const MediaQueryData(size: Size(1024, 1400)),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final pill = tester.getRect(find.byType(GalleryNavPill));
+    final blob = tester.getRect(find.byType(GallerySearchBlob));
+
+    expect(pill.width, lessThan(1024 - 28 - 12 - 50), reason: 'pill must hug its tabs, not stretch to the free width');
+    expect(
+      (pill.left - (1024 - blob.right)).abs(),
+      lessThan(0.5),
+      reason: 'the pill+blob cluster stays centred: equal gaps either side',
+    );
+  });
+
+  testWidgets('narrow phone: the search blob is still tappable (#909)', (tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(360, 800);
+    addTearDown(() {
+      tester.view.resetDevicePixelRatio();
+      tester.view.resetPhysicalSize();
+    });
+
+    final router = FakeTabsRouter(initialIndex: GalleryTabEnum.photos.index);
+    final container = ProviderContainer(
+      overrides: [
+        readonlyModeProvider.overrideWith(() => _FakeReadonly(false)),
+        hapticFeedbackProvider.overrideWith((ref) => _NoOpHaptic(ref)),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(size: Size(360, 800)),
+            child: Material(child: GalleryBottomNav(tabsRouter: router)),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(GallerySearchBlob));
+    await tester.pumpAndSettle();
+
+    expect(container.read(photosFilterSheetProvider), FilterSheetSnap.deep);
   });
 
   testWidgets('re-tap Photos (already active): emits ScrollToTopEvent', (tester) async {

--- a/mobile/test/presentation/widgets/gallery_nav/gallery_nav_pill_test.dart
+++ b/mobile/test/presentation/widgets/gallery_nav/gallery_nav_pill_test.dart
@@ -122,6 +122,63 @@ void main() {
     expect((underlayAfterLibrary.width - librarySeg.width).abs(), lessThan(0.5));
   });
 
+  // #909: long localized labels (e.g. French "Bibliothèque") made the tab row
+  // wider than the pill, so the trailing tab was clipped away and unreachable.
+  // `Center` matters: a bare `SizedBox(width:)` under the tight full-screen
+  // constraints of `pumpConsumerWidget` is a no-op, so the pill would never
+  // actually be narrowed.
+  Widget constrained(
+    double width, {
+    GalleryTabEnum active = GalleryTabEnum.photos,
+    void Function(GalleryTabEnum)? onTap,
+  }) {
+    return Center(
+      child: SizedBox(
+        width: width,
+        child: GalleryNavPill(activeTab: active, onTabTap: onTap ?? (_) {}),
+      ),
+    );
+  }
+
+  testWidgets('constrained width: every segment stays inside the pill (#909)', (tester) async {
+    await tester.pumpConsumerWidget(constrained(300));
+    await tester.pumpAndSettle();
+
+    final pill = tester.getRect(find.byType(GalleryNavPill));
+    for (final tab in GalleryTabEnum.values) {
+      final segment = tester.getRect(find.byKey(Key('gallery-nav-segment-${tab.name}')));
+      expect(segment.left, greaterThanOrEqualTo(pill.left - 0.5), reason: '${tab.name} overflows the pill on the left');
+      expect(
+        segment.right,
+        lessThanOrEqualTo(pill.right + 0.5),
+        reason: '${tab.name} overflows the pill on the right and is clipped away',
+      );
+    }
+  });
+
+  testWidgets('constrained width: every tab is still tappable (#909)', (tester) async {
+    final tapped = <GalleryTabEnum>[];
+    await tester.pumpConsumerWidget(constrained(300, onTap: tapped.add));
+    await tester.pumpAndSettle();
+
+    for (final tab in GalleryTabEnum.values) {
+      await tester.tap(find.byKey(Key('gallery-nav-segment-${tab.name}')));
+      await tester.pumpAndSettle();
+    }
+
+    expect(tapped, GalleryTabEnum.values);
+  });
+
+  testWidgets('constrained width: underlay still lines up with the active segment (#909)', (tester) async {
+    await tester.pumpConsumerWidget(constrained(300, active: GalleryTabEnum.albums));
+    await tester.pumpAndSettle();
+
+    final segment = tester.getRect(find.byKey(const Key('gallery-nav-segment-albums')));
+    final underlay = tester.getRect(find.byKey(const Key('gallery-nav-underlay')));
+    expect((underlay.left - segment.left).abs(), lessThan(0.5));
+    expect((underlay.width - segment.width).abs(), lessThan(0.5));
+  });
+
   testWidgets('disabledTabs: dims Albums+Library to 0.3 opacity, blocks taps', (tester) async {
     int tapped = -1;
     await tester.pumpConsumerWidget(


### PR DESCRIPTION
Fixes #909.

## What was wrong

The bottom nav lays the tab pill and the search blob out as fixed-size children of a centred `Row`. The pill sizes itself to its tab labels, so in locales with long ones (French *Bibliothèque*, German *Bibliothek*) its natural width plus the 12pt gap and the 50pt blob exceeds the width of a narrow phone.

`RenderFlex` does not shrink anything in that case — it clamps the remaining space to zero, lays the cluster out from the left edge and reports an overflow. The search blob therefore ended up past the right edge of the screen: off-screen and untappable, exactly as reported.

## The fix

- The pill is now `Flexible`. `RenderFlex` lays out the non-flex children first, so the search blob keeps its full 50pt and the pill gets whatever is left.
- Inside the pill, the tab row is wrapped in `FittedBox(fit: BoxFit.scaleDown)`, so a too-wide tab row shrinks to fit instead of overflowing its own clip and losing the trailing tab. `scaleDown` never enlarges, so the pill still hugs its tabs whenever there is room and the cluster stays centred.
- The active-tab underlay sits outside that `FittedBox`, so `_measure()` now projects each segment rect through the full transform (`getTransformTo`) instead of diffing origins — otherwise the underlay would keep the pre-scale width.

Landscape (`NavigationRail`) is untouched.

## Tests

Written first, each watched fail against the old layout:

| Test | Failed before as |
|---|---|
| narrow phone: the whole cluster stays inside the screen | blob right edge at 624 on a 360pt screen |
| narrow phone: the search blob is still tappable | tap missed; filter sheet stayed `hidden` |
| constrained width: every segment stays inside the pill | Library segment 79pt past the pill's right edge |
| constrained width: every tab is still tappable | only Photos and Albums registered a tap |
| constrained width: underlay lines up with the active segment | `RenderFlex overflowed by 87 pixels` |
| roomy screen: pill stays content-sized and the cluster stays centred | guard against over-correcting — fails if the pill is made `Expanded` |

`flutter test` (mobile): 2898 passed, 1 skipped. `dart analyze --fatal-infos lib test` clean, `dart format` clean.