### PR TITLE
ci: run the full branding check, not just the i18n slice

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -279,6 +279,13 @@ jobs:
           persist-credentials: false
           token: ${{ github.token }}
 
+      # apply-branding resizes the Android 12 splash assets and verify-mobile-assets
+      # measures icon bounds, both via ImageMagick. It is no longer preinstalled on
+      # the ubuntu runner images, so install it explicitly rather than letting the
+      # check fail with "ImageMagick convert or magick is required".
+      - name: Install ImageMagick
+        run: sudo apt-get update && sudo apt-get install -y imagemagick
+
       - name: Run branding pipeline checks
         run: ./branding/scripts/gallery-branding-check.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,9 +52,6 @@ jobs:
             machine-learning:
               - 'machine-learning/**'
               - 'mise.toml'
-            branding:
-              - 'branding/**'
-              - 'i18n/**'
             upstream-preflight:
               - '.github/workflows/test.yml'
               - 'tools/upstream-preflight/**'
@@ -250,12 +247,28 @@ jobs:
   # Behavioural gate for the branding pipeline. ShellCheck only lints these
   # scripts; nothing in CI ran patch_i18n() and asserted what it produces, which
   # is how the delete-and-fall-back-to-English behaviour behind issue #844 went
-  # unnoticed. The script patches a throwaway copy of i18n/, so it needs no
-  # image tooling, no network and no build — just bash and jq.
-  branding-i18n-tests:
-    name: Test i18n Branding
+  # unnoticed. Only test-i18n-branding.sh was ever wired up; the other five
+  # branding scripts ran in no workflow at all.
+  #
+  # This runs branding/scripts/gallery-branding-check.sh, the umbrella gate: it
+  # creates a throwaway detached worktree at HEAD, runs every branding
+  # regression test (email, app-download, i18n, oauth-callback), then applies the
+  # full branding overlay and verifies the result. It never mutates the checkout
+  # and asserts as much on exit. ~14s end to end, and it works on the shallow
+  # clone actions/checkout produces.
+  #
+  # It is deliberately NOT gated on a path filter. apply-branding rewrites SOURCE
+  # files (web/, server/, mobile/), so what breaks it is usually an edit to a file
+  # it patches, not to branding/ itself. Upstream #30527 is the worked example: it
+  # moved the app-download store URLs out of AppDownloadModal.svelte into
+  # @immich/ui `Constants`, turning apply-branding's literal-URL rewrites into
+  # silent no-ops so a branded build shipped upstream's Play/App Store links. It
+  # touched only web/, so the old `branding/**` filter would have skipped this job
+  # precisely when it was needed. At ~14s, always running it is cheaper than
+  # trying to enumerate which paths can invalidate branding.
+  branding-tests:
+    name: Test Branding
     needs: pre-job
-    if: ${{ fromJSON(needs.pre-job.outputs.should_run).branding == true }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -266,8 +279,8 @@ jobs:
           persist-credentials: false
           token: ${{ github.token }}
 
-      - name: Run i18n branding regression tests
-        run: ./branding/scripts/test-i18n-branding.sh
+      - name: Run branding pipeline checks
+        run: ./branding/scripts/gallery-branding-check.sh
 
   i18n-tests:
     name: Test i18n


### PR DESCRIPTION
## What

CI ran only `test-i18n-branding.sh`. The other five branding scripts — including `test-app-download-branding.sh`, `test-email-branding.sh` and `test-oauth-callback-branding.sh` — were referenced by **no workflow at all**, leaving the branding pipeline effectively ungated.

This wires up `branding/scripts/gallery-branding-check.sh`, which already existed and already does the right thing:

1. creates a throwaway **detached worktree at HEAD** (never touches the checkout, and asserts as much on exit)
2. runs every branding regression test — email, app-download, i18n, oauth-callback
3. applies the **full** branding overlay via `apply-branding.sh`
4. verifies the result with `verify-branding.sh`

## Why it isn't path-gated

`apply-branding` rewrites **source** files under `web/`, `server/` and `mobile/`. What invalidates branding is therefore usually an edit to a file it patches — not a change under `branding/`.

Upstream **#30527** is the worked example. It moved the app-download store URLs out of `AppDownloadModal.svelte` into `@immich/ui` `Constants`, so `apply-branding`'s literal-URL rewrites matched nothing and became silent no-ops — a branded build would have shipped **upstream's** Play Store and App Store links. It touched only `web/`, so the old `branding/**` filter would have **skipped this job precisely when it was needed**.

The `branding` filter is removed rather than widened, so nobody re-gates the job on a predicate that structurally under-triggers. At ~14s, always running it is cheaper than enumerating which paths can invalidate branding.

## Verification

- `gallery-branding-check.sh` passes on this branch: **exit 0, ~14s**
- Works on a **shallow clone** (`git clone --depth 1`), which is what `actions/checkout` produces — the script's `git worktree add --detach HEAD` was the risk here
- **The gate has teeth**: with #30527 replayed onto this branch, it exits **1**:
  ```
  FAIL: play store link is the Noodle Gallery app — 'https://play.google.com/...id=de.opennoodle.gallery' missing
  FAIL: app store link is the Noodle Gallery app  — 'https://apps.apple.com/us/app/noodle-gallery/id6761776289' missing
  ```
- No required status check pins the old job name (the `main` ruleset has only `deletion` / `pull_request` / `non_fast_forward`), so the rename is safe
- YAML parses; prettier clean

## Known gap, not fixed here

`verify-branding.sh`'s `AppDownloadModal` check is **absent-only** — it greps for Immich strings and passes vacuously once a value moves out of source into a package. It should also assert the Noodle URLs are *present*, which is what `test-app-download-branding.sh` does correctly and why that one catches this class. Left for a follow-up.