### PR TITLE
fix(web): include shared spaces in search-page results (#830)

### DIFF
--- a/server/src/services/search.service.spec.ts
+++ b/server/src/services/search.service.spec.ts
@@ -1017,6 +1017,28 @@ describe(SearchService.name, () => {
         );
       });
 
+      // #830: the reference asset for "Show similar photos" is often one the caller reaches only
+      // through a Space, so the access check has to clear on space membership rather than
+      // ownership, and the space scope has to survive onto the queryAssetId path.
+      it('should scope a queryAssetId search to shared spaces for a member who does not own the reference asset', async () => {
+        const assetId = newUuid();
+        const spaceId = newUuid();
+        mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set());
+        mocks.access.asset.checkAlbumAccess.mockResolvedValue(new Set());
+        mocks.access.asset.checkPartnerAccess.mockResolvedValue(new Set());
+        mocks.access.asset.checkSpaceAccess.mockResolvedValue(new Set([assetId]));
+        mocks.search.getEmbedding.mockResolvedValue('[4, 5, 6]');
+        mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([{ spaceId }]);
+
+        await sut.searchSmart(authStub.user1, { queryAssetId: assetId, withSharedSpaces: true });
+
+        expect(mocks.search.getEmbedding).toHaveBeenCalledWith(assetId);
+        expect(mocks.search.searchSmart).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({ embedding: '[4, 5, 6]', timelineSpaceIds: [spaceId] }),
+        );
+      });
+
       it('should fall back to owner-only when withSharedSpaces is true but user has no spaces', async () => {
         mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([]);
 

--- a/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -177,6 +177,14 @@
     const searchDto: SearchTerms = {
       page: nextPage,
       withExif: true,
+      // #830: this page is Gallery's global search surface, but a URL-driven search only ever
+      // covered the caller's own (and partner) assets. A Space member who opened "Show similar
+      // photos" on a photo shared with them — or pasted the same `queryAssetId` URL — got zero
+      // results while the space owner got a long list. Opt into shared spaces the way the command
+      // palette already does (#894); the server scopes them to spaces the member has kept in their
+      // timeline. Spread before `terms` so an explicit value in the URL still wins, and skip it
+      // entirely for a space-scoped URL — the server rejects `spaceId` + `withSharedSpaces`.
+      ...(!terms.spaceId && { withSharedSpaces: true }),
       ...terms,
     };
 

--- a/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/search-page.spec.ts
+++ b/web/src/routes/(user)/search/[[photos=photos]]/[[assetId=id]]/search-page.spec.ts
@@ -266,6 +266,63 @@ describe('Search page cmdk selection context', () => {
     await waitFor(() => expect(screen.getByTestId('gallery-viewer')).toHaveAttribute('data-enable-grouping', 'true'));
   });
 
+  // #830: "Show similar photos" on a photo shared through a Space returned nothing for a member
+  // who does not own it — the page searched only the caller's own (and partner) assets, so the
+  // space owner got a long list and every other member got zero. Global search on this page has to
+  // cover shared-space content the way the command palette already does (#894).
+  it('includes shared spaces when searching by a reference asset', async () => {
+    mockFeatureFlagsManager.value.smartSearch = true;
+    const query = encodeURIComponent(JSON.stringify({ queryAssetId: 'asset-1' }));
+    mockPage.url = new URL(`https://gallery.test/search?${QueryParameter.QUERY}=${query}`);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(mockSearchSmart).toHaveBeenCalledWith({
+        smartSearchDto: expect.objectContaining({ queryAssetId: 'asset-1', withSharedSpaces: true }),
+      });
+    });
+  });
+
+  it('includes shared spaces for metadata searches', async () => {
+    const query = encodeURIComponent(JSON.stringify({ city: 'Berlin' }));
+    mockPage.url = new URL(`https://gallery.test/search?${QueryParameter.QUERY}=${query}`);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(mockSearchAssets).toHaveBeenCalledWith({
+        metadataSearchDto: expect.objectContaining({ city: 'Berlin', withSharedSpaces: true }),
+      });
+    });
+  });
+
+  // The server rejects `spaceId` + `withSharedSpaces` together with a 400, so a space-scoped URL
+  // must not pick up the global default.
+  it('omits shared spaces when the search is already scoped to one space', async () => {
+    mockFeatureFlagsManager.value.smartSearch = true;
+    const query = encodeURIComponent(JSON.stringify({ query: 'beach', spaceId: 'space-1' }));
+    mockPage.url = new URL(`https://gallery.test/search?${QueryParameter.QUERY}=${query}`);
+
+    renderPage();
+
+    await waitFor(() => expect(mockSearchSmart).toHaveBeenCalled());
+    expect(mockSearchSmart.mock.calls[0][0].smartSearchDto).not.toHaveProperty('withSharedSpaces');
+  });
+
+  it('lets an explicit withSharedSpaces:false in the URL win over the default', async () => {
+    const query = encodeURIComponent(JSON.stringify({ city: 'Berlin', withSharedSpaces: false }));
+    mockPage.url = new URL(`https://gallery.test/search?${QueryParameter.QUERY}=${query}`);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(mockSearchAssets).toHaveBeenCalledWith({
+        metadataSearchDto: expect.objectContaining({ withSharedSpaces: false }),
+      });
+    });
+  });
+
   it('resolves scoped person filter chips from shared people search', async () => {
     const query = encodeURIComponent(
       JSON.stringify({ personIds: ['space-person:space-person-1'], withSharedSpaces: true }),


### PR DESCRIPTION
Fixes #830.

## Problem

"Show similar photos" returned nothing for a Space member who does not own the photo, while the space owner got a long list of matches for the exact same `queryAssetId`.

The action navigates to `/search?query={"queryAssetId":"…"}`, and that page builds its request from the URL terms alone. Nothing on the path ever set `withSharedSpaces`, so the server scoped the search to the caller's own (and partner) assets — a member searching from a photo that lives in someone else's library matched nothing. Pasting the URL by hand, as the reporter did to isolate it, hit the same wall.

This is the same defect class as #894 (the palette's field modes omitted the flag) and it made every entry point into `/search` owner-only: "Show similar photos", the Places/Explore city tiles, and the detail-panel camera/lens links.

## Fix

`web/src/routes/(user)/search/…/+page.svelte` now sends `withSharedSpaces: true`, matching what the command palette already does for global search and what mobile already sends on its smart-search path (`search_api.repository.dart`). The server scopes that to spaces the member has kept in their timeline, so nothing new becomes visible — the search just stops ignoring content the member can already see.

Two details in the spread order:

- it goes **before** `...terms`, so an explicit `withSharedSpaces` in the URL still wins;
- it is skipped when the terms carry a `spaceId` — the server rejects `spaceId` + `withSharedSpaces` with a 400.

The server side already worked: `Permission.AssetRead` clears the reference asset through `checkSpaceAccess`, and `resolveSmartSearch` carries `timelineSpaceIds` onto the `queryAssetId` path. No server change — just a unit test pinning that combination, since the fix depends on it.

## Tests

Four new web tests on the search page (reference-asset search, metadata search, the `spaceId` guard, and URL precedence) and one server unit test for a `queryAssetId` search by a member who reaches the reference asset only through a Space.

Each new test was checked against a mutated implementation to confirm it fails when the behaviour is removed.

Verified locally: web unit suite (4150 passed), `check:typescript`, `check:svelte` (575 files, 0 problems), `pnpm lint` for web and server, prettier, and the server `search.service` / `search.controller` specs (246 passed).

## Manual verification

Not yet run against a live instance with two accounts — worth an RC check that a Viewer's "Show similar photos" now returns the space's matches.
