### PR TITLE
feat(web): search descriptions in the album/space picker

### DIFF
--- a/web/src/lib/components/shared-components/collection-selection/collection-selection-utils.spec.ts
+++ b/web/src/lib/components/shared-components/collection-selection/collection-selection-utils.spec.ts
@@ -84,8 +84,10 @@ describe('collection helpers', () => {
 
 describe('CollectionModalRowConverter', () => {
   const conv = new CollectionModalRowConverter();
-  const a = (id: string, name: string) => albumToCollection(album(id, name));
-  const s = (id: string, name: string) => spaceToCollection(space(id, name));
+  const a = (id: string, name: string, extra: Record<string, unknown> = {}) =>
+    albumToCollection({ ...album(id, name), ...extra } as AlbumResponseDto);
+  const s = (id: string, name: string, extra: Record<string, unknown> = {}) =>
+    spaceToCollection(space(id, name, extra));
   const opts = { showSpaces: true };
 
   it('always emits New Album then New Space first when spaces shown', () => {
@@ -118,6 +120,36 @@ describe('CollectionModalRowConverter', () => {
     const items = rows.filter((r) => r.type === CollectionModalRowType.COLLECTION_ITEM);
     expect(items).toHaveLength(1);
     expect(items[0].collection!.id).toBe('a1');
+  });
+
+  it('matches descriptions as well as names, for albums and spaces alike', () => {
+    const all = [
+      a('a1', 'Vacances 2019', { description: 'Crete' }),
+      s('s1', 'Sommer', { description: 'Crete again' }),
+      a('a2', 'Construction'),
+      s('s2', 'Renovation'),
+    ];
+    const items = conv
+      .toModalRows('crete', [], all, -1, [], opts)
+      .filter((r) => r.type === CollectionModalRowType.COLLECTION_ITEM);
+    expect(items.map((r) => r.collection!.id).sort()).toEqual(['a1', 's1']);
+  });
+
+  it('normalizes description matches the same way it normalizes names', () => {
+    const all = [a('a1', 'Trip', { description: 'Tüscany' }), s('s1', 'Other')];
+    const items = conv
+      .toModalRows('tuscany', [], all, -1, [], opts)
+      .filter((r) => r.type === CollectionModalRowType.COLLECTION_ITEM);
+    expect(items.map((r) => r.collection!.id)).toEqual(['a1']);
+  });
+
+  it('tolerates absent and null descriptions without matching everything', () => {
+    // Space description is `string | null | undefined` in the SDK; album description may be ''.
+    const all = [a('a1', 'Alpha', { description: '' }), s('s1', 'Beta', { description: null }), s('s2', 'Gamma')];
+    const items = conv
+      .toModalRows('zzz', [], all, -1, [], opts)
+      .filter((r) => r.type === CollectionModalRowType.COLLECTION_ITEM);
+    expect(items).toHaveLength(0);
   });
 
   it('focus offset is 2 (two create rows): index 2 selects the first item', () => {

--- a/web/src/lib/components/shared-components/collection-selection/collection-selection-utils.ts
+++ b/web/src/lib/components/shared-components/collection-selection/collection-selection-utils.ts
@@ -32,6 +32,12 @@ export const isWritableSpace = (space: SharedSpaceResponseDto, currentUserId: st
   return role === SharedSpaceRole.Owner || role === SharedSpaceRole.Editor;
 };
 
+// Album description is `string`, space description is `string | null | undefined` — normalise both to
+// '' so an absent description can never match (`''.includes(query)` is false for a non-empty query,
+// and the converter only filters when the query is non-empty).
+export const descriptionOf = (c: PickerCollection): string =>
+  (c.kind === 'album' ? c.album.description : c.space.description) ?? '';
+
 export const recencyOf = (c: PickerCollection): number =>
   c.kind === 'album'
     ? new Date(c.album.updatedAt).getTime()
@@ -52,6 +58,12 @@ export const isValidNewSpaceName = (name: string): boolean => {
 // row components share one matcher. (Imported above to keep a single source of truth.)
 export const matchesSearch = (name: string, search: string): boolean =>
   normalizeSearchString(name).includes(normalizeSearchString(search));
+
+// Name or description, for albums and spaces alike. Upstream matches album descriptions in its
+// album-only picker (#30462); this list mixes both kinds, and a user typing a word cannot tell which
+// rows are albums and which are spaces, so both kinds match on the same fields.
+export const matchesCollection = (c: PickerCollection, search: string): boolean =>
+  matchesSearch(c.name, search) || matchesSearch(descriptionOf(c), search);
 
 export enum CollectionModalRowType {
   NEW_ALBUM = 'newAlbum',
@@ -98,7 +110,7 @@ export class CollectionModalRowConverter {
     const visible = options.showSpaces ? all : all.filter((c) => c.kind !== 'space');
     const isSearching = search.trim().length > 0;
     const recentToShow = isSearching ? [] : recent;
-    const filtered = sortByNameAsc(isSearching ? visible.filter((c) => matchesSearch(c.name, search)) : visible);
+    const filtered = sortByNameAsc(isSearching ? visible.filter((c) => matchesCollection(c, search)) : visible);
 
     if (filtered.length === 0) {
       rows.push({


### PR DESCRIPTION
Regains an upstream improvement the fork silently dropped.

Upstream [#30462](https://github.com/immich-app/immich/pull/30462) made the add-to-album picker match an album **description** as well as its name. Gallery replaced that picker with a unified one that lists albums **and** spaces (`collection-selection-utils.ts`), and that one filtered on `c.name` only — so the improvement never reached us. Upstream's album-only path (`album-selection-utils.ts`) still has it and is untouched here.

## Decision

Both kinds match on name or description, rather than albums only.

A user typing a word into that box cannot tell which rows are albums and which are spaces. Applying the rule to one kind would make a single list behave two ways for no reason the user can see. Spaces already have a description field (`z.string().max(500)`), so there was nothing to add server-side.

## Details

- `descriptionOf()` mirrors the existing `recencyOf()` shape rather than reshaping `PickerCollection`, so no other consumer changes.
- Description goes through the same `normalizeSearchString` as the name — accent- and case-folding behave identically for both fields.
- Space description is `string | null | undefined` in the SDK; it collapses to ``, which can never match a non-empty query, and the converter only filters when the query is non-empty.
- **Highlighting was the thing worth checking**: a row can now match via description while its name does not contain the query, which is exactly the case upstream had to patch in `AlbumListItem.svelte`. Both `AlbumListItem.svelte` and `space-list-item.svelte` already guard `indexOf === -1` and fall back to the unhighlighted name, so such a row renders correctly rather than mis-sliced. No change needed.

## Tests

Three added to the existing spec: both kinds matching on description, accent-normalisation on the description path, and null/empty descriptions not matching. Confirmed failing before the change (2 red), passing after.

`vitest` 35/35 in the directory and 51/51 across every spec touching the picker; `tsc --noEmit`, `eslint`, `prettier --check` clean.

## Follow-up, not done here

The empty-state string is `no_albums_or_spaces_with_name`, which now slightly understates the match (name *or* description). Left alone to keep this diff to the behaviour change — say the word and I'll reword it across the locales.