### PR TITLE
fix(branding): assert Noodle URLs are present, not just Immich URLs absent

### DIFF
--- a/branding/scripts/verify-branding.sh
+++ b/branding/scripts/verify-branding.sh
@@ -12,6 +12,13 @@ DEEP_LINK_SCHEME=$(jq -r '.mobile.deep_link_scheme' "$CONFIG")
 BUNDLE_ID=$(jq -r '.mobile.bundle_id' "$CONFIG")
 OAUTH_CALLBACK=$(jq -r '.mobile.oauth_callback' "$CONFIG")
 OAUTH_CALLBACK_SCHEME="${OAUTH_CALLBACK%%:*}"
+# Used by the modal checks below to assert the Noodle URLs are actually PRESENT, not
+# merely that the Immich ones are gone. Same keys apply-branding.sh patches them from.
+APP_STORE_URL=$(jq -r '.mobile.app_store_url' "$CONFIG")
+PLAY_STORE_URL=$(jq -r '.mobile.play_store_url' "$CONFIG")
+REPO_DOCS_URL=$(jq -r '.repository.docs_url' "$CONFIG")
+REPO_ISSUES_URL=$(jq -r '.repository.issues_url' "$CONFIG")
+REPO_RELEASES_URL=$(jq -r '.repository.releases_url' "$CONFIG")
 EXIT_CODE=0
 
 echo "=== Verifying branding: $NAME ==="
@@ -165,7 +172,19 @@ if [[ -f "$help_modal" ]]; then
     echo "  WARN: Upstream GitHub URL found outside upstream section in HelpAndFeedbackModal.svelte"
     EXIT_CODE=1
   else
-    echo "  OK: HelpAndFeedbackModal.svelte (URLs patched)"
+    # Same absent-only weakness as the app-download check below: if upstream restructures
+    # these hrefs the Immich pattern vanishes and this passes vacuously. Require the
+    # patched-in Noodle URLs to be present too.
+    missing=""
+    grep -qF "$REPO_DOCS_URL" "$help_modal" || missing="$missing docs"
+    grep -qF "$REPO_ISSUES_URL" "$help_modal" || missing="$missing issues"
+    if [[ -n "$missing" ]]; then
+      echo "  WARN: HelpAndFeedbackModal.svelte is missing Noodle URL(s):$missing"
+      echo "        (no upstream URL either — the hrefs likely moved and apply-branding no-opped)"
+      EXIT_CODE=1
+    else
+      echo "  OK: HelpAndFeedbackModal.svelte (URLs patched)"
+    fi
   fi
 fi
 
@@ -177,7 +196,23 @@ if [[ -f "$app_download_modal" ]]; then
     echo "  WARN: Immich store link/F-Droid badge still present in AppDownloadModal.svelte"
     EXIT_CODE=1
   else
-    echo "  OK: AppDownloadModal.svelte (store links patched)"
+    # Absence is not proof of branding. If upstream moves the hrefs out of this file the
+    # Immich patterns disappear too, so the check above passes while the branded build
+    # still ships upstream's links. Upstream #30527 did exactly that — it replaced the
+    # literal URLs with @immich/ui `Constants.Get.*` expressions, silently neutering
+    # apply-branding's seds. So also require the Noodle links to actually be here;
+    # apply-branding resolves both the literal and the Constants form to literals.
+    missing=""
+    grep -qF "$PLAY_STORE_URL" "$app_download_modal" || missing="$missing play-store"
+    grep -qF "$APP_STORE_URL" "$app_download_modal" || missing="$missing app-store"
+    grep -qF "$REPO_RELEASES_URL" "$app_download_modal" || missing="$missing github-releases"
+    if [[ -n "$missing" ]]; then
+      echo "  WARN: AppDownloadModal.svelte is missing Noodle link(s):$missing"
+      echo "        (no Immich links either — the hrefs likely moved and apply-branding no-opped)"
+      EXIT_CODE=1
+    else
+      echo "  OK: AppDownloadModal.svelte (store links patched)"
+    fi
   fi
 fi
 


### PR DESCRIPTION
Closes the false-OK class in `verify-branding.sh` found while root-causing upstream #30527.

## The defect

The `AppDownloadModal` and `HelpAndFeedbackModal` checks asserted only that upstream strings were **gone**. That cannot tell "branding was applied" apart from "the value moved somewhere the patch can no longer reach" — both leave the file free of Immich strings.

Upstream [#30527](https://github.com/immich-app/immich/pull/30527) is the worked example: it replaced the literal store URLs with `@immich/ui` `Constants.Get.*` expressions, so `apply-branding`'s literal-URL `sed`s matched nothing and a branded build shipped **Immich's** Play/App Store links — while this verifier reported `OK`. `test-app-download-branding.sh` caught it precisely because it asserts the Noodle URLs are *present*.

## Change

Both checks now also require the patched-in Noodle URLs (`play_store_url`, `app_store_url`, `repository.releases_url`; `docs_url`, `issues_url` for the help modal) — read from the same `branding/config.json` keys `apply-branding` patches them from. A rewrite that silently no-ops now fails here instead of passing vacuously.

The `HelpAndFeedbackModal` check had the identical structural weakness, so it is fixed in the same pass rather than left as a half-fix.

## Verification — the before/after, on one tree

Replayed #30527 locally by moving the three hrefs onto `Constants.Get.*` (leaving no Immich literal for `apply-branding` to match), then ran both versions of the script against the same regressed-and-branded tree:

| Script | Result |
|---|---|
| **`origin/main`** | `OK: AppDownloadModal.svelte (store links patched)` → exit **0**, `Branding verification passed` |
| **this PR** | `WARN: AppDownloadModal.svelte is missing Noodle link(s): play-store app-store` → `Branding verification FAILED` |

On the clean tree the full `gallery-branding-check.sh` umbrella still passes end to end (`Gallery branding check passed`), with both modal checks reporting `OK`. `shellcheck` clean, `bash -n` clean.

Note the umbrella runs `test-app-download-branding.sh` *before* `verify-branding.sh` and aborts on failure, so the two are belt-and-braces rather than redundant: this one also covers the help modal, which has no dedicated regression test.

## Compatibility with the rolling rebase branch

Safe there too. The rolling branch already carries `3c05755cef2`, which rewrites `{Constants.Get.Android}` / `{Constants.Get.iOS}` to literal Noodle URLs — so the modal ends up containing the literals under both the pre- and post-#30527 upstream shapes, and this presence assertion holds either way.