### PR TITLE
fix(mobile): leave the search results when jumping to the timeline (#898)

### DIFF
--- a/mobile/lib/pages/backup/drift_backup_asset_detail.page.dart
+++ b/mobile/lib/pages/backup/drift_backup_asset_detail.page.dart
@@ -8,7 +8,7 @@ import 'package:immich_mobile/extensions/theme_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
 import 'package:immich_mobile/pages/common/large_leading_tile.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
-import 'package:immich_mobile/providers/asset_viewer/scroll_to_asset_notifier.provider.dart';
+import 'package:immich_mobile/providers/asset_viewer/view_in_timeline_action.dart';
 import 'package:immich_mobile/providers/backup/drift_backup.provider.dart';
 import 'package:immich_mobile/repositories/asset_media.repository.dart';
 import 'package:immich_mobile/routing/router.dart';
@@ -85,11 +85,12 @@ class DriftBackupAssetDetailPage extends ConsumerWidget {
                       padding: EdgeInsets.only(right: 24, left: 8),
                       child: Icon(Icons.image_search),
                     ),
-                    onTap: () async {
-                      await context.maybePop();
-                      await context.navigateTo(const MainTimelineRoute());
-                      scrollToAssetNotifierProvider.scrollToAsset(asset);
-                    },
+                    onTap: () => viewAssetInTimeline(
+                      asset: asset,
+                      read: ref.read,
+                      popViewer: () => context.maybePop(),
+                      goToTimeline: () => context.navigateTo(const MainTimelineRoute()),
+                    ),
                   );
                 },
               );

--- a/mobile/lib/presentation/widgets/memory/memory_bottom_info.widget.dart
+++ b/mobile/lib/presentation/widgets/memory/memory_bottom_info.widget.dart
@@ -3,9 +3,10 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/memory.model.dart';
-import 'package:immich_mobile/providers/asset_viewer/scroll_to_asset_notifier.provider.dart';
+import 'package:immich_mobile/providers/asset_viewer/view_in_timeline_action.dart';
 import 'package:immich_mobile/routing/router.dart';
 
 /// The asset shown on [page] of [memory], clamped to the memory's bounds.
@@ -15,13 +16,13 @@ import 'package:immich_mobile/routing/router.dart';
 /// not have.
 RemoteAsset memoryAssetForPage(DriftMemory memory, int page) => memory.assets[page.clamp(0, memory.assets.length - 1)];
 
-class DriftMemoryBottomInfo extends StatelessWidget {
+class DriftMemoryBottomInfo extends ConsumerWidget {
   final RemoteAsset asset;
   final String title;
   const DriftMemoryBottomInfo({super.key, required this.asset, required this.title});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final df = DateFormat.yMMMMd();
     final fileCreatedDate = asset.createdAt;
     return Padding(
@@ -46,14 +47,14 @@ class DriftMemoryBottomInfo extends StatelessWidget {
             message: 'view_in_timeline'.tr(),
             child: MaterialButton(
               minWidth: 0,
-              onPressed: () async {
-                await context.maybePop();
+              onPressed: () => viewAssetInTimeline(
+                asset: asset,
+                read: ref.read,
+                popViewer: () => context.maybePop(),
                 // Activate the existing timeline tab without rebuilding it (a fresh
                 // TabShellRoute would reload the timeline to the top and discard the scroll).
-                await context.navigateTo(const MainTimelineRoute());
-                // #28941: the notifier converts to the viewer's local time itself.
-                scrollToAssetNotifierProvider.scrollToAsset(asset);
-              },
+                goToTimeline: () => context.navigateTo(const MainTimelineRoute()),
+              ),
               shape: const CircleBorder(),
               color: Colors.white.withValues(alpha: 0.2),
               elevation: 0,

--- a/mobile/lib/presentation/widgets/timeline/scroll_drain.dart
+++ b/mobile/lib/presentation/widgets/timeline/scroll_drain.dart
@@ -1,4 +1,18 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/segment.model.dart';
+
+/// The segments a drain may act on, or null while the timeline is still swapping
+/// to a different source.
+///
+/// `AsyncValue.valueOrNull` keeps serving the PREVIOUS segments while the stream
+/// refreshes, which is exactly the window a "view in timeline" jump out of search
+/// opens: clearing the Photos filter swaps `timelineServiceProvider`, but the
+/// search segments — same dates, same matches — stay visible to the drain for a
+/// few frames. Scrolling to one of those moves the timeline being left behind and
+/// consumes the request, so the jump never lands (#898). Treat a refreshing stream
+/// as not-loaded-yet and let the drain retry until the new segments arrive.
+List<Segment>? drainableSegments(AsyncValue<List<Segment>> segments) =>
+    segments.isLoading ? null : segments.valueOrNull;
 
 /// What the timeline should do this frame with a pending "view in timeline"
 /// scroll request.

--- a/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
+++ b/mobile/lib/presentation/widgets/timeline/timeline.widget.dart
@@ -435,7 +435,7 @@ class _SliverTimelineState extends ConsumerState<_SliverTimeline> with WidgetsBi
 
     final target = scrollToAssetNotifierProvider.value;
     final date = target?.date;
-    final segments = ref.read(timelineSegmentProvider).valueOrNull;
+    final segments = drainableSegments(ref.read(timelineSegmentProvider));
     final laidOut = _scrollController.hasClients && _scrollController.position.hasContentDimensions;
     final matched = date != null && segments != null && _findSegmentForDate(segments, date) != null;
     final isOverview = segmentsAreOverview(segments);

--- a/mobile/lib/providers/asset_viewer/view_in_timeline_action.dart
+++ b/mobile/lib/providers/asset_viewer/view_in_timeline_action.dart
@@ -1,0 +1,38 @@
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/providers/asset_viewer/scroll_to_asset_notifier.provider.dart';
+import 'package:immich_mobile/providers/gallery_nav/gallery_search_action.dart';
+import 'package:immich_mobile/providers/photos_filter/filter_sheet.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
+
+/// Jumps from a scoped timeline (search results, a person, a place, an album, a
+/// memory, the backup detail list) to [asset]'s place in the global Photos
+/// timeline.
+///
+/// [popViewer] closes the surface the action was invoked from, [goToTimeline]
+/// activates the main timeline route. They are injected so the sequencing can be
+/// tested without a router.
+///
+/// Clearing the Photos filter is what makes this work from search results (#898).
+/// Unlike web, mobile has no separate search route: `MainTimelinePage` renders the
+/// results itself, swapping its `timelineServiceProvider` for a search-backed one
+/// while the filter is non-empty. The timeline route is therefore already on screen
+/// behind the viewer, so popping and navigating to it lands right back in the same
+/// results. The filter — not the route — is what has to change.
+///
+/// The order is load-bearing:
+/// * pop first, because clearing the filter disposes the search `TimelineService`
+///   the viewer was handed by value;
+/// * latch the scroll target last, so the drain resolves against the global
+///   timeline instead of the results it is replacing.
+Future<void> viewAssetInTimeline({
+  required BaseAsset asset,
+  required ProviderReader read,
+  required Future<void> Function() popViewer,
+  required Future<void> Function() goToTimeline,
+}) async {
+  await popViewer();
+  read(photosFilterProvider.notifier).reset();
+  read(photosFilterSheetProvider.notifier).state = FilterSheetSnap.hidden;
+  await goToTimeline();
+  scrollToAssetNotifierProvider.scrollToAsset(asset);
+}

--- a/mobile/lib/utils/action_button.utils.dart
+++ b/mobile/lib/utils/action_button.utils.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/constants/enums.dart';
 import 'package:immich_mobile/domain/models/album/album.model.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
@@ -32,7 +33,7 @@ import 'package:immich_mobile/presentation/widgets/action_buttons/trash_action_b
 import 'package:immich_mobile/presentation/widgets/action_buttons/unarchive_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/unstack_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/upload_action_button.widget.dart';
-import 'package:immich_mobile/providers/asset_viewer/scroll_to_asset_notifier.provider.dart';
+import 'package:immich_mobile/providers/asset_viewer/view_in_timeline_action.dart';
 import 'package:immich_mobile/routing/router.dart';
 
 class ActionButtonContext {
@@ -279,11 +280,17 @@ enum ActionButtonType {
         menuItem: menuItem,
         onPressed: buildContext == null
             ? null
-            : () async {
-                await buildContext.maybePop();
-                await buildContext.navigateTo(const MainTimelineRoute());
-                scrollToAssetNotifierProvider.scrollToAsset(context.asset);
-              },
+            // Everything is resolved off [buildContext] — the kebab menu's own context —
+            // rather than this menu item's: activating an item closes the menu, which
+            // tears the item's element down while the jump is still in flight.
+            : () => viewAssetInTimeline(
+                asset: context.asset,
+                read: ProviderScope.containerOf(buildContext, listen: false).read,
+                popViewer: () => buildContext.maybePop(),
+                // Activate the existing timeline tab without rebuilding it (a fresh
+                // TabShellRoute would reload the timeline to the top and discard the scroll).
+                goToTimeline: () => buildContext.navigateTo(const MainTimelineRoute()),
+              ),
       ),
       ActionButtonType.cast => CastActionButton(iconOnly: iconOnly, menuItem: menuItem),
     };

--- a/mobile/test/presentation/widgets/timeline/scroll_drain_test.dart
+++ b/mobile/test/presentation/widgets/timeline/scroll_drain_test.dart
@@ -1,9 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/timeline.model.dart';
 import 'package:immich_mobile/domain/models/timeline_grouping.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/fixed/segment.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/overview/overview_segment.model.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/scroll_drain.dart';
+import 'package:immich_mobile/presentation/widgets/timeline/segment.model.dart';
 
 void main() {
   group('decideScrollDrain', () {
@@ -158,6 +160,34 @@ void main() {
       // Defensive: the builder never mixes them today, but treating "any overview
       // card present" as overview keeps the scroll from targeting a card.
       expect(segmentsAreOverview([_fixedSegment(), _overviewSegment()]), isTrue);
+    });
+  });
+
+  group('drainableSegments', () {
+    test('serves the segments of a settled stream', () {
+      final segments = [_fixedSegment()];
+
+      expect(drainableSegments(AsyncData(segments)), same(segments));
+    });
+
+    test('has nothing to drain before the first segments arrive', () {
+      expect(drainableSegments(const AsyncLoading()), isNull);
+    });
+
+    test('withholds the previous timeline segments while the stream is refreshing', () {
+      // #898: clearing the Photos filter swaps the timeline off its search-backed
+      // service, but `valueOrNull` keeps serving the SEARCH segments until the new
+      // ones arrive. Draining against those scrolls the results being left behind
+      // and consumes the request, so the jump never lands on the global timeline.
+      final searchSegments = [_fixedSegment()];
+      final refreshing = const AsyncLoading<List<Segment>>().copyWithPrevious(AsyncData(searchSegments));
+
+      expect(refreshing.valueOrNull, same(searchSegments), reason: 'precondition: the stale value is still served');
+      expect(drainableSegments(refreshing), isNull);
+    });
+
+    test('has nothing to drain when the stream failed', () {
+      expect(drainableSegments(AsyncError(Exception('boom'), StackTrace.empty)), isNull);
     });
   });
 

--- a/mobile/test/providers/asset_viewer/view_in_timeline_action_test.dart
+++ b/mobile/test/providers/asset_viewer/view_in_timeline_action_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/providers/asset_viewer/scroll_to_asset_notifier.provider.dart';
+import 'package:immich_mobile/providers/asset_viewer/view_in_timeline_action.dart';
+import 'package:immich_mobile/providers/photos_filter/filter_sheet.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
+
+/// Records the order of the navigation steps so the sequencing the timeline jump
+/// depends on can be asserted without a router.
+class _Steps {
+  final List<String> calls = [];
+
+  Future<void> pop() async => calls.add('pop');
+
+  Future<void> goToTimeline() async => calls.add('timeline');
+}
+
+void main() {
+  late ProviderContainer container;
+  late _Steps steps;
+
+  setUp(() {
+    container = ProviderContainer();
+    steps = _Steps();
+    // The notifier is a process-wide singleton; drop anything a previous test left.
+    scrollToAssetNotifierProvider.consume();
+  });
+
+  tearDown(() {
+    container.dispose();
+    scrollToAssetNotifierProvider.consume();
+  });
+
+  Future<void> run() => viewAssetInTimeline(
+    asset: _asset('a1'),
+    read: container.read,
+    popViewer: steps.pop,
+    goToTimeline: steps.goToTimeline,
+  );
+
+  test('clears an active Photos filter so the jump leaves the search results', () async {
+    // #898: mobile renders search results as the main Photos timeline with a filter
+    // applied, so the timeline route is ALREADY on screen behind the viewer. Popping
+    // and navigating to it changes nothing — only clearing the filter turns those
+    // results back into the global timeline.
+    container.read(photosFilterProvider.notifier).setText('beach');
+    expect(container.read(photosFilterProvider).isEmpty, isFalse, reason: 'precondition: a search is active');
+
+    await run();
+
+    expect(container.read(photosFilterProvider).isEmpty, isTrue);
+  });
+
+  test('hides the filter sheet so it cannot cover the photo it lands on', () async {
+    container.read(photosFilterSheetProvider.notifier).state = FilterSheetSnap.browse;
+
+    await run();
+
+    expect(container.read(photosFilterSheetProvider), FilterSheetSnap.hidden);
+  });
+
+  test('closes the viewer before the filter clears out of under it', () async {
+    // The viewer holds the search TimelineService by value; clearing the filter
+    // disposes it. Pop first so nothing is torn out from under a live viewer.
+    container.read(photosFilterProvider.notifier).setText('beach');
+    String? filterClearedAfter;
+    container.listen(photosFilterProvider, (_, next) {
+      filterClearedAfter ??= next.isEmpty ? steps.calls.join(',') : null;
+    });
+
+    await run();
+
+    expect(filterClearedAfter, 'pop');
+  });
+
+  test('latches the scroll target only once the filter is already cleared', () async {
+    // Latching while the search timeline is still the active one lets the drain
+    // resolve against the results being left behind and burn the request.
+    container.read(photosFilterProvider.notifier).setText('beach');
+    bool? filterWasEmptyAtLatch;
+    void listener() => filterWasEmptyAtLatch ??= container.read(photosFilterProvider).isEmpty;
+    scrollToAssetNotifierProvider.addListener(listener);
+    addTearDown(() => scrollToAssetNotifierProvider.removeListener(listener));
+
+    await run();
+
+    expect(filterWasEmptyAtLatch, isTrue);
+    expect(scrollToAssetNotifierProvider.value?.asset.heroTag, _asset('a1').heroTag);
+  });
+
+  test('activates the main timeline route after closing the viewer', () async {
+    await run();
+
+    expect(steps.calls, ['pop', 'timeline']);
+  });
+}
+
+RemoteAsset _asset(String id) => RemoteAsset(
+  id: id,
+  name: '$id.jpg',
+  ownerId: 'owner-1',
+  checksum: 'checksum-$id',
+  type: AssetType.image,
+  createdAt: DateTime(2026, 4, 3, 12),
+  updatedAt: DateTime(2026, 4, 3, 12),
+  isEdited: false,
+);

--- a/mobile/test/utils_legacy/action_button_utils_test.dart
+++ b/mobile/test/utils_legacy/action_button_utils_test.dart
@@ -1143,6 +1143,31 @@ void main() {
     });
   });
 
+  group('view in timeline button', () {
+    ActionButtonContext contextFor(TimelineOrigin origin) => ActionButtonContext(
+      asset: createRemoteAsset(),
+      isOwner: true,
+      isArchived: false,
+      isTrashEnabled: true,
+      isInLockedView: false,
+      currentAlbum: null,
+      advancedTroubleshooting: false,
+      isStacked: false,
+      source: ActionSource.viewer,
+      timelineOrigin: origin,
+    );
+
+    test('is offered on a photo opened from search results', () {
+      // The entry point #898 is about: search results are the Photos timeline with a
+      // filter applied, so the viewer opened from them carries the search origin.
+      expect(ActionButtonType.viewInTimeline.shouldShow(contextFor(TimelineOrigin.search)), isTrue);
+    });
+
+    test('is not offered when the photo is already in the global timeline', () {
+      expect(ActionButtonType.viewInTimeline.shouldShow(contextFor(TimelineOrigin.main)), isFalse);
+    });
+  });
+
   group('ActionButtonBuilder', () {
     test('should return buttons that should show', () {
       final remoteAsset = createRemoteAsset();


### PR DESCRIPTION
Closes #898.

## The bug

On mobile, "View in timeline" on a photo opened from search results closes the photo and drops the user back into the same results. Reported on iOS; the code path is shared, so Android behaves identically.

## Root cause

Unlike web, mobile has no separate search route. `MainTimelinePage` renders the results itself — `photosTimelineQueryProvider` swaps its `timelineServiceProvider` for a search-backed one for as long as the Photos filter is non-empty. The timeline route is therefore *already on screen behind the viewer*, so the action's `maybePop()` + `navigateTo(MainTimelineRoute())` is a no-op with the filter still applied. The filter, not the route, is what has to change.

## The fix

- New shared `viewAssetInTimeline` clears the Photos filter and hides the filter sheet between closing the viewer and latching the scroll target.
- The memory page and the backup-detail list jump through the same helper — they hit the same wall whenever a filter happens to be active.
- The ordering is load-bearing and covered by tests:
  - **pop first** — the viewer is handed the search `TimelineService` by value, and clearing the filter disposes it;
  - **latch last** — so the drain resolves against the global timeline rather than the results being replaced.
- The scroll drain now ignores segments from a refreshing stream. `AsyncValue.valueOrNull` keeps serving the *previous* timeline's segments while the service swaps, and those still match the target date — draining against them would scroll the timeline on its way out and consume the request. `drainableSegments` treats a refreshing stream as not-loaded-yet so the existing retry budget (180 frames) waits for the real segments.

Everything is resolved off the kebab menu's `buildContext` rather than the menu item's own: activating an item closes the menu, tearing that element down while the jump is still in flight.

## Testing

TDD — the action tests were written first and failed on the exact defect (filter still set, sheet still open, target latched too early) before the fix.

- `mobile/test/providers/asset_viewer/view_in_timeline_action_test.dart` (new, 5 tests)
- `mobile/test/presentation/widgets/timeline/scroll_drain_test.dart` (+4 for `drainableSegments`, including a precondition assertion that `valueOrNull` really does serve stale segments during a refresh)
- `mobile/test/utils_legacy/action_button_utils_test.dart` (+2 guarding the search entry point)

`flutter test` 3015 passed / 1 skipped, `dart analyze --fatal-infos lib test` clean, `dart format` clean (Flutter 3.44.8).

Not manually verified on a device.