### PR TITLE
fix(web): filter the current timeline from palette person and place results (#922)

### DIFF
--- a/docs/docs/features/search-palette.md
+++ b/docs/docs/features/search-palette.md
@@ -8,16 +8,16 @@ The top navigation search field opens this same palette. On searchable pages, th
 
 Each query runs in parallel against the configured providers and groups the results into named sections:
 
-| Section           | What it returns                                                              |
-| ----------------- | ---------------------------------------------------------------------------- |
-| **Photos**        | Top smart-search matches with thumbnails. Activate to open the asset viewer. |
-| **People**        | Named faces from your library and any shared spaces you can access.          |
-| **Places**        | Cities, regions, and countries from your reverse-geocoded photos.            |
-| **Tags**          | Tags assigned to your assets, plus inherited tags from parent tags.          |
-| **Albums**        | Your albums, matched on album name.                                          |
-| **Shared spaces** | Spaces you own or belong to, matched on space name.                          |
-| **Commands**      | Verbs — upload files, create things, sign out, toggle theme, manage pages.   |
-| **Navigation**    | Admin and settings pages — fuzzy-matched against the live page catalog.      |
+| Section           | What it returns                                                                                                               |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| **Photos**        | Top smart-search matches with thumbnails. Activate to open the asset viewer.                                                  |
+| **People**        | Named faces from your library and any shared spaces you can access. Activate to filter the timeline you're on by that person. |
+| **Places**        | Cities, regions, and countries from your reverse-geocoded photos. Activate to filter the timeline you're on by that city.     |
+| **Tags**          | Tags assigned to your assets, plus inherited tags from parent tags.                                                           |
+| **Albums**        | Your albums, matched on album name.                                                                                           |
+| **Shared spaces** | Spaces you own or belong to, matched on space name.                                                                           |
+| **Commands**      | Verbs — upload files, create things, sign out, toggle theme, manage pages.                                                    |
+| **Navigation**    | Admin and settings pages — fuzzy-matched against the live page catalog.                                                       |
 
 Empty sections collapse silently so the result list stays tight. If smart search is unhealthy (the ML server is unreachable), a banner appears at the top of the palette and offers a one-tap switch to filename mode.
 
@@ -285,7 +285,7 @@ When you open the palette for the first time on a fresh browser — no recents y
 On large screens (≥ `lg` breakpoint) a preview pane appears to the right of the result list:
 
 - **Photos** → larger thumbnail with file name and an **Open** affordance
-- **People** → face thumbnail with the person's name
+- **People** → face thumbnail with the person's name and an **Open person page** button
 - **Places** → region/country breakdown
 - **Tags** → tag value with parent path
 

--- a/docs/superpowers/plans/2026-08-03-search-palette-contextual-routing.md
+++ b/docs/superpowers/plans/2026-08-03-search-palette-contextual-routing.md
@@ -18,7 +18,7 @@ Spec: `docs/superpowers/specs/2026-08-03-search-palette-contextual-routing-desig
 - **`$t()` returns raw translation keys** in specs that do not call `init()`/`waitLocale()`. Assert on `'cmdk_open_person_page'`, never on `'Open person page'`.
 - **New i18n keys go in `i18n/en.json` only** — `i18n/` is shared by web and mobile, and en is the source locale; other locales come from Weblate.
 - **ESLint runs with `--max-warnings 0`,** and `prettier --check` is a separate CI gate from eslint. Both must pass.
-- **`svelte/prefer-svelte-reactivity`** flags plain `Map`/`URL` construction. The existing code disables it inline with a comment explaining the value is ephemeral; copy that pattern verbatim where the code below shows it.
+- **`svelte/prefer-svelte-reactivity`** flags plain `Map`/`URL` construction. The existing code disables it inline with a comment explaining the value is ephemeral; copy that pattern where the code below shows it — **but eslint also reports _unused_ disable directives as warnings, and `--max-warnings 0` turns those into failures.** The rule only fires inside the exported class, not on module-level functions. If eslint says a directive is unused, delete it; do not keep a directive the plan shows just because the plan shows it. (Verified in Task 1: the disable the plan originally placed on `withoutEmptyLabels` was unused and had to go.)
 - **Baseline on this branch: 4092 passing web tests across 300 files.** Every task ends green against the full suite or the touched files, as stated per task.
 - **Commit trailers:** do not add `Co-Authored-By` or `Generated with` trailers.
 - **Every URL string asserted in this plan was computed by running the real `buildSearchablePageUrl`, `getSearchablePageBasePath`, `getPhotosPersonFilterId`, `Route.map` and `getGlobalPersonHref`** — they are not guesses. Notably: `URLSearchParams` encodes `:` as `%3A` and `,` as `%2C`; `Route.map` emits a Leaflet hash (`/map#12/48.8566/2.3522`), not a query string; and `getSearchablePageBasePath` returns `null` for `/albums/x`, `/map` **and** `/spaces/<id>/albums/<id>`. If an assertion fails during implementation, re-derive it rather than assuming the plan is right.
@@ -136,7 +136,7 @@ Insert immediately before `private navigateToFieldResults(...)`:
 
 Replace the whole method body. Keep the docstring above it unchanged.
 
-The `switch` is written exhaustively over all four `SearchMode` values, including `smart`. TypeScript does not carry the outer `if (mode === 'smart') return;` narrowing into a closure — `mode` is a parameter, not a `const` — so a three-case switch inside `applyFilter` would fail with "not all code paths return a value". The early return preserves the old no-navigation behaviour; the `smart` case exists only to satisfy exhaustiveness.
+The early `if (mode === 'smart') return;` preserves the old no-navigation behaviour. **This repo's TypeScript _does_ carry that narrowing into the closure** (`mode` is a parameter that is never reassigned), so inside `applyFilter` the type is already `'metadata' | 'description' | 'ocr'` and the three-case switch is exhaustive. Do **not** add a `case 'smart'` — it is a hard `TS2678: Type '"smart"' is not comparable to type '"description" | "metadata" | "ocr"'`. (Verified in Task 1 by adding the branch back and running `tsc --noEmit`.)
 
 ```ts
   private navigateToFieldResults(text: string, mode: SearchMode): void {

--- a/docs/superpowers/plans/2026-08-03-search-palette-contextual-routing.md
+++ b/docs/superpowers/plans/2026-08-03-search-palette-contextual-routing.md
@@ -21,6 +21,7 @@ Spec: `docs/superpowers/specs/2026-08-03-search-palette-contextual-routing-desig
 - **`svelte/prefer-svelte-reactivity`** flags plain `Map`/`URL` construction. The existing code disables it inline with a comment explaining the value is ephemeral; copy that pattern verbatim where the code below shows it.
 - **Baseline on this branch: 4092 passing web tests across 300 files.** Every task ends green against the full suite or the touched files, as stated per task.
 - **Commit trailers:** do not add `Co-Authored-By` or `Generated with` trailers.
+- **Every URL string asserted in this plan was computed by running the real `buildSearchablePageUrl`, `getSearchablePageBasePath`, `getPhotosPersonFilterId`, `Route.map` and `getGlobalPersonHref`** — they are not guesses. Notably: `URLSearchParams` encodes `:` as `%3A` and `,` as `%2C`; `Route.map` emits a Leaflet hash (`/map#12/48.8566/2.3522`), not a query string; and `getSearchablePageBasePath` returns `null` for `/albums/x`, `/map` **and** `/spaces/<id>/albums/<id>`. If an assertion fails during implementation, re-derive it rather than assuming the plan is right.
 
 ---
 
@@ -228,7 +229,60 @@ git commit -m "refactor(web): funnel palette filter navigation through one helpe
   - module-level `function getCurrentSpaceTimelineId(pathname: string): string | undefined`
   - `private navigateToPersonResults(person: PhotosPersonFilterReference & { name?: string }): void`
 
-- [ ] **Step 1: Write the failing tests**
+- [ ] **Step 1a: Rewrite the three existing tests that pin the old destination**
+
+Do this **before** implementing. Three tests in the `describe('activate(...)')` block near line 1083 assert the old `/people/:id` navigation — they pin the bug. Rewriting them first means Step 2 shows every expectation of the new behaviour going red at once. Do not delete them: they also assert the recent-entry side effects, which this task does not change.
+
+Replace the test at ~line 1083:
+
+```ts
+it('activate("person", item) filters the timeline and records recent entry', () => {
+  const m = new GlobalSearchManager();
+  m.open();
+  m.activate('person', { id: 'p1', name: 'Alice' });
+  // No primaryProfile and no filterId, so getPhotosPersonFilterId falls through to the raw id.
+  expect(goto).toHaveBeenCalledWith('/photos?people=p1');
+  const entries = getEntries();
+  expect(entries[0]).toMatchObject({ kind: 'person', personId: 'p1', label: 'Alice' });
+});
+```
+
+Replace the test at ~line 1092:
+
+```ts
+it('activate("person", item) filters by the scoped filterId for an identity-backed space person', () => {
+  const m = new GlobalSearchManager();
+  m.open();
+  m.activate('person', {
+    id: 'space-person-1',
+    name: 'Alice',
+    primaryProfile: { type: 'space-person', id: 'space-person-1', spaceId: 'space-1' },
+    filterId: 'space-person:space-person-1',
+  });
+
+  // On /photos (not that space's timeline), so the prefixed id is the correct encoding.
+  expect(goto).toHaveBeenCalledWith('/photos?people=space-person%3Aspace-person-1');
+  expect(getEntries()).toHaveLength(0);
+});
+```
+
+Replace the test at ~line 1105:
+
+```ts
+it('activate("person", item) reconstructs the prefixed id for a legacy space person', () => {
+  const m = new GlobalSearchManager();
+  m.open();
+  m.activate('person', {
+    id: 'space-person-1',
+    name: 'Alice',
+    primaryProfile: { type: 'space-person', id: 'space-person-1', spaceId: 'space-1' },
+  });
+  expect(goto).toHaveBeenCalledWith('/photos?people=space-person%3Aspace-person-1');
+  expect(getEntries()).toHaveLength(0);
+});
+```
+
+- [ ] **Step 1b: Write the new failing tests**
 
 Append this `describe` block to `web/src/lib/managers/global-search-manager.svelte.spec.ts`, immediately after the closing `});` of `describe('tag activation navigation')`:
 
@@ -461,7 +515,7 @@ describe('person activation navigation', () => {
 
   it('closes the palette after navigating', () => {
     const m = new GlobalSearchManager();
-    m.isOpen = true;
+    m.open();
 
     m.activate('person', userPerson());
 
@@ -488,13 +542,17 @@ describe('person activation navigation', () => {
 
 - [ ] **Step 2: Run the tests to verify they fail**
 
-Run from `web/`:
+Run the whole file from `web/` — both the rewritten tests and the new block must be red:
 
 ```bash
-npx vitest run src/lib/managers/global-search-manager.svelte.spec.ts -t "person activation navigation"
+npx vitest run src/lib/managers/global-search-manager.svelte.spec.ts
 ```
 
-Expected: FAIL. The first assertions report `/people/p1` where `/photos?people=person%3Ap1` was expected — `activate('person')` still calls `goto(getPersonRoute(p))`.
+Expected: FAIL with **24 red tests** — the 3 rewritten ones plus 21 of the 24 new ones. Each reports a `/people/...` destination where a `/photos?people=...` (or `/spaces/...?people=...`) one was expected, because `activate('person')` still calls `goto(getPersonRoute(p))`.
+
+Three of the new tests pass already, and that is correct: `'closes the palette after navigating'`, `'records a recent entry for a personal person'` and `'records no recent entry for a space person'` assert side effects this task does not change. They are there to pin that the rewire does not regress them.
+
+If anything outside those 24 is red, Task 1's refactor broke something — fix that before continuing.
 
 - [ ] **Step 3: Export the filter-reference type**
 
@@ -506,7 +564,7 @@ export type PhotosPersonFilterReference = {
 
 - [ ] **Step 4: Add the space-timeline helper to the manager**
 
-In `global-search-manager.svelte.ts`, **delete** the now-unused `getPersonRoute` function (lines ~157-159) and add in its place:
+In `global-search-manager.svelte.ts`, add this module-level function next to `getPersonRoute` (~line 157). `getPersonRoute` and its `getGlobalPersonHref` import stay for now — they are deleted in Step 7, once their only caller is gone, so the file keeps type-checking between steps.
 
 ```ts
 /**
@@ -524,15 +582,9 @@ function getCurrentSpaceTimelineId(pathname: string): string | undefined {
 }
 ```
 
-- [ ] **Step 5: Fix the imports**
+- [ ] **Step 5: Add the filter-id import**
 
-`getGlobalPersonHref` is now unused in the manager (eslint `--max-warnings 0` fails on an unused import). Remove this line:
-
-```ts
-import { getGlobalPersonHref } from '$lib/utils/global-person-route';
-```
-
-and add:
+Add to the imports in `global-search-manager.svelte.ts`:
 
 ```ts
 import { getPhotosPersonFilterId, type PhotosPersonFilterReference } from '$lib/utils/photos-filter-options';
@@ -601,60 +653,15 @@ In `activate()`, replace `void goto(getPersonRoute(p));` with `this.navigateToPe
       }
 ```
 
-- [ ] **Step 8: Update the three existing tests that pin the old destination**
-
-Three tests in the `describe('activate(...)')` block near line 1083 assert the old `/people/:id` navigation. They are pinning the bug, so they must be rewritten — not deleted, since they also assert the recent-entry side effects, which are unchanged.
-
-Replace the test at ~line 1083:
+`getPersonRoute` now has no callers. Delete the function (~line 157) and its import:
 
 ```ts
-it('activate("person", item) filters the timeline and records recent entry', () => {
-  const m = new GlobalSearchManager();
-  m.open();
-  m.activate('person', { id: 'p1', name: 'Alice' });
-  // No primaryProfile and no filterId, so getPhotosPersonFilterId falls through to the raw id.
-  expect(goto).toHaveBeenCalledWith('/photos?people=p1');
-  const entries = getEntries();
-  expect(entries[0]).toMatchObject({ kind: 'person', personId: 'p1', label: 'Alice' });
-});
+import { getGlobalPersonHref } from '$lib/utils/global-person-route';
 ```
 
-Replace the test at ~line 1092:
+Both must go, or eslint `--max-warnings 0` fails on the unused symbols. `getGlobalPersonHref` itself stays in `$lib/utils/global-person-route` — `/people`, `/explore` and Task 5's preview button all use it.
 
-```ts
-it('activate("person", item) filters by the scoped filterId for an identity-backed space person', () => {
-  const m = new GlobalSearchManager();
-  m.open();
-  m.activate('person', {
-    id: 'space-person-1',
-    name: 'Alice',
-    primaryProfile: { type: 'space-person', id: 'space-person-1', spaceId: 'space-1' },
-    filterId: 'space-person:space-person-1',
-  });
-
-  // On /photos (not that space's timeline), so the prefixed id is the correct encoding.
-  expect(goto).toHaveBeenCalledWith('/photos?people=space-person%3Aspace-person-1');
-  expect(getEntries()).toHaveLength(0);
-});
-```
-
-Replace the test at ~line 1105:
-
-```ts
-it('activate("person", item) reconstructs the prefixed id for a legacy space person', () => {
-  const m = new GlobalSearchManager();
-  m.open();
-  m.activate('person', {
-    id: 'space-person-1',
-    name: 'Alice',
-    primaryProfile: { type: 'space-person', id: 'space-person-1', spaceId: 'space-1' },
-  });
-  expect(goto).toHaveBeenCalledWith('/photos?people=space-person%3Aspace-person-1');
-  expect(getEntries()).toHaveLength(0);
-});
-```
-
-- [ ] **Step 9: Run the tests to verify they pass**
+- [ ] **Step 8: Run the tests to verify they pass**
 
 Run from `web/`:
 
@@ -664,7 +671,7 @@ npx vitest run src/lib/managers/global-search-manager.svelte.spec.ts
 
 Expected: PASS — the new block plus every pre-existing test in the file, with nothing left red. This task changes `activate()` only, so the recents test `'person entry navigates and closes'` (~line 2648) still asserts `/people/p1` and still passes; Task 3 updates it.
 
-- [ ] **Step 10: Commit**
+- [ ] **Step 9: Commit**
 
 ```bash
 git add web/src/lib/managers/global-search-manager.svelte.ts web/src/lib/managers/global-search-manager.svelte.spec.ts web/src/lib/utils/photos-filter-options.ts
@@ -685,7 +692,21 @@ git commit -m "fix(web): filter the current timeline from a palette person resul
 - Consumes: `navigateToPersonResults` from Task 2.
 - Produces: nothing new.
 
-- [ ] **Step 1: Write the failing tests**
+- [ ] **Step 1a: Rewrite the existing recents test that pins the old destination**
+
+Do this **before** implementing, so Step 2 shows the whole expectation going red at once. The test `'person entry navigates and closes'` (~line 2648, in the recents `describe`) asserts `/people/p1`. Rewrite it — it also asserts the palette closes, which is unchanged:
+
+```ts
+it('person entry filters the timeline and closes', () => {
+  const m = new GlobalSearchManager();
+  m.open();
+  m.activateRecent({ kind: 'person', id: 'person:p1', personId: 'p1', label: 'Alice', lastUsed: 1 });
+  expect(goto).toHaveBeenCalledWith('/photos?people=person%3Ap1');
+  expect(m.isOpen).toBe(false);
+});
+```
+
+- [ ] **Step 1b: Write the new failing tests**
 
 Append to the `describe('person activation navigation')` block from Task 2, before its closing `});`:
 
@@ -724,13 +745,15 @@ it('ignores a corrupt person recent without navigating', () => {
 
 - [ ] **Step 2: Run the tests to verify they fail**
 
-Run from `web/`:
+Run the whole file from `web/`:
 
 ```bash
-npx vitest run src/lib/managers/global-search-manager.svelte.spec.ts -t "recent person entry"
+npx vitest run src/lib/managers/global-search-manager.svelte.spec.ts
 ```
 
-Expected: FAIL — `activateRecent` still calls `goto(Route.viewPerson(...))`, producing `/people/p1`.
+Expected: FAIL with **3 red tests** — the rewritten `'person entry filters the timeline and closes'` plus the two new routing tests. Each reports `/people/p1`, because `activateRecent` still calls `goto(Route.viewPerson(...))`.
+
+`'ignores a corrupt person recent without navigating'` passes already — `isValidRecentEntry` bails before the switch, and this task does not change that. It is there to pin that the rewire does not bypass the guard.
 
 - [ ] **Step 3: Rewire the recent case**
 
@@ -760,21 +783,7 @@ with:
       }
 ```
 
-- [ ] **Step 4: Update the existing recents test that pins the old destination**
-
-The test `'person entry navigates and closes'` (~line 2648, in the recents `describe`) asserts `/people/p1`. Rewrite it — it also asserts the palette closes, which is unchanged:
-
-```ts
-it('person entry filters the timeline and closes', () => {
-  const m = new GlobalSearchManager();
-  m.open();
-  m.activateRecent({ kind: 'person', id: 'person:p1', personId: 'p1', label: 'Alice', lastUsed: 1 });
-  expect(goto).toHaveBeenCalledWith('/photos?people=person%3Ap1');
-  expect(m.isOpen).toBe(false);
-});
-```
-
-- [ ] **Step 5: Run the tests to verify they pass**
+- [ ] **Step 4: Run the tests to verify they pass**
 
 Run from `web/`:
 
@@ -784,7 +793,7 @@ npx vitest run src/lib/managers/global-search-manager.svelte.spec.ts
 
 Expected: PASS, whole file, nothing left red.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
 git add web/src/lib/managers/global-search-manager.svelte.ts web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -805,7 +814,41 @@ git commit -m "fix(web): replay a recent person into the filtered timeline (#922
 - Consumes: `navigateToFilteredResults` from Task 1.
 - Produces: `private navigateToPlaceResults(place: { name?: string; latitude: number; longitude: number }): void`
 
-- [ ] **Step 1: Write the failing tests**
+- [ ] **Step 1a: Rewrite the two existing tests that pin the old destination**
+
+Do this **before** implementing. Replace the test at ~line 1118 (`describe('activate(...)')`):
+
+```ts
+it('activate("place", item) filters the timeline by city and records recent entry', () => {
+  const m = new GlobalSearchManager();
+  m.open();
+  m.activate('place', { name: 'Paris', latitude: 48.8566, longitude: 2.3522 });
+  expect(goto).toHaveBeenCalledWith('/photos?city=Paris');
+  const entries = getEntries();
+  expect(entries[0]).toMatchObject({ kind: 'place', id: 'place:48.8566:2.3522', label: 'Paris' });
+});
+```
+
+Replace the test at ~line 2656 (the recents `describe`):
+
+```ts
+it('place entry filters the timeline by city and closes', () => {
+  const m = new GlobalSearchManager();
+  m.open();
+  m.activateRecent({
+    kind: 'place',
+    id: 'place:48.8566:2.3522',
+    latitude: 48.8566,
+    longitude: 2.3522,
+    label: 'Paris',
+    lastUsed: 1,
+  });
+  expect(goto).toHaveBeenCalledWith('/photos?city=Paris');
+  expect(m.isOpen).toBe(false);
+});
+```
+
+- [ ] **Step 1b: Write the new failing tests**
 
 Append this `describe` block after the `describe('person activation navigation')` block:
 
@@ -849,6 +892,15 @@ describe('place activation navigation', () => {
     expect(lastGoto()).toBe('/photos?city=Paris');
   });
 
+  it('stays on /recently-added', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/recently-added');
+
+    m.activate('place', paris);
+
+    expect(lastGoto()).toBe('/recently-added?city=Paris');
+  });
+
   it('recentres the map when the user is already on the map', () => {
     const m = new GlobalSearchManager();
     mockPage.url = new URL('https://gallery.test/map');
@@ -890,7 +942,7 @@ describe('place activation navigation', () => {
 
   it('records a recent entry and closes the palette', () => {
     const m = new GlobalSearchManager();
-    m.isOpen = true;
+    m.open();
 
     m.activate('place', paris);
 
@@ -932,13 +984,15 @@ describe('place activation navigation', () => {
 
 - [ ] **Step 2: Run the tests to verify they fail**
 
-Run from `web/`:
+Run the whole file from `web/`:
 
 ```bash
-npx vitest run src/lib/managers/global-search-manager.svelte.spec.ts -t "place activation navigation"
+npx vitest run src/lib/managers/global-search-manager.svelte.spec.ts
 ```
 
-Expected: FAIL — the first test reports `/map?zoom=12&lat=48.85&lng=2.35` where `/photos?city=Paris` was expected.
+Expected: FAIL with **9 red tests** — the 2 rewritten ones plus 7 of the 11 new ones. Each reports `/map#12/48.8566/2.3522` where a `?city=Paris` destination was expected.
+
+Four of the new tests pass already, correctly: `'recentres the map when the user is already on the map'` and `'recentres the map for a nameless place…'` describe behaviour that is unchanged, and `'records a recent entry and closes the palette'` plus `'falls back to recentring the map for a recent place with no label'` assert side effects and the map fallback. They pin that the rewire does not regress them.
 
 - [ ] **Step 3: Add `navigateToPlaceResults`**
 
@@ -993,41 +1047,7 @@ with:
       }
 ```
 
-- [ ] **Step 6: Update the two existing tests that pin the old destination**
-
-Replace the test at ~line 1118 (`describe('activate(...)')`):
-
-```ts
-it('activate("place", item) filters the timeline by city and records recent entry', () => {
-  const m = new GlobalSearchManager();
-  m.open();
-  m.activate('place', { name: 'Paris', latitude: 48.8566, longitude: 2.3522 });
-  expect(goto).toHaveBeenCalledWith('/photos?city=Paris');
-  const entries = getEntries();
-  expect(entries[0]).toMatchObject({ kind: 'place', id: 'place:48.8566:2.3522', label: 'Paris' });
-});
-```
-
-Replace the test at ~line 2656 (the recents `describe`):
-
-```ts
-it('place entry filters the timeline by city and closes', () => {
-  const m = new GlobalSearchManager();
-  m.open();
-  m.activateRecent({
-    kind: 'place',
-    id: 'place:48.8566:2.3522',
-    latitude: 48.8566,
-    longitude: 2.3522,
-    label: 'Paris',
-    lastUsed: 1,
-  });
-  expect(goto).toHaveBeenCalledWith('/photos?city=Paris');
-  expect(m.isOpen).toBe(false);
-});
-```
-
-- [ ] **Step 7: Run the tests to verify they pass**
+- [ ] **Step 6: Run the tests to verify they pass**
 
 Run from `web/`:
 
@@ -1037,7 +1057,7 @@ npx vitest run src/lib/managers/global-search-manager.svelte.spec.ts
 
 Expected: PASS, whole file, nothing left red.
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add web/src/lib/managers/global-search-manager.svelte.ts web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -1269,7 +1289,9 @@ Run from `web/`:
 npx vitest run src/lib/managers/global-search-manager.svelte.spec.ts -t "palette destination table"
 ```
 
-Expected: PASS. This guard documents behaviour Tasks 2–4 already implemented; it is not expected to go red first. If any row fails, the earlier task is wrong — fix that, not the table.
+Expected: PASS. This guard characterises behaviour Tasks 2–4 already implemented, so it is not expected to go red first. If any row fails, the earlier task is wrong — fix that, not the table.
+
+A guard that cannot fail is worthless, so prove it bites: temporarily change the `person` row's expected value to `'/people/p1'`, re-run, and confirm it FAILS on that row only. Restore it and re-run to confirm PASS.
 
 - [ ] **Step 3: Write the failing `Route.search` allowlist guard**
 
@@ -1317,7 +1339,7 @@ describe('Route.search call sites', () => {
 });
 ```
 
-Add the node imports at the top of `route.spec.ts` if they are not already there:
+`route.spec.ts` currently imports only `$lib/constants` and `$lib/route` — vitest globals are enabled, so `describe`/`it`/`expect` need no import. Add these three at the top:
 
 ```ts
 import { readdirSync, readFileSync, statSync } from 'node:fs';

--- a/docs/superpowers/plans/2026-08-03-search-palette-contextual-routing.md
+++ b/docs/superpowers/plans/2026-08-03-search-palette-contextual-routing.md
@@ -1,0 +1,1424 @@
+# Search-palette contextual routing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Person and Place results in the search palette filter the timeline you are already looking at, instead of navigating away to `/people/<id>` and `/map`.
+
+**Architecture:** `global-search-manager.svelte.ts` already routes tags and field searches to the current searchable page through two near-identical private methods. Task 1 extracts those into one `navigateToFilteredResults` funnel; Tasks 2–4 add person and place on top of it. Task 5 restores one-click access to the person management page from the preview pane. Task 6 adds two regression guards.
+
+**Tech Stack:** SvelteKit + Svelte 5 runes, TypeScript strict, vitest + `@testing-library/svelte` + happy-dom.
+
+Spec: `docs/superpowers/specs/2026-08-03-search-palette-contextual-routing-design.md`
+
+## Global Constraints
+
+- **Web only.** No server, DTO, OpenAPI or SQL change. Do not run `make open-api` or `make sql`.
+- **Run a single test file with `npx vitest run <path>` from `web/`.** `pnpm test -- --run <path>` silently drops the path filter and runs all 300 files — it is not a valid verification of one file.
+- **`clearMocks` is not configured in this repo.** Mock call history leaks between tests within a file. Every new `describe` block resets what it asserts on in `beforeEach`, following the existing `describe('tag activation navigation')` block.
+- **`$t()` returns raw translation keys** in specs that do not call `init()`/`waitLocale()`. Assert on `'cmdk_open_person_page'`, never on `'Open person page'`.
+- **New i18n keys go in `i18n/en.json` only** — `i18n/` is shared by web and mobile, and en is the source locale; other locales come from Weblate.
+- **ESLint runs with `--max-warnings 0`,** and `prettier --check` is a separate CI gate from eslint. Both must pass.
+- **`svelte/prefer-svelte-reactivity`** flags plain `Map`/`URL` construction. The existing code disables it inline with a comment explaining the value is ephemeral; copy that pattern verbatim where the code below shows it.
+- **Baseline on this branch: 4092 passing web tests across 300 files.** Every task ends green against the full suite or the touched files, as stated per task.
+- **Commit trailers:** do not add `Co-Authored-By` or `Generated with` trailers.
+
+---
+
+## File Structure
+
+| File                                                                    | Responsibility                                                                                                           | Task   |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------ |
+| `web/src/lib/utils/photos-filter-options.ts`                            | export the `PhotosPersonFilterReference` type so the manager can accept both a full DTO and a reconstructed recent entry | 2      |
+| `web/src/lib/managers/global-search-manager.svelte.ts`                  | the routing funnel + person/place destinations                                                                           | 1–4    |
+| `web/src/lib/managers/global-search-manager.svelte.spec.ts`             | person/place routing behaviour, destination table guard                                                                  | 2–4, 6 |
+| `web/src/lib/components/global-search/previews/person-preview.svelte`   | "Open person page" escape hatch                                                                                          | 5      |
+| `web/src/lib/components/global-search/__tests__/person-preview.spec.ts` | preview button behaviour                                                                                                 | 5      |
+| `i18n/en.json`                                                          | `cmdk_open_person_page`                                                                                                  | 5      |
+| `web/src/lib/route.spec.ts`                                             | `Route.search` call-site allowlist guard                                                                                 | 6      |
+
+---
+
+### Task 1: Extract the `navigateToFilteredResults` funnel
+
+Pure refactor — no behaviour change, no new tests. The existing `describe('tag activation navigation')` and field-search blocks in `global-search-manager.svelte.spec.ts` are the safety net: they must stay green without modification.
+
+**Files:**
+
+- Modify: `web/src/lib/managers/global-search-manager.svelte.ts` (`navigateToFieldResults` ~1624-1655, `navigateToTagResults` ~1665-1686)
+- Test: `web/src/lib/managers/global-search-manager.svelte.spec.ts` (existing tests only)
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `private navigateToFilteredResults(options: { applyFilter: (filters: FilterState) => FilterState; target?: URL; names?: { personNames?: Map<string, string>; tagNames?: Map<string, string> } }): void`
+  - module-level `function withoutEmptyLabels(names?: Map<string, string>): Map<string, string>`
+
+- [ ] **Step 1: Run the existing routing tests to record the green baseline**
+
+Run from `web/`:
+
+```bash
+npx vitest run src/lib/managers/global-search-manager.svelte.spec.ts
+```
+
+Expected: PASS. Note the test count — it must be identical at the end of this task.
+
+- [ ] **Step 2: Add the `withoutEmptyLabels` module helper**
+
+Add just above `function getPersonRoute(...)` (~line 157) in `global-search-manager.svelte.ts`:
+
+```ts
+/**
+ * Drop `id -> ''` pairs before they reach the typed-search name cache. `active-filters-bar` falls
+ * back to rendering the raw id only for a *missing* entry, so caching an empty string renders a
+ * blank chip instead.
+ */
+function withoutEmptyLabels(names?: Map<string, string>): Map<string, string> {
+  // Ephemeral map, serialized into sessionStorage by storeTypedSearchNames; nothing reads it
+  // reactively, so a plain Map is correct here.
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity
+  return new Map([...(names ?? [])].filter(([, label]) => label.trim() !== ''));
+}
+```
+
+- [ ] **Step 3: Add the funnel method**
+
+Insert immediately before `private navigateToFieldResults(...)`:
+
+```ts
+  /**
+   * Single funnel for "palette result -> filter the surface you're on".
+   *
+   * Every row that maps onto a filter-panel filter (tag, person, place) and every field-search
+   * mode routes through here so they cannot drift apart. The rule: AND the new filter into
+   * whatever the current searchable page is already filtered by and stay put; if the current page
+   * is not searchable, fall back to /photos.
+   *
+   * `target` overrides the base page for the case where the current surface *cannot express* the
+   * filter (a space-scoped person id means nothing on /photos and vice versa). Passing it also
+   * drops the current surface's filters: leaving the surface leaves its filter state behind,
+   * because those ids are scoped to the surface we are leaving.
+   *
+   * `buildSearchDestination` deliberately does NOT use this — it owns the smart-search `/map?q=`
+   * special case, which would silently drop a filter if inherited here.
+   *
+   * `names` seeds the typed-search name cache so a freshly added chip reads "Alice" rather than a
+   * raw uuid. Passing it at all — even with empty maps — writes an entry; omitting it writes
+   * nothing, which is what the field modes want, as their chips carry their own text.
+   */
+  private navigateToFilteredResults(options: {
+    applyFilter: (filters: FilterState) => FilterState;
+    target?: URL;
+    names?: { personNames?: Map<string, string>; tagNames?: Map<string, string> };
+  }): void {
+    const current = options.target
+      ? createFilterState()
+      : (this.searchablePageFiltersProvider?.() ?? createFilterState());
+    const filters = options.applyFilter({ ...current });
+    // Ephemeral URL object for destination construction only; no reactive state is retained.
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity
+    const fallback = new URL('/photos', page.url);
+    const base = options.target ?? (getSearchablePageBasePath(page.url.pathname) ? page.url : fallback);
+    const destination = buildSearchablePageUrl(base, '', this.searchSortOrder, filters) ?? '/photos';
+    if (options.names) {
+      storeTypedSearchNames(destination, {
+        personNames: withoutEmptyLabels(options.names.personNames),
+        tagNames: withoutEmptyLabels(options.names.tagNames),
+      });
+    }
+    void goto(destination);
+  }
+```
+
+- [ ] **Step 4: Rewrite `navigateToFieldResults` to use the funnel**
+
+Replace the whole method body. Keep the docstring above it unchanged.
+
+The `switch` is written exhaustively over all four `SearchMode` values, including `smart`. TypeScript does not carry the outer `if (mode === 'smart') return;` narrowing into a closure — `mode` is a parameter, not a `const` — so a three-case switch inside `applyFilter` would fail with "not all code paths return a value". The early return preserves the old no-navigation behaviour; the `smart` case exists only to satisfy exhaustiveness.
+
+```ts
+  private navigateToFieldResults(text: string, mode: SearchMode): void {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      return;
+    }
+    if (mode === 'smart') {
+      // Unreachable: navigateToFieldResults is only called for field modes.
+      return;
+    }
+    this.navigateToFilteredResults({
+      applyFilter: (filters: FilterState): FilterState => {
+        switch (mode) {
+          case 'metadata': {
+            return { ...filters, originalFileName: trimmed };
+          }
+          case 'description': {
+            return { ...filters, description: trimmed };
+          }
+          case 'ocr': {
+            return { ...filters, ocr: trimmed };
+          }
+          case 'smart': {
+            // Unreachable — guarded above. Present so the switch is exhaustive over SearchMode.
+            return filters;
+          }
+        }
+      },
+    });
+  }
+```
+
+- [ ] **Step 5: Rewrite `navigateToTagResults` to use the funnel**
+
+Replace the whole method body, keeping its docstring:
+
+```ts
+  private navigateToTagResults(tagId: string, tagName: string): void {
+    this.navigateToFilteredResults({
+      applyFilter: (filters) => ({
+        ...filters,
+        tagIds: filters.tagIds.includes(tagId) ? filters.tagIds : [...filters.tagIds, tagId],
+      }),
+      // Ephemeral map, serialized into sessionStorage by storeTypedSearchNames; an empty tag name
+      // is stripped by withoutEmptyLabels so the chip falls back to the id, not a blank label.
+      // eslint-disable-next-line svelte/prefer-svelte-reactivity
+      names: { tagNames: new Map([[tagId, tagName]]) },
+    });
+  }
+```
+
+- [ ] **Step 6: Run the manager suite — same tests, still green**
+
+Run from `web/`:
+
+```bash
+npx vitest run src/lib/managers/global-search-manager.svelte.spec.ts
+```
+
+Expected: PASS, with the same test count as Step 1. In particular these four must pass untouched, proving the refactor preserved behaviour:
+
+- `'caches the tag name for the destination so the filter chip is not a raw id'`
+- `'caches no name for a nameless tag so the chip falls back to the id, not a blank label'`
+- `'stays on a space timeline so the tag filters the space'`
+- `'does not duplicate a tag that is already filtering the page'`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/lib/managers/global-search-manager.svelte.ts
+git commit -m "refactor(web): funnel palette filter navigation through one helper"
+```
+
+---
+
+### Task 2: Person results filter the current surface
+
+**Files:**
+
+- Modify: `web/src/lib/utils/photos-filter-options.ts:7` (export the type)
+- Modify: `web/src/lib/managers/global-search-manager.svelte.ts` (delete `getPersonRoute`, add `getCurrentSpaceTimelineId` + `navigateToPersonResults`, rewire `activate('person')`)
+- Test: `web/src/lib/managers/global-search-manager.svelte.spec.ts`
+
+**Interfaces:**
+
+- Consumes: `navigateToFilteredResults` from Task 1.
+- Produces:
+  - `export type PhotosPersonFilterReference` from `$lib/utils/photos-filter-options`
+  - module-level `function getCurrentSpaceTimelineId(pathname: string): string | undefined`
+  - `private navigateToPersonResults(person: PhotosPersonFilterReference & { name?: string }): void`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append this `describe` block to `web/src/lib/managers/global-search-manager.svelte.spec.ts`, immediately after the closing `});` of `describe('tag activation navigation')`:
+
+```ts
+describe('person activation navigation', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    localStorage.clear();
+    resetRecentStore();
+    mockPage.url = new URL('https://gallery.test/photos');
+  });
+
+  const lastGoto = () => vi.mocked(goto).mock.calls.at(-1)?.[0] as string | undefined;
+
+  const userPerson = (overrides: Partial<PersonResponseDto> = {}) =>
+    ({
+      id: 'p1',
+      name: 'Alice',
+      primaryProfile: { id: 'p1', type: 'user-person' },
+      ...overrides,
+    }) as PersonResponseDto;
+
+  const spacePerson = (spaceId: string, overrides: Partial<PersonResponseDto> = {}) =>
+    ({
+      id: 'sp1',
+      name: 'Bob',
+      primaryProfile: { id: 'profile-1', type: 'space-person', spaceId },
+      ...overrides,
+    }) as PersonResponseDto;
+
+  it('filters the timeline instead of opening the person management page', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/photos?people=person%3Ap1');
+  });
+
+  it('preserves the filters already on the page (AND)', () => {
+    const m = new GlobalSearchManager();
+    m.registerSearchablePageFilters(() => ({ ...createFilterState(), tagIds: ['t1'], rating: 4 }));
+
+    m.activate('person', userPerson());
+
+    const dest = lastGoto();
+    expect(dest).toContain('tags=t1');
+    expect(dest).toContain('rating=4');
+    expect(dest).toContain('people=person%3Ap1');
+  });
+
+  it('drops a stale smart query so the person filter is the only constraint', () => {
+    const m = new GlobalSearchManager();
+    // Matches the existing tag behaviour — buildSearchablePageUrl is called with an empty query,
+    // which deletes both `q` and a non-explicit `sort`.
+    mockPage.url = new URL('https://gallery.test/photos?q=sunset&sort=asc');
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/photos?people=person%3Ap1');
+  });
+
+  it('does not duplicate a person already filtering the page', () => {
+    const m = new GlobalSearchManager();
+    m.registerSearchablePageFilters(() => ({ ...createFilterState(), personIds: ['person:p1'] }));
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/photos?people=person%3Ap1');
+  });
+
+  it('appends to people already filtering the page', () => {
+    const m = new GlobalSearchManager();
+    m.registerSearchablePageFilters(() => ({ ...createFilterState(), personIds: ['person:p0'] }));
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/photos?people=person%3Ap0%2Cperson%3Ap1');
+  });
+
+  it('stays on a space timeline and uses the bare profile id for that space person', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1');
+
+    m.activate('person', spacePerson('space-1'));
+
+    expect(lastGoto()).toBe('/spaces/space-1?people=profile-1');
+  });
+
+  it('stays on the /photos sub-route of a space timeline', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos');
+
+    m.activate('person', spacePerson('space-1'));
+
+    expect(lastGoto()).toBe('/spaces/space-1/photos?people=profile-1');
+  });
+
+  it('leaves the space for /photos when the person belongs to a different space', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1');
+
+    m.activate('person', spacePerson('space-2'));
+
+    expect(lastGoto()).toBe('/photos?people=space-person%3Aprofile-1');
+  });
+
+  it('leaves the space for /photos for a personal person', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1');
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/photos?people=person%3Ap1');
+  });
+
+  it('drops the space surface filters when it leaves the space', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1');
+    // Space-scoped person ids are bare profile ids and mean nothing on /photos, so carrying the
+    // space's filter state across would produce a garbage query.
+    m.registerSearchablePageFilters(() => ({ ...createFilterState(), personIds: ['space-profile-9'] }));
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/photos?people=person%3Ap1');
+  });
+
+  it('uses the prefixed id for a space person while on /photos', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('person', spacePerson('space-2'));
+
+    expect(lastGoto()).toBe('/photos?people=space-person%3Aprofile-1');
+  });
+
+  it('targets /photos from a space page that is not a timeline', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/albums/album-1');
+
+    m.activate('person', spacePerson('space-1'));
+
+    expect(lastGoto()).toBe('/photos?people=space-person%3Aprofile-1');
+  });
+
+  it('targets /photos from a non-searchable page', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/albums/album-1');
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/photos?people=person%3Ap1');
+  });
+
+  it('targets /photos from the map, matching the tag precedent', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/map');
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/photos?people=person%3Ap1');
+  });
+
+  it('stays on /recently-added', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/recently-added');
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/recently-added?people=person%3Ap1');
+  });
+
+  it('prefers the server-supplied filterId', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('person', userPerson({ filterId: 'person:identity-7' }));
+
+    expect(lastGoto()).toBe('/photos?people=person%3Aidentity-7');
+  });
+
+  it('falls back to person:<id> when there is no primaryProfile', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('person', { id: 'p9', name: 'Zoe' } as PersonResponseDto);
+
+    expect(lastGoto()).toBe('/photos?people=p9');
+  });
+
+  it('drops a stale ?at= scroll target from the destination', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/photos?at=asset-1');
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/photos?people=person%3Ap1');
+  });
+
+  it('caches the person name so the filter chip is not a raw id', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('person', userPerson());
+
+    expect(storeTypedSearchNames).toHaveBeenCalledWith('/photos?people=person%3Ap1', {
+      personNames: new Map([['person:p1', 'Alice']]),
+      tagNames: new Map(),
+    });
+  });
+
+  it('caches the bare profile id as the key for an in-space person', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1');
+
+    m.activate('person', spacePerson('space-1'));
+
+    expect(storeTypedSearchNames).toHaveBeenCalledWith('/spaces/space-1?people=profile-1', {
+      personNames: new Map([['profile-1', 'Bob']]),
+      tagNames: new Map(),
+    });
+  });
+
+  it('caches no name for a nameless person so the chip falls back to the id', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('person', userPerson({ name: '' }));
+
+    expect(storeTypedSearchNames).toHaveBeenCalledWith('/photos?people=person%3Ap1', {
+      personNames: new Map(),
+      tagNames: new Map(),
+    });
+  });
+
+  it('closes the palette after navigating', () => {
+    const m = new GlobalSearchManager();
+    m.isOpen = true;
+
+    m.activate('person', userPerson());
+
+    expect(m.isOpen).toBe(false);
+  });
+
+  it('records a recent entry for a personal person', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('person', userPerson());
+
+    expect(getEntries().some((e) => e.kind === 'person' && e.id === 'person:p1')).toBe(true);
+  });
+
+  it('records no recent entry for a space person', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('person', spacePerson('space-1'));
+
+    expect(getEntries().some((e) => e.kind === 'person')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run from `web/`:
+
+```bash
+npx vitest run src/lib/managers/global-search-manager.svelte.spec.ts -t "person activation navigation"
+```
+
+Expected: FAIL. The first assertions report `/people/p1` where `/photos?people=person%3Ap1` was expected — `activate('person')` still calls `goto(getPersonRoute(p))`.
+
+- [ ] **Step 3: Export the filter-reference type**
+
+In `web/src/lib/utils/photos-filter-options.ts`, change line 7 from `type PhotosPersonFilterReference = {` to:
+
+```ts
+export type PhotosPersonFilterReference = {
+```
+
+- [ ] **Step 4: Add the space-timeline helper to the manager**
+
+In `global-search-manager.svelte.ts`, **delete** the now-unused `getPersonRoute` function (lines ~157-159) and add in its place:
+
+```ts
+/**
+ * The space id of the current page when that page is a space *timeline* (`/spaces/<id>` or
+ * `/spaces/<id>/photos`). Deliberately not a `pathname.startsWith('/spaces/')` test:
+ * `/spaces/<id>/albums/<albumId>` is a space page but not a searchable one, so no filter can be
+ * applied in place there.
+ */
+function getCurrentSpaceTimelineId(pathname: string): string | undefined {
+  const base = getSearchablePageBasePath(pathname);
+  if (!base?.startsWith('/spaces/')) {
+    return undefined;
+  }
+  return base.split('/').filter(Boolean)[1];
+}
+```
+
+- [ ] **Step 5: Fix the imports**
+
+`getGlobalPersonHref` is now unused in the manager (eslint `--max-warnings 0` fails on an unused import). Remove this line:
+
+```ts
+import { getGlobalPersonHref } from '$lib/utils/global-person-route';
+```
+
+and add:
+
+```ts
+import { getPhotosPersonFilterId, type PhotosPersonFilterReference } from '$lib/utils/photos-filter-options';
+```
+
+Exact placement does not matter — `prettier-plugin-organize-imports` sorts and dedupes the block on `prettier --write` (Task 7).
+
+- [ ] **Step 6: Add `navigateToPersonResults`**
+
+Insert immediately after `navigateToTagResults`:
+
+```ts
+  /**
+   * Navigate to the current surface filtered by `person`.
+   *
+   * The filter-id encoding is scope-dependent, and getting it wrong yields a silently empty
+   * timeline: a space timeline forwards `personIds` to the API as `spacePersonIds` — bare profile
+   * ids scoped to that space (space-filter-options.ts) — while /photos and /recently-added forward
+   * them prefixed, `person:` / `space-person:` (photos-filter-options.ts). So a space person can
+   * only filter in place on its OWN space; every other combination targets /photos with the
+   * prefixed id. This mirrors `getPersonFilterId(person, scope)` in the typed-search resolver,
+   * which already splits on exactly this distinction.
+   */
+  private navigateToPersonResults(person: PhotosPersonFilterReference & { name?: string }): void {
+    const spaceId = getCurrentSpaceTimelineId(page.url.pathname);
+    const profile = person.primaryProfile;
+    const spaceProfileId =
+      spaceId !== undefined && profile?.type === 'space-person' && profile.spaceId === spaceId ? profile.id : undefined;
+    const filterId = spaceProfileId ?? getPhotosPersonFilterId(person);
+    // Ephemeral URL object for destination construction only; no reactive state is retained.
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity
+    const target = spaceId !== undefined && spaceProfileId === undefined ? new URL('/photos', page.url) : undefined;
+    this.navigateToFilteredResults({
+      target,
+      applyFilter: (filters) => ({
+        ...filters,
+        personIds: filters.personIds.includes(filterId) ? filters.personIds : [...filters.personIds, filterId],
+      }),
+      // Ephemeral map, serialized into sessionStorage by storeTypedSearchNames; an empty name is
+      // stripped by withoutEmptyLabels so the chip falls back to the id, not a blank label.
+      // eslint-disable-next-line svelte/prefer-svelte-reactivity
+      names: { personNames: new Map([[filterId, person.name ?? '']]) },
+    });
+  }
+```
+
+- [ ] **Step 7: Rewire `activate('person')`**
+
+In `activate()`, replace `void goto(getPersonRoute(p));` with `this.navigateToPersonResults(p);`. The `addEntry` block above it is unchanged. The case now reads:
+
+```ts
+      case 'person': {
+        const p = item as PersonResponseDto;
+        if (p.primaryProfile?.type !== 'space-person') {
+          const personId = p.primaryProfile?.id ?? p.id;
+          addEntry({
+            kind: 'person',
+            id: `person:${personId}`,
+            personId,
+            label: p.name ?? '',
+            lastUsed: now,
+          });
+        }
+        this.navigateToPersonResults(p);
+        break;
+      }
+```
+
+- [ ] **Step 8: Update the three existing tests that pin the old destination**
+
+Three tests in the `describe('activate(...)')` block near line 1083 assert the old `/people/:id` navigation. They are pinning the bug, so they must be rewritten — not deleted, since they also assert the recent-entry side effects, which are unchanged.
+
+Replace the test at ~line 1083:
+
+```ts
+it('activate("person", item) filters the timeline and records recent entry', () => {
+  const m = new GlobalSearchManager();
+  m.open();
+  m.activate('person', { id: 'p1', name: 'Alice' });
+  // No primaryProfile and no filterId, so getPhotosPersonFilterId falls through to the raw id.
+  expect(goto).toHaveBeenCalledWith('/photos?people=p1');
+  const entries = getEntries();
+  expect(entries[0]).toMatchObject({ kind: 'person', personId: 'p1', label: 'Alice' });
+});
+```
+
+Replace the test at ~line 1092:
+
+```ts
+it('activate("person", item) filters by the scoped filterId for an identity-backed space person', () => {
+  const m = new GlobalSearchManager();
+  m.open();
+  m.activate('person', {
+    id: 'space-person-1',
+    name: 'Alice',
+    primaryProfile: { type: 'space-person', id: 'space-person-1', spaceId: 'space-1' },
+    filterId: 'space-person:space-person-1',
+  });
+
+  // On /photos (not that space's timeline), so the prefixed id is the correct encoding.
+  expect(goto).toHaveBeenCalledWith('/photos?people=space-person%3Aspace-person-1');
+  expect(getEntries()).toHaveLength(0);
+});
+```
+
+Replace the test at ~line 1105:
+
+```ts
+it('activate("person", item) reconstructs the prefixed id for a legacy space person', () => {
+  const m = new GlobalSearchManager();
+  m.open();
+  m.activate('person', {
+    id: 'space-person-1',
+    name: 'Alice',
+    primaryProfile: { type: 'space-person', id: 'space-person-1', spaceId: 'space-1' },
+  });
+  expect(goto).toHaveBeenCalledWith('/photos?people=space-person%3Aspace-person-1');
+  expect(getEntries()).toHaveLength(0);
+});
+```
+
+- [ ] **Step 9: Run the tests to verify they pass**
+
+Run from `web/`:
+
+```bash
+npx vitest run src/lib/managers/global-search-manager.svelte.spec.ts
+```
+
+Expected: PASS — the new block plus every pre-existing test in the file, with nothing left red. This task changes `activate()` only, so the recents test `'person entry navigates and closes'` (~line 2648) still asserts `/people/p1` and still passes; Task 3 updates it.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add web/src/lib/managers/global-search-manager.svelte.ts web/src/lib/managers/global-search-manager.svelte.spec.ts web/src/lib/utils/photos-filter-options.ts
+git commit -m "fix(web): filter the current timeline from a palette person result (#922)"
+```
+
+---
+
+### Task 3: Person recents replay to the same destination
+
+**Files:**
+
+- Modify: `web/src/lib/managers/global-search-manager.svelte.ts` (`activateRecent`, `case 'person'` ~line 1969)
+- Test: `web/src/lib/managers/global-search-manager.svelte.spec.ts`
+
+**Interfaces:**
+
+- Consumes: `navigateToPersonResults` from Task 2.
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `describe('person activation navigation')` block from Task 2, before its closing `});`:
+
+```ts
+it('routes a recent person entry to the filtered timeline too', () => {
+  const m = new GlobalSearchManager();
+
+  m.activateRecent({ kind: 'person', id: 'person:p1', personId: 'p1', label: 'Alice', lastUsed: 1 });
+
+  expect(lastGoto()).toBe('/photos?people=person%3Ap1');
+  expect(storeTypedSearchNames).toHaveBeenCalledWith('/photos?people=person%3Ap1', {
+    personNames: new Map([['person:p1', 'Alice']]),
+    tagNames: new Map(),
+  });
+});
+
+it('routes a recent person entry onto the space timeline it is replayed from', () => {
+  const m = new GlobalSearchManager();
+  mockPage.url = new URL('https://gallery.test/spaces/space-1');
+
+  // Recents only ever hold personal people, so replaying one inside a space leaves the space.
+  m.activateRecent({ kind: 'person', id: 'person:p1', personId: 'p1', label: 'Alice', lastUsed: 1 });
+
+  expect(lastGoto()).toBe('/photos?people=person%3Ap1');
+});
+
+it('ignores a corrupt person recent without navigating', () => {
+  const m = new GlobalSearchManager();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+  m.activateRecent({ kind: 'person', id: 'person:broken', label: 'Alice', lastUsed: 1 } as never);
+
+  expect(goto).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run from `web/`:
+
+```bash
+npx vitest run src/lib/managers/global-search-manager.svelte.spec.ts -t "recent person entry"
+```
+
+Expected: FAIL — `activateRecent` still calls `goto(Route.viewPerson(...))`, producing `/people/p1`.
+
+- [ ] **Step 3: Rewire the recent case**
+
+In `activateRecent`, replace:
+
+```ts
+      case 'person': {
+        void goto(Route.viewPerson({ id: entry.personId }));
+        break;
+      }
+```
+
+with:
+
+```ts
+      case 'person': {
+        // Recents only ever hold non-space people — activate('person') skips the addEntry for a
+        // space person — and the server builds filterId as `person:<profileId>`
+        // (face-identity.repository.ts), so this reconstruction is exact and a replayed recent
+        // lands exactly where a fresh pick lands.
+        this.navigateToPersonResults({
+          id: entry.personId,
+          filterId: `person:${entry.personId}`,
+          name: entry.label,
+        });
+        break;
+      }
+```
+
+- [ ] **Step 4: Update the existing recents test that pins the old destination**
+
+The test `'person entry navigates and closes'` (~line 2648, in the recents `describe`) asserts `/people/p1`. Rewrite it — it also asserts the palette closes, which is unchanged:
+
+```ts
+it('person entry filters the timeline and closes', () => {
+  const m = new GlobalSearchManager();
+  m.open();
+  m.activateRecent({ kind: 'person', id: 'person:p1', personId: 'p1', label: 'Alice', lastUsed: 1 });
+  expect(goto).toHaveBeenCalledWith('/photos?people=person%3Ap1');
+  expect(m.isOpen).toBe(false);
+});
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run from `web/`:
+
+```bash
+npx vitest run src/lib/managers/global-search-manager.svelte.spec.ts
+```
+
+Expected: PASS, whole file, nothing left red.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/lib/managers/global-search-manager.svelte.ts web/src/lib/managers/global-search-manager.svelte.spec.ts
+git commit -m "fix(web): replay a recent person into the filtered timeline (#922)"
+```
+
+---
+
+### Task 4: Place results filter the current surface, except on the map
+
+**Files:**
+
+- Modify: `web/src/lib/managers/global-search-manager.svelte.ts` (`activate('place')` ~line 1817, `activateRecent` `case 'place'` ~line 1973)
+- Test: `web/src/lib/managers/global-search-manager.svelte.spec.ts`
+
+**Interfaces:**
+
+- Consumes: `navigateToFilteredResults` from Task 1.
+- Produces: `private navigateToPlaceResults(place: { name?: string; latitude: number; longitude: number }): void`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append this `describe` block after the `describe('person activation navigation')` block:
+
+```ts
+describe('place activation navigation', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    localStorage.clear();
+    resetRecentStore();
+    mockPage.url = new URL('https://gallery.test/photos');
+  });
+
+  const lastGoto = () => vi.mocked(goto).mock.calls.at(-1)?.[0] as string | undefined;
+  const paris = { name: 'Paris', latitude: 48.8566, longitude: 2.3522 };
+  // Route.map builds a Leaflet-style hash, not a query string: `/map#<zoom>/<lat>/<lng>`.
+  const PARIS_MAP = '/map#12/48.8566/2.3522';
+
+  it('filters the timeline by city instead of jumping to the map', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('place', paris);
+
+    expect(lastGoto()).toBe('/photos?city=Paris');
+  });
+
+  it('stays on a space timeline', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1');
+
+    m.activate('place', paris);
+
+    expect(lastGoto()).toBe('/spaces/space-1?city=Paris');
+  });
+
+  it('targets /photos from a non-searchable page', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/albums/album-1');
+
+    m.activate('place', paris);
+
+    expect(lastGoto()).toBe('/photos?city=Paris');
+  });
+
+  it('recentres the map when the user is already on the map', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/map');
+
+    m.activate('place', paris);
+
+    expect(lastGoto()).toBe(PARIS_MAP);
+  });
+
+  it('replaces a city already filtering the page rather than accumulating', () => {
+    const m = new GlobalSearchManager();
+    m.registerSearchablePageFilters(() => ({ ...createFilterState(), city: 'Berlin' }));
+
+    m.activate('place', paris);
+
+    expect(lastGoto()).toBe('/photos?city=Paris');
+  });
+
+  it('preserves the other filters already on the page and drops a stale smart query', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/photos?q=beach');
+    m.registerSearchablePageFilters(() => ({ ...createFilterState(), personIds: ['person:p1'] }));
+
+    m.activate('place', paris);
+
+    const dest = lastGoto();
+    expect(dest).toContain('people=person%3Ap1');
+    expect(dest).toContain('city=Paris');
+    expect(dest).not.toContain('q=beach');
+  });
+
+  it('recentres the map for a nameless place, which cannot produce a city filter', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('place', { latitude: 48.8566, longitude: 2.3522 });
+
+    expect(lastGoto()).toBe(PARIS_MAP);
+  });
+
+  it('records a recent entry and closes the palette', () => {
+    const m = new GlobalSearchManager();
+    m.isOpen = true;
+
+    m.activate('place', paris);
+
+    expect(getEntries().some((e) => e.kind === 'place')).toBe(true);
+    expect(m.isOpen).toBe(false);
+  });
+
+  it('routes a recent place entry to the filtered timeline too', () => {
+    const m = new GlobalSearchManager();
+
+    m.activateRecent({
+      kind: 'place',
+      id: 'place:48.8566:2.3522',
+      latitude: 48.8566,
+      longitude: 2.3522,
+      label: 'Paris',
+      lastUsed: 1,
+    });
+
+    expect(lastGoto()).toBe('/photos?city=Paris');
+  });
+
+  it('falls back to recentring the map for a recent place with no label', () => {
+    const m = new GlobalSearchManager();
+
+    m.activateRecent({
+      kind: 'place',
+      id: 'place:48.8566:2.3522',
+      latitude: 48.8566,
+      longitude: 2.3522,
+      label: '',
+      lastUsed: 1,
+    });
+
+    expect(lastGoto()).toBe(PARIS_MAP);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run from `web/`:
+
+```bash
+npx vitest run src/lib/managers/global-search-manager.svelte.spec.ts -t "place activation navigation"
+```
+
+Expected: FAIL — the first test reports `/map?zoom=12&lat=48.85&lng=2.35` where `/photos?city=Paris` was expected.
+
+- [ ] **Step 3: Add `navigateToPlaceResults`**
+
+Insert immediately after `navigateToPersonResults`:
+
+```ts
+  /**
+   * Navigate to the current surface filtered by `place`.
+   *
+   * PlacesResponseDto carries name / lat / lng / admin1name / admin2name. Of those only `name`
+   * maps onto a searchable-page param (`city`) — there is no `state` filter — and it is already
+   * what place-preview searches by, so the preview and the destination agree.
+   *
+   * /map is the exception: it is a place's own contextual surface, and it is not a searchable
+   * page, so the filter path would bounce the user off the map they were reading. A nameless
+   * place cannot produce a city filter at all, so it recentres too.
+   */
+  private navigateToPlaceResults(place: { name?: string; latitude: number; longitude: number }): void {
+    const city = place.name?.trim();
+    if (!city || page.url.pathname.startsWith('/map')) {
+      void goto(Route.map({ zoom: 12, lat: place.latitude, lng: place.longitude }));
+      return;
+    }
+    this.navigateToFilteredResults({
+      // `city` is single-valued, so a new place replaces whatever city was filtering the page.
+      applyFilter: (filters) => ({ ...filters, city }),
+    });
+  }
+```
+
+- [ ] **Step 4: Rewire `activate('place')`**
+
+Replace `void goto(Route.map({ zoom: 12, lat: p.latitude, lng: p.longitude }));` with `this.navigateToPlaceResults(p);`. The `addEntry` block above it is unchanged.
+
+- [ ] **Step 5: Rewire the place recent**
+
+In `activateRecent`, replace:
+
+```ts
+      case 'place': {
+        void goto(Route.map({ zoom: 12, lat: entry.latitude, lng: entry.longitude }));
+        break;
+      }
+```
+
+with:
+
+```ts
+      case 'place': {
+        this.navigateToPlaceResults({ name: entry.label, latitude: entry.latitude, longitude: entry.longitude });
+        break;
+      }
+```
+
+- [ ] **Step 6: Update the two existing tests that pin the old destination**
+
+Replace the test at ~line 1118 (`describe('activate(...)')`):
+
+```ts
+it('activate("place", item) filters the timeline by city and records recent entry', () => {
+  const m = new GlobalSearchManager();
+  m.open();
+  m.activate('place', { name: 'Paris', latitude: 48.8566, longitude: 2.3522 });
+  expect(goto).toHaveBeenCalledWith('/photos?city=Paris');
+  const entries = getEntries();
+  expect(entries[0]).toMatchObject({ kind: 'place', id: 'place:48.8566:2.3522', label: 'Paris' });
+});
+```
+
+Replace the test at ~line 2656 (the recents `describe`):
+
+```ts
+it('place entry filters the timeline by city and closes', () => {
+  const m = new GlobalSearchManager();
+  m.open();
+  m.activateRecent({
+    kind: 'place',
+    id: 'place:48.8566:2.3522',
+    latitude: 48.8566,
+    longitude: 2.3522,
+    label: 'Paris',
+    lastUsed: 1,
+  });
+  expect(goto).toHaveBeenCalledWith('/photos?city=Paris');
+  expect(m.isOpen).toBe(false);
+});
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run from `web/`:
+
+```bash
+npx vitest run src/lib/managers/global-search-manager.svelte.spec.ts
+```
+
+Expected: PASS, whole file, nothing left red.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/src/lib/managers/global-search-manager.svelte.ts web/src/lib/managers/global-search-manager.svelte.spec.ts
+git commit -m "fix(web): filter the current timeline from a palette place result (#922)"
+```
+
+---
+
+### Task 5: "Open person page" button in the preview pane
+
+**Files:**
+
+- Modify: `i18n/en.json:977` (new key after `cmdk_open`)
+- Modify: `web/src/lib/components/global-search/previews/person-preview.svelte`
+- Test: `web/src/lib/components/global-search/__tests__/person-preview.spec.ts`
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks.
+- Produces: i18n key `cmdk_open_person_page`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`person-preview.spec.ts` does not currently mock `$app/navigation`; this is the first test in the palette preview specs that needs it. Add the mock at module scope, directly under the existing `vi.mock('@immich/sdk', ...)` block:
+
+```ts
+vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
+```
+
+and add `import { goto } from '$app/navigation';` to the imports.
+
+Then append these tests inside `describe('person-preview')`:
+
+```ts
+it('offers a button to the person management page', () => {
+  render(PersonPreview, { props: { person: { id: 'p1', name: 'Alice' } as never } });
+
+  // This spec does not init svelte-i18n, so $t() returns the raw key.
+  expect(screen.getByText('cmdk_open_person_page')).toBeInTheDocument();
+});
+
+it('navigates to the person page for a personal person', async () => {
+  render(PersonPreview, {
+    props: { person: { id: 'p1', name: 'Alice', primaryProfile: { id: 'p1', type: 'user-person' } } as never },
+  });
+
+  await fireEvent.click(screen.getByText('cmdk_open_person_page'));
+
+  expect(goto).toHaveBeenCalledWith('/people/p1');
+});
+
+it('navigates to the profile id for a space person', async () => {
+  render(PersonPreview, {
+    props: {
+      person: {
+        id: 'sp1',
+        name: 'Bob',
+        primaryProfile: { id: 'profile-1', type: 'space-person', spaceId: 'space-1' },
+      } as never,
+    },
+  });
+
+  await fireEvent.click(screen.getByText('cmdk_open_person_page'));
+
+  expect(goto).toHaveBeenCalledWith('/people/profile-1');
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run from `web/`:
+
+```bash
+npx vitest run src/lib/components/global-search/__tests__/person-preview.spec.ts
+```
+
+Expected: FAIL with `Unable to find an element with the text: cmdk_open_person_page` — the button does not exist yet.
+
+- [ ] **Step 3: Add the i18n key**
+
+In `i18n/en.json`, insert after the `"cmdk_open"` line (keys in this file are alphabetical):
+
+```json
+  "cmdk_open_person_page": "Open person page",
+```
+
+Only `en.json` — the other locales are managed by Weblate.
+
+- [ ] **Step 4: Add the button to the preview**
+
+In `person-preview.svelte`, extend the script imports:
+
+```ts
+import { goto } from '$app/navigation';
+import { Button } from '@immich/ui';
+import { getGlobalPersonHref } from '$lib/utils/global-person-route';
+```
+
+and add this block as the last child of the root `<div data-cmdk-preview-person …>`, after the `{#if loaded && photos.length > 0}` block:
+
+```svelte
+  <div class="flex gap-2">
+    <Button variant="ghost" size="small" onclick={() => goto(getGlobalPersonHref(person))}>
+      {$t('cmdk_open_person_page')}
+    </Button>
+  </div>
+```
+
+Enter on the row now filters the timeline; this button is the path to rename / merge / hide / birthday. The palette dismisses itself on navigation via `close-palette-on-navigate`, so no explicit `close()` is needed.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run from `web/`:
+
+```bash
+npx vitest run src/lib/components/global-search/__tests__/person-preview.spec.ts
+```
+
+Expected: PASS, including the three pre-existing tests in the file.
+
+- [ ] **Step 6: Verify no other locale file was touched**
+
+```bash
+git status --porcelain i18n/
+```
+
+Expected: only `i18n/en.json` listed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add i18n/en.json web/src/lib/components/global-search/previews/person-preview.svelte web/src/lib/components/global-search/__tests__/person-preview.spec.ts
+git commit -m "feat(web): open the person page from the palette preview pane"
+```
+
+---
+
+### Task 6: Regression guards
+
+Two guards: a destination table over every palette result kind, and an allowlist that stops new `Route.search` call sites from appearing.
+
+**Files:**
+
+- Modify: `web/src/lib/managers/global-search-manager.svelte.spec.ts` (destination table)
+- Modify: `web/src/lib/route.spec.ts` (allowlist)
+
+**Interfaces:**
+
+- Consumes: everything from Tasks 2–4.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Write the destination-table guard**
+
+Append after `describe('place activation navigation')`:
+
+```ts
+describe('palette destination table', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    localStorage.clear();
+    resetRecentStore();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1');
+  });
+
+  const lastGoto = () => vi.mocked(goto).mock.calls.at(-1)?.[0] as string | undefined;
+
+  // Pinned from /spaces/space-1 so any result kind that silently starts navigating off the
+  // surface the user was reading shows up as a diff here. Album / space / photo / nav are
+  // destinations rather than filters and are expected to leave.
+  it.each([
+    ['tag', { id: 't1', name: 'beach' }, '/spaces/space-1?tags=t1'],
+    [
+      'person',
+      { id: 'p1', name: 'Alice', primaryProfile: { id: 'p1', type: 'user-person' } },
+      '/photos?people=person%3Ap1',
+    ],
+    ['place', { name: 'Paris', latitude: 48.8566, longitude: 2.3522 }, '/spaces/space-1?city=Paris'],
+    ['photo', { id: 'a1', originalFileName: 'IMG_1.jpg' }, '/photos/a1'],
+  ])('activate(%s) lands on %s', (kind, item, expected) => {
+    const m = new GlobalSearchManager();
+
+    m.activate(kind as 'tag' | 'person' | 'place' | 'photo', item);
+
+    expect(lastGoto()).toBe(expected);
+  });
+
+  it.each([
+    [{ kind: 'tag', id: 'tag:t1', tagId: 't1', label: 'beach', lastUsed: 1 }, '/spaces/space-1?tags=t1'],
+    [{ kind: 'person', id: 'person:p1', personId: 'p1', label: 'Alice', lastUsed: 1 }, '/photos?people=person%3Ap1'],
+    [
+      { kind: 'place', id: 'place:48.8566:2.3522', latitude: 48.8566, longitude: 2.3522, label: 'Paris', lastUsed: 1 },
+      '/spaces/space-1?city=Paris',
+    ],
+    [{ kind: 'photo', id: 'photo:a1', assetId: 'a1', label: 'IMG_1.jpg', lastUsed: 1 }, '/photos/a1'],
+  ])('activateRecent(%o) lands on %s', (entry, expected) => {
+    const m = new GlobalSearchManager();
+
+    m.activateRecent(entry as RecentEntry);
+
+    expect(lastGoto()).toBe(expected);
+  });
+
+  it('never routes a palette result to the deprecated /search page', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('tag', { id: 't1', name: 'beach' });
+    m.activate('person', { id: 'p1', name: 'Alice' });
+    m.activate('place', { name: 'Paris', latitude: 48.8566, longitude: 2.3522 });
+    m.activate('photo', { id: 'a1' });
+
+    const destinations = vi.mocked(goto).mock.calls.map((c) => String(c[0]));
+    expect(destinations).toHaveLength(4);
+    expect(destinations.filter((d) => d.startsWith('/search'))).toEqual([]);
+  });
+});
+```
+
+Add `type RecentEntry` to the existing `$lib/stores/cmdk-recent` import at the top of the file:
+
+```ts
+import { addEntry, getEntries, __resetForTests as resetRecentStore, type RecentEntry } from '$lib/stores/cmdk-recent';
+```
+
+- [ ] **Step 2: Run it — expect PASS**
+
+Run from `web/`:
+
+```bash
+npx vitest run src/lib/managers/global-search-manager.svelte.spec.ts -t "palette destination table"
+```
+
+Expected: PASS. This guard documents behaviour Tasks 2–4 already implemented; it is not expected to go red first. If any row fails, the earlier task is wrong — fix that, not the table.
+
+- [ ] **Step 3: Write the failing `Route.search` allowlist guard**
+
+Append to `web/src/lib/route.spec.ts`. Model follows `navigation-items.spec.ts`, which already scans source files this way.
+
+```ts
+describe('Route.search call sites', () => {
+  // web/src/lib/ -> up 1 -> web/src
+  const SRC_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+  // Every in-app link to the deprecated /search page. The page itself is kept as a landing page
+  // for old bookmarks, but nothing new may point at it: a palette/search-bar result belongs on
+  // the surface it has context of (#922). This is a SUBSET assertion, so PRs that remove a call
+  // site (#778 for the info panel, #884 for the Explore/Places tiles) do not have to edit it.
+  const ALLOWED = new Set([
+    'lib/components/asset-viewer/DetailPanel.svelte',
+    'lib/services/asset.service.ts',
+    'routes/(user)/explore/+page.svelte',
+    'routes/(user)/places/PlacesCardGroup.svelte',
+    'routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte',
+  ]);
+
+  function walk(dir: string, found: string[] = []): string[] {
+    for (const name of readdirSync(dir)) {
+      const full = join(dir, name);
+      if (statSync(full).isDirectory()) {
+        walk(full, found);
+        continue;
+      }
+      if (!/\.(ts|svelte)$/.test(name) || /\.spec\.ts$/.test(name)) {
+        continue;
+      }
+      if (readFileSync(full, 'utf8').includes('Route.search')) {
+        found.push(relative(SRC_ROOT, full));
+      }
+    }
+    return found;
+  }
+
+  it('are a subset of the allowlist', () => {
+    const unexpected = walk(SRC_ROOT).filter((file) => !ALLOWED.has(file));
+
+    expect(unexpected).toEqual([]);
+  });
+});
+```
+
+Add the node imports at the top of `route.spec.ts` if they are not already there:
+
+```ts
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+```
+
+- [ ] **Step 4: Run it — verify it passes, then verify it can fail**
+
+Run from `web/`:
+
+```bash
+npx vitest run src/lib/route.spec.ts
+```
+
+Expected: PASS.
+
+A guard that cannot fail is worthless, so prove it bites. Temporarily delete one entry from `ALLOWED` (e.g. `'lib/services/asset.service.ts'`), re-run, and confirm it FAILS listing that file. Restore the entry and re-run to confirm PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/lib/managers/global-search-manager.svelte.spec.ts web/src/lib/route.spec.ts
+git commit -m "test(web): guard palette destinations and Route.search call sites"
+```
+
+---
+
+### Task 7: Full gates
+
+**Files:** none modified unless a gate fails.
+
+- [ ] **Step 1: Full web unit suite**
+
+Run from `web/`:
+
+```bash
+pnpm test
+```
+
+Expected: PASS. Baseline was 4092 tests / 300 files; expect ~4130+ tests and 300 files (no new spec files were created — all new tests were appended to existing ones).
+
+- [ ] **Step 2: Type check**
+
+Run from `web/`:
+
+```bash
+pnpm check:typescript
+```
+
+Expected: PASS, no errors.
+
+- [ ] **Step 3: Svelte check**
+
+Run from `web/`:
+
+```bash
+pnpm check:svelte
+```
+
+Expected: PASS. Note this can scan zero files in a fresh worktree; if it reports 0 files it has told you nothing, and CI is the real gate.
+
+- [ ] **Step 4: Lint**
+
+Run from `web/`:
+
+```bash
+pnpm lint
+```
+
+Expected: PASS with zero warnings. Most likely failure: an unused `Route` or `getGlobalPersonHref` import left in the manager after Tasks 2–4.
+
+- [ ] **Step 5: Prettier**
+
+Run from the repo root — eslint passing does not imply prettier passing; they are separate CI gates, and the docs gate covers `docs/superpowers/`:
+
+```bash
+npx prettier --check web/src i18n/en.json docs/superpowers
+```
+
+Expected: `All matched files use Prettier code style!` If not, run the same command with `--write` and commit.
+
+- [ ] **Step 6: Commit any formatting fixes**
+
+```bash
+git add -A
+git commit -m "chore(web): formatting"
+```
+
+Skip if there is nothing to commit.
+
+---
+
+## Manual verification
+
+Run `make dev` and open `http://localhost:2283`.
+
+1. On `/photos`, apply a tag filter. Press ⌘K, type a person's name, press Enter. **Expect:** URL becomes `/photos?tags=…&people=person:…`, the tag chip and a named person chip are both in the filter bar, and the grid is the justified, selectable layout.
+2. Press ⌘K again, arrow to the same person, click **Open person page** in the preview pane. **Expect:** `/people/<id>`, the management view with rename/merge available.
+3. Open a shared space timeline. ⌘K, pick a person who is a member of that space. **Expect:** you stay on `/spaces/<id>?people=<profileId>` and the space timeline filters in place.
+4. From the same space, pick a _personal_ person. **Expect:** you land on `/photos?people=person:…` — the space's own filters are not carried over.
+5. On `/photos`, ⌘K, pick a Place. **Expect:** `/photos?city=<name>` with a city chip.
+6. Navigate to `/map`, ⌘K, pick a Place. **Expect:** the map recentres — it does not bounce you to `/photos`.
+7. Reopen ⌘K with no query and replay the person and place recents. **Expect:** the same destinations as steps 1 and 5.

--- a/docs/superpowers/specs/2026-08-03-search-palette-contextual-routing-design.md
+++ b/docs/superpowers/specs/2026-08-03-search-palette-contextual-routing-design.md
@@ -31,11 +31,11 @@ Extract a single helper and fold the existing two into it:
 
 ```ts
 private navigateToFilteredResults(options: {
+  applyFilter: (filters: FilterState) => FilterState;
   /** Override the base page. Used when the current surface cannot express the filter. */
   target?: URL;
-  applyFilter: (filters: FilterState) => FilterState;
-  personNames?: Map<string, string>;
-  tagNames?: Map<string, string>;
+  /** Omitted entirely = write nothing to the name cache; present = write, even if empty. */
+  names?: { personNames?: Map<string, string>; tagNames?: Map<string, string> };
 }): void
 ```
 
@@ -43,7 +43,7 @@ Behaviour, unchanged from what `navigateToTagResults` does today:
 
 - Base page = `options.target`, else `page.url` when `getSearchablePageBasePath` recognises it, else `new URL('/photos', page.url)`.
 - Start from `this.searchablePageFiltersProvider?.() ?? createFilterState()` so filters already on screen survive.
-- Build with `buildSearchablePageUrl(base, '', this.searchSortOrder, filters)`, falling back to `'/photos'`.
+- Build with `buildSearchablePageUrl(base, '', this.searchSortOrder, filters)`, falling back to `'/photos'`. The empty query argument drops a stale `q` (and a non-explicit `sort`) so the newly picked filter is the only constraint — this is existing tag behaviour, pinned by `'drops a stale smart query so the tag filter is the only constraint'`, and person and place inherit it.
 - Seed `storeTypedSearchNames(destination, { personNames, tagNames })` so a new chip renders a label rather than a uuid. The helper drops empty labels before storing, so every caller inherits the guard — `active-filters-bar` falls back to the raw id only for a _missing_ entry, so caching `''` renders a blank chip.
 - `goto(destination)`.
 
@@ -110,44 +110,46 @@ Unit tests are vitest + `@testing-library/svelte`. Two traps apply from this rep
 
 ### Person routing
 
-| #   | Scenario                                               | Expected                                               |
-| --- | ------------------------------------------------------ | ------------------------------------------------------ |
-| 1   | personal person, on `/photos`                          | `/photos?people=person:p1`                             |
-| 2   | personal person, on `/photos?q=beach&sort=asc&tags=t1` | `q`, `sort` and `tags` all preserved; `people` added   |
-| 3   | person already in the active `people` filter           | still navigates; the id appears once, not twice        |
-| 4   | space-person of A, on `/spaces/A`                      | `/spaces/A?people=<bare profileId>`                    |
-| 5   | space-person of A, on `/spaces/A/photos`               | base is `/spaces/A/photos`, bare id                    |
-| 6   | space-person of **B**, on `/spaces/A`                  | `/photos?people=space-person:<profileId>`              |
-| 7   | personal person, on `/spaces/A`                        | `/photos?people=person:p1`                             |
-| 8   | space-person, on `/photos`                             | `/photos?people=space-person:<profileId>`              |
-| 9   | any person, on `/spaces/A/albums/x`                    | `/photos?…` — not a searchable page                    |
-| 10  | any person, on `/albums/x`                             | `/photos?…`                                            |
-| 11  | any person, on `/map`                                  | `/photos?…` — matches the tag precedent                |
-| 12  | any person, on `/recently-added`                       | stays on `/recently-added`, prefixed id                |
-| 13  | person with server-supplied `filterId`                 | `filterId` used verbatim                               |
-| 14  | person with no `primaryProfile`                        | `person:<person.id>`                                   |
-| 15  | person name present                                    | `personNames` seeded under the filter id actually used |
-| 16  | person name empty                                      | nothing written to `personNames`                       |
-| 17  | `?at=<assetId>` on the current URL                     | dropped from the destination                           |
-| 18  | any person                                             | palette closes after navigation                        |
-| 19  | non-space person                                       | recent written, as today                               |
-| 20  | space person                                           | **no** recent written, as today                        |
-| 21  | person recent replayed                                 | same destination as case 1                             |
-| 22  | recent missing `personId`                              | bails silently, no `goto`                              |
+| #   | Scenario                                        | Expected                                               |
+| --- | ----------------------------------------------- | ------------------------------------------------------ |
+| 1   | personal person, on `/photos`                   | `/photos?people=person:p1`                             |
+| 2   | personal person, on `/photos?tags=t1&rating=4`  | `tags` and `rating` preserved; `people` AND-ed in      |
+| 2b  | personal person, on `/photos?q=sunset&sort=asc` | stale `q` and `sort` dropped, as the tag path does     |
+| 3   | person already in the active `people` filter    | still navigates; the id appears once, not twice        |
+| 4   | space-person of A, on `/spaces/A`               | `/spaces/A?people=<bare profileId>`                    |
+| 5   | space-person of A, on `/spaces/A/photos`        | base is `/spaces/A/photos`, bare id                    |
+| 6   | space-person of **B**, on `/spaces/A`           | `/photos?people=space-person:<profileId>`              |
+| 7   | personal person, on `/spaces/A`                 | `/photos?people=person:p1`                             |
+| 8   | space-person, on `/photos`                      | `/photos?people=space-person:<profileId>`              |
+| 9   | any person, on `/spaces/A/albums/x`             | `/photos?…` — not a searchable page                    |
+| 10  | any person, on `/albums/x`                      | `/photos?…`                                            |
+| 11  | any person, on `/map`                           | `/photos?…` — matches the tag precedent                |
+| 12  | any person, on `/recently-added`                | stays on `/recently-added`, prefixed id                |
+| 13  | person with server-supplied `filterId`          | `filterId` used verbatim                               |
+| 14  | person with no `primaryProfile`                 | `person:<person.id>`                                   |
+| 15  | person name present                             | `personNames` seeded under the filter id actually used |
+| 16  | person name empty                               | nothing written to `personNames`                       |
+| 17  | `?at=<assetId>` on the current URL              | dropped from the destination                           |
+| 18  | any person                                      | palette closes after navigation                        |
+| 19  | non-space person                                | recent written, as today                               |
+| 20  | space person                                    | **no** recent written, as today                        |
+| 21  | person recent replayed                          | same destination as case 1                             |
+| 22  | recent missing `personId`                       | bails silently, no `goto`                              |
 
 ### Place routing
 
-| #   | Scenario                                     | Expected                                        |
-| --- | -------------------------------------------- | ----------------------------------------------- |
-| 23  | place, on `/photos`                          | `/photos?city=Paris`                            |
-| 24  | place, on `/spaces/A`                        | `/spaces/A?city=Paris`                          |
-| 25  | place, on `/albums/x`                        | `/photos?city=Paris`                            |
-| 26  | place, on `/map`                             | `Route.map({ zoom: 12, lat, lng })` — unchanged |
-| 27  | place, on `/photos?city=Berlin`              | city replaced, not accumulated                  |
-| 28  | place, on `/photos?q=beach&people=person:p1` | `q` and `people` preserved                      |
-| 29  | place                                        | recent written and palette closed, as today     |
-| 30  | place recent replayed, non-empty label       | `?city=<label>`                                 |
-| 31  | place recent replayed, empty label           | falls back to map centring                      |
+| #   | Scenario                                     | Expected                                    |
+| --- | -------------------------------------------- | ------------------------------------------- |
+| 23  | place, on `/photos`                          | `/photos?city=Paris`                        |
+| 24  | place, on `/spaces/A`                        | `/spaces/A?city=Paris`                      |
+| 25  | place, on `/albums/x`                        | `/photos?city=Paris`                        |
+| 26  | place, on `/map`                             | `/map#12/<lat>/<lng>` — unchanged           |
+| 27  | place, on `/photos?city=Berlin`              | city replaced, not accumulated              |
+| 28  | place, on `/photos?q=beach&people=person:p1` | `people` preserved, stale `q` dropped       |
+| 28b | place with no name                           | falls back to map centring                  |
+| 29  | place                                        | recent written and palette closed, as today |
+| 30  | place recent replayed, non-empty label       | `?city=<label>`                             |
+| 31  | place recent replayed, empty label           | falls back to map centring                  |
 
 ### Preview pane
 

--- a/docs/superpowers/specs/2026-08-03-search-palette-contextual-routing-design.md
+++ b/docs/superpowers/specs/2026-08-03-search-palette-contextual-routing-design.md
@@ -1,0 +1,182 @@
+# Search palette: every result filters the surface you're on
+
+Design for [#922](https://github.com/open-noodle/gallery/issues/922).
+
+## Problem
+
+Picking a **Person** in the search palette navigates to `/people/<id>` — the person management page — instead of filtering the timeline you were looking at. Picking a **Place** navigates to `/map`. Every other palette result either filters the current surface (tags, typed search, field search) or opens a genuine destination (album, space, asset, nav route).
+
+Two results out of eight break the rule, and both are the ones a user reaches for while browsing a timeline.
+
+### What is _not_ the problem
+
+The issue was filed as "the palette routes to the deprecated `/search` page". It does not. Tags were moved off `/search` for #894, and `buildSearchDestination` has always targeted the searchable page. The palette's navigation catalogue has no `/search` entry. The remaining in-app links to `/search` all live outside the palette:
+
+| Call site                                                     | Status                                                                                                        |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `DetailPanel.svelte` — camera make/model, lens                | PR #778 in flight                                                                                             |
+| `explore/+page.svelte`, `PlacesCardGroup.svelte` — city tiles | PR #884 in flight                                                                                             |
+| `asset.service.ts` — "View similar photos"                    | not covered; out of scope here                                                                                |
+| `search/+page.svelte` — the legacy page's own re-navigation   | intentional; the page is kept as a landing page for old bookmarks, with a "use ⌘K" banner pinned by e2e tests |
+
+This design keeps the palette clean and adds a guard so it stays that way. It does not delete the `/search` route.
+
+## Design
+
+### 1. One funnel for "result → filter the surface you're on"
+
+`global-search-manager.svelte.ts` already carries two near-identical private methods, `navigateToTagResults` (from #894) and `navigateToFieldResults`. Both compute a base page, AND a filter into the current filter state, build a searchable-page URL, and `goto` it. Adding person and place would make four copies.
+
+Extract a single helper and fold the existing two into it:
+
+```ts
+private navigateToFilteredResults(options: {
+  /** Override the base page. Used when the current surface cannot express the filter. */
+  target?: URL;
+  applyFilter: (filters: FilterState) => FilterState;
+  personNames?: Map<string, string>;
+  tagNames?: Map<string, string>;
+}): void
+```
+
+Behaviour, unchanged from what `navigateToTagResults` does today:
+
+- Base page = `options.target`, else `page.url` when `getSearchablePageBasePath` recognises it, else `new URL('/photos', page.url)`.
+- Start from `this.searchablePageFiltersProvider?.() ?? createFilterState()` so filters already on screen survive.
+- Build with `buildSearchablePageUrl(base, '', this.searchSortOrder, filters)`, falling back to `'/photos'`.
+- Seed `storeTypedSearchNames(destination, { personNames, tagNames })` so a new chip renders a label rather than a uuid. The helper drops empty labels before storing, so every caller inherits the guard — `active-filters-bar` falls back to the raw id only for a _missing_ entry, so caching `''` renders a blank chip.
+- `goto(destination)`.
+
+`buildSearchDestination` (smart/typed search) is deliberately left alone: it has a `/map?q=` special case this helper must not inherit.
+
+### 2. Person → `?people=…`
+
+The filter-id encoding is scope-dependent, and getting it wrong yields a silently empty timeline. A space searchable page sends `personIds` on to the API as `spacePersonIds` — bare profile ids scoped to that space (`space-filter-options.ts`). `/photos` and `/recently-added` send them prefixed, `person:<profileId>` or `space-person:<profileId>` (`photos-filter-options.ts`, `getPhotosPersonFilterId`). The typed-search resolver already splits on exactly this distinction (`getPersonFilterId(person, scope)`), so the palette follows the same rule:
+
+| Current page                                       | Person                      | Destination                             |
+| -------------------------------------------------- | --------------------------- | --------------------------------------- |
+| `/spaces/<sid>`, `/spaces/<sid>/photos`            | space-person **of `<sid>`** | stay put, `?people=<bare profileId>`    |
+| `/spaces/<sid>`, `/spaces/<sid>/photos`            | anything else               | `/photos?people=<prefixed filterId>`    |
+| `/photos`, `/recently-added`                       | any                         | stay put, `?people=<prefixed filterId>` |
+| anything else (`/albums/x`, `/map`, `/explore`, …) | any                         | `/photos?people=<prefixed filterId>`    |
+
+The space branch requires **both** that the base path is a space searchable page and that the person is a space-person of that same space. `/spaces/<sid>/albums/<aid>` is not a searchable page, so it falls to `/photos` like any other unrecognised surface.
+
+Prefixed ids come from the existing `getPhotosPersonFilterId`, which prefers the server-supplied `filterId` and otherwise reconstructs `<person|space-person>:<primaryProfile.id>` — matching how the server builds it (`face-identity.repository.ts`).
+
+`person.name` is written into `personNames` keyed by the filter id used, so the chip reads the name.
+
+**Recents.** `activate('person')` only records a recent for non-space people, and stores `personId = primaryProfile?.id ?? id`. Replaying a person recent therefore reconstructs `person:${entry.personId}`, which is exact for a user-person. Replay goes through the same helper, so a recent lands where a fresh pick lands.
+
+### 3. Place → `?city=…`, except on `/map`
+
+`PlacesResponseDto` carries `name`, `latitude`, `longitude`, `admin1name`, `admin2name`. Of those only `name` maps to a searchable-page param (`city`); there is no `state` filter. This is already what `place-preview.svelte` searches by, so the preview and the destination agree.
+
+| Current page                  | Destination                                     |
+| ----------------------------- | ----------------------------------------------- |
+| `pathname.startsWith('/map')` | `Route.map({ zoom: 12, lat, lng })` (unchanged) |
+| any searchable page           | stay put, `?city=<place.name>`                  |
+| anything else                 | `/photos?city=<place.name>`                     |
+
+`city` is single-valued, so a new place replaces any city filter already applied rather than accumulating. Place recents replay through the same rule, falling back to map centring when the stored label is empty (an unnamed place cannot produce a `city` filter).
+
+### 4. "Open person page" in the preview pane
+
+With Enter re-pointed at the timeline, the palette loses its one-click path to rename / merge / hide / birthday / fix-incorrect-match. `person-preview.svelte` gains a button in the same slot `photo-preview`, `album-preview` and `space-preview` already use:
+
+```svelte
+<div class="flex gap-2">
+  <Button variant="ghost" size="small" onclick={() => goto(getGlobalPersonHref(person))}>
+    {$t('cmdk_open_person_page')}
+  </Button>
+</div>
+```
+
+A new i18n key rather than the shared `cmdk_open`, because Enter and the button now do different things and "Open" no longer disambiguates. English only — `i18n/en.json` is the source locale.
+
+The palette closes itself on navigation via `close-palette-on-navigate`, so the button needs no explicit `close()`.
+
+### 5. Regression guard
+
+**Destination table.** A table-driven spec enumerating every `activate()` kind and every recent kind against its expected destination, so a result type cannot silently start navigating off-surface again.
+
+**`Route.search` allowlist.** A spec asserting the set of files calling `Route.search` is a **subset** of a listed set (info panel, Explore, Places, "View similar photos", the `/search` page itself). A new call site fails; PRs #778 and #884 removing theirs does not.
+
+## Testing
+
+Test-driven throughout: for each slice below, write the test, watch it fail for the stated reason, then implement. Existing suites in `global-search-manager.svelte.spec.ts` cover the tag and field paths and must stay green across the extraction in §1 — that is the refactor's own safety net, so §1 lands with no new tests and no behaviour change.
+
+Unit tests are vitest + `@testing-library/svelte`. Two traps apply from this repo's history: `clearMocks` is not configured, so mock history leaks within a file and each test must reset what it asserts on; and `$t()` returns raw keys under test, so assert on `cmdk_open_person_page`, not "Open person page".
+
+### Person routing
+
+| #   | Scenario                                               | Expected                                               |
+| --- | ------------------------------------------------------ | ------------------------------------------------------ |
+| 1   | personal person, on `/photos`                          | `/photos?people=person:p1`                             |
+| 2   | personal person, on `/photos?q=beach&sort=asc&tags=t1` | `q`, `sort` and `tags` all preserved; `people` added   |
+| 3   | person already in the active `people` filter           | still navigates; the id appears once, not twice        |
+| 4   | space-person of A, on `/spaces/A`                      | `/spaces/A?people=<bare profileId>`                    |
+| 5   | space-person of A, on `/spaces/A/photos`               | base is `/spaces/A/photos`, bare id                    |
+| 6   | space-person of **B**, on `/spaces/A`                  | `/photos?people=space-person:<profileId>`              |
+| 7   | personal person, on `/spaces/A`                        | `/photos?people=person:p1`                             |
+| 8   | space-person, on `/photos`                             | `/photos?people=space-person:<profileId>`              |
+| 9   | any person, on `/spaces/A/albums/x`                    | `/photos?…` — not a searchable page                    |
+| 10  | any person, on `/albums/x`                             | `/photos?…`                                            |
+| 11  | any person, on `/map`                                  | `/photos?…` — matches the tag precedent                |
+| 12  | any person, on `/recently-added`                       | stays on `/recently-added`, prefixed id                |
+| 13  | person with server-supplied `filterId`                 | `filterId` used verbatim                               |
+| 14  | person with no `primaryProfile`                        | `person:<person.id>`                                   |
+| 15  | person name present                                    | `personNames` seeded under the filter id actually used |
+| 16  | person name empty                                      | nothing written to `personNames`                       |
+| 17  | `?at=<assetId>` on the current URL                     | dropped from the destination                           |
+| 18  | any person                                             | palette closes after navigation                        |
+| 19  | non-space person                                       | recent written, as today                               |
+| 20  | space person                                           | **no** recent written, as today                        |
+| 21  | person recent replayed                                 | same destination as case 1                             |
+| 22  | recent missing `personId`                              | bails silently, no `goto`                              |
+
+### Place routing
+
+| #   | Scenario                                     | Expected                                        |
+| --- | -------------------------------------------- | ----------------------------------------------- |
+| 23  | place, on `/photos`                          | `/photos?city=Paris`                            |
+| 24  | place, on `/spaces/A`                        | `/spaces/A?city=Paris`                          |
+| 25  | place, on `/albums/x`                        | `/photos?city=Paris`                            |
+| 26  | place, on `/map`                             | `Route.map({ zoom: 12, lat, lng })` — unchanged |
+| 27  | place, on `/photos?city=Berlin`              | city replaced, not accumulated                  |
+| 28  | place, on `/photos?q=beach&people=person:p1` | `q` and `people` preserved                      |
+| 29  | place                                        | recent written and palette closed, as today     |
+| 30  | place recent replayed, non-empty label       | `?city=<label>`                                 |
+| 31  | place recent replayed, empty label           | falls back to map centring                      |
+
+### Preview pane
+
+| #   | Scenario        | Expected                                |
+| --- | --------------- | --------------------------------------- |
+| 32  | personal person | button href/target is `/people/<id>`    |
+| 33  | space person    | target is `/people/<primaryProfile.id>` |
+| 34  | button clicked  | `goto` called once with that target     |
+
+### Guards
+
+| #   | Scenario                  | Expected                      |
+| --- | ------------------------- | ----------------------------- |
+| 35  | every `activate()` kind   | matches the destination table |
+| 36  | every recent kind         | matches the destination table |
+| 37  | `Route.search` call sites | subset of the allowlist       |
+
+### Suite-level gates
+
+`pnpm test` in `web/` (baseline on this branch: 4092 passed, 300 files), plus `check:typescript`, `check:svelte`, `pnpm lint`, and `prettier --check`. `svelte-check` can scan zero files locally in a fresh worktree, so it is treated as a push-only gate.
+
+No server change, so no OpenAPI regeneration and no SQL sync.
+
+### Manual verification
+
+On `/photos` with a tag filter already applied: ⌘K, type a person's name, Enter — the timeline stays on `/photos`, gains a person chip alongside the tag chip, and renders the justified selectable grid. Repeat from `/spaces/<id>` with a space member: the space timeline filters in place. Repeat with a place: a city chip. From `/map`, a place still recentres the map.
+
+## Out of scope
+
+- **"View similar photos"** (`asset.service.ts:310`) — the one in-app `/search` link no open PR covers. Not a palette result. The allowlist guard lists it so it cannot multiply.
+- **Photo results** continue to open `/photos/<id>` rather than `/spaces/<sid>/photos/<id>`. The palette's photo provider searches globally, so a hit need not be in the space you are viewing.
+- **Deleting or redirecting `/search`** — it is deliberately retained as a landing page for old bookmarks, with e2e tests pinning the banner behaviour.

--- a/docs/superpowers/specs/2026-08-03-search-palette-contextual-routing-design.md
+++ b/docs/superpowers/specs/2026-08-03-search-palette-contextual-routing-design.md
@@ -70,7 +70,7 @@ Prefixed ids come from the existing `getPhotosPersonFilterId`, which prefers the
 
 ### 3. Place → `?city=…`, except on `/map`
 
-`PlacesResponseDto` carries `name`, `latitude`, `longitude`, `admin1name`, `admin2name`. Of those only `name` maps to a searchable-page param (`city`); there is no `state` filter. This is already what `place-preview.svelte` searches by, so the preview and the destination agree.
+`PlacesResponseDto` carries `name`, `latitude`, `longitude`, `admin1name`, `admin2name`. Of those only `name` maps to a searchable-page param (`city`); there is no `state` filter. `place-preview.svelte` searches by both `city: place.name` and `state: place.admin1name`, so for two same-named cities in different states the destination is a deliberate superset of what the preview showed.
 
 | Current page                  | Destination                                     |
 | ----------------------------- | ----------------------------------------------- |
@@ -110,31 +110,31 @@ Unit tests are vitest + `@testing-library/svelte`. Two traps apply from this rep
 
 ### Person routing
 
-| #   | Scenario                                        | Expected                                               |
-| --- | ----------------------------------------------- | ------------------------------------------------------ |
-| 1   | personal person, on `/photos`                   | `/photos?people=person:p1`                             |
-| 2   | personal person, on `/photos?tags=t1&rating=4`  | `tags` and `rating` preserved; `people` AND-ed in      |
-| 2b  | personal person, on `/photos?q=sunset&sort=asc` | stale `q` and `sort` dropped, as the tag path does     |
-| 3   | person already in the active `people` filter    | still navigates; the id appears once, not twice        |
-| 4   | space-person of A, on `/spaces/A`               | `/spaces/A?people=<bare profileId>`                    |
-| 5   | space-person of A, on `/spaces/A/photos`        | base is `/spaces/A/photos`, bare id                    |
-| 6   | space-person of **B**, on `/spaces/A`           | `/photos?people=space-person:<profileId>`              |
-| 7   | personal person, on `/spaces/A`                 | `/photos?people=person:p1`                             |
-| 8   | space-person, on `/photos`                      | `/photos?people=space-person:<profileId>`              |
-| 9   | any person, on `/spaces/A/albums/x`             | `/photos?…` — not a searchable page                    |
-| 10  | any person, on `/albums/x`                      | `/photos?…`                                            |
-| 11  | any person, on `/map`                           | `/photos?…` — matches the tag precedent                |
-| 12  | any person, on `/recently-added`                | stays on `/recently-added`, prefixed id                |
-| 13  | person with server-supplied `filterId`          | `filterId` used verbatim                               |
-| 14  | person with no `primaryProfile`                 | `person:<person.id>`                                   |
-| 15  | person name present                             | `personNames` seeded under the filter id actually used |
-| 16  | person name empty                               | nothing written to `personNames`                       |
-| 17  | `?at=<assetId>` on the current URL              | dropped from the destination                           |
-| 18  | any person                                      | palette closes after navigation                        |
-| 19  | non-space person                                | recent written, as today                               |
-| 20  | space person                                    | **no** recent written, as today                        |
-| 21  | person recent replayed                          | same destination as case 1                             |
-| 22  | recent missing `personId`                       | bails silently, no `goto`                              |
+| #   | Scenario                                        | Expected                                                                                                       |
+| --- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| 1   | personal person, on `/photos`                   | `/photos?people=person:p1`                                                                                     |
+| 2   | personal person, on `/photos?tags=t1&rating=4`  | `tags` and `rating` preserved; `people` AND-ed in                                                              |
+| 2b  | personal person, on `/photos?q=sunset&sort=asc` | stale `q` and `sort` dropped, as the tag path does                                                             |
+| 3   | person already in the active `people` filter    | still navigates; the id appears once, not twice                                                                |
+| 4   | space-person of A, on `/spaces/A`               | `/spaces/A?people=<bare profileId>`                                                                            |
+| 5   | space-person of A, on `/spaces/A/photos`        | base is `/spaces/A/photos`, bare id                                                                            |
+| 6   | space-person of **B**, on `/spaces/A`           | `/photos?people=space-person:<profileId>`                                                                      |
+| 7   | personal person, on `/spaces/A`                 | `/photos?people=person:p1`                                                                                     |
+| 8   | space-person, on `/photos`                      | `/photos?people=space-person:<profileId>`                                                                      |
+| 9   | any person, on `/spaces/A/albums/x`             | `/photos?…` — not a searchable page                                                                            |
+| 10  | any person, on `/albums/x`                      | `/photos?…`                                                                                                    |
+| 11  | any person, on `/map`                           | `/photos?…` — matches the tag precedent                                                                        |
+| 12  | any person, on `/recently-added`                | stays on `/recently-added`, prefixed id                                                                        |
+| 13  | person with server-supplied `filterId`          | `filterId` used verbatim                                                                                       |
+| 14  | person with no `primaryProfile`                 | `<person.id>` (bare — unlike the typed-search resolver's `getPersonFilterId`, which prefixes an unprefixed id) |
+| 15  | person name present                             | `personNames` seeded under the filter id actually used                                                         |
+| 16  | person name empty                               | nothing written to `personNames`                                                                               |
+| 17  | `?at=<assetId>` on the current URL              | dropped from the destination                                                                                   |
+| 18  | any person                                      | palette closes after navigation                                                                                |
+| 19  | non-space person                                | recent written, as today                                                                                       |
+| 20  | space person                                    | **no** recent written, as today                                                                                |
+| 21  | person recent replayed                          | same destination as case 1                                                                                     |
+| 22  | recent missing `personId`                       | bails silently, no `goto`                                                                                      |
 
 ### Place routing
 
@@ -183,3 +183,4 @@ On `/photos` with a tag filter already applied: ⌘K, type a person's name, Ente
 - **"View similar photos"** (`asset.service.ts:310`) — the one in-app `/search` link no open PR covers. Not a palette result. The allowlist guard lists it so it cannot multiply.
 - **Photo results** continue to open `/photos/<id>` rather than `/spaces/<sid>/photos/<id>`. The palette's photo provider searches globally, so a hit need not be in the space you are viewing.
 - **Deleting or redirecting `/search`** — it is deliberately retained as a landing page for old bookmarks, with e2e tests pinning the banner behaviour.
+- **No route to the person page below the 1024px preview-pane breakpoint** — the "Open person page" button lives in the palette's preview pane (`showPreview = $derived(mediaQueryManager.minLg)` in `global-search.svelte`), which only renders at `lg` and above. Below that width the palette has no button to reach person management. Accepted: below 1024px the palette is a quick-jump-to-filtered-timeline tool, and the person page stays reachable via `/people`.

--- a/docs/superpowers/specs/2026-08-03-search-palette-contextual-routing-design.md
+++ b/docs/superpowers/specs/2026-08-03-search-palette-contextual-routing-design.md
@@ -143,6 +143,7 @@ Unit tests are vitest + `@testing-library/svelte`. Two traps apply from this rep
 | 23  | place, on `/photos`                          | `/photos?city=Paris`                        |
 | 24  | place, on `/spaces/A`                        | `/spaces/A?city=Paris`                      |
 | 25  | place, on `/albums/x`                        | `/photos?city=Paris`                        |
+| 25b | place, on `/recently-added`                  | `/recently-added?city=Paris`                |
 | 26  | place, on `/map`                             | `/map#12/<lat>/<lng>` — unchanged           |
 | 27  | place, on `/photos?city=Berlin`              | city replaced, not accumulated              |
 | 28  | place, on `/photos?q=beach&people=person:p1` | `people` preserved, stale `q` dropped       |

--- a/e2e/src/specs/web/global-search.e2e-spec.ts
+++ b/e2e/src/specs/web/global-search.e2e-spec.ts
@@ -576,7 +576,7 @@ test.describe('global search palette', () => {
     // fixtures inline — the outer beforeAll already handled admin setup + the baseline
     // asset upload + metadata drain. We reuse the outer beforeEach so auth cookies and
     // the /photos landing + cmdk input trigger hydration wait are handled automatically.
-    test('scope @ narrows to people section and activating navigates to /people/:id', async ({ page }) => {
+    test('scope @ narrows to people section and activating filters the timeline', async ({ page }) => {
       // The palette searches with withSharedSpaces=true, so people are surfaced through
       // identity-backed faces rather than legacy owner-only name search.
       const person = await createSearchablePerson(admin.accessToken, 'Alice Scope');
@@ -595,7 +595,7 @@ test.describe('global search palette', () => {
         .getByText(/alice scope/i)
         .first()
         .click();
-      await expect(page).toHaveURL(new RegExp(`/people/${person.id}`));
+      await expect(page).toHaveURL(new RegExp(String.raw`/photos\?people=person%3A${person.id}`));
     });
 
     test('scope / activates album', async ({ page }) => {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -974,6 +974,7 @@
   "cmdk_no_tagged_photos": "No photos tagged yet",
   "cmdk_nothing_to_preview": "Select a result to preview",
   "cmdk_open": "Open",
+  "cmdk_open_person_page": "Open person page",
   "cmdk_people_heading": "People",
   "cmdk_photos_heading": "Photos",
   "cmdk_placeholder": "Search Gallery — try @ for people, # tags, / albums, > pages",

--- a/web/src/lib/components/global-search/__tests__/person-preview.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/person-preview.spec.ts
@@ -1,12 +1,15 @@
 import { searchAssets } from '@immich/sdk';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { goto } from '$app/navigation';
 import PersonPreview from '../previews/person-preview.svelte';
 
 vi.mock('@immich/sdk', async () => {
   const actual = await vi.importActual<typeof import('@immich/sdk')>('@immich/sdk');
   return { ...actual, searchAssets: vi.fn() };
 });
+
+vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
 
 describe('person-preview', () => {
   beforeEach(() => {
@@ -85,5 +88,38 @@ describe('person-preview', () => {
     await fireEvent.error(img!);
     expect(container.querySelector(':scope [data-cmdk-preview-person] > img')).toBeNull();
     expect(container.querySelector(':scope [data-cmdk-preview-person] > div[aria-hidden="true"]')).not.toBeNull();
+  });
+
+  it('offers a button to the person management page', () => {
+    render(PersonPreview, { props: { person: { id: 'p1', name: 'Alice' } as never } });
+
+    // This spec does not init svelte-i18n, so $t() returns the raw key.
+    expect(screen.getByText('cmdk_open_person_page')).toBeInTheDocument();
+  });
+
+  it('navigates to the person page for a personal person', async () => {
+    render(PersonPreview, {
+      props: { person: { id: 'p1', name: 'Alice', primaryProfile: { id: 'p1', type: 'user-person' } } as never },
+    });
+
+    await fireEvent.click(screen.getByText('cmdk_open_person_page'));
+
+    expect(goto).toHaveBeenCalledWith('/people/p1');
+  });
+
+  it('navigates to the profile id for a space person', async () => {
+    render(PersonPreview, {
+      props: {
+        person: {
+          id: 'sp1',
+          name: 'Bob',
+          primaryProfile: { id: 'profile-1', type: 'space-person', spaceId: 'space-1' },
+        } as never,
+      },
+    });
+
+    await fireEvent.click(screen.getByText('cmdk_open_person_page'));
+
+    expect(goto).toHaveBeenCalledWith('/people/profile-1');
   });
 });

--- a/web/src/lib/components/global-search/previews/person-preview.svelte
+++ b/web/src/lib/components/global-search/previews/person-preview.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
+  import { goto } from '$app/navigation';
   import { createUrl, getAssetMediaUrl, getPeopleThumbnailUrl } from '$lib/utils';
+  import { getGlobalPersonHref } from '$lib/utils/global-person-route';
   import { AssetMediaSize, searchAssets, type AssetResponseDto, type PersonResponseDto } from '@immich/sdk';
+  import { Button } from '@immich/ui';
   import { t } from 'svelte-i18n';
 
   interface Props {
@@ -90,4 +93,9 @@
       {/each}
     </div>
   {/if}
+  <div class="flex gap-2">
+    <Button variant="ghost" size="small" onclick={() => goto(getGlobalPersonHref(person))}>
+      {$t('cmdk_open_person_page')}
+    </Button>
+  </div>
 </div>

--- a/web/src/lib/managers/edit/transform-manager.svelte.ts
+++ b/web/src/lib/managers/edit/transform-manager.svelte.ts
@@ -194,7 +194,6 @@ class TransformManager implements EditToolManager {
       passive: true,
     });
 
-    // eslint-disable-next-line unicorn/no-unnecessary-global-this
     addEventListener('mousemove', (e: MouseEvent) => transformManager.handleMouseMove(e), { passive: true });
 
     const transformEdits = edits.filter((e) => e.action === 'rotate' || e.action === 'mirror');
@@ -212,7 +211,6 @@ class TransformManager implements EditToolManager {
   }
 
   onDeactivate() {
-    // eslint-disable-next-line unicorn/no-unnecessary-global-this
     removeEventListener('mousemove', transformManager.handleMouseMove);
 
     this.reset();
@@ -556,7 +554,6 @@ class TransformManager implements EditToolManager {
     }
 
     document.body.style.userSelect = 'none';
-    // eslint-disable-next-line unicorn/no-unnecessary-global-this
     addEventListener('mouseup', () => this.handleMouseUp(), { passive: true });
   }
 
@@ -575,7 +572,6 @@ class TransformManager implements EditToolManager {
   }
 
   handleMouseUp() {
-    // eslint-disable-next-line unicorn/no-unnecessary-global-this
     removeEventListener('mouseup', this.handleMouseUp);
     document.body.style.userSelect = '';
 

--- a/web/src/lib/managers/edit/transform-manager.svelte.ts
+++ b/web/src/lib/managers/edit/transform-manager.svelte.ts
@@ -194,7 +194,7 @@ class TransformManager implements EditToolManager {
       passive: true,
     });
 
-     
+    // eslint-disable-next-line unicorn/no-unnecessary-global-this
     addEventListener('mousemove', (e: MouseEvent) => transformManager.handleMouseMove(e), { passive: true });
 
     const transformEdits = edits.filter((e) => e.action === 'rotate' || e.action === 'mirror');
@@ -212,7 +212,7 @@ class TransformManager implements EditToolManager {
   }
 
   onDeactivate() {
-     
+    // eslint-disable-next-line unicorn/no-unnecessary-global-this
     removeEventListener('mousemove', transformManager.handleMouseMove);
 
     this.reset();
@@ -556,7 +556,7 @@ class TransformManager implements EditToolManager {
     }
 
     document.body.style.userSelect = 'none';
-     
+    // eslint-disable-next-line unicorn/no-unnecessary-global-this
     addEventListener('mouseup', () => this.handleMouseUp(), { passive: true });
   }
 
@@ -575,7 +575,7 @@ class TransformManager implements EditToolManager {
   }
 
   handleMouseUp() {
-     
+    // eslint-disable-next-line unicorn/no-unnecessary-global-this
     removeEventListener('mouseup', this.handleMouseUp);
     document.body.style.userSelect = '';
 

--- a/web/src/lib/managers/edit/transform-manager.svelte.ts
+++ b/web/src/lib/managers/edit/transform-manager.svelte.ts
@@ -194,7 +194,7 @@ class TransformManager implements EditToolManager {
       passive: true,
     });
 
-    // eslint-disable-next-line unicorn/no-unnecessary-global-this
+     
     addEventListener('mousemove', (e: MouseEvent) => transformManager.handleMouseMove(e), { passive: true });
 
     const transformEdits = edits.filter((e) => e.action === 'rotate' || e.action === 'mirror');
@@ -212,7 +212,7 @@ class TransformManager implements EditToolManager {
   }
 
   onDeactivate() {
-    // eslint-disable-next-line unicorn/no-unnecessary-global-this
+     
     removeEventListener('mousemove', transformManager.handleMouseMove);
 
     this.reset();
@@ -556,7 +556,7 @@ class TransformManager implements EditToolManager {
     }
 
     document.body.style.userSelect = 'none';
-    // eslint-disable-next-line unicorn/no-unnecessary-global-this
+     
     addEventListener('mouseup', () => this.handleMouseUp(), { passive: true });
   }
 
@@ -575,7 +575,7 @@ class TransformManager implements EditToolManager {
   }
 
   handleMouseUp() {
-    // eslint-disable-next-line unicorn/no-unnecessary-global-this
+     
     removeEventListener('mouseup', this.handleMouseUp);
     document.body.style.userSelect = '';
 

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -7225,8 +7225,15 @@ describe('palette destination table', () => {
   const lastGoto = () => vi.mocked(goto).mock.calls.at(-1)?.[0] as string | undefined;
 
   // Pinned from /spaces/space-1 so any result kind that silently starts navigating off the
-  // surface the user was reading shows up as a diff here. Album / space / photo / nav are
-  // destinations rather than filters and are expected to leave.
+  // surface the user was reading shows up as a diff here. Album / space / nav / command are
+  // destinations rather than filters and are expected to leave; `photo` is included as a
+  // destination control alongside the three kinds (tag / person / place) whose filter-vs-
+  // destination behaviour Tasks 2-5 actually changed, so this table deliberately covers only
+  // those four kinds. The rest are pinned elsewhere, not duplicated here: album/space via
+  // activateAlbum/activateSpace (same spec file, ~line 2690-2805), nav in
+  // describe('activate navigation') (~line 4373-4423), command handlers in
+  // command-items.spec.ts (~lines 661, 910, 934), and the typed/smart-search commit path at
+  // ~line 1517.
   it.each([
     ['tag', { id: 't1', name: 'beach' }, '/spaces/space-1?tags=t1'],
     [

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -21,7 +21,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 import { goto } from '$app/navigation';
 import { createFilterState, type FilterState } from '$lib/components/filter-panel/filter-panel';
 import * as recentModule from '$lib/stores/cmdk-recent';
-import { addEntry, getEntries, __resetForTests as resetRecentStore } from '$lib/stores/cmdk-recent';
+import { addEntry, getEntries, __resetForTests as resetRecentStore, type RecentEntry } from '$lib/stores/cmdk-recent';
 import { getTypedSearchDisplayText, storeTypedSearchNames } from '$lib/utils/typed-search/typed-search-name-cache';
 import type { TypedSearchResolveContext } from '$lib/utils/typed-search/typed-search-resolver';
 import { installFakeAbortTimeout, restoreAbortTimeout } from './__tests__/fake-abort-timeout';
@@ -7211,5 +7211,65 @@ describe('place activation navigation', () => {
     });
 
     expect(lastGoto()).toBe(PARIS_MAP);
+  });
+});
+
+describe('palette destination table', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    localStorage.clear();
+    resetRecentStore();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1');
+  });
+
+  const lastGoto = () => vi.mocked(goto).mock.calls.at(-1)?.[0] as string | undefined;
+
+  // Pinned from /spaces/space-1 so any result kind that silently starts navigating off the
+  // surface the user was reading shows up as a diff here. Album / space / photo / nav are
+  // destinations rather than filters and are expected to leave.
+  it.each([
+    ['tag', { id: 't1', name: 'beach' }, '/spaces/space-1?tags=t1'],
+    [
+      'person',
+      { id: 'p1', name: 'Alice', primaryProfile: { id: 'p1', type: 'user-person' } },
+      '/photos?people=person%3Ap1',
+    ],
+    ['place', { name: 'Paris', latitude: 48.8566, longitude: 2.3522 }, '/spaces/space-1?city=Paris'],
+    ['photo', { id: 'a1', originalFileName: 'IMG_1.jpg' }, '/photos/a1'],
+  ])('activate(%s) lands on %s', (kind, item, expected) => {
+    const m = new GlobalSearchManager();
+
+    m.activate(kind as 'tag' | 'person' | 'place' | 'photo', item);
+
+    expect(lastGoto()).toBe(expected);
+  });
+
+  it.each([
+    [{ kind: 'tag', id: 'tag:t1', tagId: 't1', label: 'beach', lastUsed: 1 }, '/spaces/space-1?tags=t1'],
+    [{ kind: 'person', id: 'person:p1', personId: 'p1', label: 'Alice', lastUsed: 1 }, '/photos?people=person%3Ap1'],
+    [
+      { kind: 'place', id: 'place:48.8566:2.3522', latitude: 48.8566, longitude: 2.3522, label: 'Paris', lastUsed: 1 },
+      '/spaces/space-1?city=Paris',
+    ],
+    [{ kind: 'photo', id: 'photo:a1', assetId: 'a1', label: 'IMG_1.jpg', lastUsed: 1 }, '/photos/a1'],
+  ])('activateRecent(%o) lands on %s', (entry, expected) => {
+    const m = new GlobalSearchManager();
+
+    m.activateRecent(entry as RecentEntry);
+
+    expect(lastGoto()).toBe(expected);
+  });
+
+  it('never routes a palette result to the deprecated /search page', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('tag', { id: 't1', name: 'beach' });
+    m.activate('person', { id: 'p1', name: 'Alice' });
+    m.activate('place', { name: 'Paris', latitude: 48.8566, longitude: 2.3522 });
+    m.activate('photo', { id: 'a1' });
+
+    const destinations = vi.mocked(goto).mock.calls.map((c) => String(c[0]));
+    expect(destinations).toHaveLength(4);
+    expect(destinations.filter((d) => d.startsWith('/search'))).toEqual([]);
   });
 });

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -1080,16 +1080,17 @@ describe('activate()', () => {
     expect(m.isOpen).toBe(false);
   });
 
-  it('activate("person", item) navigates to /people/:id and records recent entry', () => {
+  it('activate("person", item) filters the timeline and records recent entry', () => {
     const m = new GlobalSearchManager();
     m.open();
     m.activate('person', { id: 'p1', name: 'Alice' });
-    expect(goto).toHaveBeenCalledWith('/people/p1');
+    // No primaryProfile and no filterId, so getPhotosPersonFilterId falls through to the raw id.
+    expect(goto).toHaveBeenCalledWith('/photos?people=p1');
     const entries = getEntries();
     expect(entries[0]).toMatchObject({ kind: 'person', personId: 'p1', label: 'Alice' });
   });
 
-  it('activate("person", item) opens identity-backed space-primary people as identity-wide person detail', () => {
+  it('activate("person", item) filters by the scoped filterId for an identity-backed space person', () => {
     const m = new GlobalSearchManager();
     m.open();
     m.activate('person', {
@@ -1099,11 +1100,12 @@ describe('activate()', () => {
       filterId: 'space-person:space-person-1',
     });
 
-    expect(goto).toHaveBeenCalledWith('/people/space-person-1');
+    // On /photos (not that space's timeline), so the prefixed id is the correct encoding.
+    expect(goto).toHaveBeenCalledWith('/photos?people=space-person%3Aspace-person-1');
     expect(getEntries()).toHaveLength(0);
   });
 
-  it('activate("person", item) navigates legacy space-primary people to identity-wide person detail', () => {
+  it('activate("person", item) reconstructs the prefixed id for a legacy space person', () => {
     const m = new GlobalSearchManager();
     m.open();
     m.activate('person', {
@@ -1111,7 +1113,7 @@ describe('activate()', () => {
       name: 'Alice',
       primaryProfile: { type: 'space-person', id: 'space-person-1', spaceId: 'space-1' },
     });
-    expect(goto).toHaveBeenCalledWith('/people/space-person-1');
+    expect(goto).toHaveBeenCalledWith('/photos?people=space-person%3Aspace-person-1');
     expect(getEntries()).toHaveLength(0);
   });
 
@@ -6798,5 +6800,257 @@ describe('tag activation navigation', () => {
       personNames: new Map(),
       tagNames: new Map([['t1', 'beach']]),
     });
+  });
+});
+
+describe('person activation navigation', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    localStorage.clear();
+    resetRecentStore();
+    mockPage.url = new URL('https://gallery.test/photos');
+  });
+
+  const lastGoto = () => vi.mocked(goto).mock.calls.at(-1)?.[0] as string | undefined;
+
+  const userPerson = (overrides: Partial<PersonResponseDto> = {}) =>
+    ({
+      id: 'p1',
+      name: 'Alice',
+      primaryProfile: { id: 'p1', type: 'user-person' },
+      ...overrides,
+    }) as PersonResponseDto;
+
+  const spacePerson = (spaceId: string, overrides: Partial<PersonResponseDto> = {}) =>
+    ({
+      id: 'sp1',
+      name: 'Bob',
+      primaryProfile: { id: 'profile-1', type: 'space-person', spaceId },
+      ...overrides,
+    }) as PersonResponseDto;
+
+  it('filters the timeline instead of opening the person management page', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/photos?people=person%3Ap1');
+  });
+
+  it('preserves the filters already on the page (AND)', () => {
+    const m = new GlobalSearchManager();
+    m.registerSearchablePageFilters(() => ({ ...createFilterState(), tagIds: ['t1'], rating: 4 }));
+
+    m.activate('person', userPerson());
+
+    const dest = lastGoto();
+    expect(dest).toContain('tags=t1');
+    expect(dest).toContain('rating=4');
+    expect(dest).toContain('people=person%3Ap1');
+  });
+
+  it('drops a stale smart query so the person filter is the only constraint', () => {
+    const m = new GlobalSearchManager();
+    // Matches the existing tag behaviour — buildSearchablePageUrl is called with an empty query,
+    // which deletes both `q` and a non-explicit `sort`.
+    mockPage.url = new URL('https://gallery.test/photos?q=sunset&sort=asc');
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/photos?people=person%3Ap1');
+  });
+
+  it('does not duplicate a person already filtering the page', () => {
+    const m = new GlobalSearchManager();
+    m.registerSearchablePageFilters(() => ({ ...createFilterState(), personIds: ['person:p1'] }));
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/photos?people=person%3Ap1');
+  });
+
+  it('appends to people already filtering the page', () => {
+    const m = new GlobalSearchManager();
+    m.registerSearchablePageFilters(() => ({ ...createFilterState(), personIds: ['person:p0'] }));
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/photos?people=person%3Ap0%2Cperson%3Ap1');
+  });
+
+  it('stays on a space timeline and uses the bare profile id for that space person', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1');
+
+    m.activate('person', spacePerson('space-1'));
+
+    expect(lastGoto()).toBe('/spaces/space-1?people=profile-1');
+  });
+
+  it('stays on the /photos sub-route of a space timeline', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos');
+
+    m.activate('person', spacePerson('space-1'));
+
+    expect(lastGoto()).toBe('/spaces/space-1/photos?people=profile-1');
+  });
+
+  it('leaves the space for /photos when the person belongs to a different space', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1');
+
+    m.activate('person', spacePerson('space-2'));
+
+    expect(lastGoto()).toBe('/photos?people=space-person%3Aprofile-1');
+  });
+
+  it('leaves the space for /photos for a personal person', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1');
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/photos?people=person%3Ap1');
+  });
+
+  it('drops the space surface filters when it leaves the space', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1');
+    // Space-scoped person ids are bare profile ids and mean nothing on /photos, so carrying the
+    // space's filter state across would produce a garbage query.
+    m.registerSearchablePageFilters(() => ({ ...createFilterState(), personIds: ['space-profile-9'] }));
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/photos?people=person%3Ap1');
+  });
+
+  it('uses the prefixed id for a space person while on /photos', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('person', spacePerson('space-2'));
+
+    expect(lastGoto()).toBe('/photos?people=space-person%3Aprofile-1');
+  });
+
+  it('targets /photos from a space page that is not a timeline', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/albums/album-1');
+
+    m.activate('person', spacePerson('space-1'));
+
+    expect(lastGoto()).toBe('/photos?people=space-person%3Aprofile-1');
+  });
+
+  it('targets /photos from a non-searchable page', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/albums/album-1');
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/photos?people=person%3Ap1');
+  });
+
+  it('targets /photos from the map, matching the tag precedent', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/map');
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/photos?people=person%3Ap1');
+  });
+
+  it('stays on /recently-added', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/recently-added');
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/recently-added?people=person%3Ap1');
+  });
+
+  it('prefers the server-supplied filterId', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('person', userPerson({ filterId: 'person:identity-7' }));
+
+    expect(lastGoto()).toBe('/photos?people=person%3Aidentity-7');
+  });
+
+  it('falls back to person:<id> when there is no primaryProfile', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('person', { id: 'p9', name: 'Zoe' } as PersonResponseDto);
+
+    expect(lastGoto()).toBe('/photos?people=p9');
+  });
+
+  it('drops a stale ?at= scroll target from the destination', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/photos?at=asset-1');
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/photos?people=person%3Ap1');
+  });
+
+  it('caches the person name so the filter chip is not a raw id', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('person', userPerson());
+
+    expect(storeTypedSearchNames).toHaveBeenCalledWith('/photos?people=person%3Ap1', {
+      personNames: new Map([['person:p1', 'Alice']]),
+      tagNames: new Map(),
+    });
+  });
+
+  it('caches the bare profile id as the key for an in-space person', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1');
+
+    m.activate('person', spacePerson('space-1'));
+
+    expect(storeTypedSearchNames).toHaveBeenCalledWith('/spaces/space-1?people=profile-1', {
+      personNames: new Map([['profile-1', 'Bob']]),
+      tagNames: new Map(),
+    });
+  });
+
+  it('caches no name for a nameless person so the chip falls back to the id', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('person', userPerson({ name: '' }));
+
+    expect(storeTypedSearchNames).toHaveBeenCalledWith('/photos?people=person%3Ap1', {
+      personNames: new Map(),
+      tagNames: new Map(),
+    });
+  });
+
+  it('closes the palette after navigating', () => {
+    const m = new GlobalSearchManager();
+    m.open();
+
+    m.activate('person', userPerson());
+
+    expect(m.isOpen).toBe(false);
+  });
+
+  it('records a recent entry for a personal person', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('person', userPerson());
+
+    expect(getEntries().some((e) => e.kind === 'person' && e.id === 'person:p1')).toBe(true);
+  });
+
+  it('records no recent entry for a space person', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('person', spacePerson('space-1'));
+
+    expect(getEntries().some((e) => e.kind === 'person')).toBe(false);
   });
 });

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -1117,11 +1117,11 @@ describe('activate()', () => {
     expect(getEntries()).toHaveLength(0);
   });
 
-  it('activate("place", item) navigates to /map with hash and records recent entry', () => {
+  it('activate("place", item) filters the timeline by city and records recent entry', () => {
     const m = new GlobalSearchManager();
     m.open();
     m.activate('place', { name: 'Paris', latitude: 48.8566, longitude: 2.3522 });
-    expect(goto).toHaveBeenCalledWith('/map#12/48.8566/2.3522');
+    expect(goto).toHaveBeenCalledWith('/photos?city=Paris');
     const entries = getEntries();
     expect(entries[0]).toMatchObject({ kind: 'place', id: 'place:48.8566:2.3522', label: 'Paris' });
   });
@@ -2655,7 +2655,7 @@ describe('activateRecent()', () => {
     expect(m.isOpen).toBe(false);
   });
 
-  it('place entry navigates and closes', () => {
+  it('place entry filters the timeline by city and closes', () => {
     const m = new GlobalSearchManager();
     m.open();
     m.activateRecent({
@@ -2666,7 +2666,7 @@ describe('activateRecent()', () => {
       label: 'Paris',
       lastUsed: 1,
     });
-    expect(goto).toHaveBeenCalledWith('/map#12/48.8566/2.3522');
+    expect(goto).toHaveBeenCalledWith('/photos?city=Paris');
     expect(m.isOpen).toBe(false);
   });
 
@@ -7083,5 +7083,133 @@ describe('person activation navigation', () => {
     m.activateRecent({ kind: 'person', id: 'person:broken', label: 'Alice', lastUsed: 1 } as never);
 
     expect(goto).not.toHaveBeenCalled();
+  });
+});
+
+describe('place activation navigation', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    localStorage.clear();
+    resetRecentStore();
+    mockPage.url = new URL('https://gallery.test/photos');
+  });
+
+  const lastGoto = () => vi.mocked(goto).mock.calls.at(-1)?.[0] as string | undefined;
+  const paris = { name: 'Paris', latitude: 48.8566, longitude: 2.3522 };
+  // Route.map builds a Leaflet-style hash, not a query string: `/map#<zoom>/<lat>/<lng>`.
+  const PARIS_MAP = '/map#12/48.8566/2.3522';
+
+  it('filters the timeline by city instead of jumping to the map', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('place', paris);
+
+    expect(lastGoto()).toBe('/photos?city=Paris');
+  });
+
+  it('stays on a space timeline', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1');
+
+    m.activate('place', paris);
+
+    expect(lastGoto()).toBe('/spaces/space-1?city=Paris');
+  });
+
+  it('targets /photos from a non-searchable page', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/albums/album-1');
+
+    m.activate('place', paris);
+
+    expect(lastGoto()).toBe('/photos?city=Paris');
+  });
+
+  it('stays on /recently-added', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/recently-added');
+
+    m.activate('place', paris);
+
+    expect(lastGoto()).toBe('/recently-added?city=Paris');
+  });
+
+  it('recentres the map when the user is already on the map', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/map');
+
+    m.activate('place', paris);
+
+    expect(lastGoto()).toBe(PARIS_MAP);
+  });
+
+  it('replaces a city already filtering the page rather than accumulating', () => {
+    const m = new GlobalSearchManager();
+    m.registerSearchablePageFilters(() => ({ ...createFilterState(), city: 'Berlin' }));
+
+    m.activate('place', paris);
+
+    expect(lastGoto()).toBe('/photos?city=Paris');
+  });
+
+  it('preserves the other filters already on the page and drops a stale smart query', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/photos?q=beach');
+    m.registerSearchablePageFilters(() => ({ ...createFilterState(), personIds: ['person:p1'] }));
+
+    m.activate('place', paris);
+
+    const dest = lastGoto();
+    expect(dest).toContain('people=person%3Ap1');
+    expect(dest).toContain('city=Paris');
+    expect(dest).not.toContain('q=beach');
+  });
+
+  it('recentres the map for a nameless place, which cannot produce a city filter', () => {
+    const m = new GlobalSearchManager();
+
+    m.activate('place', { latitude: 48.8566, longitude: 2.3522 });
+
+    expect(lastGoto()).toBe(PARIS_MAP);
+  });
+
+  it('records a recent entry and closes the palette', () => {
+    const m = new GlobalSearchManager();
+    m.open();
+
+    m.activate('place', paris);
+
+    expect(getEntries().some((e) => e.kind === 'place')).toBe(true);
+    expect(m.isOpen).toBe(false);
+  });
+
+  it('routes a recent place entry to the filtered timeline too', () => {
+    const m = new GlobalSearchManager();
+
+    m.activateRecent({
+      kind: 'place',
+      id: 'place:48.8566:2.3522',
+      latitude: 48.8566,
+      longitude: 2.3522,
+      label: 'Paris',
+      lastUsed: 1,
+    });
+
+    expect(lastGoto()).toBe('/photos?city=Paris');
+  });
+
+  it('falls back to recentring the map for a recent place with no label', () => {
+    const m = new GlobalSearchManager();
+
+    m.activateRecent({
+      kind: 'place',
+      id: 'place:48.8566:2.3522',
+      latitude: 48.8566,
+      longitude: 2.3522,
+      label: '',
+      lastUsed: 1,
+    });
+
+    expect(lastGoto()).toBe(PARIS_MAP);
   });
 });

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -6978,7 +6978,7 @@ describe('person activation navigation', () => {
     expect(lastGoto()).toBe('/photos?people=person%3Aidentity-7');
   });
 
-  it('falls back to person:<id> when there is no primaryProfile', () => {
+  it('falls back to the bare id when there is no primaryProfile', () => {
     const m = new GlobalSearchManager();
 
     m.activate('person', { id: 'p9', name: 'Zoe' } as PersonResponseDto);

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -2647,11 +2647,11 @@ describe('activateRecent()', () => {
     expect(m.isOpen).toBe(false);
   });
 
-  it('person entry navigates and closes', () => {
+  it('person entry filters the timeline and closes', () => {
     const m = new GlobalSearchManager();
     m.open();
     m.activateRecent({ kind: 'person', id: 'person:p1', personId: 'p1', label: 'Alice', lastUsed: 1 });
-    expect(goto).toHaveBeenCalledWith('/people/p1');
+    expect(goto).toHaveBeenCalledWith('/photos?people=person%3Ap1');
     expect(m.isOpen).toBe(false);
   });
 
@@ -7052,5 +7052,36 @@ describe('person activation navigation', () => {
     m.activate('person', spacePerson('space-1'));
 
     expect(getEntries().some((e) => e.kind === 'person')).toBe(false);
+  });
+
+  it('routes a recent person entry to the filtered timeline too', () => {
+    const m = new GlobalSearchManager();
+
+    m.activateRecent({ kind: 'person', id: 'person:p1', personId: 'p1', label: 'Alice', lastUsed: 1 });
+
+    expect(lastGoto()).toBe('/photos?people=person%3Ap1');
+    expect(storeTypedSearchNames).toHaveBeenCalledWith('/photos?people=person%3Ap1', {
+      personNames: new Map([['person:p1', 'Alice']]),
+      tagNames: new Map(),
+    });
+  });
+
+  it('routes a recent person entry onto the space timeline it is replayed from', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1');
+
+    // Recents only ever hold personal people, so replaying one inside a space leaves the space.
+    m.activateRecent({ kind: 'person', id: 'person:p1', personId: 'p1', label: 'Alice', lastUsed: 1 });
+
+    expect(lastGoto()).toBe('/photos?people=person%3Ap1');
+  });
+
+  it('ignores a corrupt person recent without navigating', () => {
+    const m = new GlobalSearchManager();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    m.activateRecent({ kind: 'person', id: 'person:broken', label: 'Alice', lastUsed: 1 } as never);
+
+    expect(goto).not.toHaveBeenCalled();
   });
 });

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -1740,8 +1740,9 @@ export class GlobalSearchManager {
    * ids scoped to that space (space-filter-options.ts) — while /photos and /recently-added forward
    * them prefixed, `person:` / `space-person:` (photos-filter-options.ts). So a space person can
    * only filter in place on its OWN space; every other combination targets /photos with the
-   * prefixed id. This mirrors `getPersonFilterId(person, scope)` in the typed-search resolver,
-   * which already splits on exactly this distinction.
+   * prefixed id. This mirrors the scope split that `getPersonFilterId(person, scope)` in the
+   * typed-search resolver already makes — but not its unprefixed-id fallback: that resolver
+   * prefixes a bare id with `person:`, while `getPhotosPersonFilterId` here returns it bare.
    */
   private navigateToPersonResults(person: PhotosPersonFilterReference & { name?: string }): void {
     const spaceId = getCurrentSpaceTimelineId(page.url.pathname);
@@ -1769,8 +1770,9 @@ export class GlobalSearchManager {
    * Navigate to the current surface filtered by `place`.
    *
    * PlacesResponseDto carries name / lat / lng / admin1name / admin2name. Of those only `name`
-   * maps onto a searchable-page param (`city`) — there is no `state` filter — and it is already
-   * what place-preview searches by, so the preview and the destination agree.
+   * maps onto a searchable-page param (`city`) — there is no `state` filter. place-preview.svelte
+   * searches by both `city: place.name` and `state: place.admin1name`, so for two same-named
+   * cities in different states the destination is a deliberate superset of what the preview showed.
    *
    * /map is the exception: it is a place's own contextual surface, and it is not a searchable
    * page, so the filter path would bounce the user off the map they were reading. A nameless

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -1765,6 +1765,29 @@ export class GlobalSearchManager {
     });
   }
 
+  /**
+   * Navigate to the current surface filtered by `place`.
+   *
+   * PlacesResponseDto carries name / lat / lng / admin1name / admin2name. Of those only `name`
+   * maps onto a searchable-page param (`city`) — there is no `state` filter — and it is already
+   * what place-preview searches by, so the preview and the destination agree.
+   *
+   * /map is the exception: it is a place's own contextual surface, and it is not a searchable
+   * page, so the filter path would bounce the user off the map they were reading. A nameless
+   * place cannot produce a city filter at all, so it recentres too.
+   */
+  private navigateToPlaceResults(place: { name?: string; latitude: number; longitude: number }): void {
+    const city = place.name?.trim();
+    if (!city || page.url.pathname.startsWith('/map')) {
+      void goto(Route.map({ zoom: 12, lat: place.latitude, lng: place.longitude }));
+      return;
+    }
+    this.navigateToFilteredResults({
+      // `city` is single-valued, so a new place replaces whatever city was filtering the page.
+      applyFilter: (filters) => ({ ...filters, city }),
+    });
+  }
+
   async applySearchSort(sortOrder: SearchablePageSortOrder, text = this.query) {
     this.searchSortOrder = sortOrder;
 
@@ -1904,7 +1927,7 @@ export class GlobalSearchManager {
           label: p.name ?? '',
           lastUsed: now,
         });
-        void goto(Route.map({ zoom: 12, lat: p.latitude, lng: p.longitude }));
+        this.navigateToPlaceResults(p);
         break;
       }
       case 'tag': {
@@ -2059,7 +2082,7 @@ export class GlobalSearchManager {
         break;
       }
       case 'place': {
-        void goto(Route.map({ zoom: 12, lat: entry.latitude, lng: entry.longitude }));
+        this.navigateToPlaceResults({ name: entry.label, latitude: entry.latitude, longitude: entry.longitude });
         break;
       }
       case 'tag': {

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -32,7 +32,7 @@ import { authManager } from '$lib/managers/auth-manager.svelte';
 import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
 import { Route } from '$lib/route';
 import { addEntry, getEntries, makePlaceId, removeEntry, type RecentEntry } from '$lib/stores/cmdk-recent';
-import { getGlobalPersonHref } from '$lib/utils/global-person-route';
+import { getPhotosPersonFilterId, type PhotosPersonFilterReference } from '$lib/utils/photos-filter-options';
 import {
   buildSearchablePageUrl,
   getSearchablePageBasePath,
@@ -165,8 +165,18 @@ function withoutEmptyLabels(names?: Map<string, string>): Map<string, string> {
   return new Map([...(names ?? [])].filter(([, label]) => label.trim() !== ''));
 }
 
-function getPersonRoute(person: Pick<PersonResponseDto, 'id' | 'primaryProfile'>): string {
-  return getGlobalPersonHref(person);
+/**
+ * The space id of the current page when that page is a space *timeline* (`/spaces/<id>` or
+ * `/spaces/<id>/photos`). Deliberately not a `pathname.startsWith('/spaces/')` test:
+ * `/spaces/<id>/albums/<albumId>` is a space page but not a searchable one, so no filter can be
+ * applied in place there.
+ */
+function getCurrentSpaceTimelineId(pathname: string): string | undefined {
+  const base = getSearchablePageBasePath(pathname);
+  if (!base?.startsWith('/spaces/')) {
+    return undefined;
+  }
+  return base.split('/').filter(Boolean)[1];
 }
 
 // Entity-section keys dispatched by runBatch per scope. Navigation is intentionally
@@ -1722,6 +1732,39 @@ export class GlobalSearchManager {
     });
   }
 
+  /**
+   * Navigate to the current surface filtered by `person`.
+   *
+   * The filter-id encoding is scope-dependent, and getting it wrong yields a silently empty
+   * timeline: a space timeline forwards `personIds` to the API as `spacePersonIds` — bare profile
+   * ids scoped to that space (space-filter-options.ts) — while /photos and /recently-added forward
+   * them prefixed, `person:` / `space-person:` (photos-filter-options.ts). So a space person can
+   * only filter in place on its OWN space; every other combination targets /photos with the
+   * prefixed id. This mirrors `getPersonFilterId(person, scope)` in the typed-search resolver,
+   * which already splits on exactly this distinction.
+   */
+  private navigateToPersonResults(person: PhotosPersonFilterReference & { name?: string }): void {
+    const spaceId = getCurrentSpaceTimelineId(page.url.pathname);
+    const profile = person.primaryProfile;
+    const spaceProfileId =
+      spaceId !== undefined && profile?.type === 'space-person' && profile.spaceId === spaceId ? profile.id : undefined;
+    const filterId = spaceProfileId ?? getPhotosPersonFilterId(person);
+    // Ephemeral URL object for destination construction only; no reactive state is retained.
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity
+    const target = spaceId !== undefined && spaceProfileId === undefined ? new URL('/photos', page.url) : undefined;
+    this.navigateToFilteredResults({
+      target,
+      applyFilter: (filters) => ({
+        ...filters,
+        personIds: filters.personIds.includes(filterId) ? filters.personIds : [...filters.personIds, filterId],
+      }),
+      // Ephemeral map, serialized into sessionStorage by storeTypedSearchNames; an empty name is
+      // stripped by withoutEmptyLabels so the chip falls back to the id, not a blank label.
+      // eslint-disable-next-line svelte/prefer-svelte-reactivity
+      names: { personNames: new Map([[filterId, person.name ?? '']]) },
+    });
+  }
+
   async applySearchSort(sortOrder: SearchablePageSortOrder, text = this.query) {
     this.searchSortOrder = sortOrder;
 
@@ -1848,7 +1891,7 @@ export class GlobalSearchManager {
             lastUsed: now,
           });
         }
-        void goto(getPersonRoute(p));
+        this.navigateToPersonResults(p);
         break;
       }
       case 'place': {

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -2047,7 +2047,15 @@ export class GlobalSearchManager {
         break;
       }
       case 'person': {
-        void goto(Route.viewPerson({ id: entry.personId }));
+        // Recents only ever hold non-space people — activate('person') skips the addEntry for a
+        // space person — and the server builds filterId as `person:<profileId>`
+        // (face-identity.repository.ts), so this reconstruction is exact and a replayed recent
+        // lands exactly where a fresh pick lands.
+        this.navigateToPersonResults({
+          id: entry.personId,
+          filterId: `person:${entry.personId}`,
+          name: entry.label,
+        });
         break;
       }
       case 'place': {

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -154,6 +154,17 @@ const PROVIDER_TIMEOUT_MS = 15_000;
 const idle = Object.freeze({ status: 'idle' as const });
 const tagCacheTooLarge = Object.freeze({ status: 'error' as const, message: 'tag_cache_too_large' });
 
+/**
+ * Drop `id -> ''` pairs before they reach the typed-search name cache. `active-filters-bar` falls
+ * back to rendering the raw id only for a *missing* entry, so caching an empty string renders a
+ * blank chip instead.
+ */
+function withoutEmptyLabels(names?: Map<string, string>): Map<string, string> {
+  // Ephemeral map, serialized into sessionStorage by storeTypedSearchNames; nothing reads it
+  // reactively, so a plain Map is correct here.
+  return new Map([...(names ?? [])].filter(([, label]) => label.trim() !== ''));
+}
+
 function getPersonRoute(person: Pick<PersonResponseDto, 'id' | 'primaryProfile'>): string {
   return getGlobalPersonHref(person);
 }
@@ -1616,6 +1627,49 @@ export class GlobalSearchManager {
   }
 
   /**
+   * Single funnel for "palette result -> filter the surface you're on".
+   *
+   * Every row that maps onto a filter-panel filter (tag, person, place) and every field-search
+   * mode routes through here so they cannot drift apart. The rule: AND the new filter into
+   * whatever the current searchable page is already filtered by and stay put; if the current page
+   * is not searchable, fall back to /photos.
+   *
+   * `target` overrides the base page for the case where the current surface *cannot express* the
+   * filter (a space-scoped person id means nothing on /photos and vice versa). Passing it also
+   * drops the current surface's filters: leaving the surface leaves its filter state behind,
+   * because those ids are scoped to the surface we are leaving.
+   *
+   * `buildSearchDestination` deliberately does NOT use this — it owns the smart-search `/map?q=`
+   * special case, which would silently drop a filter if inherited here.
+   *
+   * `names` seeds the typed-search name cache so a freshly added chip reads "Alice" rather than a
+   * raw uuid. Passing it at all — even with empty maps — writes an entry; omitting it writes
+   * nothing, which is what the field modes want, as their chips carry their own text.
+   */
+  private navigateToFilteredResults(options: {
+    applyFilter: (filters: FilterState) => FilterState;
+    target?: URL;
+    names?: { personNames?: Map<string, string>; tagNames?: Map<string, string> };
+  }): void {
+    const current = options.target
+      ? createFilterState()
+      : (this.searchablePageFiltersProvider?.() ?? createFilterState());
+    const filters = options.applyFilter({ ...current });
+    // Ephemeral URL object for destination construction only; no reactive state is retained.
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity
+    const fallback = new URL('/photos', page.url);
+    const base = options.target ?? (getSearchablePageBasePath(page.url.pathname) ? page.url : fallback);
+    const destination = buildSearchablePageUrl(base, '', this.searchSortOrder, filters) ?? '/photos';
+    if (options.names) {
+      storeTypedSearchNames(destination, {
+        personNames: withoutEmptyLabels(options.names.personNames),
+        tagNames: withoutEmptyLabels(options.names.tagNames),
+      });
+    }
+    void goto(destination);
+  }
+
+  /**
    * Navigate the current searchable page (or `/photos`) to a full result set filtered by the
    * active field-search mode. The current filters are preserved and the one text field is
    * AND-ed in, so "See all" / Enter from a field mode lands on the filterable timeline rather
@@ -1626,32 +1680,25 @@ export class GlobalSearchManager {
     if (!trimmed) {
       return;
     }
-    const filters: FilterState = { ...(this.searchablePageFiltersProvider?.() ?? createFilterState()) };
-    switch (mode) {
-      case 'metadata': {
-        filters.originalFileName = trimmed;
-        break;
-      }
-      case 'description': {
-        filters.description = trimmed;
-        break;
-      }
-      case 'ocr': {
-        filters.ocr = trimmed;
-        break;
-      }
-      case 'smart': {
-        // Unreachable: navigateToFieldResults is only called for field modes.
-        return;
-      }
+    if (mode === 'smart') {
+      // Unreachable: navigateToFieldResults is only called for field modes.
+      return;
     }
-    // Field results are always a filtered timeline, never a /map view. Target the current
-    // searchable page if there is one, else /photos — going through buildSearchDestination
-    // would route /map through its `q=` special-case and drop the text filter entirely.
-    // Ephemeral URL object for destination construction only; no reactive state is retained.
-    // eslint-disable-next-line svelte/prefer-svelte-reactivity
-    const base = getSearchablePageBasePath(page.url.pathname) ? page.url : new URL('/photos', page.url);
-    void goto(buildSearchablePageUrl(base, '', this.searchSortOrder, filters) ?? '/photos');
+    this.navigateToFilteredResults({
+      applyFilter: (filters: FilterState): FilterState => {
+        switch (mode) {
+          case 'metadata': {
+            return { ...filters, originalFileName: trimmed };
+          }
+          case 'description': {
+            return { ...filters, description: trimmed };
+          }
+          case 'ocr': {
+            return { ...filters, ocr: trimmed };
+          }
+        }
+      },
+    });
   }
 
   /**
@@ -1663,26 +1710,16 @@ export class GlobalSearchManager {
    * typed-search name cache so that chip reads "beach" instead of a raw uuid.
    */
   private navigateToTagResults(tagId: string, tagName: string): void {
-    const current = this.searchablePageFiltersProvider?.() ?? createFilterState();
-    const filters: FilterState = {
-      ...current,
-      tagIds: current.tagIds.includes(tagId) ? current.tagIds : [...current.tagIds, tagId],
-    };
-    // Same targeting rule as navigateToFieldResults: a tag is always a filtered timeline, so
-    // skip buildSearchDestination and its /map `q=` special-case, which would drop the filter.
-    // Ephemeral URL object for destination construction only; no reactive state is retained.
-    // eslint-disable-next-line svelte/prefer-svelte-reactivity
-    const base = getSearchablePageBasePath(page.url.pathname) ? page.url : new URL('/photos', page.url);
-    const destination = buildSearchablePageUrl(base, '', this.searchSortOrder, filters) ?? '/photos';
-    // An empty name must stay OUT of the map: active-filters-bar falls back to the raw id only
-    // for a missing entry, so caching '' would render a blank chip.
-    // Ephemeral maps, serialized into sessionStorage by storeTypedSearchNames on the next line;
-    // nothing reads them reactively, so plain Maps are correct here.
-    /* eslint-disable svelte/prefer-svelte-reactivity */
-    const tagNames = tagName ? new Map([[tagId, tagName]]) : new Map<string, string>();
-    storeTypedSearchNames(destination, { personNames: new Map(), tagNames });
-    /* eslint-enable svelte/prefer-svelte-reactivity */
-    void goto(destination);
+    this.navigateToFilteredResults({
+      applyFilter: (filters) => ({
+        ...filters,
+        tagIds: filters.tagIds.includes(tagId) ? filters.tagIds : [...filters.tagIds, tagId],
+      }),
+      // Ephemeral map, serialized into sessionStorage by storeTypedSearchNames; an empty tag name
+      // is stripped by withoutEmptyLabels so the chip falls back to the id, not a blank label.
+      // eslint-disable-next-line svelte/prefer-svelte-reactivity
+      names: { tagNames: new Map([[tagId, tagName]]) },
+    });
   }
 
   async applySearchSort(sortOrder: SearchablePageSortOrder, text = this.query) {

--- a/web/src/lib/route.spec.ts
+++ b/web/src/lib/route.spec.ts
@@ -1,3 +1,6 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { OpenQueryParam } from '$lib/constants';
 import { Route } from '$lib/route';
 
@@ -126,5 +129,45 @@ describe('Route', () => {
     it('links to a space albums tab', () => {
       expect(Route.viewSpaceAlbums({ id: 'space-1' })).toBe('/spaces/space-1/albums');
     });
+  });
+});
+
+describe('Route.search call sites', () => {
+  // web/src/lib/ -> up 1 -> web/src
+  const SRC_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+  // Every in-app link to the deprecated /search page. The page itself is kept as a landing page
+  // for old bookmarks, but nothing new may point at it: a palette/search-bar result belongs on
+  // the surface it has context of (#922). This is a SUBSET assertion, so PRs that remove a call
+  // site (#778 for the info panel, #884 for the Explore/Places tiles) do not have to edit it.
+  const ALLOWED = new Set([
+    'lib/components/asset-viewer/DetailPanel.svelte',
+    'lib/services/asset.service.ts',
+    'routes/(user)/explore/+page.svelte',
+    'routes/(user)/places/PlacesCardGroup.svelte',
+    'routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte',
+  ]);
+
+  function walk(dir: string, found: string[] = []): string[] {
+    for (const name of readdirSync(dir)) {
+      const full = join(dir, name);
+      if (statSync(full).isDirectory()) {
+        walk(full, found);
+        continue;
+      }
+      if (!/\.(ts|svelte)$/.test(name) || /\.spec\.ts$/.test(name)) {
+        continue;
+      }
+      if (readFileSync(full, 'utf8').includes('Route.search')) {
+        found.push(relative(SRC_ROOT, full));
+      }
+    }
+    return found;
+  }
+
+  it('are a subset of the allowlist', () => {
+    const unexpected = walk(SRC_ROOT).filter((file) => !ALLOWED.has(file));
+
+    expect(unexpected).toEqual([]);
   });
 });

--- a/web/src/lib/route.spec.ts
+++ b/web/src/lib/route.spec.ts
@@ -140,6 +140,13 @@ describe('Route.search call sites', () => {
   // for old bookmarks, but nothing new may point at it: a palette/search-bar result belongs on
   // the surface it has context of (#922). This is a SUBSET assertion, so PRs that remove a call
   // site (#778 for the info panel, #884 for the Explore/Places tiles) do not have to edit it.
+  // If this fails, the fix is almost never to add the new file here — it's to route the result
+  // contextually (filter the surface the user is already on), the way Tasks 2-5 did for the
+  // palette. Only extend the allowlist for a genuinely new, deliberate landing-page-style link.
+  // The check is a literal substring match on `Route.search`, not an AST or type-aware scan: it
+  // does not catch computed access (`Route['search'](...)`) or an aliased import
+  // (`import { Route as R } from '$lib/route'; R.search(...)`). Neither shape exists in web/src
+  // today; if one appears, this guard will not see it.
   const ALLOWED = new Set([
     'lib/components/asset-viewer/DetailPanel.svelte',
     'lib/services/asset.service.ts',

--- a/web/src/lib/stores/keyboard-manager.svelte.ts
+++ b/web/src/lib/stores/keyboard-manager.svelte.ts
@@ -8,11 +8,11 @@ class KeyboardManager {
     if (globalThis.window === undefined) {
       return;
     }
-    // eslint-disable-next-line unicorn/no-unnecessary-global-this
+     
     addEventListener('keydown', this.#update);
-    // eslint-disable-next-line unicorn/no-unnecessary-global-this
+     
     addEventListener('keyup', this.#update);
-    // eslint-disable-next-line unicorn/no-unnecessary-global-this
+     
     addEventListener('blur', this.#clear);
   }
 

--- a/web/src/lib/stores/keyboard-manager.svelte.ts
+++ b/web/src/lib/stores/keyboard-manager.svelte.ts
@@ -8,11 +8,8 @@ class KeyboardManager {
     if (globalThis.window === undefined) {
       return;
     }
-    // eslint-disable-next-line unicorn/no-unnecessary-global-this
     addEventListener('keydown', this.#update);
-    // eslint-disable-next-line unicorn/no-unnecessary-global-this
     addEventListener('keyup', this.#update);
-    // eslint-disable-next-line unicorn/no-unnecessary-global-this
     addEventListener('blur', this.#clear);
   }
 

--- a/web/src/lib/stores/keyboard-manager.svelte.ts
+++ b/web/src/lib/stores/keyboard-manager.svelte.ts
@@ -8,11 +8,11 @@ class KeyboardManager {
     if (globalThis.window === undefined) {
       return;
     }
-     
+    // eslint-disable-next-line unicorn/no-unnecessary-global-this
     addEventListener('keydown', this.#update);
-     
+    // eslint-disable-next-line unicorn/no-unnecessary-global-this
     addEventListener('keyup', this.#update);
-     
+    // eslint-disable-next-line unicorn/no-unnecessary-global-this
     addEventListener('blur', this.#clear);
   }
 

--- a/web/src/lib/utils/photos-filter-options.ts
+++ b/web/src/lib/utils/photos-filter-options.ts
@@ -4,7 +4,7 @@ import { applyTextFilters, buildFilterContext } from '$lib/components/filter-pan
 import { createUrl } from '$lib/utils';
 import { clearTimelineTemporalFilter } from '$lib/utils/timeline-temporal-filters';
 
-type PhotosPersonFilterReference = {
+export type PhotosPersonFilterReference = {
   id: string;
   filterId?: string | null;
   primaryProfile?: {

--- a/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -62,7 +62,6 @@
   let nextPage = $state(1);
   let searchResultAlbums: AlbumResponseDto[] = $state([]);
   let searchResultAssets: AssetResponseDto[] = $state([]);
-  let searchResultTotal = $state(0);
   let isLoading = $state(true);
   let scrollY = $state(0);
   let scrollYHistory = 0;
@@ -165,7 +164,6 @@
     nextPage = 1;
     searchResultAssets = [];
     searchResultAlbums = [];
-    searchResultTotal = 0;
     await loadNextPage(true);
   }
 
@@ -192,7 +190,6 @@
 
       searchResultAlbums.push(...albums.items);
       searchResultAssets.push(...assets.items);
-      searchResultTotal = assets.total;
 
       nextPage = Number(assets.nextPage) || 0;
     } catch (error) {

--- a/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -62,6 +62,7 @@
   let nextPage = $state(1);
   let searchResultAlbums: AlbumResponseDto[] = $state([]);
   let searchResultAssets: AssetResponseDto[] = $state([]);
+  let searchResultTotal = $state(0);
   let isLoading = $state(true);
   let scrollY = $state(0);
   let scrollYHistory = 0;
@@ -164,6 +165,7 @@
     nextPage = 1;
     searchResultAssets = [];
     searchResultAlbums = [];
+    searchResultTotal = 0;
     await loadNextPage(true);
   }
 
@@ -190,6 +192,7 @@
 
       searchResultAlbums.push(...albums.items);
       searchResultAssets.push(...assets.items);
+      searchResultTotal = assets.total;
 
       nextPage = Number(assets.nextPage) || 0;
     } catch (error) {


### PR DESCRIPTION
Fixes #922.

## Problem

In the ⌘K search palette, picking a **Person** navigated to `/people/<id>` — the person management page — instead of filtering the timeline you were looking at. Picking a **Place** recentred `/map`. Every other palette result either filters the current surface (tags, typed search, field search) or opens a genuine destination (album, space, asset, nav route), so those two were the outliers, and they are the ones you reach for while browsing a timeline.

One correction to the issue as filed: the palette does **not** route to the deprecated `/search` page. Tags were moved off it for #894, and `buildSearchDestination` has always targeted the searchable page. The remaining in-app links to `/search` all live outside the palette (info panel — #778; Explore/Places tiles — #884; "View similar photos", not covered by either).

## Change

**Person → `?people=…` on the surface you're on.** The filter-id encoding is scope-dependent, and getting it wrong yields a silently *empty* timeline rather than an error: a space timeline forwards `personIds` to the API as `spacePersonIds` (bare profile ids scoped to that space), while `/photos` and `/recently-added` forward them prefixed (`person:` / `space-person:`). So a space person filters in place only on its **own** space; every other combination targets `/photos` with the prefixed id, and leaves the space's filters behind — a space-scoped id means nothing globally. This mirrors the split the typed-search resolver already makes.

| You're on | Person is | Destination |
| --- | --- | --- |
| `/spaces/<sid>` | a space-person **of `<sid>`** | `/spaces/<sid>?people=<bare profileId>` |
| `/spaces/<sid>` | anything else | `/photos?people=person:…` |
| `/photos`, `/recently-added` | any | stay put, `?people=<prefixed filterId>` |
| anywhere else | any | `/photos?people=<prefixed filterId>` |

**Place → `?city=…`, except on `/map`,** where recentring *is* the contextual behaviour. A nameless place recentres too, since it cannot produce a city filter.

**Recents replay identically** to a fresh pick, for both kinds.

**Groundwork:** `navigateToTagResults` and `navigateToFieldResults` were two near-identical private methods; adding person and place would have made four copies. They now share one `navigateToFilteredResults` funnel.

**"Open person page"** button in the palette's person preview pane keeps rename / merge / hide / birthday one click away, in the same slot the photo, album and space previews already use.

**Two regression guards:** a destination table over every palette result kind, and a subset allowlist so a new `Route.search` call site fails the build (subset, not equality, so #778/#884 removing theirs doesn't break it).

## Scope note

The last commit clears 8 pre-existing lint warnings in three files this branch doesn't otherwise touch (`transform-manager`, `keyboard-manager`, the legacy `/search` page). They are present on `main` and were failing `pnpm lint` there; folded in here so this PR's lint gate can go green.

## Tests

Written first, confirmed red, then green — the red runs hit exactly the predicted failure counts (24 / 3 / 9).

- **web unit** — 37 new cases: all four person scope combinations, the unrecognised-surface fallbacks (`/albums/x`, `/map`, `/spaces/<sid>/albums/<aid>`), filter preservation and stale-`q` dropping, de-duplication, `filterId` vs reconstructed id, empty-name cache guard, recents replay parity, corrupt recents; place across three surfaces plus the `/map` exemption, city replacement, nameless fallback; the preview button for personal and space people.
- **e2e** — updated the people-scope Playwright test, which still asserted the old `/people/:id` destination.

Full suites green locally: web 4143 passed / 300 files, plus `tsc --noEmit`, `svelte-check` (575 files, 0 warnings), `eslint --max-warnings 0` across all of `web/`, and `prettier --check`. No server change, so no OpenAPI or SQL regeneration.

## Known limitation

Below 1024px the palette's preview pane doesn't render, so the "Open person page" button isn't available there. Accepted deliberately: below that width the palette is a quick-jump-to-filtered-timeline tool, and the person page stays reachable via `/people`. Recorded in the design doc's Out-of-scope section.

Separately, the place preview searches by city *and* state while the destination can only set `city` (there is no `state` filter param), so for two same-named cities in different states the filtered result is a deliberate superset of what the preview showed.

## Verifying by hand

1. On `/photos` with a tag filter applied: ⌘K → type a person's name → Enter. Stays on `/photos`, gains a named person chip beside the tag chip, justified selectable grid.
2. ⌘K → arrow to that person → **Open person page** → `/people/<id>`.
3. On a shared space timeline, pick a member of that space: filters in place. Pick a *personal* person: lands on `/photos`, space filters not carried over.
4. On `/photos`, pick a Place → `?city=…`. From `/map`, pick a Place → the map recentres.
