### PR TITLE
fix(web): stop the filter panel's stored section list from drifting per browser (#797)

### DIFF
--- a/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
+import { tick } from 'svelte';
 import { init, register, waitLocale } from 'svelte-i18n';
 import type { FilterPanelConfig, FilterSection } from '../filter-panel';
 import { ALL_FILTER_SECTIONS, createFilterState } from '../filter-panel';
@@ -985,6 +986,80 @@ describe('Section Selector', () => {
       renderPanel([...ALL_FILTER_SECTIONS]);
 
       expect(screen.queryByTestId('filter-section-text')).toBeNull();
+    });
+  });
+
+  // #797: two people on the same version saw different filter category lists. Which sections a
+  // user sees is a per-browser ledger, and it could silently diverge from the app's section list.
+  describe('#797 stored-ledger divergence', () => {
+    // What a browser stored before #447 replaced the bare array with { selected, known }: the
+    // sections that existed at the time. Everything added since must still be revealed.
+    const PRE_LEDGER_STORED: FilterSection[] = ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media'];
+
+    it('reveals every section added since the ledger format to a browser on legacy storage', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(PRE_LEDGER_STORED));
+
+      renderPanel([...ALL_FILTER_SECTIONS]);
+
+      for (const section of ALL_FILTER_SECTIONS) {
+        expect(screen.getByTestId(`filter-section-${section}`)).toBeTruthy();
+      }
+    });
+
+    it('reveals sections added since the ledger without un-hiding ones hidden back then', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(['timeline', 'people']));
+
+      renderPanel([...ALL_FILTER_SECTIONS]);
+
+      expect(screen.getByTestId('filter-section-favorites')).toBeTruthy();
+      expect(screen.getByTestId('filter-section-albums')).toBeTruthy();
+      expect(screen.getByTestId('filter-section-text')).toBeTruthy();
+      expect(screen.queryByTestId('filter-section-camera')).toBeNull();
+      expect(screen.queryByTestId('filter-section-rating')).toBeNull();
+    });
+
+    // Album detail and the album asset picker share one storage key but offer different section
+    // lists (detail drops 'albums'). Visiting detail must not erase the picker's record.
+    it('keeps a hidden section hidden after a surface that does not offer it rewrites the ledger', async () => {
+      const picker = renderPanel([...ALL_FILTER_SECTIONS]);
+      await openSectionMenu();
+      await fireEvent.click(screen.getByTestId('section-toggle-albums'));
+      picker.unmount();
+
+      const detail = renderPanel(ALL_FILTER_SECTIONS.filter((section) => section !== 'albums'));
+      await tick();
+      detail.unmount();
+
+      renderPanel([...ALL_FILTER_SECTIONS]);
+
+      expect(screen.queryByTestId('filter-section-albums')).toBeNull();
+    });
+
+    it('keeps a visible section visible after a surface that does not offer it rewrites the ledger', async () => {
+      const detail = renderPanel(ALL_FILTER_SECTIONS.filter((section) => section !== 'albums'));
+      await openSectionMenu();
+      await fireEvent.click(screen.getByTestId('section-toggle-camera'));
+      detail.unmount();
+
+      renderPanel([...ALL_FILTER_SECTIONS]);
+
+      expect(screen.getByTestId('filter-section-albums')).toBeTruthy();
+      expect(screen.queryByTestId('filter-section-camera')).toBeNull();
+    });
+
+    it('offers to show all sections when every section this surface renders is hidden', async () => {
+      const picker = renderPanel([...ALL_FILTER_SECTIONS]);
+      await openSectionMenu();
+      for (const section of ALL_FILTER_SECTIONS) {
+        if (section !== 'albums') {
+          await fireEvent.click(screen.getByTestId(`section-toggle-${section}`));
+        }
+      }
+      picker.unmount();
+
+      renderPanel(ALL_FILTER_SECTIONS.filter((section) => section !== 'albums'));
+
+      expect(screen.getByTestId('show-all-sections')).toBeTruthy();
     });
   });
 

--- a/web/src/lib/components/filter-panel/filter-panel.svelte
+++ b/web/src/lib/components/filter-panel/filter-panel.svelte
@@ -12,7 +12,14 @@
     PersonOption,
     TagOption,
   } from './filter-panel';
-  import { buildFilterContext, createFilterState, loadFilterCollapsed, saveFilterCollapsed } from './filter-panel';
+  import {
+    ALL_FILTER_SECTIONS,
+    buildFilterContext,
+    createFilterState,
+    loadFilterCollapsed,
+    PRE_LEDGER_FILTER_SECTIONS,
+    saveFilterCollapsed,
+  } from './filter-panel';
   import FilterSection from './filter-section.svelte';
   import FilterSectionMenu from './filter-section-menu.svelte';
   import TemporalPicker from './temporal-picker.svelte';
@@ -351,109 +358,91 @@
 
   type StoredSectionSet = string[] | { selected?: string[]; known?: string[] };
 
-  const LEGACY_INTRODUCED_SECTIONS = new Set<FilterSectionType>(['favorites', 'albums']);
-
-  function isFilterSection(value: string, configSections: FilterSectionType[]): value is FilterSectionType {
-    return configSections.includes(value as FilterSectionType);
+  /**
+   * The stored record behind a section set. It is scoped to the browser, not to the surface:
+   * album detail and the album asset picker share a storage key but offer different section
+   * lists, so entries this surface does not render are carried through untouched rather than
+   * intersected away — otherwise the shorter surface forgets them and the longer one keeps
+   * treating them as brand new (#797).
+   */
+  interface SectionLedger {
+    selected: FilterSectionType[];
+    known: FilterSectionType[];
   }
 
-  function getValidSections(values: unknown, configSections: FilterSectionType[]): FilterSectionType[] {
+  const PRE_LEDGER_SECTIONS = new Set<FilterSectionType>(PRE_LEDGER_FILTER_SECTIONS);
+
+  function isFilterSection(value: unknown): value is FilterSectionType {
+    return typeof value === 'string' && (ALL_FILTER_SECTIONS as readonly string[]).includes(value);
+  }
+
+  function getValidSections(values: unknown): FilterSectionType[] {
     if (!Array.isArray(values)) {
       return [];
     }
-    return values.filter((value): value is FilterSectionType => {
-      return typeof value === 'string' && isFilterSection(value, configSections);
-    });
+    return values.filter((value): value is FilterSectionType => isFilterSection(value));
   }
 
-  function getLegacyKnownSections(
-    selected: FilterSectionType[],
-    configSections: FilterSectionType[],
-  ): FilterSectionType[] {
-    const selectedSections = new Set(selected);
-    return configSections.filter(
-      (section) => selectedSections.has(section) || !LEGACY_INTRODUCED_SECTIONS.has(section),
-    );
-  }
-
-  function getLegacySections(
-    values: unknown,
-    configSections: FilterSectionType[],
-    fallback: () => SvelteSet<FilterSectionType>,
-  ): SvelteSet<FilterSectionType> {
-    if (!Array.isArray(values)) {
-      return fallback();
-    }
-
-    const selected = getValidSections(values, configSections);
-    if (values.length > 0 && selected.length === 0) {
-      return fallback();
-    }
-
-    const known = getLegacyKnownSections(selected, configSections);
-    const knownSet = new Set(known);
-    const introduced = configSections.filter((section) => !knownSet.has(section));
-    return new SvelteSet([...selected, ...introduced]);
-  }
-
-  function hydrateSectionSet(
-    configSections: FilterSectionType[],
-    raw: string | null,
-    fallback: () => SvelteSet<FilterSectionType>,
-  ): SvelteSet<FilterSectionType> {
+  function readLedger(raw: string | null): SectionLedger | undefined {
     if (raw === null) {
-      return fallback();
+      return undefined;
     }
 
+    let parsed: StoredSectionSet;
     try {
-      const parsed = JSON.parse(raw) as StoredSectionSet;
-      if (Array.isArray(parsed)) {
-        return getLegacySections(parsed, configSections, fallback);
-      }
-
-      const selected = getValidSections(parsed?.selected, configSections);
-      const known = getValidSections(parsed?.known, configSections);
-      const knownSet = new Set(known);
-      const introduced = configSections.filter((section) => !knownSet.has(section));
-
-      return new SvelteSet([...selected, ...introduced]);
+      parsed = JSON.parse(raw) as StoredSectionSet;
     } catch {
-      return fallback();
+      return undefined;
     }
+
+    if (!Array.isArray(parsed)) {
+      return { selected: getValidSections(parsed?.selected), known: getValidSections(parsed?.known) };
+    }
+
+    const selected = getValidSections(parsed);
+    // A stored list none of whose entries survive is unusable — fall back to showing everything.
+    if (parsed.length > 0 && selected.length === 0) {
+      return undefined;
+    }
+
+    // Legacy storage predates the `known` list, so the sections that existed back then are all it
+    // can vouch for; everything added since counts as introduced and is revealed on upgrade.
+    return { selected, known: [...new Set([...selected, ...PRE_LEDGER_SECTIONS])] };
   }
 
-  function serializeSectionSet(sections: SvelteSet<FilterSectionType>, configSections: FilterSectionType[]): string {
+  function resolveSections(
+    configSections: FilterSectionType[],
+    ledger: SectionLedger | undefined,
+  ): SvelteSet<FilterSectionType> {
+    if (!ledger) {
+      return new SvelteSet(configSections);
+    }
+
+    const known = new Set(ledger.known);
+    const introduced = configSections.filter((section) => !known.has(section));
+    return new SvelteSet([...ledger.selected, ...introduced]);
+  }
+
+  function serializeSectionSet(
+    sections: SvelteSet<FilterSectionType>,
+    configSections: FilterSectionType[],
+    ledger: SectionLedger | undefined,
+  ): string {
     return JSON.stringify({
       selected: [...sections],
-      known: [...configSections],
+      known: [...new Set([...(ledger?.known ?? []), ...configSections])],
     });
   }
 
-  function loadVisibleSections(configSections: FilterSectionType[], key: string): SvelteSet<FilterSectionType> {
-    if (browser) {
-      return hydrateSectionSet(configSections, localStorage.getItem(key), () => new SvelteSet(configSections));
-    }
-    return new SvelteSet(configSections);
-  }
-
-  let visibleSections = $state(loadVisibleSections(config.sections, storageKey));
+  const visibleLedger = readLedger(browser ? localStorage.getItem(storageKey) : null);
+  let visibleSections = $state(resolveSections(config.sections, visibleLedger));
 
   let sectionMenuOpen = $state(false);
 
   const EXPANDED_SECTIONS_KEY = 'gallery-filter-expanded-sections';
 
-  function loadExpandedSections(configSections: FilterSectionType[]): SvelteSet<FilterSectionType> {
-    if (browser) {
-      return hydrateSectionSet(
-        configSections,
-        localStorage.getItem(EXPANDED_SECTIONS_KEY),
-        () => new SvelteSet(configSections),
-      );
-    }
-    return new SvelteSet(configSections);
-  }
-
-  let expandedSections = $state(loadExpandedSections(config.sections));
+  const expandedLedger = readLedger(browser ? localStorage.getItem(EXPANDED_SECTIONS_KEY) : null);
+  let expandedSections = $state(resolveSections(config.sections, expandedLedger));
 
   function toggleSectionExpanded(section: FilterSectionType) {
     const next = new SvelteSet(expandedSections);
@@ -476,13 +465,15 @@
   }
 
   function showAllSections() {
-    visibleSections = new SvelteSet(config.sections);
+    // Union rather than replace: sections another surface tracks under the same storage key are
+    // not this surface's to clear.
+    visibleSections = new SvelteSet([...visibleSections, ...config.sections]);
   }
 
   $effect(() => {
     if (browser) {
       try {
-        localStorage.setItem(storageKey, serializeSectionSet(visibleSections, config.sections));
+        localStorage.setItem(storageKey, serializeSectionSet(visibleSections, config.sections, visibleLedger));
       } catch {
         /* localStorage unavailable */
       }
@@ -500,7 +491,10 @@
   $effect(() => {
     if (browser) {
       try {
-        localStorage.setItem(EXPANDED_SECTIONS_KEY, serializeSectionSet(expandedSections, config.sections));
+        localStorage.setItem(
+          EXPANDED_SECTIONS_KEY,
+          serializeSectionSet(expandedSections, config.sections, expandedLedger),
+        );
       } catch {
         /* localStorage unavailable */
       }
@@ -865,7 +859,9 @@
             {/if}
           {/each}
 
-          {#if visibleSections.size === 0}
+          <!-- Emptiness is per surface, not per ledger: the set can still hold a section another
+               surface tracks under the same storage key (#797). -->
+          {#if config.sections.every((section) => !visibleSections.has(section))}
             <div class="flex flex-col items-center gap-2 px-4 py-8 text-center">
               <p class="text-xs text-gray-500 dark:text-gray-400">{$t('filter_show_sections_hint')}</p>
               <button

--- a/web/src/lib/components/filter-panel/filter-panel.ts
+++ b/web/src/lib/components/filter-panel/filter-panel.ts
@@ -56,6 +56,27 @@ export const ALL_FILTER_SECTIONS: readonly FilterSection[] = [
   'text',
 ] as const;
 
+/**
+ * The sections a browser could already have recorded before #447 replaced the stored
+ * `string[]` of visible sections with a `{ selected, known }` ledger — a frozen historical
+ * fact, not a list to keep in step with `ALL_FILTER_SECTIONS`.
+ *
+ * Legacy storage carries no `known` list, so on upgrade every section outside this baseline
+ * counts as introduced-since and is revealed. Deriving that from the baseline rather than
+ * naming the newer sections explicitly is what keeps it correct: the old list named `favorites`
+ * and `albums` but was never extended with `text` when #722 added it, so browsers still holding
+ * legacy storage lost that section for good (#797).
+ */
+export const PRE_LEDGER_FILTER_SECTIONS: readonly FilterSection[] = [
+  'timeline',
+  'people',
+  'location',
+  'camera',
+  'tags',
+  'rating',
+  'media',
+] as const;
+
 export interface PersonOption {
   id: string;
   name: string;


### PR DESCRIPTION
Fixes #797.

## What the report turned out to be

The reporter compared an admin's filter panel (10 icons, ending in _Alben_ + _Text_) with a non-admin's (8 icons, stopping at _Favoriten_) and asked whether the shorter list was a permission restriction.

It is not — nothing in the filter panel branches on role or ownership. On v5.1.1 the section list was hardcoded per surface and had drifted: Photos/Spaces offered 10, Map 9, album views 8. The two screenshots are two different pages, not two different permission levels. That drift is already fixed — #810 derives every surface from `ALL_FILTER_SECTIONS`, shipped in **v5.2.1**. Album detail still omits _Albums_ deliberately: `asset.repository.ts` guards both `isInAlbum` and `isNotInAlbum` with `&& !options.albumId`, so inside one album they are a tautology and an empty set respectively.

## What is still broken, and what this fixes

Section *visibility* is a per-browser ledger in `localStorage`, and it could still drift away from the app's section list in two ways — which produces exactly the reported symptom (two people, same version, same page, different filter categories) without anyone touching a toggle.

**1. Sections introduced after the ledger format were lost forever.** #447 replaced the stored `string[]` with a `{ selected, known }` pair and listed the sections that predated it — `favorites`, later `albums` — so they'd be treated as new and revealed on upgrade. `text` (#722) was never added to that list. A browser still holding the pre-#447 array recorded `text` as already-known-and-hidden on its next visit and never showed it again.

The rule is now inverted: `PRE_LEDGER_FILTER_SECTIONS` records the sections that existed *before* the ledger — a frozen historical fact — and everything outside it counts as introduced since. There is no longer a list to keep in step with `ALL_FILTER_SECTIONS`, so the next section added cannot repeat this.

**2. Two surfaces with different section lists sharing one storage key overwrote each other.** Album detail (no `albums`) and the album asset picker (all ten) both write `gallery-filter-visible-sections-album-detail`. Both `selected` and `known` were intersected with whichever surface wrote last, so a visit to album detail erased any record of `albums` and the picker re-introduced it on the next visit — hiding it there never stuck. Entries the current surface does not render are now carried through untouched; rendering already intersects with `config.sections`.

Two follow-ons from the ledger outliving a single surface: "show all sections" unions rather than replaces, and the empty-state hint asks whether *this surface's* sections are all hidden rather than whether the set is empty.

## Tests

TDD — five tests in `filter-panel.spec.ts`, three of which failed first for the right reasons (`filter-section-text` absent on legacy storage; `filter-section-albums` resurrected after the shorter surface rewrote the ledger):

- reveals every section added since the ledger format to a browser on legacy storage
- reveals sections added since the ledger without un-hiding ones hidden back then
- keeps a hidden section hidden after a surface that does not offer it rewrites the ledger
- keeps a visible section visible after a surface that does not offer it rewrites the ledger
- offers to show all sections when every section this surface renders is hidden

The last two were green before the change and guard against the obvious ways of over-correcting it.

## Verification

From `web/`: `pnpm test` (4151 passed, 2 skipped, 8 todo — 300 files), `pnpm check:typescript`, `pnpm check:svelte` (575 files, 0 errors/warnings), `pnpm lint`, `pnpm format`. All green.

## Upgrade behaviour

A user whose browser is missing _Text_ gets it back on next load. Sections they deliberately hid stay hidden — covered by test 2 above.
