### PR TITLE
fix(web): include shared-space assets in the info-panel camera/lens search (#732)

### DIFF
--- a/web/src/lib/components/asset-viewer/DetailPanel.svelte
+++ b/web/src/lib/components/asset-viewer/DetailPanel.svelte
@@ -225,11 +225,19 @@
 
           <div>
             {#if asset.exifInfo?.make || asset.exifInfo?.model}
+              <!--
+                withSharedSpaces:true — /search is scoped to own + partner assets without it, so a
+                Space member clicking the camera of a photo another member shared into the Space got
+                zero results, not even the photo they clicked on (#732). Same omission the palette
+                had in #894. Safe unconditionally: the server rejects withSharedSpaces only when it
+                is combined with spaceId/albumId, which these links never send.
+              -->
               <p>
                 <a
                   href={Route.search({
                     make: asset.exifInfo?.make ?? undefined,
                     model: asset.exifInfo?.model ?? undefined,
+                    withSharedSpaces: true,
                   })}
                   title="{$t('search_for')} {asset.exifInfo.make || ''} {asset.exifInfo.model || ''}"
                   class="hover:text-primary"
@@ -261,7 +269,7 @@
             {#if asset.exifInfo?.lensModel}
               <p>
                 <a
-                  href={Route.search({ lensModel: asset.exifInfo.lensModel })}
+                  href={Route.search({ lensModel: asset.exifInfo.lensModel, withSharedSpaces: true })}
                   title="{$t('search_for')} {asset.exifInfo.lensModel}"
                   class="line-clamp-1 hover:text-primary"
                 >

--- a/web/src/lib/components/asset-viewer/detail-panel.spec.ts
+++ b/web/src/lib/components/asset-viewer/detail-panel.spec.ts
@@ -135,6 +135,11 @@ vi.mock('$lib/components/shared-components/LoadingSpinner.svelte', async () => {
 });
 
 describe('DetailPanel', () => {
+  const searchTermsFromHref = (href: string | null) => {
+    const query = new URL(href ?? '', 'https://gallery.test').searchParams.get('query');
+    return query === null ? {} : JSON.parse(query);
+  };
+
   const makeFace = (
     id: string,
     person: PersonResponseDto,
@@ -406,6 +411,51 @@ describe('DetailPanel', () => {
 
     await waitFor(() => expect(screen.getByText('Karolin')).toBeInTheDocument());
     expect(container.querySelector('p[title*="2027"]')).toBeNull();
+  });
+
+  // #732: the camera and lens links jump to the deprecated /search page, whose metadata search is
+  // scoped to own + partner assets unless `withSharedSpaces` is set. Without it a Space member
+  // clicking the camera of a photo another member shared into the Space gets zero results — not
+  // even the photo they clicked on. Same omission, same fix as the palette in #894.
+  it('scopes the camera link search to shared spaces', async () => {
+    const asset = assetFactory.build({
+      ownerId: 'someone-else',
+      exifInfo: { make: 'Apple', model: 'iPhone 17 Pro' },
+    });
+
+    const { container } = renderWithTooltips(DetailPanel, { asset, currentAlbum: null });
+
+    const link = await waitFor(() => {
+      const anchor = container.querySelector<HTMLAnchorElement>(':scope [data-testid="detail-panel-camera"] a');
+      expect(anchor).not.toBeNull();
+      return anchor!;
+    });
+
+    expect(searchTermsFromHref(link.getAttribute('href'))).toEqual({
+      make: 'Apple',
+      model: 'iPhone 17 Pro',
+      withSharedSpaces: true,
+    });
+  });
+
+  it('scopes the lens link search to shared spaces', async () => {
+    const asset = assetFactory.build({
+      ownerId: 'someone-else',
+      exifInfo: { lensModel: 'iPhone 17 Pro front camera' },
+    });
+
+    const { container } = renderWithTooltips(DetailPanel, { asset, currentAlbum: null });
+
+    const link = await waitFor(() => {
+      const anchor = container.querySelector<HTMLAnchorElement>(':scope [data-testid="detail-panel-lens"] a');
+      expect(anchor).not.toBeNull();
+      return anchor!;
+    });
+
+    expect(searchTermsFromHref(link.getAttribute('href'))).toEqual({
+      lensModel: 'iPhone 17 Pro front camera',
+      withSharedSpaces: true,
+    });
   });
 
   it('renders Google, Apple, and OpenStreetMap links in the image info panel map popup', async () => {


### PR DESCRIPTION
Fixes #732.

## Problem

Clicking the camera or lens name in the asset viewer's info panel returned **zero results** — not even the photo the click started from. The report frames it as admin vs non-admin, but the real axis is **owner vs Space member**: the reporter's admin owns the photos, so the search worked for them.

Those links jump to `/search?query={"make":…,"model":…}`, and `POST /search/metadata` is scoped to own + partner assets unless the DTO carries `withSharedSpaces`. `Route.search()` never set it, so a member looking at a photo another member shared into a Space searched only their own library and came back empty.

This is the same omission the search palette had in #894 (fixed by #896) — the comment left behind there even says `withSharedSpaces:true` "mirrors Gallery's main search page", but since the search bar became the palette no call site actually sends the flag.

## Fix

Both info-panel links now send `withSharedSpaces: true`.

Safe unconditionally: the server rejects the flag only when it is combined with `spaceId`/`albumId`, which these links never send. The search page already forwards it from the URL to the API and excludes it from the filter chips (`getVisibleSearchKeys`), so no stray pill appears, and removing a chip preserves it.

## Tests

Two tests in `detail-panel.spec.ts` decode the `query` param off the rendered `href` and assert the whole decoded DTO — so they go red if the flag is dropped *or* if the make/model/lens payload changes shape. Both were watched failing first (`withSharedSpaces` absent, everything else matching), then passing.

Server-side coverage for the other half already exists: `search.service.spec.ts` (medium) pins that `searchMetadata` with `withSharedSpaces: true` returns another member's shared timeline asset, and `make`/`model`/`lensModel` are plain AND-narrowing `asset_exif` predicates, orthogonal to the space-scope OR-group in `searchAssetBuilder`.

## Not covered by this PR

- A member who has switched **off** "show in timeline" for that Space still gets nothing, because `withSharedSpaces` resolves only timeline-enabled spaces. `showInTimeline` defaults to `true`, so the common case is covered; the real answer for the Space surface is #778 (filter the surface you're on).
- "Search similar" (`asset.service.ts`, `Route.search({ queryAssetId })`) has the identical omission and is unreported — left out to keep this scoped.
- The Explore/Places city tiles also omit the flag, but they are built from owner-scoped `getExploreData`, so adding it there would return more than the tile represents. That one needs a decision, not a one-liner.

## Verification

- `web` unit suite: 4148 passed, 0 failed (299 files)
- `check:typescript` clean; `check:svelte` 575 files, 0 errors, 0 warnings
- `pnpm lint` clean; `prettier --check` clean on both changed files
