### PR TITLE
feat: do not offer filter sections that cannot filter anything (#910)

### DIFF
--- a/docs/docs/features/dynamic-filter-suggestions.md
+++ b/docs/docs/features/dynamic-filter-suggestions.md
@@ -1,12 +1,12 @@
 # Dynamic Filter Suggestions
 
-When you apply a filter on the Photos page or inside an album, all other filter panels dynamically update to show only values that exist in the current result set. Every visible option is guaranteed to return results.
+When you apply a filter on the Photos page or inside an album, all other filter panels dynamically update to show only values that exist in the current result set. Every visible option is guaranteed to return results. Sections that could never filter anything in this scope stay out of the way entirely, and sections your current filters happen to have emptied grey out rather than sitting there uselessly.
 
 ## How it works
 
 Select any filter value and the other panels narrow immediately:
 
-1. Select **Germany** in Location -- People, Camera, Tags, Rating, and Media Type panels update to show only values present in German photos
+1. Select **Germany** in Location -- People, Camera, and Tags panels update to show only values present in German photos. Rating and Media Type keep every star and every Photo/Video button visible -- see [What updates](#what-updates) -- but their whole section can hide or grey depending on what your German photos contain.
 2. Then select **Canon** in Camera -- the remaining panels narrow further to show only values for Canon photos taken in Germany
 3. Every combination is valid -- you can never select a filter that produces zero results
 
@@ -14,20 +14,35 @@ This is called **faceted search** -- the same pattern used by Amazon, eBay, and 
 
 ## What updates
 
-| Filter     | Updates when other filters change? | Notes                                                    |
-| ---------- | ---------------------------------- | -------------------------------------------------------- |
-| People     | Yes                                | Only people appearing in the filtered photos             |
-| Location   | Yes (countries)                    | Cities update when you expand a country                  |
-| Camera     | Yes (makes)                        | Models update when you expand a make                     |
-| Tags       | Yes                                | Only tags assigned to filtered photos                    |
-| Rating     | Yes                                | Shows ratings that can still satisfy the current minimum |
-| Media Type | Yes                                | Photo/Video buttons hidden when no assets of that type   |
-| Timeline   | Drives filtering                   | Selecting a year/month narrows all other panels          |
-| Favorites  | Not dynamic                        | Simple toggle, always visible                            |
+| Filter     | Options narrow with other filters?  | Whole section hidden when it cannot filter?            |
+| ---------- | ----------------------------------- | ------------------------------------------------------ |
+| People     | Yes                                 | Yes, unless unnamed faces exist                        |
+| Location   | Yes (countries)                     | Yes, when no photo has a location                      |
+| Camera     | Yes (makes)                         | Yes, when no photo has camera metadata                 |
+| Tags       | Yes                                 | Yes, when nothing is tagged                            |
+| Rating     | No -- all five stars always show    | Yes, when nothing is rated                             |
+| Media Type | No -- all three buttons always show | Yes, unless you have both photos and videos            |
+| Favorites  | n/a -- a toggle, not a list         | Yes, when nothing is favourited                        |
+| Albums     | n/a -- a toggle, not a list         | Yes, unless some photos are in albums and some are not |
+| Timeline   | Drives filtering                    | Never -- it greys out instead                          |
+| Text       | No -- free text                     | Never                                                  |
+
+## Sections you do not see
+
+A filter section only appears when it can change what you are looking at.
+
+- **Hidden.** Nothing in this library, album or space could ever populate the section -- you have no videos, so there is no Media Type section, and no way to filter by something you do not have. The section reappears on its own as soon as the content does.
+- **Greyed out, with `(0)`.** The section could normally filter, but the filters you have applied right now leave it nothing to offer. Clear or change a filter and it comes back.
+
+A section holding an active filter is never hidden or greyed, so you can always undo a selection.
+
+The greyed `(0)` state is a web detail. The mobile app's filter sheet has no in-between treatment: a section is either hidden (nothing to offer at all, in this scope) or shown normally -- a section merely emptied by your current filters still renders on mobile rather than dimming.
 
 ## Orphaned selections
 
-If you select a value and then apply another filter that removes it from the available options, the selected value stays visible but appears **dimmed**. This lets you see why your result set might be empty and undo the selection with one click.
+If you select a value from a list -- a person, country, camera or tag -- and then apply another filter that removes it from the available options, the selected value stays visible but appears **dimmed**. This lets you see why your result set might be empty and undo the selection with one click.
+
+Rating stars and the Photo/Video buttons never dim or disappear individually: their meaning comes from their position, so a gap in the row would be misleading. When they cannot help, the whole section is hidden or greyed instead.
 
 ## Debouncing
 
@@ -41,7 +56,7 @@ Previous in-flight requests are automatically cancelled when a new filter change
 
 ## Architecture
 
-A single API endpoint (`GET /search/suggestions/filters`) returns all suggestion categories in one round trip. The server runs 6 parallel queries -- one per category -- each applying all active filters **except its own category**. This exclusion is what makes it faceted: selecting Germany still shows all countries that match the other filters, not just Germany.
+A single API endpoint (`GET /search/suggestions/filters`) returns all suggestion categories in one round trip. The server runs eight parallel facet queries -- one per category, including the favourites and album-membership presence checks -- each applying all active filters **except its own category**. This exclusion is what makes it faceted: selecting Germany still shows all countries that match the other filters, not just Germany. Album membership is one of those eight but issues two SQL probes internally (one asking whether any matching asset is already filed, one asking whether any is unfiled), so nine queries actually reach the database.
 
 For album detail pages, the same endpoint is scoped with `albumId`. Album scoping cannot be combined with `spaceId` or `withSharedSpaces`, because an album and a space are separate collection boundaries.
 
@@ -53,13 +68,17 @@ Client: GET /search/suggestions/filters?country=Germany&withSharedSpaces=true
 Server:
   1. Resolve user IDs (own + partners)
   2. Resolve shared space IDs (if withSharedSpaces)
-  3. Run 6 queries in parallel:
+  3. Run 8 facet queries in parallel:
      - Countries: all filters EXCEPT country/city
      - Camera makes: all filters EXCEPT make/model
      - Tags: all filters EXCEPT tagIds
      - People: all filters EXCEPT personIds
      - Ratings: all filters EXCEPT rating
      - Media types: all filters EXCEPT mediaType
+     - Favourites: all filters EXCEPT isFavorite
+     - Album membership: all filters EXCEPT isInAlbum/isNotInAlbum
+       - probe 1: is any matching asset already filed in an album?
+       - probe 2: is any matching asset not filed in any album?
   4. Return unified response
 ```
 
@@ -72,12 +91,12 @@ FilterPanel:
   3. Call suggestionsProvider(currentFilterState)
   4. Receive response with narrowed suggestions
   5. Update all filter panels
-  6. Orphaned selections shown dimmed
+  6. Orphaned list-style selections shown dimmed; sections left with nothing to offer hide or grey
 ```
 
 ### Shared query helper
 
-All 6 extraction queries share a common `buildFilteredAssetIds` helper that applies user/space scoping, temporal bounds, exif filters, person filters (via EXISTS), tag filters (via EXISTS), media type, and favorites. Each extraction method passes its own filter through `without()` to exclude its category before building the query.
+All eight facet queries share a common `buildFilteredAssetIds` helper that applies user/space scoping, temporal bounds, exif filters, person filters (via EXISTS), tag filters (via EXISTS), media type, and favorites. Each extraction method passes its own filter through `without()` to exclude its category before building the query. Album membership calls the helper once per probe.
 
 ## Supported pages
 

--- a/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-1.md
+++ b/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-1.md
@@ -23,8 +23,19 @@ moved out of the candidate temp table first, so it can be excluded per facet the
 
 - Server imports use the `src/` path alias. Relative imports are a lint error.
 - Prettier: 120-char lines, single quotes, trailing commas, semicolons. `eslint --max-warnings 0`.
-- `make sql` **requires a running database**. Without one it deletes every file in
-  `server/src/queries/`. Start the dev stack (`make dev`) or a Postgres container first.
+- **Do not insert a `--` before `--run`.** Per `feedback_local_verify_command_traps` §1, this pnpm
+  passes the literal `--` through and vitest then **drops the path filter and runs the whole suite** —
+  verified, not theoretical. The `-t` name filter is unreliable the same way. Every command in this
+  plan is `pnpm test:medium --run <path>`; keep it that way, and sanity-check the reported file count
+  against what you asked for before believing a red or a green.
+- **`make sql`, `make lint-server` and `make format-server` do not work.** `make sql` is a removed
+  stub that prints "use mise sql" and exits 1; the `lint-server` / `format-server` targets do not
+  exist in the `Makefile` at all (CLAUDE.md is stale — `feedback_local_verify_command_traps` §2).
+  Use `mise sql` and `cd server && pnpm lint` / `pnpm format`.
+- `mise sql` **requires a running database**. Without one it deletes every file in
+  `server/src/queries/`. Start the dev stack (`mise dev`) or a Postgres container first. Use the bare
+  `mise sql`, never `mise run //:sql` — from a worktree the `//:` prefix targets the **main** checkout
+  (`reference_mise_run_from_worktree_wrong_dir`).
 - Medium tests need the dev prerequisites from `reference_fresh_worktree_medium_test_prereqs`:
   `mise run plugins` (sdk + plugin-sdk + plugin-core) before `pnpm test:medium`.
 - Do not touch `server/src/schema/` — no migration is involved.
@@ -118,7 +129,7 @@ describe('hasFavorites (#910)', () => {
 - [ ] **Step 2: Run the tests to verify they fail**
 
 ```bash
-cd server && pnpm test:medium -- --run test/medium/specs/repositories/search.repository.spec.ts -t 'hasFavorites'
+cd server && pnpm test:medium --run test/medium/specs/repositories/search.repository.spec.ts -t 'hasFavorites'
 ```
 
 Expected: FAIL — `expected undefined to be false`. `hasFavorites` is not on the result yet.
@@ -203,7 +214,7 @@ them until slice 4.
 - [ ] **Step 6: Run the tests to verify they pass**
 
 ```bash
-cd server && pnpm test:medium -- --run test/medium/specs/repositories/search.repository.spec.ts -t 'hasFavorites'
+cd server && pnpm test:medium --run test/medium/specs/repositories/search.repository.spec.ts -t 'hasFavorites'
 ```
 
 Expected: PASS, 4 tests.
@@ -325,7 +336,7 @@ describe('album membership (#910)', () => {
 - [ ] **Step 2: Run the tests to verify they fail**
 
 ```bash
-cd server && pnpm test:medium -- --run test/medium/specs/repositories/search.repository.spec.ts -t 'album membership'
+cd server && pnpm test:medium --run test/medium/specs/repositories/search.repository.spec.ts -t 'album membership'
 ```
 
 Expected: FAIL — every `hasAssetsInAlbum` assertion gets `false` from Task 1's placeholder, so the
@@ -390,7 +401,7 @@ return {
 - [ ] **Step 5: Run the tests to verify they pass**
 
 ```bash
-cd server && pnpm test:medium -- --run test/medium/specs/repositories/search.repository.spec.ts -t 'album membership'
+cd server && pnpm test:medium --run test/medium/specs/repositories/search.repository.spec.ts -t 'album membership'
 ```
 
 Expected: PASS, 6 tests.
@@ -441,7 +452,7 @@ it('computes hasFavorites ignoring its own isFavorite filter (#910)', async () =
 - [ ] **Step 2: Run it to verify it fails**
 
 ```bash
-cd server && pnpm test:medium -- --run test/medium/specs/repositories/search.repository.spec.ts -t 'hasFavorites ignoring'
+cd server && pnpm test:medium --run test/medium/specs/repositories/search.repository.spec.ts -t 'hasFavorites ignoring'
 ```
 
 Expected: FAIL — `hasFavorites` is not on `SmartSearchFacetsResult` yet.
@@ -506,7 +517,7 @@ query runs inside one transaction against the same temp table.
 - [ ] **Step 6: Run the test to verify it passes**
 
 ```bash
-cd server && pnpm test:medium -- --run test/medium/specs/repositories/search.repository.spec.ts -t 'getSmartSearchFacets'
+cd server && pnpm test:medium --run test/medium/specs/repositories/search.repository.spec.ts -t 'getSmartSearchFacets'
 ```
 
 Expected: PASS — the new test plus every pre-existing `getSmartSearchFacets` test.
@@ -584,7 +595,7 @@ it('still applies isNotInAlbum to the non-album facets (#910)', async () => {
 - [ ] **Step 2: Run them to verify they fail**
 
 ```bash
-cd server && pnpm test:medium -- --run test/medium/specs/repositories/search.repository.spec.ts -t 'isNotInAlbum'
+cd server && pnpm test:medium --run test/medium/specs/repositories/search.repository.spec.ts -t 'isNotInAlbum'
 ```
 
 Expected: FAIL — the first on `hasAssetsInAlbum` being the `false` placeholder from Task 3. The second
@@ -676,7 +687,7 @@ return object.
 - [ ] **Step 6: Run the full repository suite**
 
 ```bash
-cd server && pnpm test:medium -- --run test/medium/specs/repositories/search.repository.spec.ts
+cd server && pnpm test:medium --run test/medium/specs/repositories/search.repository.spec.ts
 ```
 
 Expected: PASS. Pay attention to the pre-existing `getSmartSearchFacets` tests — moving a predicate out of
@@ -692,16 +703,17 @@ git commit -m "feat(server): add album-membership smart-search facets (#910)"
 
 ---
 
-## Task 5: Degenerate-input coverage
+## Task 5: Degenerate-input and scope coverage
 
 **Files:**
 
 - Test only: `server/test/medium/specs/repositories/search.repository.spec.ts`
 
-Spec §4.6. No source change is expected — if either test fails, stop and report rather than "fixing" it,
-because it means the client-side reasoning in the spec is wrong.
+Spec §4.6 and the last two rows of §8.1. No source change is expected in this task — if any test here
+fails, stop and report rather than "fixing" it, because it means the client-side reasoning in the spec
+is wrong.
 
-- [ ] **Step 1: Write the tests**
+- [ ] **Step 1: Write the `forceEmptyResult` test**
 
 ```ts
 it('reports every #910 facet false under forceEmptyResult', async () => {
@@ -717,20 +729,84 @@ it('reports every #910 facet false under forceEmptyResult', async () => {
 });
 ```
 
-- [ ] **Step 2: Run and confirm they pass without source changes**
+- [ ] **Step 2: Write the `withSharedSpaces` scope test**
+
+Spec §8.1's last row, and the one that pins §4.6's third degenerate input. The whole client-side
+argument that a scope mismatch "can only grey, never wrongly hide" rests on the baseline seeing a
+**wider** set than the favourites-filtered current — this is what proves the server side of that.
+
+Copy the space fixture shape from the existing test at `:382` (`newSharedSpace` /
+`newSharedSpaceMember` / `newSharedSpaceAsset`); `SharedSpaceRepository` is already in `setup()`'s
+`real` list.
+
+```ts
+it('sees a shared-space favourite only with timelineSpaceIds (#910)', async () => {
+  const { ctx, sut } = setup();
+  const { user: owner } = await ctx.newUser();
+  const { user: member } = await ctx.newUser();
+  const { asset } = await ctx.newAsset({ ownerId: owner.id, isFavorite: true });
+
+  const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: 'viewer' });
+  await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: owner.id });
+
+  // The member owns nothing. Without the space in scope the favourite is invisible to them...
+  const ownScope = await sut.getFilterSuggestions([member.id], {});
+  expect(ownScope.hasFavorites).toBe(false);
+
+  // ...and with it, it is. The two scopes disagree, which is exactly what §4.6 documents:
+  // the photos page drops withSharedSpaces when isFavorite is set, so `current` is narrower
+  // than `baseline`. Subset, so it can only grey — never wrongly hide.
+  const spaceScope = await sut.getFilterSuggestions([member.id], { timelineSpaceIds: [space.id] });
+  expect(spaceScope.hasFavorites).toBe(true);
+});
+```
+
+- [ ] **Step 3: Write the smart-path verdict tests**
+
+§8.1's "smart-search path, each of the above" row. Tasks 3 and 4 only covered the two _exclusion_
+cases; the ordinary verdicts on the smart path are still unpinned, and they run through a completely
+different query builder (`buildSmartFacetFilteredAssetIds` over the temp table, not
+`buildFilteredAssetIds`). Mirror Task 1's and Task 2's cases with `addEmbedding` + `matchingEmbedding`:
+
+```ts
+it('reports no favourites and mixed album membership on the smart path (#910)', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  const { asset: filed } = await ctx.newAsset({ ownerId: user.id });
+  await addEmbedding(defaultDatabase, filed.id);
+  const { asset: unfiled } = await ctx.newAsset({ ownerId: user.id });
+  await addEmbedding(defaultDatabase, unfiled.id);
+  const { album } = await ctx.newAlbum({ ownerId: user.id });
+  await ctx.newAlbumAsset({ albumId: album.id, assetId: filed.id });
+
+  const result = await sut.getSmartSearchFacets({ userIds: [user.id], embedding: matchingEmbedding });
+
+  expect(result.hasFavorites).toBe(false);
+  expect(result.hasAssetsInAlbum).toBe(true);
+  expect(result.hasAssetsNotInAlbum).toBe(true);
+});
+```
+
+Add the two single-sided album cases (everything filed → `hasAssetsNotInAlbum` false; nothing filed →
+`hasAssetsInAlbum` false) the same way, plus one favourite present → `hasFavorites` true.
+
+- [ ] **Step 4: Run and confirm they pass without source changes**
 
 ```bash
-cd server && pnpm test:medium -- --run test/medium/specs/repositories/search.repository.spec.ts -t 'forceEmptyResult'
+cd server && pnpm test:medium --run test/medium/specs/repositories/search.repository.spec.ts
 ```
 
 Expected: PASS. `buildFilteredAssetIds` already honours `forceEmptyResult` at `:1402`, so the probes
-inherit it.
+inherit it; the space scoping is `applySuggestionScope`'s existing behaviour; and Tasks 3–4 already
+built the smart-path probes.
 
-- [ ] **Step 3: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
 git add server/test/medium/specs/repositories/search.repository.spec.ts
-git commit -m "test(server): lock forceEmptyResult behaviour for the #910 facets"
+git commit -m "test(server): lock degenerate-input and scope behaviour for the #910 facets"
 ```
 
 ---
@@ -767,40 +843,56 @@ Add the same three lines to `SmartSearchFacetsResponseSchema` (`:260`), after `h
 
 - [ ] **Step 2: Update the SQL-generation hints**
 
-`sortQueries` at `:1245` lists the leading fragment of each generated query so `make sql` orders them
-deterministically. Run `make sql` first (Step 4), read the new fragments out of the generated file, then
-add them here and re-run. Do not guess the strings.
+`sortQueries` at `:1245` lists the leading fragment of each generated query so `mise sql` orders them
+deterministically. **This step is a loop, not a line:** run Step 4 first, read the new fragments out of
+the generated file, come back here and add them, then run Step 4 again. Do not guess the strings.
+
+The three probes add four queries, not three — `getFilteredAlbumMembership` issues two.
 
 - [ ] **Step 3: Update unit-test fixtures**
 
-`search.service.spec.ts:1218`, `:1866`, `:1880`, `:1966` and `search.controller.spec.ts:175`, `:474`,
-`:489`, `:543` build literal facet objects. Add
-`hasFavorites: false, hasAssetsInAlbum: false, hasAssetsNotInAlbum: false` to each, except where the
-surrounding test is about a populated library — match the neighbouring `ratings` / `mediaTypes` values.
+**Do not work from a hand-written list — let `tsc` enumerate them.** An earlier draft of this plan
+named four sites in `search.service.spec.ts`; there are eleven `hasUnnamedPeople` literals in that file
+alone (`:30, 1220, 1868, 1882, 1886, 1915, 1968, 2068, 2101, 2126, 2151`) plus four in
+`search.controller.spec.ts` (`:177, 476, 491, 545`). Only the ones typed as `FilterSuggestionsResult` /
+`SmartSearchFacetsResult` need the fields, and the compiler knows which:
 
 ```bash
-cd server && pnpm test -- --run src/services/search.service.spec.ts src/controllers/search.controller.spec.ts
+cd server && pnpm check 2>&1 | grep -E "hasFavorites|hasAssetsInAlbum|hasAssetsNotInAlbum"
+```
+
+Add `hasFavorites: false, hasAssetsInAlbum: false, hasAssetsNotInAlbum: false` to each site it names,
+except where the surrounding test is about a populated library — there, match the neighbouring
+`ratings` / `mediaTypes` values.
+
+```bash
+cd server && pnpm test --run src/services/search.service.spec.ts src/controllers/search.controller.spec.ts
 ```
 
 Expected: PASS.
 
 - [ ] **Step 4: Regenerate the SQL**
 
-Start a database first — `make dev` in another terminal, or any Postgres the server config points at.
-**`make sql` against no database deletes every file in `server/src/queries/`.**
+Start a database first — `mise dev` in another terminal, or any Postgres the server config points at.
+**`mise sql` against no database deletes every file in `server/src/queries/`.** It also runs out of
+`dist/`, so the server must be built first.
 
 ```bash
-make sql
+cd server && pnpm build
+mise sql
 git diff --stat server/src/queries/
 ```
 
-Expected: `search.repository.sql` changed, nothing deleted. If the diff shows deletions, `git checkout --
-server/src/queries/` and start a database.
+Expected: `search.repository.sql` changed, nothing deleted. If the diff shows deletions,
+`git checkout -- server/src/queries/` and start a database.
 
 - [ ] **Step 5: Full server gate**
 
+`make lint-server` and `make format-server` do not exist — they are not stubs, there is simply no such
+target (`feedback_local_verify_command_traps` §2).
+
 ```bash
-cd server && pnpm test -- --run && pnpm check && make lint-server && make format-server
+cd server && pnpm test --run && pnpm check && pnpm lint && pnpm format
 ```
 
 - [ ] **Step 6: Commit**
@@ -814,8 +906,11 @@ git commit -m "feat(server): expose favourites and album-membership facets in th
 
 ## Done when
 
-- `pnpm test:medium -- --run test/medium/specs/repositories/search.repository.spec.ts` is green, including
-  every pre-existing test.
-- `pnpm test`, `pnpm check`, `make lint-server`, `make format-server` are green.
-- `server/src/queries/search.repository.sql` contains the three new probe queries and nothing was deleted.
+- `pnpm test:medium --run test/medium/specs/repositories/search.repository.spec.ts` is green, including
+  every pre-existing test — and the reported file count is 1, not the whole suite (Global Constraints).
+- `pnpm test --run`, `pnpm check`, `pnpm lint`, `pnpm format` are green from `server/`.
+- `server/src/queries/search.repository.sql` contains the four new probe queries (album membership is
+  two) and nothing was deleted.
+- Every row of spec §8.1 has a test. The two easiest to skip are `withSharedSpaces` and the
+  smart-path verdicts — both are Task 5.
 - No web, mobile, or `open-api/` file is touched — those are slices 2 and 4.

--- a/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-1.md
+++ b/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-1.md
@@ -912,8 +912,8 @@ git commit -m "feat(server): expose favourites and album-membership facets in th
 - `pnpm test:medium --run test/medium/specs/repositories/search.repository.spec.ts` is green, including
   every pre-existing test — and the reported file count is 1, not the whole suite (Global Constraints).
 - `pnpm test --run`, `pnpm check`, `pnpm lint`, `pnpm format` are green from `server/`.
-- `server/src/queries/search.repository.sql` contains the four new probe queries (album membership is
-  two) and nothing was deleted.
+- `server/src/queries/search.repository.sql` contains the six new probe queries — three per
+  `@GenerateSql` call site, since album membership issues two — and nothing was deleted.
 - Every row of spec §8.1 has a test. The two easiest to skip are `withSharedSpaces` and the
   smart-path verdicts — both are Task 5.
 - No web, mobile, or `open-api/` file is touched — those are slices 2 and 4.

--- a/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-1.md
+++ b/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-1.md
@@ -1,0 +1,821 @@
+# Slice 1 — Server favourites and album-membership facets (#910)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for
+> tracking.
+
+**Goal:** `getFilterSuggestions` and `getSmartSearchFacets` return `hasFavorites`, `hasAssetsInAlbum` and
+`hasAssetsNotInAlbum`, each computed with its own filter excluded, so the clients can tell a structurally
+useless Favourites or Albums section from a transiently empty one.
+
+**Architecture:** Three `limit 1` probes reusing the existing faceted asset-id subquery. The browse path
+drops them into the existing `Promise.all`. The smart-search path needs the album-membership predicate
+moved out of the candidate temp table first, so it can be excluded per facet the way favourites already is.
+
+**Tech Stack:** NestJS, Kysely, Vitest, testcontainers (medium tests).
+
+- **Spec:** `docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md` §5
+- **Branch:** `fix/910-interdependent-filter-sections`
+- **Depends on:** nothing
+- **Scope:** two server source files, three server test files, one generated SQL file. No web, no mobile.
+
+## Global Constraints
+
+- Server imports use the `src/` path alias. Relative imports are a lint error.
+- Prettier: 120-char lines, single quotes, trailing commas, semicolons. `eslint --max-warnings 0`.
+- `make sql` **requires a running database**. Without one it deletes every file in
+  `server/src/queries/`. Start the dev stack (`make dev`) or a Postgres container first.
+- Medium tests need the dev prerequisites from `reference_fresh_worktree_medium_test_prereqs`:
+  `mise run plugins` (sdk + plugin-sdk + plugin-core) before `pnpm test:medium`.
+- Do not touch `server/src/schema/` — no migration is involved.
+
+## File Structure
+
+| File                                                              | Responsibility                                         |
+| ----------------------------------------------------------------- | ------------------------------------------------------ |
+| `server/src/repositories/search.repository.ts`                    | the three probes, both call sites, `SmartFacetExclude` |
+| `server/src/dtos/search.dto.ts`                                   | the three booleans on both response schemas            |
+| `server/test/medium/specs/repositories/search.repository.spec.ts` | behavioural coverage against a real database           |
+| `server/src/services/search.service.spec.ts`                      | fixture updates only                                   |
+| `server/src/controllers/search.controller.spec.ts`                | fixture updates only                                   |
+| `server/src/queries/search.repository.sql`                        | generated — never hand-edited                          |
+
+**Interfaces produced** (slices 2 and 4 consume these exact names):
+
+```ts
+// FilterSuggestionsResult and SmartSearchFacetsResult both gain:
+hasFavorites: boolean;
+hasAssetsInAlbum: boolean;
+hasAssetsNotInAlbum: boolean;
+```
+
+---
+
+## Task 1: Browse-path favourites facet
+
+**Files:**
+
+- Modify: `server/src/repositories/search.repository.ts:297-305` (`FilterSuggestionsResult`), `:1254-1273`
+  (`getFilterSuggestions`)
+- Test: `server/test/medium/specs/repositories/search.repository.spec.ts` — inside the existing
+  `describe('getFilterSuggestions', …)` block that starts at `:474`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `describe('getFilterSuggestions', …)`. The `ctx.newUser()` / `ctx.newAsset()` / `ctx.newExif()`
+helpers and the `setup()` factory are already defined at the top of the file — do not redefine them.
+
+```ts
+describe('hasFavorites (#910)', () => {
+  it('is false when the scope has no favourite', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    await ctx.newAsset({ ownerId: user.id });
+
+    const result = await sut.getFilterSuggestions([user.id], {});
+
+    expect(result.hasFavorites).toBe(false);
+  });
+
+  it('is true when the scope has a favourite', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    await ctx.newAsset({ ownerId: user.id, isFavorite: true });
+
+    const result = await sut.getFilterSuggestions([user.id], {});
+
+    expect(result.hasFavorites).toBe(true);
+  });
+
+  it('ignores its own isFavorite filter', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    await ctx.newAsset({ ownerId: user.id, isFavorite: true });
+    await ctx.newAsset({ ownerId: user.id });
+
+    // Filtering to non-favourites must not make the facet claim there are none.
+    const result = await sut.getFilterSuggestions([user.id], { isFavorite: false });
+
+    expect(result.hasFavorites).toBe(true);
+  });
+
+  it('honours the other active dimensions', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset: favourite } = await ctx.newAsset({ ownerId: user.id, isFavorite: true });
+    await ctx.newExif({ assetId: favourite.id, make: 'Canon' });
+    const { asset: plain } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newExif({ assetId: plain.id, make: 'Nikon' });
+
+    // The only favourite is a Canon, so a Nikon filter must report no favourites.
+    const result = await sut.getFilterSuggestions([user.id], { make: 'Nikon' });
+
+    expect(result.hasFavorites).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd server && pnpm test:medium -- --run test/medium/specs/repositories/search.repository.spec.ts -t 'hasFavorites'
+```
+
+Expected: FAIL — `expected undefined to be false`. `hasFavorites` is not on the result yet.
+
+- [ ] **Step 3: Add the field to the result type**
+
+In `search.repository.ts`, extend `FilterSuggestionsResult` (`:297`):
+
+```ts
+export interface FilterSuggestionsResult {
+  countries: string[];
+  cameraMakes: string[];
+  tags: Array<{ id: string; value: string }>;
+  people: FilterSuggestionPerson[];
+  ratings: number[];
+  mediaTypes: string[];
+  hasUnnamedPeople: boolean;
+  hasFavorites: boolean;
+  hasAssetsInAlbum: boolean;
+  hasAssetsNotInAlbum: boolean;
+}
+```
+
+Add all three now even though only `hasFavorites` is populated in this task — Task 2 fills the other two,
+and splitting the interface edit across tasks makes the file churn twice for no benefit.
+
+- [ ] **Step 4: Write the probe**
+
+Add next to `getFilteredMediaTypes` (`search.repository.ts:1737`), at the end of the class:
+
+```ts
+  /**
+   * #910: presence probes for the Favourites / Albums sections. `limit 1` rather than an aggregate so
+   * Postgres stops at the first matching row — the answer is "does one exist", not "how many".
+   */
+  private async getFilteredHasFavorites(userIds: string[], options: FilterSuggestionsOptions): Promise<boolean> {
+    const row = await this.db
+      .selectFrom('asset')
+      .select('asset.id')
+      .where('asset.id', 'in', this.buildFilteredAssetIds(userIds, options))
+      .where('asset.isFavorite', '=', true)
+      .limit(1)
+      .executeTakeFirst();
+    return !!row;
+  }
+```
+
+- [ ] **Step 5: Wire it into the fan-out**
+
+In `getFilterSuggestions` (`:1254`):
+
+```ts
+  async getFilterSuggestions(userIds: string[], options: FilterSuggestionsOptions): Promise<FilterSuggestionsResult> {
+    const [countries, cameraMakes, tags, peopleResult, ratings, mediaTypes, hasFavorites] = await Promise.all([
+      this.getFilteredCountries(userIds, without(options, 'country', 'city')),
+      this.getFilteredCameraMakes(userIds, without(options, 'make', 'model')),
+      this.getFilteredTags(userIds, without(options, 'tagIds')),
+      this.getFilteredPeople(userIds, without(options, 'personIds', 'identityIds')),
+      this.getFilteredRatings(userIds, without(options, 'rating')),
+      this.getFilteredMediaTypes(userIds, without(options, 'mediaType')),
+      this.getFilteredHasFavorites(userIds, without(options, 'isFavorite')),
+    ]);
+
+    return {
+      countries,
+      cameraMakes,
+      tags,
+      people: peopleResult.people,
+      ratings,
+      mediaTypes,
+      hasUnnamedPeople: peopleResult.hasUnnamedPeople,
+      hasFavorites,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: false,
+    };
+  }
+```
+
+The two `false` placeholders are replaced in Task 2. They are safe in the meantime because no client reads
+them until slice 4.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+cd server && pnpm test:medium -- --run test/medium/specs/repositories/search.repository.spec.ts -t 'hasFavorites'
+```
+
+Expected: PASS, 4 tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/repositories/search.repository.ts server/test/medium/specs/repositories/search.repository.spec.ts
+git commit -m "feat(server): add hasFavorites filter-suggestion facet (#910)"
+```
+
+---
+
+## Task 2: Browse-path album-membership facet
+
+**Files:**
+
+- Modify: `server/src/repositories/search.repository.ts` — new probe, `getFilterSuggestions` fan-out
+- Test: `server/test/medium/specs/repositories/search.repository.spec.ts`
+
+**Interfaces:**
+
+- Consumes: `FilterSuggestionsResult.hasAssetsInAlbum` / `.hasAssetsNotInAlbum` from Task 1.
+- Produces: `getFilteredAlbumMembership(userIds, options)` →
+  `Promise<{ hasAssetsInAlbum: boolean; hasAssetsNotInAlbum: boolean }>`
+
+- [ ] **Step 1: Write the failing tests**
+
+`ctx.newAlbum` and `ctx.newAlbumAsset` are the medium-factory helpers used elsewhere in this file (see
+the `albumId` test at `:494`); confirm their exact signatures there before writing, and match them.
+
+```ts
+describe('album membership (#910)', () => {
+  it('reports not-in-album only when the scope has no albums', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    await ctx.newAsset({ ownerId: user.id });
+
+    const result = await sut.getFilterSuggestions([user.id], {});
+
+    expect(result.hasAssetsInAlbum).toBe(false);
+    expect(result.hasAssetsNotInAlbum).toBe(true);
+  });
+
+  it('reports in-album only when every asset is filed', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    const { album } = await ctx.newAlbum({ ownerId: user.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+
+    const result = await sut.getFilterSuggestions([user.id], {});
+
+    expect(result.hasAssetsInAlbum).toBe(true);
+    expect(result.hasAssetsNotInAlbum).toBe(false);
+  });
+
+  it('reports both when the scope is mixed', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset: filed } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newAsset({ ownerId: user.id });
+    const { album } = await ctx.newAlbum({ ownerId: user.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: filed.id });
+
+    const result = await sut.getFilterSuggestions([user.id], {});
+
+    expect(result.hasAssetsInAlbum).toBe(true);
+    expect(result.hasAssetsNotInAlbum).toBe(true);
+  });
+
+  it('ignores its own isNotInAlbum filter', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset: filed } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newAsset({ ownerId: user.id });
+    const { album } = await ctx.newAlbum({ ownerId: user.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: filed.id });
+
+    // Filtering to un-filed assets must not erase the evidence that filed ones exist.
+    const result = await sut.getFilterSuggestions([user.id], { isNotInAlbum: true });
+
+    expect(result.hasAssetsInAlbum).toBe(true);
+    expect(result.hasAssetsNotInAlbum).toBe(true);
+  });
+
+  it('reports every asset filed when scoped to one album', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newAsset({ ownerId: user.id });
+    const { album } = await ctx.newAlbum({ ownerId: user.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+
+    const result = await sut.getFilterSuggestions([user.id], { albumId: album.id });
+
+    expect(result.hasAssetsInAlbum).toBe(true);
+    expect(result.hasAssetsNotInAlbum).toBe(false);
+  });
+
+  it('honours the other active dimensions', async () => {
+    const { ctx, sut } = setup();
+    const { user } = await ctx.newUser();
+    const { asset: filed } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newExif({ assetId: filed.id, make: 'Canon' });
+    const { asset: unfiled } = await ctx.newAsset({ ownerId: user.id });
+    await ctx.newExif({ assetId: unfiled.id, make: 'Nikon' });
+    const { album } = await ctx.newAlbum({ ownerId: user.id });
+    await ctx.newAlbumAsset({ albumId: album.id, assetId: filed.id });
+
+    const result = await sut.getFilterSuggestions([user.id], { make: 'Nikon' });
+
+    expect(result.hasAssetsInAlbum).toBe(false);
+    expect(result.hasAssetsNotInAlbum).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd server && pnpm test:medium -- --run test/medium/specs/repositories/search.repository.spec.ts -t 'album membership'
+```
+
+Expected: FAIL — every `hasAssetsInAlbum` assertion gets `false` from Task 1's placeholder, so the
+"reports in-album", "mixed", "ignores its own", and "scoped to one album" cases fail.
+
+- [ ] **Step 3: Write the probe**
+
+```ts
+  private async getFilteredAlbumMembership(
+    userIds: string[],
+    options: FilterSuggestionsOptions,
+  ): Promise<{ hasAssetsInAlbum: boolean; hasAssetsNotInAlbum: boolean }> {
+    const probe = (filed: boolean) =>
+      this.db
+        .selectFrom('asset')
+        .select('asset.id')
+        .where('asset.id', 'in', this.buildFilteredAssetIds(userIds, options))
+        .where((eb) => {
+          const inAlbum = eb.exists(
+            eb.selectFrom('album_asset').whereRef('album_asset.assetId', '=', 'asset.id'),
+          );
+          return filed ? inAlbum : eb.not(inAlbum);
+        })
+        .limit(1)
+        .executeTakeFirst();
+
+    const [filed, unfiled] = await Promise.all([probe(true), probe(false)]);
+    return { hasAssetsInAlbum: !!filed, hasAssetsNotInAlbum: !!unfiled };
+  }
+```
+
+- [ ] **Step 4: Wire it into the fan-out**
+
+Replace the two `false` placeholders from Task 1:
+
+```ts
+const [countries, cameraMakes, tags, peopleResult, ratings, mediaTypes, hasFavorites, albumMembership] =
+  await Promise.all([
+    this.getFilteredCountries(userIds, without(options, 'country', 'city')),
+    this.getFilteredCameraMakes(userIds, without(options, 'make', 'model')),
+    this.getFilteredTags(userIds, without(options, 'tagIds')),
+    this.getFilteredPeople(userIds, without(options, 'personIds', 'identityIds')),
+    this.getFilteredRatings(userIds, without(options, 'rating')),
+    this.getFilteredMediaTypes(userIds, without(options, 'mediaType')),
+    this.getFilteredHasFavorites(userIds, without(options, 'isFavorite')),
+    this.getFilteredAlbumMembership(userIds, without(options, 'isInAlbum', 'isNotInAlbum')),
+  ]);
+
+return {
+  countries,
+  cameraMakes,
+  tags,
+  people: peopleResult.people,
+  ratings,
+  mediaTypes,
+  hasUnnamedPeople: peopleResult.hasUnnamedPeople,
+  hasFavorites,
+  ...albumMembership,
+};
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+cd server && pnpm test:medium -- --run test/medium/specs/repositories/search.repository.spec.ts -t 'album membership'
+```
+
+Expected: PASS, 6 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/repositories/search.repository.ts server/test/medium/specs/repositories/search.repository.spec.ts
+git commit -m "feat(server): add album-membership filter-suggestion facets (#910)"
+```
+
+---
+
+## Task 3: Make favourites excludable on the smart-search path
+
+**Files:**
+
+- Modify: `server/src/repositories/search.repository.ts:187-188` (`SmartFacetExclude`), `:666`
+- Test: `server/test/medium/specs/repositories/search.repository.spec.ts` — `describe('getSmartSearchFacets', …)`
+
+This is a bug fix in its own right: every other dimension in `buildSmartFacetFilteredAssetIds` is guarded
+by `exclude !== …`; `isFavorite` alone is applied unconditionally.
+
+- [ ] **Step 1: Write the failing test**
+
+Follow the existing `getSmartSearchFacets` tests for embedding setup — they use `addEmbedding(db, assetId)`
+and pass `embedding: matchingEmbedding` in the options. Copy the option shape from the test at `:52`.
+
+```ts
+it('computes hasFavorites ignoring its own isFavorite filter (#910)', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  const { asset: favourite } = await ctx.newAsset({ ownerId: user.id, isFavorite: true });
+  await addEmbedding(defaultDatabase, favourite.id);
+  const { asset: plain } = await ctx.newAsset({ ownerId: user.id });
+  await addEmbedding(defaultDatabase, plain.id);
+
+  const result = await sut.getSmartSearchFacets({
+    userIds: [user.id],
+    embedding: matchingEmbedding,
+    isFavorite: false,
+  });
+
+  expect(result.hasFavorites).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+```bash
+cd server && pnpm test:medium -- --run test/medium/specs/repositories/search.repository.spec.ts -t 'hasFavorites ignoring'
+```
+
+Expected: FAIL — `hasFavorites` is not on `SmartSearchFacetsResult` yet.
+
+- [ ] **Step 3: Widen the exclude union**
+
+```ts
+type SmartFacetExclude =
+  | 'time'
+  | 'people'
+  | 'location'
+  | 'city'
+  | 'camera'
+  | 'cameraModel'
+  | 'tags'
+  | 'rating'
+  | 'media'
+  | 'favorites'
+  | 'albums';
+```
+
+- [ ] **Step 4: Guard the favourites predicate**
+
+`search.repository.ts:666` becomes:
+
+```ts
+      .$if(exclude !== 'favorites' && options.isFavorite !== undefined, (qb) =>
+        qb.where('asset.isFavorite', '=', options.isFavorite!),
+      )
+```
+
+- [ ] **Step 5: Add the field and the probe**
+
+Extend `SmartSearchFacetsResult` (`:191-203`) with the same three booleans as
+`FilterSuggestionsResult`, then add next to `getSmartFacetMediaTypes` (`:904`):
+
+```ts
+  private async getSmartFacetHasFavorites(trx: Kysely<DB>, options: SmartSearchFacetsOptions): Promise<boolean> {
+    const row = await trx
+      .selectFrom('asset')
+      .select('asset.id')
+      .where('asset.id', 'in', this.buildSmartFacetFilteredAssetIds(trx, options, 'favorites'))
+      .where('asset.isFavorite', '=', true)
+      .limit(1)
+      .executeTakeFirst();
+    return !!row;
+  }
+```
+
+Then in `getSmartSearchFacets` (`:562`), after `mediaTypes`:
+
+```ts
+const hasFavorites = await this.getSmartFacetHasFavorites(trx, options);
+```
+
+and add `hasFavorites` plus `hasAssetsInAlbum: false, hasAssetsNotInAlbum: false` to the returned object.
+Task 4 replaces the placeholders.
+
+Keep the sequential `await` style — this method deliberately does not use `Promise.all`, because every
+query runs inside one transaction against the same temp table.
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+```bash
+cd server && pnpm test:medium -- --run test/medium/specs/repositories/search.repository.spec.ts -t 'getSmartSearchFacets'
+```
+
+Expected: PASS — the new test plus every pre-existing `getSmartSearchFacets` test.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/repositories/search.repository.ts server/test/medium/specs/repositories/search.repository.spec.ts
+git commit -m "fix(server): exclude isFavorite from its own smart-search facet (#910)"
+```
+
+---
+
+## Task 4: Move album membership out of the candidate table
+
+**Files:**
+
+- Modify: `server/src/repositories/search.repository.ts:594-617` (`buildSmartFacetCandidateQuery`),
+  `:639-709` (`buildSmartFacetFilteredAssetIds`), `:562` (`getSmartSearchFacets`)
+- Test: `server/test/medium/specs/repositories/search.repository.spec.ts`
+
+`isNotInAlbum` / `isInAlbum` are currently applied by `searchAssetBuilderLegacy` while building the
+`smart_search_facet_candidates` temp table (`database.ts:954-959`), so no facet can exclude them. They move
+out, exactly as `isFavorite` already is.
+
+- [ ] **Step 1: Write the failing tests**
+
+The second test is not optional. Deleting the album predicate outright would make the first test pass, so
+the pair is what actually pins the behaviour.
+
+```ts
+it('computes album membership ignoring its own isNotInAlbum filter (#910)', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  const { asset: filed } = await ctx.newAsset({ ownerId: user.id });
+  await addEmbedding(defaultDatabase, filed.id);
+  const { asset: unfiled } = await ctx.newAsset({ ownerId: user.id });
+  await addEmbedding(defaultDatabase, unfiled.id);
+  const { album } = await ctx.newAlbum({ ownerId: user.id });
+  await ctx.newAlbumAsset({ albumId: album.id, assetId: filed.id });
+
+  const result = await sut.getSmartSearchFacets({
+    userIds: [user.id],
+    embedding: matchingEmbedding,
+    isNotInAlbum: true,
+  });
+
+  expect(result.hasAssetsInAlbum).toBe(true);
+  expect(result.hasAssetsNotInAlbum).toBe(true);
+});
+
+it('still applies isNotInAlbum to the non-album facets (#910)', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  const { asset: filed } = await ctx.newAsset({ ownerId: user.id });
+  await ctx.newExif({ assetId: filed.id, make: 'Canon' });
+  await addEmbedding(defaultDatabase, filed.id);
+  const { asset: unfiled } = await ctx.newAsset({ ownerId: user.id });
+  await ctx.newExif({ assetId: unfiled.id, make: 'Nikon' });
+  await addEmbedding(defaultDatabase, unfiled.id);
+  const { album } = await ctx.newAlbum({ ownerId: user.id });
+  await ctx.newAlbumAsset({ albumId: album.id, assetId: filed.id });
+
+  const result = await sut.getSmartSearchFacets({
+    userIds: [user.id],
+    embedding: matchingEmbedding,
+    isNotInAlbum: true,
+  });
+
+  // Only the un-filed Nikon survives the filter, so Canon must be gone from the makes facet.
+  expect(result.cameraMakes).toEqual(['Nikon']);
+});
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+```bash
+cd server && pnpm test:medium -- --run test/medium/specs/repositories/search.repository.spec.ts -t 'isNotInAlbum'
+```
+
+Expected: FAIL — the first on `hasAssetsInAlbum` being the `false` placeholder from Task 3. The second
+passes already; it is the guard that must stay green through this task.
+
+- [ ] **Step 3: Take album membership out of the candidate query**
+
+In `buildSmartFacetCandidateQuery` (`:597`), add the two keys to the `without(...)` list:
+
+```ts
+return searchAssetBuilderLegacy(kysely, {
+  ...without(
+    options,
+    'city',
+    'country',
+    'make',
+    'model',
+    'rating',
+    'type',
+    'isFavorite',
+    'isInAlbum',
+    'isNotInAlbum',
+    'takenAfter',
+    'takenBefore',
+    'personIds',
+    'personMatchAny',
+    'identityIds',
+    'forceEmptyResult',
+    'spacePersonIds',
+    'tagIds',
+    'tagMatchAny',
+  ),
+  ratingIsMinimum: true,
+});
+```
+
+- [ ] **Step 4: Re-apply it per facet**
+
+In `buildSmartFacetFilteredAssetIds`, directly after the favourites guard from Task 3:
+
+```ts
+      .$if(exclude !== 'albums' && !!options.isNotInAlbum, (qb) =>
+        qb.where((eb) =>
+          eb.not(eb.exists(eb.selectFrom('album_asset').whereRef('album_asset.assetId', '=', 'asset.id'))),
+        ),
+      )
+      .$if(exclude !== 'albums' && !!options.isInAlbum, (qb) =>
+        qb.where((eb) =>
+          eb.exists(eb.selectFrom('album_asset').whereRef('album_asset.assetId', '=', 'asset.id')),
+        ),
+      )
+```
+
+`database.ts:954` guards these with `!options.albumIds?.length`; that guard is not needed here because
+`getSmartSearchFacets` is never called with `albumIds` — verify with
+`grep -n "getSmartSearchFacets" -A 15 server/src/services/search.service.ts` before implementing, and if
+`albumIds` is ever passed, add the same guard.
+
+- [ ] **Step 5: Add the probe and replace the placeholders**
+
+```ts
+  private async getSmartFacetAlbumMembership(
+    trx: Kysely<DB>,
+    options: SmartSearchFacetsOptions,
+  ): Promise<{ hasAssetsInAlbum: boolean; hasAssetsNotInAlbum: boolean }> {
+    const probe = (filed: boolean) =>
+      trx
+        .selectFrom('asset')
+        .select('asset.id')
+        .where('asset.id', 'in', this.buildSmartFacetFilteredAssetIds(trx, options, 'albums'))
+        .where((eb) => {
+          const inAlbum = eb.exists(
+            eb.selectFrom('album_asset').whereRef('album_asset.assetId', '=', 'asset.id'),
+          );
+          return filed ? inAlbum : eb.not(inAlbum);
+        })
+        .limit(1)
+        .executeTakeFirst();
+
+    const [filed, unfiled] = await Promise.all([probe(true), probe(false)]);
+    return { hasAssetsInAlbum: !!filed, hasAssetsNotInAlbum: !!unfiled };
+  }
+```
+
+In `getSmartSearchFacets`, replace the placeholders with
+`const albumMembership = await this.getSmartFacetAlbumMembership(trx, options);` and spread it into the
+return object.
+
+- [ ] **Step 6: Run the full repository suite**
+
+```bash
+cd server && pnpm test:medium -- --run test/medium/specs/repositories/search.repository.spec.ts
+```
+
+Expected: PASS. Pay attention to the pre-existing `getSmartSearchFacets` tests — moving a predicate out of
+the candidate table changes which rows every other facet sees, so a regression here is the signal that the
+move was done wrong.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/src/repositories/search.repository.ts server/test/medium/specs/repositories/search.repository.spec.ts
+git commit -m "feat(server): add album-membership smart-search facets (#910)"
+```
+
+---
+
+## Task 5: Degenerate-input coverage
+
+**Files:**
+
+- Test only: `server/test/medium/specs/repositories/search.repository.spec.ts`
+
+Spec §4.6. No source change is expected — if either test fails, stop and report rather than "fixing" it,
+because it means the client-side reasoning in the spec is wrong.
+
+- [ ] **Step 1: Write the tests**
+
+```ts
+it('reports every #910 facet false under forceEmptyResult', async () => {
+  const { ctx, sut } = setup();
+  const { user } = await ctx.newUser();
+  await ctx.newAsset({ ownerId: user.id, isFavorite: true });
+
+  const result = await sut.getFilterSuggestions([user.id], { forceEmptyResult: true });
+
+  expect(result.hasFavorites).toBe(false);
+  expect(result.hasAssetsInAlbum).toBe(false);
+  expect(result.hasAssetsNotInAlbum).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run and confirm they pass without source changes**
+
+```bash
+cd server && pnpm test:medium -- --run test/medium/specs/repositories/search.repository.spec.ts -t 'forceEmptyResult'
+```
+
+Expected: PASS. `buildFilteredAssetIds` already honours `forceEmptyResult` at `:1402`, so the probes
+inherit it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/test/medium/specs/repositories/search.repository.spec.ts
+git commit -m "test(server): lock forceEmptyResult behaviour for the #910 facets"
+```
+
+---
+
+## Task 6: DTOs, fixtures and generated SQL
+
+**Files:**
+
+- Modify: `server/src/dtos/search.dto.ts:248-276`
+- Modify: `server/src/repositories/search.repository.ts:1245-1252` (`sortQueries`)
+- Modify: `server/src/services/search.service.spec.ts`, `server/src/controllers/search.controller.spec.ts`
+- Regenerate: `server/src/queries/search.repository.sql`
+
+- [ ] **Step 1: Extend both response schemas**
+
+```ts
+const FilterSuggestionsResponseSchema = z
+  .object({
+    countries: z.array(z.string()).describe('Available countries'),
+    cameraMakes: z.array(z.string()).describe('Available camera makes'),
+    tags: z.array(FilterSuggestionsTagSchema).describe('Available tags'),
+    people: z.array(FilterSuggestionsPersonSchema).describe('Available people (named, non-hidden, with thumbnails)'),
+    ratings: z.array(z.number()).describe('Available ratings'),
+    mediaTypes: z.array(z.string()).describe('Available media types'),
+    hasUnnamedPeople: z.boolean().describe('Whether unnamed people exist in the filtered set'),
+    hasFavorites: z.boolean().describe('Whether any favourite exists in the filtered set, ignoring isFavorite'),
+    hasAssetsInAlbum: z.boolean().describe('Whether any filtered asset belongs to an album'),
+    hasAssetsNotInAlbum: z.boolean().describe('Whether any filtered asset belongs to no album'),
+  })
+  .meta({ id: 'FilterSuggestionsResponseDto' });
+```
+
+Add the same three lines to `SmartSearchFacetsResponseSchema` (`:260`), after `hasUnnamedPeople`.
+
+- [ ] **Step 2: Update the SQL-generation hints**
+
+`sortQueries` at `:1245` lists the leading fragment of each generated query so `make sql` orders them
+deterministically. Run `make sql` first (Step 4), read the new fragments out of the generated file, then
+add them here and re-run. Do not guess the strings.
+
+- [ ] **Step 3: Update unit-test fixtures**
+
+`search.service.spec.ts:1218`, `:1866`, `:1880`, `:1966` and `search.controller.spec.ts:175`, `:474`,
+`:489`, `:543` build literal facet objects. Add
+`hasFavorites: false, hasAssetsInAlbum: false, hasAssetsNotInAlbum: false` to each, except where the
+surrounding test is about a populated library — match the neighbouring `ratings` / `mediaTypes` values.
+
+```bash
+cd server && pnpm test -- --run src/services/search.service.spec.ts src/controllers/search.controller.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Regenerate the SQL**
+
+Start a database first — `make dev` in another terminal, or any Postgres the server config points at.
+**`make sql` against no database deletes every file in `server/src/queries/`.**
+
+```bash
+make sql
+git diff --stat server/src/queries/
+```
+
+Expected: `search.repository.sql` changed, nothing deleted. If the diff shows deletions, `git checkout --
+server/src/queries/` and start a database.
+
+- [ ] **Step 5: Full server gate**
+
+```bash
+cd server && pnpm test -- --run && pnpm check && make lint-server && make format-server
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/
+git commit -m "feat(server): expose favourites and album-membership facets in the search DTOs (#910)"
+```
+
+---
+
+## Done when
+
+- `pnpm test:medium -- --run test/medium/specs/repositories/search.repository.spec.ts` is green, including
+  every pre-existing test.
+- `pnpm test`, `pnpm check`, `make lint-server`, `make format-server` are green.
+- `server/src/queries/search.repository.sql` contains the three new probe queries and nothing was deleted.
+- No web, mobile, or `open-api/` file is touched — those are slices 2 and 4.

--- a/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-1.md
+++ b/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-1.md
@@ -847,7 +847,10 @@ Add the same three lines to `SmartSearchFacetsResponseSchema` (`:260`), after `h
 deterministically. **This step is a loop, not a line:** run Step 4 first, read the new fragments out of
 the generated file, come back here and add them, then run Step 4 again. Do not guess the strings.
 
-The three probes add four queries, not three — `getFilteredAlbumMembership` issues two.
+The three probes add six queries total, not three — three per `@GenerateSql` call site. Each of
+`getFilterSuggestions` and `getSmartSearchFacets` gains one favourites query plus two
+album-membership probes (`getFilteredAlbumMembership` / `getSmartFacetAlbumMembership` each issue
+two, one per `filed`/`unfiled` branch).
 
 - [ ] **Step 3: Update unit-test fixtures**
 

--- a/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-2.md
+++ b/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-2.md
@@ -23,8 +23,19 @@ output.
 - The live TypeScript SDK is `packages/sdk/src/fetch-client.ts`, not `open-api/typescript-sdk/`. Generated
   output lands in both; the one the web app imports is `packages/sdk`.
 - Never hand-edit generated files. If output looks wrong, fix the DTO in `server/src/dtos/` and regenerate.
-- `make build-sdk` does **not** exist despite CLAUDE.md mentioning it. Build the SDK with
-  `pnpm --filter @immich/sdk build`.
+- **Three of the commands CLAUDE.md documents for this workflow do not work** — verified against the
+  `Makefile` and `server/package.json` (`feedback_local_verify_command_traps` §2 and §4):
+
+  | Don't                | Why                                                | Do                                      |
+  | -------------------- | -------------------------------------------------- | --------------------------------------- |
+  | `make build-sdk`     | no such target                                     | `pnpm --filter @immich/sdk build`       |
+  | `make open-api`      | removed stub — prints "use mise open-api", exits 1 | `mise open-api`                         |
+  | `pnpm sync:open-api` | no such script in `server/package.json`            | `node server/dist/bin/sync-open-api.js` |
+
+- Run `mise open-api`, not `mise run //:open-api`: from a worktree the `//:` prefix targets the **main**
+  checkout (`reference_mise_run_from_worktree_wrong_dir`).
+- **Run this slice before slice 3.** Slice 3 knowingly leaves `check:typescript` red until slice 4, and
+  Step 6 below uses a clean `check:typescript` as its evidence that the generator emitted valid output.
 
 ## File Structure
 
@@ -70,22 +81,29 @@ top of uncommitted work makes the generated diff impossible to review.
 - [ ] **Step 2: Build the server and sync the spec**
 
 ```bash
-cd server && pnpm build && pnpm sync:open-api
+cd server && pnpm build
+node dist/bin/sync-open-api.js
 ```
 
 - [ ] **Step 3: Verify the spec picked up the new fields**
 
 ```bash
-grep -c 'hasAssetsNotInAlbum' open-api/immich-openapi-specs.json
+grep -c '"hasAssetsNotInAlbum": {' open-api/immich-openapi-specs.json
 ```
 
-Expected: `2` — once in `FilterSuggestionsResponseDto`, once in `SmartSearchFacetsResponseDto`. A `0` means
-slice 1's DTO edit is missing or the server build was stale; go back rather than continuing.
+Expected: `2` — the property declaration in `FilterSuggestionsResponseDto` and in
+`SmartSearchFacetsResponseDto`. A `0` means slice 1's DTO edit is missing or the server build was
+stale; go back rather than continuing.
+
+The `": {"` suffix is load-bearing. A bare `grep -c 'hasAssetsNotInAlbum'` returns **4**, because each
+schema also lists the name in its `required` array — confirmed by running it against the existing
+`hasUnnamedPeople`, which reports 4 on today's spec. An earlier draft of this plan expected 2 from the
+bare grep and would have read a correct regeneration as a failure.
 
 - [ ] **Step 4: Regenerate both clients**
 
 ```bash
-make open-api
+mise open-api
 ```
 
 - [ ] **Step 5: Verify the generated clients**
@@ -107,6 +125,10 @@ cd web && pnpm check:typescript
 
 Expected: PASS. Nothing in web reads the new fields yet, so widening the response type cannot break it.
 A failure here means the generator emitted something malformed.
+
+This gate only means that **if slice 3 has not run yet**. If `check:typescript` is already red with
+`hasFavorites`-shaped errors in `web/src/lib/utils/`, you ran slice 3 first: those errors are slice 3's
+deliberate red, not a generator problem. Confirm no error points at `packages/sdk` and move on.
 
 - [ ] **Step 7: Confirm the Dart client still analyses**
 
@@ -131,7 +153,8 @@ git commit -m "chore(api): regenerate clients for the #910 filter facets"
 
 ## Done when
 
-- `grep -c hasAssetsNotInAlbum open-api/immich-openapi-specs.json` returns 2.
+- `grep -c '"hasAssetsNotInAlbum": {' open-api/immich-openapi-specs.json` returns 2 (the bare grep
+  returns 4 — see Task 1 Step 3).
 - `packages/sdk/src/fetch-client.ts` and `mobile/openapi/` both carry all three fields.
 - `pnpm check:typescript` (web) and `dart analyze --fatal-infos lib` (mobile) are green.
 - The commit touches only generated directories.

--- a/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-2.md
+++ b/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-2.md
@@ -1,0 +1,137 @@
+# Slice 2 — Regenerate the API clients (#910)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for
+> tracking.
+
+**Goal:** The TypeScript SDK and the Dart client expose `hasFavorites`, `hasAssetsInAlbum` and
+`hasAssetsNotInAlbum` on `FilterSuggestionsResponseDto` and `SmartSearchFacetsResponseDto`.
+
+**Architecture:** Pure regeneration. No hand-written code in this slice — every changed file is generated
+output.
+
+**Tech Stack:** oazapfts (TypeScript SDK), OpenAPI Generator with fork mustache templates (Dart).
+
+- **Spec:** `docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md` §5.4
+- **Branch:** `fix/910-interdependent-filter-sections`
+- **Depends on:** Slice 1. Without the DTO change there is nothing to generate.
+- **Scope:** `open-api/`, `packages/sdk/`, `mobile/openapi/`. No hand-written source.
+
+## Global Constraints
+
+- **Java is required** for the Dart generator. `java -version` must succeed before starting.
+- The live TypeScript SDK is `packages/sdk/src/fetch-client.ts`, not `open-api/typescript-sdk/`. Generated
+  output lands in both; the one the web app imports is `packages/sdk`.
+- Never hand-edit generated files. If output looks wrong, fix the DTO in `server/src/dtos/` and regenerate.
+- `make build-sdk` does **not** exist despite CLAUDE.md mentioning it. Build the SDK with
+  `pnpm --filter @immich/sdk build`.
+
+## File Structure
+
+| File                                 | Responsibility                              |
+| ------------------------------------ | ------------------------------------------- |
+| `open-api/immich-openapi-specs.json` | generated spec, source for both clients     |
+| `packages/sdk/src/fetch-client.ts`   | generated TypeScript SDK — what web imports |
+| `mobile/openapi/**`                  | generated Dart client                       |
+
+**Interfaces produced** (slices 4 and 7 consume these):
+
+```ts
+// @immich/sdk
+FilterSuggestionsResponseDto.hasFavorites: boolean
+FilterSuggestionsResponseDto.hasAssetsInAlbum: boolean
+FilterSuggestionsResponseDto.hasAssetsNotInAlbum: boolean
+// and the same three on SmartSearchFacetsResponseDto
+```
+
+```dart
+// package:openapi/api.dart
+FilterSuggestionsResponseDto.hasFavorites // bool
+FilterSuggestionsResponseDto.hasAssetsInAlbum // bool
+FilterSuggestionsResponseDto.hasAssetsNotInAlbum // bool
+```
+
+---
+
+## Task 1: Regenerate and verify
+
+**Files:** all generated. No test file — the verification is that the symbols exist and the SDK compiles.
+
+- [ ] **Step 1: Confirm the prerequisites**
+
+```bash
+java -version
+git status --short
+```
+
+Expected: Java prints a version; the working tree is clean apart from slice 1's commits. Regenerating on
+top of uncommitted work makes the generated diff impossible to review.
+
+- [ ] **Step 2: Build the server and sync the spec**
+
+```bash
+cd server && pnpm build && pnpm sync:open-api
+```
+
+- [ ] **Step 3: Verify the spec picked up the new fields**
+
+```bash
+grep -c 'hasAssetsNotInAlbum' open-api/immich-openapi-specs.json
+```
+
+Expected: `2` — once in `FilterSuggestionsResponseDto`, once in `SmartSearchFacetsResponseDto`. A `0` means
+slice 1's DTO edit is missing or the server build was stale; go back rather than continuing.
+
+- [ ] **Step 4: Regenerate both clients**
+
+```bash
+make open-api
+```
+
+- [ ] **Step 5: Verify the generated clients**
+
+```bash
+grep -n 'hasAssetsNotInAlbum' packages/sdk/src/fetch-client.ts
+grep -rn 'hasAssetsNotInAlbum' mobile/openapi/lib/model/filter_suggestions_response_dto.dart
+```
+
+Expected: hits in both. The Dart field must be a non-nullable `bool` — the Zod schema has no `.optional()`,
+so a nullable `bool?` means the DTO was written wrong in slice 1.
+
+- [ ] **Step 6: Build the SDK and typecheck the web app**
+
+```bash
+pnpm --filter @immich/sdk build
+cd web && pnpm check:typescript
+```
+
+Expected: PASS. Nothing in web reads the new fields yet, so widening the response type cannot break it.
+A failure here means the generator emitted something malformed.
+
+- [ ] **Step 7: Confirm the Dart client still analyses**
+
+```bash
+cd mobile && dart analyze --fatal-infos lib
+```
+
+Expected: PASS. Per `feedback_rebase_three_state_dart_codegen`, a generator bump can turn a class into a
+real Dart `enum` and break `.value` access — `dart analyze` catches that here, before slice 7 depends on it.
+
+- [ ] **Step 8: Commit**
+
+Generated output goes in one commit, separate from hand-written code, so a later rebase can regenerate
+rather than merge it.
+
+```bash
+git add open-api/ packages/sdk/ mobile/openapi/
+git commit -m "chore(api): regenerate clients for the #910 filter facets"
+```
+
+---
+
+## Done when
+
+- `grep -c hasAssetsNotInAlbum open-api/immich-openapi-specs.json` returns 2.
+- `packages/sdk/src/fetch-client.ts` and `mobile/openapi/` both carry all three fields.
+- `pnpm check:typescript` (web) and `dart analyze --fatal-infos lib` (mobile) are green.
+- The commit touches only generated directories.

--- a/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-3.md
+++ b/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-3.md
@@ -12,18 +12,21 @@ the rules are testable as data and the panel wiring in slice 5 stays mechanical.
 
 **Tech Stack:** TypeScript, Vitest.
 
-- **Spec:** `docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md` §4.1, §4.3, §4.4, §6.1
+- **Spec:** `docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md` §4.1, §4.3, §4.4, §4.5, §6.1
 - **Branch:** `fix/910-interdependent-filter-sections`
-- **Depends on:** nothing at runtime. It types against `FilterSuggestionsResponse`, which slice 4 widens —
-  see Task 1 Step 3 for how to avoid blocking on that.
+- **Depends on:** nothing at runtime — but **run it after slice 2**. This slice deliberately leaves
+  `check:typescript` red until slice 4, and slice 2's gate reads a clean `check:typescript` as proof the
+  generated SDK is well-formed. Running 3 first destroys that signal.
 - **Scope:** one new web source file, one new web test file. Nothing else.
 
 ## Global Constraints
 
 - Web uses Svelte 5 runes in new code, but this module is plain TypeScript — no runes, no `$state`.
 - Prettier: 120-char lines, single quotes, trailing commas, semicolons. `eslint --max-warnings 0`.
-- Web unit tests: `cd web && pnpm test -- --run <path>`. Per `feedback_local_verify_command_traps`, the
-  `--run` flag must come **before** the path or vitest silently ignores the filter.
+- Web unit tests: `cd web && pnpm test --run <path>`. Per `feedback_local_verify_command_traps` §1 the
+  trap is the **`--` separator**, not the flag order: `pnpm test -- --run <path>` passes the literal
+  `--` through, vitest drops the path filter, and all ~300 web spec files run (~60s) while looking like
+  a scoped run. Check the reported file count before trusting a red or a green.
 - Per `feedback_web_vitest_no_clearmocks`, mock history leaks across a file. This module has no mocks, so
   it does not apply here — but do not add any.
 
@@ -124,8 +127,26 @@ describe('getSectionAvailability', () => {
       expect(getSectionAvailability('media', input({ current: single, baseline: single }))).toBe('unavailable');
     });
 
-    it('treats two media types as usable', () => {
+    it('treats photos plus videos as usable', () => {
       expect(getSectionAvailability('media', input())).toBe('available');
+    });
+
+    // `getFilteredMediaTypes` returns raw `distinct asset.type`, and AssetType is
+    // IMAGE | VIDEO | AUDIO | OTHER. A length>=2 rule would call this section usable while the
+    // Videos button is still dead — the exact thing #910 exists to stop.
+    it.each([['OTHER'], ['AUDIO']])('does not count %s towards a usable media section', (other) => {
+      const noVideo = { ...full(), mediaTypes: ['IMAGE', other] };
+      expect(getSectionAvailability('media', input({ current: noVideo, baseline: noVideo }))).toBe('unavailable');
+    });
+
+    it('keeps media usable when an extra type accompanies both photos and videos', () => {
+      const extra = { ...full(), mediaTypes: ['IMAGE', 'OTHER', 'VIDEO'] };
+      expect(getSectionAvailability('media', input({ current: extra, baseline: extra }))).toBe('available');
+    });
+
+    it('treats videos-only as unusable, mirroring photos-only', () => {
+      const single = { ...full(), mediaTypes: ['VIDEO'] };
+      expect(getSectionAvailability('media', input({ current: single, baseline: single }))).toBe('unavailable');
     });
 
     it('keeps people available when unnamed faces exist', () => {
@@ -187,6 +208,13 @@ describe('getSectionAvailability', () => {
       const state = input({ current: barren(), baseline: barren(), timeBucketCount: 0 });
       expect(getSectionAvailability('text', state)).toBe('available');
     });
+
+    // The `default:` branch of isSectionEmpty. A section added to FilterSection in future must
+    // default to visible, not silently vanish because nobody wrote it a rule.
+    it('reports an unrecognised section available rather than hiding it', () => {
+      const state = input({ current: barren(), baseline: barren() });
+      expect(getSectionAvailability('newcomer' as FilterSection, state)).toBe('available');
+    });
   });
 });
 ```
@@ -194,7 +222,7 @@ describe('getSectionAvailability', () => {
 - [ ] **Step 2: Run the tests to verify they fail**
 
 ```bash
-cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-availability.spec.ts
+cd web && pnpm test --run src/lib/components/filter-panel/__tests__/filter-availability.spec.ts
 ```
 
 Expected: FAIL — `Failed to resolve import "../filter-availability"`.
@@ -226,6 +254,32 @@ export interface FilterSuggestionsResponse {
 This breaks `check:typescript` for every surface config until slice 4 lands, which is expected and is why
 slice 4 immediately follows. Do not add optional markers (`?`) to dodge it — optional fields would let a
 surface silently forget to forward one, and `undefined` would then read as "structurally empty".
+
+Add the baseline hook to `FilterPanelConfig` in the same edit (spec §4.5). Slice 4 wires the six
+surfaces to it and slice 5 consumes it; declaring it here keeps all the type churn in one commit:
+
+```ts
+export interface FilterPanelConfig {
+  sections: FilterSection[];
+  suggestionsProvider?: (filters: FilterState) => Promise<FilterSuggestionsResponse>;
+  /**
+   * Facets for this surface's scope with no filters applied (#910). The panel only calls this when it
+   * mounts with filters already active — otherwise the ordinary response is already the baseline.
+   *
+   * Resolving `undefined` means "no cheap baseline here", and the panel then never hides a section.
+   * The three query-mode surfaces return `undefined` deliberately: their `smartFacetInFlight` slot is
+   * single-entry and their `smartFacets` state feeds the timeline and the result count, so a second
+   * concurrent facet request would abort the first and then overwrite the page's own data. See spec
+   * §4.5 — this hook exists because `suggestionsProvider(createFilterState())` cannot be used.
+   */
+  baselineProvider?: () => Promise<FilterSuggestionsResponse | undefined>;
+  providers?: {/* unchanged */};
+}
+```
+
+Optional on purpose, and it is the one field `tsc` will **not** chase for you: a surface that omits it
+just never hides anything. That is the safe direction, but it is silent, so slice 4 enumerates the six
+sites by hand and slice 5 asserts per surface that the call happens.
 
 - [ ] **Step 4: Write the module**
 
@@ -278,8 +332,13 @@ function isSectionEmpty(section: FilterSection, facets: FilterSuggestionsRespons
       return facets.ratings.length === 0;
     }
     case 'media': {
-      // One media type means "Photos" (or "Videos") is a synonym for "All" and the other is empty.
-      return facets.mediaTypes.length < 2;
+      // The control offers All / Photos / Videos, so it needs both of those types to discriminate:
+      // with only images, "Photos" is a synonym for "All" and "Videos" is empty.
+      //
+      // NOT `mediaTypes.length < 2`. getFilteredMediaTypes returns raw `distinct asset.type` and
+      // AssetType is IMAGE | VIDEO | AUDIO | OTHER (enum.ts:38), so a photo library holding one
+      // OTHER asset would pass a length test with a dead Videos button.
+      return !(facets.mediaTypes.includes('IMAGE') && facets.mediaTypes.includes('VIDEO'));
     }
     case 'favorites': {
       return !facets.hasFavorites;
@@ -329,10 +388,11 @@ export function getSectionAvailability(section: FilterSection, input: Availabili
 - [ ] **Step 5: Run the tests to verify they pass**
 
 ```bash
-cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-availability.spec.ts
+cd web && pnpm test --run src/lib/components/filter-panel/__tests__/filter-availability.spec.ts
 ```
 
-Expected: PASS. The `it.each(GATED)` blocks give 8 cases each, so the count should be well above 30.
+Expected: PASS. The `it.each(GATED)` blocks give 8 cases each, so the count should be well above 40.
+Check the reported **file** count is 1 — if it is ~300 you hit the `--` trap from Global Constraints.
 
 - [ ] **Step 6: Lint and format**
 
@@ -356,7 +416,7 @@ git commit -m "feat(web): add the filter-section availability rules (#910)"
 
 ## Done when
 
-- `pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-availability.spec.ts` is green.
+- `pnpm test --run src/lib/components/filter-panel/__tests__/filter-availability.spec.ts` is green.
 - `pnpm lint` and `pnpm format` are green.
 - `check:typescript` is knowingly red on the surface configs, and only there. Confirm with
   `pnpm check:typescript 2>&1 | grep -c "filter-availability"` returning `0` — no error may point at the

--- a/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-3.md
+++ b/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-3.md
@@ -1,0 +1,364 @@
+# Slice 3 — The `filter-availability` rule module (#910)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for
+> tracking.
+
+**Goal:** A pure function that answers, for one filter section, whether it should render normally, render
+greyed with `(0)`, or not render at all — from facet data alone, with no component, DOM or fetch involved.
+
+**Architecture:** One exported function over a plain input record. All of spec §4.3 and §4.4 lives here, so
+the rules are testable as data and the panel wiring in slice 5 stays mechanical.
+
+**Tech Stack:** TypeScript, Vitest.
+
+- **Spec:** `docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md` §4.1, §4.3, §4.4, §6.1
+- **Branch:** `fix/910-interdependent-filter-sections`
+- **Depends on:** nothing at runtime. It types against `FilterSuggestionsResponse`, which slice 4 widens —
+  see Task 1 Step 3 for how to avoid blocking on that.
+- **Scope:** one new web source file, one new web test file. Nothing else.
+
+## Global Constraints
+
+- Web uses Svelte 5 runes in new code, but this module is plain TypeScript — no runes, no `$state`.
+- Prettier: 120-char lines, single quotes, trailing commas, semicolons. `eslint --max-warnings 0`.
+- Web unit tests: `cd web && pnpm test -- --run <path>`. Per `feedback_local_verify_command_traps`, the
+  `--run` flag must come **before** the path or vitest silently ignores the filter.
+- Per `feedback_web_vitest_no_clearmocks`, mock history leaks across a file. This module has no mocks, so
+  it does not apply here — but do not add any.
+
+## File Structure
+
+| File                                                                        | Responsibility              |
+| --------------------------------------------------------------------------- | --------------------------- |
+| `web/src/lib/components/filter-panel/filter-availability.ts`                | the rules, and nothing else |
+| `web/src/lib/components/filter-panel/__tests__/filter-availability.spec.ts` | the rules as a truth table  |
+
+**Interfaces produced** (slice 5 consumes these exact names):
+
+```ts
+export type SectionAvailability = 'available' | 'empty' | 'unavailable';
+
+export interface AvailabilityInput {
+  current: FilterSuggestionsResponse;
+  baseline: FilterSuggestionsResponse | undefined;
+  hasActiveFilter: boolean;
+  timeBucketCount: number;
+}
+
+export function getSectionAvailability(section: FilterSection, input: AvailabilityInput): SectionAvailability;
+```
+
+---
+
+## Task 1: The rule module
+
+**Files:**
+
+- Create: `web/src/lib/components/filter-panel/filter-availability.ts`
+- Create: `web/src/lib/components/filter-panel/__tests__/filter-availability.spec.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import type { FilterSection, FilterSuggestionsResponse } from '../filter-panel';
+import { getSectionAvailability, type AvailabilityInput } from '../filter-availability';
+
+/** A scope in which every section is usable. Individual tests knock out one dimension at a time. */
+const full = (): FilterSuggestionsResponse => ({
+  countries: ['Germany'],
+  cameraMakes: ['Canon'],
+  tags: [{ id: 'tag-1', name: 'Vacation' }],
+  people: [{ id: 'person-1', name: 'Alice' }],
+  ratings: [5],
+  mediaTypes: ['IMAGE', 'VIDEO'],
+  hasUnnamedPeople: false,
+  hasFavorites: true,
+  hasAssetsInAlbum: true,
+  hasAssetsNotInAlbum: true,
+});
+
+/** A scope in which no section can filter anything. */
+const barren = (): FilterSuggestionsResponse => ({
+  countries: [],
+  cameraMakes: [],
+  tags: [],
+  people: [],
+  ratings: [],
+  mediaTypes: ['IMAGE'],
+  hasUnnamedPeople: false,
+  hasFavorites: false,
+  hasAssetsInAlbum: false,
+  hasAssetsNotInAlbum: true,
+});
+
+const input = (overrides: Partial<AvailabilityInput> = {}): AvailabilityInput => ({
+  current: full(),
+  baseline: full(),
+  hasActiveFilter: false,
+  timeBucketCount: 3,
+  ...overrides,
+});
+
+const GATED: FilterSection[] = ['people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites', 'albums'];
+
+describe('getSectionAvailability', () => {
+  describe('the three verdicts', () => {
+    it.each(GATED)('reports %s available when its facet is populated', (section) => {
+      expect(getSectionAvailability(section, input())).toBe('available');
+    });
+
+    it.each(GATED)('reports %s empty when only the current facet is bare', (section) => {
+      expect(getSectionAvailability(section, input({ current: barren() }))).toBe('empty');
+    });
+
+    it.each(GATED)('reports %s unavailable when both facets are bare', (section) => {
+      expect(getSectionAvailability(section, input({ current: barren(), baseline: barren() }))).toBe('unavailable');
+    });
+  });
+
+  describe('per-section emptiness rules', () => {
+    it('treats a single media type as unusable', () => {
+      const single = { ...full(), mediaTypes: ['IMAGE'] };
+      expect(getSectionAvailability('media', input({ current: single, baseline: single }))).toBe('unavailable');
+    });
+
+    it('treats two media types as usable', () => {
+      expect(getSectionAvailability('media', input())).toBe('available');
+    });
+
+    it('keeps people available when unnamed faces exist', () => {
+      const unnamed = { ...barren(), hasUnnamedPeople: true };
+      expect(getSectionAvailability('people', input({ current: unnamed, baseline: unnamed }))).toBe('available');
+    });
+
+    it('hides people when there are none at all', () => {
+      expect(getSectionAvailability('people', input({ current: barren(), baseline: barren() }))).toBe('unavailable');
+    });
+
+    it('hides albums when nothing is filed', () => {
+      const none = { ...full(), hasAssetsInAlbum: false };
+      expect(getSectionAvailability('albums', input({ current: none, baseline: none }))).toBe('unavailable');
+    });
+
+    it('hides albums when everything is filed', () => {
+      const all = { ...full(), hasAssetsNotInAlbum: false };
+      expect(getSectionAvailability('albums', input({ current: all, baseline: all }))).toBe('unavailable');
+    });
+
+    it('keeps albums available only when both sides exist', () => {
+      expect(getSectionAvailability('albums', input())).toBe('available');
+    });
+
+    it('hides favorites when nothing is favourited', () => {
+      const none = { ...full(), hasFavorites: false };
+      expect(getSectionAvailability('favorites', input({ current: none, baseline: none }))).toBe('unavailable');
+    });
+  });
+
+  describe('overriding rules', () => {
+    it.each(GATED)('never hides or greys %s while it has an active filter', (section) => {
+      const state = input({ current: barren(), baseline: barren(), hasActiveFilter: true });
+      expect(getSectionAvailability(section, state)).toBe('available');
+    });
+
+    it.each(GATED)('never hides %s while the baseline is unknown', (section) => {
+      expect(getSectionAvailability(section, input({ current: barren(), baseline: undefined }))).toBe('empty');
+    });
+  });
+
+  describe('exempt sections', () => {
+    it('greys timeline on an empty bucket list but never hides it', () => {
+      const state = input({ current: barren(), baseline: barren(), timeBucketCount: 0 });
+      expect(getSectionAvailability('timeline', state)).toBe('empty');
+    });
+
+    it('keeps timeline available while it has buckets', () => {
+      expect(getSectionAvailability('timeline', input())).toBe('available');
+    });
+
+    it('keeps timeline available while a date filter is active', () => {
+      const state = input({ timeBucketCount: 0, hasActiveFilter: true });
+      expect(getSectionAvailability('timeline', state)).toBe('available');
+    });
+
+    it('always reports text available', () => {
+      const state = input({ current: barren(), baseline: barren(), timeBucketCount: 0 });
+      expect(getSectionAvailability('text', state)).toBe('available');
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-availability.spec.ts
+```
+
+Expected: FAIL — `Failed to resolve import "../filter-availability"`.
+
+- [ ] **Step 3: Handle the type dependency**
+
+The tests construct `FilterSuggestionsResponse` objects carrying `hasFavorites`, `hasAssetsInAlbum` and
+`hasAssetsNotInAlbum`. Slice 4 adds those to the interface; this slice needs them now.
+
+Add them to `web/src/lib/components/filter-panel/filter-panel.ts:80-90` **as part of this slice**:
+
+```ts
+export interface FilterSuggestionsResponse {
+  countries: string[];
+  cities?: string[];
+  cameraMakes: string[];
+  cameraModels?: string[];
+  tags: TagOption[];
+  people: PersonOption[];
+  ratings: number[];
+  mediaTypes: string[];
+  hasUnnamedPeople: boolean;
+  hasFavorites: boolean;
+  hasAssetsInAlbum: boolean;
+  hasAssetsNotInAlbum: boolean;
+}
+```
+
+This breaks `check:typescript` for every surface config until slice 4 lands, which is expected and is why
+slice 4 immediately follows. Do not add optional markers (`?`) to dodge it — optional fields would let a
+surface silently forget to forward one, and `undefined` would then read as "structurally empty".
+
+- [ ] **Step 4: Write the module**
+
+Create `web/src/lib/components/filter-panel/filter-availability.ts`:
+
+```ts
+import type { FilterSection, FilterSuggestionsResponse } from './filter-panel';
+
+/**
+ * Whether a filter section can do anything for the user right now (#910).
+ *
+ * - `available`   — render normally.
+ * - `empty`       — the current filters narrowed it to nothing; grey it out with `(0)`.
+ * - `unavailable` — nothing in this scope could ever populate it; do not render it at all.
+ */
+export type SectionAvailability = 'available' | 'empty' | 'unavailable';
+
+export interface AvailabilityInput {
+  /** Facets for the filters the user has applied right now. */
+  current: FilterSuggestionsResponse;
+  /** Facets for the same scope with no filters applied. `undefined` while it is still in flight. */
+  baseline: FilterSuggestionsResponse | undefined;
+  /** Whether this section itself currently holds a filter value. */
+  hasActiveFilter: boolean;
+  /** Timeline is fed by the page's own buckets rather than a server facet. */
+  timeBucketCount: number;
+}
+
+/**
+ * Whether this section's facet offers the user a choice. Not simply "is the list empty": a control that
+ * can only select everything, or only select nothing, is equally useless.
+ */
+function isSectionEmpty(section: FilterSection, facets: FilterSuggestionsResponse): boolean {
+  switch (section) {
+    case 'people': {
+      // Zero named people is still useful while unnamed faces exist — the empty state is the only
+      // prompt to name one.
+      return facets.people.length === 0 && !facets.hasUnnamedPeople;
+    }
+    case 'location': {
+      return facets.countries.length === 0;
+    }
+    case 'camera': {
+      return facets.cameraMakes.length === 0;
+    }
+    case 'tags': {
+      return facets.tags.length === 0;
+    }
+    case 'rating': {
+      return facets.ratings.length === 0;
+    }
+    case 'media': {
+      // One media type means "Photos" (or "Videos") is a synonym for "All" and the other is empty.
+      return facets.mediaTypes.length < 2;
+    }
+    case 'favorites': {
+      return !facets.hasFavorites;
+    }
+    case 'albums': {
+      // Needs both sides: with nothing filed "Has album" is empty, with everything filed "Has no
+      // album" is, and either way the control cannot discriminate.
+      return !(facets.hasAssetsInAlbum && facets.hasAssetsNotInAlbum);
+    }
+    default: {
+      return false;
+    }
+  }
+}
+
+export function getSectionAvailability(section: FilterSection, input: AvailabilityInput): SectionAvailability {
+  // Free text has no enumerable domain to be empty of.
+  if (section === 'text') {
+    return 'available';
+  }
+
+  // Never strand a filter the user cannot then reach to clear. Cross-section narrowing can empty a
+  // facet whose own filter is set — person X plus rating 5, where X has no rated photos.
+  if (input.hasActiveFilter) {
+    return 'available';
+  }
+
+  // Timeline's emptiness means "this page has no assets", which the surfaces handle with the panel's
+  // `hidden` prop, so it greys but never hides.
+  if (section === 'timeline') {
+    return input.timeBucketCount === 0 ? 'empty' : 'available';
+  }
+
+  if (!isSectionEmpty(section, input.current)) {
+    return 'available';
+  }
+
+  // A section is never hidden on missing information.
+  if (input.baseline === undefined) {
+    return 'empty';
+  }
+
+  return isSectionEmpty(section, input.baseline) ? 'unavailable' : 'empty';
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-availability.spec.ts
+```
+
+Expected: PASS. The `it.each(GATED)` blocks give 8 cases each, so the count should be well above 30.
+
+- [ ] **Step 6: Lint and format**
+
+```bash
+cd web && pnpm lint && pnpm format
+```
+
+`check:typescript` will **fail** at this point because of Step 3 — that is expected and slice 4 fixes it.
+Do not run it as a gate here.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/filter-availability.ts \
+        web/src/lib/components/filter-panel/__tests__/filter-availability.spec.ts \
+        web/src/lib/components/filter-panel/filter-panel.ts
+git commit -m "feat(web): add the filter-section availability rules (#910)"
+```
+
+---
+
+## Done when
+
+- `pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-availability.spec.ts` is green.
+- `pnpm lint` and `pnpm format` are green.
+- `check:typescript` is knowingly red on the surface configs, and only there. Confirm with
+  `pnpm check:typescript 2>&1 | grep -c "filter-availability"` returning `0` — no error may point at the
+  new module itself.
+- The panel component is untouched. Wiring is slice 5.

--- a/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-4.md
+++ b/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-4.md
@@ -23,7 +23,7 @@ emptiness.
 ## Global Constraints
 
 - Prettier: 120-char lines, single quotes, trailing commas, semicolons. `eslint --max-warnings 0`.
-- `cd web && pnpm test -- --run <path>` — `--run` before the path, or the filter is silently dropped.
+- `cd web && pnpm test --run <path>` — `--run` before the path, or the filter is silently dropped.
 - Per `reference_web_checks_and_pr_base`, the web gate is three commands: `pnpm check:typescript`,
   `pnpm check:svelte`, `pnpm lint`.
 - Per `reference_web_check_svelte_blind_locally`, `check:svelte` can scan zero files locally. Treat a
@@ -59,11 +59,18 @@ emptiness.
 - Modify: `web/src/lib/utils/space-search.ts:116-136` (`mapSmartSearchFacetsToFilterSuggestions`)
 - Test: `web/src/lib/utils/__tests__/album-filter-config.spec.ts`,
   `web/src/lib/utils/__tests__/map-filter-config.spec.ts`,
-  `web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts`
+  `web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts`,
+  `web/src/lib/utils/__tests__/space-search.spec.ts`
 
 - [ ] **Step 1: Write the failing tests**
 
-One assertion per mapper. Add to the existing `describe` block in each spec — these files already mock
+One assertion per mapper — **all four**, including `space-search.ts`. That one is the easiest to skip
+and the most important to cover: it is the mapper behind all three smart-search surfaces (photos,
+spaces and recently-added in query mode), so a missed field there breaks three pages at once.
+`space-search.spec.ts:347` already has a `describe('mapSmartSearchFacetsToFilterSuggestions')` block
+with literal facet objects — extend those.
+
+For the other three, add to the existing `describe` block in each spec — these files already mock
 `@immich/sdk` and already have a populated `getFilterSuggestions` fixture, so extend that fixture rather
 than adding a second mock.
 
@@ -80,17 +87,19 @@ it('forwards the #910 availability facets', async () => {
 });
 ```
 
-Add the equivalent to `map-filter-config.spec.ts` (using `buildMapFilterConfig()`) and to
-`recently-added-filter-config.spec.ts` (using `buildRecentlyAddedFilterConfig()`), extending each file's
-existing fixture the same way. Use distinct true/false combinations per file so a copy-paste mapper bug
-that hard-codes one value cannot pass all three.
+Add the equivalent to `map-filter-config.spec.ts` (using `buildMapFilterConfig()`), to
+`recently-added-filter-config.spec.ts` (using `buildRecentlyAddedFilterConfig()`), and to
+`space-search.spec.ts` (calling `mapSmartSearchFacetsToFilterSuggestions` directly), extending each
+file's existing fixture the same way. Use distinct true/false combinations per file so a copy-paste
+mapper bug that hard-codes one value cannot pass all four.
 
 - [ ] **Step 2: Run them to verify they fail**
 
 ```bash
-cd web && pnpm test -- --run src/lib/utils/__tests__/album-filter-config.spec.ts \
+cd web && pnpm test --run src/lib/utils/__tests__/album-filter-config.spec.ts \
                           src/lib/utils/__tests__/map-filter-config.spec.ts \
-                          src/lib/utils/__tests__/recently-added-filter-config.spec.ts
+                          src/lib/utils/__tests__/recently-added-filter-config.spec.ts \
+                          src/lib/utils/__tests__/space-search.spec.ts
 ```
 
 Expected: FAIL — `expected undefined to be true`.
@@ -125,9 +134,10 @@ In all four mappers, add three lines after `hasUnnamedPeople`. `map-filter-confi
 - [ ] **Step 4: Run the tests to verify they pass**
 
 ```bash
-cd web && pnpm test -- --run src/lib/utils/__tests__/album-filter-config.spec.ts \
+cd web && pnpm test --run src/lib/utils/__tests__/album-filter-config.spec.ts \
                           src/lib/utils/__tests__/map-filter-config.spec.ts \
-                          src/lib/utils/__tests__/recently-added-filter-config.spec.ts
+                          src/lib/utils/__tests__/recently-added-filter-config.spec.ts \
+                          src/lib/utils/__tests__/space-search.spec.ts
 ```
 
 Expected: PASS.
@@ -141,14 +151,106 @@ git commit -m "feat(web): forward the availability facets through every filter m
 
 ---
 
+## Task 1b: Wire `baselineProvider` on all six surfaces
+
+**Files:** the four mappers from Task 1, plus the photos and spaces page configs.
+
+Slice 3 declared `FilterPanelConfig.baselineProvider` (spec §4.5). This task supplies it. Read §4.5
+before starting — the obvious implementation is wrong, and the reason is not visible from the panel.
+
+**Why the panel cannot just call `suggestionsProvider(createFilterState())`.** All three query-mode
+pages keep a _single_ `smartFacetInFlight` slot and abort it whenever an incoming request has a
+different key (`photos/…/+page.svelte:239-247` and the same shape in spaces `:239-247` and
+recently-added `:210-247`). Two concurrent facet requests under different keys therefore kill each
+other. Worse, on resolve those pages assign `smartFacets = result`, and `smartFacets` drives the
+Timeline buckets and the result count — so an unfiltered baseline response landing in that slot would
+make the page display unfiltered data while filters are applied.
+
+- [ ] **Step 1: Write the failing tests**
+
+Two per query-mode page, one per simple surface.
+
+```ts
+it('offers a browse-mode baseline computed with no filters (#910)', async () => {
+  const config = getRenderedFilterConfig();
+  sdkMock.getFilterSuggestions.mockClear();
+
+  const baseline = await config.baselineProvider!();
+
+  expect(baseline).toBeDefined();
+  // The whole point: the baseline ignores whatever filters are active.
+  expect(sdkMock.getFilterSuggestions).toHaveBeenCalledWith(
+    expect.objectContaining({ rating: undefined, personIds: undefined }),
+  );
+});
+
+it('offers no baseline in query mode, and leaves the page facets alone (#910)', async () => {
+  await commitQuery('beach');
+  const config = getRenderedFilterConfig();
+  sdkMock.searchSmartFacets.mockClear();
+
+  await expect(config.baselineProvider!()).resolves.toBeUndefined();
+
+  // Regression guard for spec §4.5: a baseline request here would abort the in-flight facet
+  // fetch and then overwrite smartFacets, corrupting the timeline and the result count.
+  expect(sdkMock.searchSmartFacets).not.toHaveBeenCalled();
+});
+```
+
+`getRenderedFilterConfig` / `commitQuery` are shorthand — reuse whatever the neighbouring smart-search
+tests in each file already do rather than inventing helpers.
+
+For `map-filter-config.spec.ts`, `album-filter-config.spec.ts` and
+`recently-added-filter-config.spec.ts`, assert only the first shape: those surfaces have no query mode.
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Expected: FAIL — `config.baselineProvider is not a function`.
+
+- [ ] **Step 3: Wire the four mappers**
+
+Each already has a `mapSuggestions` and an SDK call. The baseline is the same call with the filter
+arguments dropped, keeping only the scope arguments (`albumId`, `spaceId`, `withSharedSpaces`, …):
+
+```ts
+    baselineProvider: async () => mapSuggestions(await getFilterSuggestions({ /* scope args only */ })),
+```
+
+- [ ] **Step 4: Wire the two page configs**
+
+Browse mode returns a real baseline; query mode returns `undefined`. On the photos page:
+
+```ts
+    // #910: no baseline in query mode. A second concurrent facet request would abort the in-flight
+    // one (single `smartFacetInFlight` slot) and then clobber `smartFacets`, which feeds the
+    // timeline and the result count. `undefined` means "don't hide anything here" — see spec §4.5.
+    baselineProvider: async () => (showSearchResults ? undefined : loadPhotoFilterSuggestions(createFilterState())),
+```
+
+The spaces page takes the identical shape with `loadSpaceFilterSuggestions`. The Recently Added page
+routes through `recently-added-filter-config.ts`, so it is covered by Step 3 — verify which branch it
+actually uses before assuming.
+
+- [ ] **Step 5: Run the tests to verify they pass, then commit**
+
+```bash
+git add web/src/lib/utils/ "web/src/routes/(user)/"
+git commit -m "feat(web): give each filter surface a no-filters baseline provider (#910)"
+```
+
+---
+
 ## Task 2: Delete the empty-response sentinel
 
 **Files:**
 
-- Modify: `routes/(user)/photos/[[assetId=id]]/+page.svelte:167-177` (`emptyFilterSuggestions`), `:271-273`
-- Modify: `routes/(user)/spaces/[spaceId]/…/+page.svelte:172-182`, `:305-307`
-- Modify: `routes/(user)/recently-added/…/+page.svelte` (its `emptyFilterSuggestions` and the
-  `if (!facets)` branch around `:266-269`)
+- Modify: `routes/(user)/photos/[[assetId=id]]/+page.svelte` — `emptyFilterSuggestions` at `:167`, its
+  call site at `:302`
+- Modify: `routes/(user)/spaces/[spaceId]/…/+page.svelte` — `:172` and `:306`
+- Modify: `routes/(user)/recently-added/…/+page.svelte` — `:184` and `:268`
+
+(Line numbers drift; `grep -rn "emptyFilterSuggestions" web/src` gives all six in one shot.)
+
 - Test: the three page spec files alongside those routes
 
 All three pages resolve their provider with every array empty when the smart-facets request fails. Today
@@ -180,7 +282,7 @@ neighbouring smart-search test in the same file and use the same mechanism rathe
 - [ ] **Step 2: Run them to verify they fail**
 
 ```bash
-cd web && pnpm test -- --run "src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts"
+cd web && pnpm test --run "src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts"
 ```
 
 Expected: FAIL — the promise resolves with the empty sentinel instead of rejecting.
@@ -211,7 +313,7 @@ not.
 - [ ] **Step 5: Run the tests to verify they pass**
 
 ```bash
-cd web && pnpm test -- --run "src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts" \
+cd web && pnpm test --run "src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts" \
                           "src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts" \
                           "src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts"
 ```
@@ -298,6 +400,11 @@ git commit -m "feat(web): forward the availability facets from every filter surf
 ## Done when
 
 - `pnpm check:typescript` is green — no surface still omits a field.
-- `pnpm test` is green, including `filter-section-parity.spec.ts` with unmodified assertions.
+- `pnpm test --run` is green, including `filter-section-parity.spec.ts` with unmodified assertions.
 - `grep -rn "emptyFilterSuggestions" web/src` returns nothing.
+- `grep -rn "baselineProvider" web/src/lib/utils "web/src/routes/(user)"` returns **six** wiring sites.
+  `tsc` cannot check this one for you — the field is optional, so a surface that forgets it silently
+  never hides anything (spec §4.5).
+- No `baselineProvider` calls `suggestionsProvider(createFilterState())`, and none of the three
+  query-mode branches issues a facet request.
 - The filter panel component is still untouched.

--- a/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-4.md
+++ b/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-4.md
@@ -1,0 +1,303 @@
+# Slice 4 — Every surface forwards the new facets, and stops faking empty ones (#910)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for
+> tracking.
+
+**Goal:** Every `suggestionsProvider` in the app returns `hasFavorites`, `hasAssetsInAlbum` and
+`hasAssetsNotInAlbum`, and no provider ever resolves with a fabricated all-empty response.
+
+**Architecture:** Four mappers and three page-level providers gain three passthrough fields. Separately,
+the `emptyFilterSuggestions()` failure sentinel on the three query-mode pages is deleted in favour of a
+rejection, so a failed facet fetch cannot be mistaken for an empty library once slice 5 starts gating on
+emptiness.
+
+**Tech Stack:** SvelteKit, TypeScript, Vitest.
+
+- **Spec:** `docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md` §4.6, §6.4
+- **Branch:** `fix/910-interdependent-filter-sections`
+- **Depends on:** Slice 2 (the SDK types) and Slice 3 (the widened `FilterSuggestionsResponse`). This slice
+  is what makes `check:typescript` green again.
+- **Scope:** four web util files, three route files, and their specs. No panel component — that is slice 5.
+
+## Global Constraints
+
+- Prettier: 120-char lines, single quotes, trailing commas, semicolons. `eslint --max-warnings 0`.
+- `cd web && pnpm test -- --run <path>` — `--run` before the path, or the filter is silently dropped.
+- Per `reference_web_checks_and_pr_base`, the web gate is three commands: `pnpm check:typescript`,
+  `pnpm check:svelte`, `pnpm lint`.
+- Per `reference_web_check_svelte_blind_locally`, `check:svelte` can scan zero files locally. Treat a
+  suspiciously fast pass as "not actually checked" and rely on CI for it.
+
+## File Structure
+
+| File                                                | Responsibility                                                        |
+| --------------------------------------------------- | --------------------------------------------------------------------- |
+| `web/src/lib/utils/map-filter-config.ts`            | map view provider                                                     |
+| `web/src/lib/utils/album-filter-config.ts`          | album detail + asset picker, via `mapSuggestions`                     |
+| `web/src/lib/utils/recently-added-filter-config.ts` | Recently Added, via its own `mapSuggestions`                          |
+| `web/src/lib/utils/space-search.ts`                 | `mapSmartSearchFacetsToFilterSuggestions` — all smart-search surfaces |
+| `routes/(user)/photos/[[assetId=id]]/+page.svelte`  | browse mapper + sentinel removal                                      |
+| `routes/(user)/spaces/[spaceId]/…/+page.svelte`     | browse mapper + sentinel removal                                      |
+| `routes/(user)/recently-added/…/+page.svelte`       | sentinel removal                                                      |
+
+**Interfaces consumed:** `FilterSuggestionsResponse` from slice 3;
+`FilterSuggestionsResponseDto` / `SmartSearchFacetsResponseDto` from slice 2.
+
+**Interfaces produced:** every `FilterPanelConfig.suggestionsProvider` in the app now satisfies the widened
+`FilterSuggestionsResponse`, and rejects rather than resolving on a failed facet fetch.
+
+---
+
+## Task 1: The four mappers
+
+**Files:**
+
+- Modify: `web/src/lib/utils/map-filter-config.ts:40-52`
+- Modify: `web/src/lib/utils/album-filter-config.ts:24-38` (`mapSuggestions`)
+- Modify: `web/src/lib/utils/recently-added-filter-config.ts:14-28` (`mapSuggestions`)
+- Modify: `web/src/lib/utils/space-search.ts:116-136` (`mapSmartSearchFacetsToFilterSuggestions`)
+- Test: `web/src/lib/utils/__tests__/album-filter-config.spec.ts`,
+  `web/src/lib/utils/__tests__/map-filter-config.spec.ts`,
+  `web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+One assertion per mapper. Add to the existing `describe` block in each spec — these files already mock
+`@immich/sdk` and already have a populated `getFilterSuggestions` fixture, so extend that fixture rather
+than adding a second mock.
+
+In `album-filter-config.spec.ts`, extend the existing `getFilterSuggestions` mock value with
+`hasFavorites: true, hasAssetsInAlbum: true, hasAssetsNotInAlbum: false`, then add:
+
+```ts
+it('forwards the #910 availability facets', async () => {
+  const result = await buildAlbumDetailFilterConfig('album-1').suggestionsProvider!(createFilterState());
+
+  expect(result.hasFavorites).toBe(true);
+  expect(result.hasAssetsInAlbum).toBe(true);
+  expect(result.hasAssetsNotInAlbum).toBe(false);
+});
+```
+
+Add the equivalent to `map-filter-config.spec.ts` (using `buildMapFilterConfig()`) and to
+`recently-added-filter-config.spec.ts` (using `buildRecentlyAddedFilterConfig()`), extending each file's
+existing fixture the same way. Use distinct true/false combinations per file so a copy-paste mapper bug
+that hard-codes one value cannot pass all three.
+
+- [ ] **Step 2: Run them to verify they fail**
+
+```bash
+cd web && pnpm test -- --run src/lib/utils/__tests__/album-filter-config.spec.ts \
+                          src/lib/utils/__tests__/map-filter-config.spec.ts \
+                          src/lib/utils/__tests__/recently-added-filter-config.spec.ts
+```
+
+Expected: FAIL — `expected undefined to be true`.
+
+- [ ] **Step 3: Forward the fields**
+
+In all four mappers, add three lines after `hasUnnamedPeople`. `map-filter-config.ts`:
+
+```ts
+      ratings: response.ratings,
+      mediaTypes: response.mediaTypes,
+      hasUnnamedPeople: response.hasUnnamedPeople,
+      hasFavorites: response.hasFavorites,
+      hasAssetsInAlbum: response.hasAssetsInAlbum,
+      hasAssetsNotInAlbum: response.hasAssetsNotInAlbum,
+    };
+```
+
+`album-filter-config.ts` and `recently-added-filter-config.ts` use the same `response.` prefix inside their
+`mapSuggestions`. `space-search.ts` uses `facets.`:
+
+```ts
+    ratings: facets.ratings,
+    mediaTypes: facets.mediaTypes,
+    hasUnnamedPeople: facets.hasUnnamedPeople,
+    hasFavorites: facets.hasFavorites,
+    hasAssetsInAlbum: facets.hasAssetsInAlbum,
+    hasAssetsNotInAlbum: facets.hasAssetsNotInAlbum,
+  };
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd web && pnpm test -- --run src/lib/utils/__tests__/album-filter-config.spec.ts \
+                          src/lib/utils/__tests__/map-filter-config.spec.ts \
+                          src/lib/utils/__tests__/recently-added-filter-config.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/lib/utils/
+git commit -m "feat(web): forward the availability facets through every filter mapper (#910)"
+```
+
+---
+
+## Task 2: Delete the empty-response sentinel
+
+**Files:**
+
+- Modify: `routes/(user)/photos/[[assetId=id]]/+page.svelte:167-177` (`emptyFilterSuggestions`), `:271-273`
+- Modify: `routes/(user)/spaces/[spaceId]/…/+page.svelte:172-182`, `:305-307`
+- Modify: `routes/(user)/recently-added/…/+page.svelte` (its `emptyFilterSuggestions` and the
+  `if (!facets)` branch around `:266-269`)
+- Test: the three page spec files alongside those routes
+
+All three pages resolve their provider with every array empty when the smart-facets request fails. Today
+that renders empty pickers. Once slice 5 gates on emptiness it would read as "this library has nothing" and
+hide every section at once.
+
+**Do not** satisfy `tsc` by adding `hasFavorites: false` to the sentinel. That is the bug. Delete it.
+
+- [ ] **Step 1: Write the failing tests**
+
+One per page. The specs already mock the SDK as `sdkMock`; follow the existing setup at
+`photos-page.spec.ts:235-250`.
+
+```ts
+it('rejects rather than reporting an empty library when the facet fetch fails (#910)', async () => {
+  sdkMock.searchSmartFacets.mockRejectedValue(new Error('boom'));
+
+  // Drive the page into query mode exactly as the neighbouring smart-search tests do, then invoke the
+  // provider the panel would call.
+  const provider = getRenderedFilterConfig().suggestionsProvider!;
+
+  await expect(provider(createFilterState())).rejects.toThrow('boom');
+});
+```
+
+`getRenderedFilterConfig()` is shorthand for however the surrounding tests reach the config — read the
+neighbouring smart-search test in the same file and use the same mechanism rather than inventing one.
+
+- [ ] **Step 2: Run them to verify they fail**
+
+```bash
+cd web && pnpm test -- --run "src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts"
+```
+
+Expected: FAIL — the promise resolves with the empty sentinel instead of rejecting.
+
+- [ ] **Step 3: Remove the sentinel from the photos page**
+
+Delete the `emptyFilterSuggestions` const, then change the provider branch:
+
+```ts
+const facets = await loadPhotoSmartFacets(nextFilters);
+if (!facets) {
+  // #910: never resolve with a fabricated empty response — the panel cannot tell it apart from a
+  // genuinely empty library and would hide every section. Rejecting lets the panel keep the last
+  // good facets.
+  throw new Error('smart-search facets unavailable');
+}
+```
+
+Apply the identical change to the spaces page and the Recently Added page.
+
+- [ ] **Step 4: Check `loadPhotoSmartFacets`'s own catch**
+
+`loadPhotoSmartFacets` swallows its error and returns the stale `smartFacets` (`:259-264`), which is
+`undefined` on a first failure — that is the path reaching the sentinel. Leave that catch as it is: it
+correctly keeps the previous facets when they exist, and the new `throw` covers the case where they do
+not.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+cd web && pnpm test -- --run "src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts" \
+                          "src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts" \
+                          "src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts"
+```
+
+Expected: PASS, including every pre-existing test in those files.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "web/src/routes/(user)/"
+git commit -m "fix(web): reject instead of faking empty filter facets on fetch failure (#910)"
+```
+
+---
+
+## Task 3: Browse-path providers, fixtures, and the typecheck gate
+
+**Files:**
+
+- Modify: `routes/(user)/photos/[[assetId=id]]/+page.svelte` — `loadPhotoFilterSuggestions`'s return object
+- Modify: `routes/(user)/spaces/[spaceId]/…/+page.svelte` — `loadSpaceFilterSuggestions`'s return object
+- Modify: `web/src/lib/utils/__tests__/filter-section-parity.spec.ts:11-20` — the mock
+- Modify: any remaining spec fixture `tsc` names
+
+- [ ] **Step 1: Let the compiler enumerate the work**
+
+```bash
+cd web && pnpm check:typescript 2>&1 | grep -E "hasFavorites|hasAssetsInAlbum|hasAssetsNotInAlbum"
+```
+
+Expected: a list of every object literal still missing the fields. This is the checklist for this task.
+Slice 3 deliberately made the interface fields required so this list is complete.
+
+- [ ] **Step 2: Forward them in the two browse-path providers**
+
+Both pages build their response inline rather than through a shared mapper. Add the same three lines used
+in Task 1 after `hasUnnamedPeople:`.
+
+- [ ] **Step 3: Update the parity-spec mock**
+
+`filter-section-parity.spec.ts` mocks `getFilterSuggestions` with a literal. Extend it:
+
+```ts
+    getFilterSuggestions: vi.fn().mockResolvedValue({
+      countries: [],
+      cameraMakes: [],
+      tags: [],
+      people: [],
+      ratings: [],
+      mediaTypes: [],
+      hasUnnamedPeople: false,
+      hasFavorites: false,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: false,
+    }),
+```
+
+This spec guards `config.sections` parity, which this change does not touch. Its assertions must stay
+exactly as they are — if one goes red, a mapper edit changed a section list and that is a bug.
+
+- [ ] **Step 4: Update the remaining fixtures**
+
+Work through the Step 1 list. Page specs at `photos-page.spec.ts:235` and `:244` and their siblings need
+the fields on both the `getFilterSuggestions` and the `searchSmartFacets` mock values.
+
+- [ ] **Step 5: Full web gate**
+
+```bash
+cd web && pnpm check:typescript && pnpm check:svelte && pnpm lint && pnpm test
+```
+
+Expected: all green. `check:typescript` returning clean is the real deliverable of this slice — it proves
+no surface was missed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/
+git commit -m "feat(web): forward the availability facets from every filter surface (#910)"
+```
+
+---
+
+## Done when
+
+- `pnpm check:typescript` is green — no surface still omits a field.
+- `pnpm test` is green, including `filter-section-parity.spec.ts` with unmodified assertions.
+- `grep -rn "emptyFilterSuggestions" web/src` returns nothing.
+- The filter panel component is still untouched.

--- a/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-5.md
+++ b/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-5.md
@@ -1,0 +1,526 @@
+# Slice 5 — Wire availability into the filter panel (#910)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for
+> tracking.
+
+**Goal:** The panel captures a no-filters baseline, hides structurally useless sections, greys transiently
+empty ones, and keeps all of that out of the persisted user ledger.
+
+**Architecture:** All rule logic already lives in slice 3's `filter-availability.ts`. This slice is
+plumbing: capture two response objects into state, derive a verdict per section, and use it in three places
+in the template. The legacy providers-only path is left byte-for-byte unchanged.
+
+**Tech Stack:** Svelte 5 runes, Vitest, @testing-library/svelte, happy-dom.
+
+- **Spec:** `docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md` §2.4, §4.2, §4.3.1, §4.5, §6.2, §6.3
+- **Branch:** `fix/910-interdependent-filter-sections`
+- **Depends on:** Slices 3 and 4. **Must not land without slice 4's sentinel removal** — gating on emptiness
+  while a failed fetch still resolves as "empty" would hide the whole panel on a network blip.
+- **Scope:** `filter-panel.svelte` and the panel's test directory. **Nothing else.**
+
+## Global Constraints
+
+- **Base this slice on PR #926.** It rewrites the `{ selected, known }` ledger and the empty-state hint in
+  `filter-panel.svelte` and `filter-panel.ts`. Read the post-#926 versions of `showAllSections`,
+  `serializeSectionSet` and the "show all sections" hint before editing — the snippets below assume them.
+- **Do not touch `rating-filter.svelte` or `media-type-filter.svelte`, and do not assign
+  `availableRatings` or `availableMediaTypes`.** Memory `feedback_no_dynamic_rating_media_hiding` records a
+  standing decision, with a real bug behind it (PR #261: filtering `visibleStars` made the fourth visible
+  star select rating 5). #910 is about sections, not about stars and buttons. Spec §2.4 has the full
+  reasoning; Task 1 Step 5 adds a regression guard so this cannot drift again.
+- Svelte 5 runes in this file. Read state inside `$effect` via `untrack` where re-triggering is not wanted;
+  the existing effects already show the pattern.
+- Per `feedback_web_vitest_no_clearmocks`, mock history leaks between tests in one file — assert call
+  counts against an explicitly reset mock, and remember `$t()` returns raw keys under test.
+- Per `feedback_web_test_assertions_that_cannot_fail`, an assertion that a section is absent must be paired
+  with one proving a sibling section is present, or a panel that rendered nothing passes it trivially.
+
+## File Structure
+
+| File                                                                        | Responsibility             |
+| --------------------------------------------------------------------------- | -------------------------- |
+| `web/src/lib/components/filter-panel/filter-panel.svelte`                   | capture, derive, gate      |
+| `web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`        | integration coverage       |
+| `web/src/lib/components/filter-panel/__tests__/unified-suggestions.spec.ts` | capture + no-dimming guard |
+
+**Interfaces consumed:** `getSectionAvailability`, `SectionAvailability`, `AvailabilityInput` from slice 3.
+
+---
+
+## Task 1: Capture the facets, without handing them to the controls
+
+**Files:**
+
+- Modify: `web/src/lib/components/filter-panel/filter-panel.svelte:81-87`, `:151-176`
+- Test: `web/src/lib/components/filter-panel/__tests__/unified-suggestions.spec.ts`
+
+- [ ] **Step 1: Extend the shared fixture**
+
+`defaultResponse` at the top of `unified-suggestions.spec.ts` is reused by every test in the file. Add the
+three slice-1 booleans so existing tests keep their sections visible once Task 2 lands:
+
+```ts
+  hasFavorites: true,
+  hasAssetsInAlbum: true,
+  hasAssetsNotInAlbum: true,
+```
+
+Do the same for the fixtures in `contextual-refetch.spec.ts` and `filter-panel.spec.ts`. Skipping this
+makes Task 2 look like it broke a dozen unrelated tests.
+
+- [ ] **Step 2: Write the failing test**
+
+The observable deliverable of this task is the guarantee that the facets reach the panel **without**
+reaching the controls. That is what this test pins, and it fails today for a different reason than you
+might expect: with `ratings: [2]` nothing is dimmed either way, so the test needs the panel to have
+consumed the response at all. Assert both halves.
+
+```ts
+it('consumes the facets without dimming the controls (#910, feedback_no_dynamic_rating_media_hiding)', async () => {
+  const suggestionsProvider = vi.fn().mockResolvedValue({
+    ...defaultResponse,
+    ratings: [2],
+    mediaTypes: ['IMAGE', 'VIDEO'],
+  });
+  const config = { sections: ['rating', 'media'] as FilterSection[], suggestionsProvider };
+
+  render(FilterPanel, { props: { config, timeBuckets: [] } });
+
+  await waitFor(() => expect(suggestionsProvider).toHaveBeenCalledTimes(1));
+  await waitFor(() => expect(screen.getByTestId('rating-star-5')).toBeInTheDocument());
+
+  // Re-introducing `availableRatings` would dim stars 1, 3, 4 and 5 here. Re-introducing
+  // `availableMediaTypes` would drop a media button. Neither may happen.
+  for (const star of [1, 2, 3, 4, 5]) {
+    expect(screen.getByTestId(`rating-star-${star}`).className).not.toContain('opacity-50');
+  }
+  for (const type of ['all', 'image', 'video']) {
+    expect(screen.getByTestId(`media-type-${type}`)).toBeInTheDocument();
+  }
+});
+```
+
+- [ ] **Step 3: Run it — it should pass**
+
+```bash
+cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/unified-suggestions.spec.ts
+```
+
+Expected: PASS. This is the rare guard-first case: the behaviour is already correct and the test exists to
+keep it correct through Task 2, which is where the temptation to assign the props arises. Note it in the
+commit message so a reviewer knows it was not expected to fail.
+
+- [ ] **Step 4: Add the state and capture the response**
+
+Alongside the existing fetched-data state (around `:81-87`):
+
+```ts
+// #910: the facets for the filters in force right now, and for the same scope with none applied.
+// The baseline answers "could this section EVER do anything here", which is what separates hiding a
+// section from merely greying it.
+let currentSuggestions = $state<FilterSuggestionsResponse | undefined>();
+let baseline = $state<FilterSuggestionsResponse | undefined>();
+let baselineRequested = false;
+```
+
+`FilterSuggestionsResponse` is already exported from `./filter-panel`; extend the existing type import
+rather than adding a second one.
+
+In the unified effect's `.then` (`:151-166`), add **one** line and change nothing else:
+
+```ts
+        .then((result) => {
+          if (controller.signal.aborted) {
+            return;
+          }
+          people = result.people;
+          countries = result.countries;
+          cameraMakes = result.cameraMakes;
+          tags = result.tags;
+          // Note: availableRatings and availableMediaTypes are intentionally NOT set from
+          // suggestionsProvider. Hiding or dimming rating stars and media type buttons based on the
+          // current result set breaks their positional meaning (PR #261) and the E2E suites that click
+          // them. #910 gates the *sections* instead — the facets reach getSectionAvailability through
+          // `currentSuggestions` below, never the controls. See spec §2.4.
+          hasUnnamedPeople = result.hasUnnamedPeople;
+          currentSuggestions = result;
+        })
+```
+
+The comment is rewritten, not deleted: it now says why the decision survives #910 rather than merely
+asserting it.
+
+- [ ] **Step 5: Run the whole panel suite**
+
+```bash
+cd web && pnpm test -- --run src/lib/components/filter-panel/
+```
+
+Expected: PASS. `currentSuggestions` and `baseline` are captured but nothing reads them yet, so this task
+changes no behaviour — which is exactly what the suite should confirm.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/
+git commit -m "refactor(web): keep the filter suggestions response for availability decisions (#910)
+
+The no-dimming guard passes on first write by design: it locks
+feedback_no_dynamic_rating_media_hiding through the gating work in the next commit."
+```
+
+---
+
+## Task 2: Capture the baseline and gate the sections
+
+**Files:**
+
+- Modify: `web/src/lib/components/filter-panel/filter-panel.svelte`
+- Test: `web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+const availableEverything = {
+  countries: ['Germany'],
+  cameraMakes: ['Canon'],
+  tags: [{ id: 't', name: 'Tag' }],
+  people: [{ id: 'p', name: 'Alice' }],
+  ratings: [5],
+  mediaTypes: ['IMAGE', 'VIDEO'],
+  hasUnnamedPeople: false,
+  hasFavorites: true,
+  hasAssetsInAlbum: true,
+  hasAssetsNotInAlbum: true,
+};
+
+describe('section availability (#910)', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('hides a structurally unavailable section and its toggle', async () => {
+    const config = {
+      sections: ['rating', 'media'] as FilterSection[],
+      suggestionsProvider: vi.fn().mockResolvedValue({ ...availableEverything, ratings: [] }),
+    };
+
+    render(FilterPanel, { props: { config, timeBuckets: [] } });
+
+    // The sibling assertion matters: without it a panel that rendered nothing would pass.
+    await waitFor(() => expect(screen.getByTestId('filter-section-media')).toBeInTheDocument());
+    expect(screen.queryByTestId('filter-section-rating')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('section-toggle-rating')).not.toBeInTheDocument();
+    expect(screen.getByTestId('section-toggle-media')).toBeInTheDocument();
+  });
+
+  it('greys a section the current filters emptied, rather than hiding it', async () => {
+    const suggestionsProvider = vi
+      .fn()
+      .mockResolvedValueOnce(availableEverything)
+      .mockResolvedValue({ ...availableEverything, tags: [] });
+    const config = { sections: ['tags', 'media'] as FilterSection[], suggestionsProvider };
+    const filters = { ...createFilterState() };
+
+    const { rerender } = render(FilterPanel, { props: { config, timeBuckets: [], filters } });
+    await waitFor(() => expect(suggestionsProvider).toHaveBeenCalledTimes(1));
+
+    await rerender({ config, timeBuckets: [], filters: { ...filters, personIds: ['p'] } });
+
+    await waitFor(() => {
+      const button = within(screen.getByTestId('filter-section-tags')).getByRole('button');
+      expect(button).toBeDisabled();
+      expect(button.textContent).toContain('(0)');
+    });
+  });
+
+  it('never writes availability into the stored ledger', async () => {
+    const config = {
+      sections: ['rating', 'media'] as FilterSection[],
+      suggestionsProvider: vi.fn().mockResolvedValue({ ...availableEverything, ratings: [] }),
+    };
+
+    render(FilterPanel, { props: { config, timeBuckets: [], storageKey: 'test-key' } });
+    await waitFor(() => expect(screen.getByTestId('filter-section-media')).toBeInTheDocument());
+
+    const stored = JSON.parse(localStorage.getItem('test-key')!);
+    // Both halves matter: `selected` keeps it un-hidden, `known` keeps PR #926 from re-introducing it
+    // as a brand-new section on the next load.
+    expect(stored.selected).toContain('rating');
+    expect(stored.known).toContain('rating');
+  });
+
+  it('shows a section again once its facet comes back', async () => {
+    const suggestionsProvider = vi
+      .fn()
+      .mockResolvedValueOnce({ ...availableEverything, ratings: [] })
+      .mockResolvedValue(availableEverything);
+    const config = { sections: ['rating', 'media'] as FilterSection[], suggestionsProvider };
+    const filters = { ...createFilterState() };
+
+    const { rerender } = render(FilterPanel, { props: { config, timeBuckets: [], filters } });
+    await waitFor(() => expect(screen.queryByTestId('filter-section-rating')).not.toBeInTheDocument());
+
+    await rerender({ config, timeBuckets: [], filters: { ...filters, personIds: ['p'] } });
+
+    await waitFor(() => expect(screen.getByTestId('filter-section-rating')).toBeInTheDocument());
+  });
+
+  it('fetches a baseline separately when it mounts with filters applied', async () => {
+    const suggestionsProvider = vi.fn().mockResolvedValue(availableEverything);
+    const config = { sections: ['rating'] as FilterSection[], suggestionsProvider };
+
+    render(FilterPanel, { props: { config, timeBuckets: [], filters: { ...createFilterState(), rating: 5 } } });
+
+    await waitFor(() => expect(suggestionsProvider).toHaveBeenCalledTimes(2));
+    expect(suggestionsProvider).toHaveBeenCalledWith(expect.objectContaining({ rating: undefined }));
+  });
+
+  it('fetches no extra baseline when it mounts clean', async () => {
+    const suggestionsProvider = vi.fn().mockResolvedValue(availableEverything);
+    const config = { sections: ['rating'] as FilterSection[], suggestionsProvider };
+
+    render(FilterPanel, { props: { config, timeBuckets: [] } });
+
+    await waitFor(() => expect(suggestionsProvider).toHaveBeenCalledTimes(1));
+    // Give any stray second request time to land before asserting it did not.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(suggestionsProvider).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides nothing when the baseline request rejects', async () => {
+    const suggestionsProvider = vi
+      .fn()
+      .mockImplementation((next) =>
+        next.rating === undefined
+          ? Promise.reject(new Error('baseline failed'))
+          : Promise.resolve({ ...availableEverything, ratings: [] }),
+      );
+    const config = { sections: ['rating'] as FilterSection[], suggestionsProvider };
+
+    render(FilterPanel, { props: { config, timeBuckets: [], filters: { ...createFilterState(), rating: 5 } } });
+
+    await waitFor(() => expect(screen.getByTestId('filter-section-rating')).toBeInTheDocument());
+  });
+
+  it('keeps a section with an active filter visible even when its facet is empty', async () => {
+    const config = {
+      sections: ['rating'] as FilterSection[],
+      suggestionsProvider: vi.fn().mockResolvedValue({ ...availableEverything, ratings: [] }),
+    };
+
+    render(FilterPanel, { props: { config, timeBuckets: [], filters: { ...createFilterState(), rating: 5 } } });
+
+    await waitFor(() => expect(screen.getByTestId('filter-section-rating')).toBeInTheDocument());
+  });
+
+  it('leaves the legacy providers path ungated', async () => {
+    const config = {
+      sections: ['people', 'camera'] as FilterSection[],
+      providers: { people: vi.fn().mockResolvedValue([]), cameras: vi.fn().mockResolvedValue([]) },
+    };
+
+    render(FilterPanel, { props: { config, timeBuckets: [] } });
+
+    await waitFor(() => expect(screen.getByTestId('filter-section-people')).toBeInTheDocument());
+    expect(screen.getByTestId('filter-section-camera')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+```bash
+cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+```
+
+Expected: FAIL on hide, grey, re-show, and baseline-request. The ledger, reject, active-filter and legacy
+tests pass already — they are the guards against over-correcting.
+
+- [ ] **Step 3: Import the rule module**
+
+```ts
+import { getSectionAvailability, type SectionAvailability } from './filter-availability';
+```
+
+`createFilterState` and `getActiveFilterCount` are already imported from `./filter-panel`; extend that
+import rather than adding a second one.
+
+- [ ] **Step 4: Capture the baseline**
+
+In the unified effect's `.then`, after `currentSuggestions = result;` from Task 1:
+
+```ts
+if (getActiveFilterCount(currentFilters) === 0) {
+  // Mounted clean, so this response is already the no-filters baseline — no second request.
+  baseline = result;
+}
+```
+
+Then add a one-shot effect next to the other `$effect`s:
+
+```ts
+// Only fires when the panel mounts with filters already applied (a deep link, or restored state) —
+// otherwise the effect above captures the baseline for free. Scope changes remount the panel, so this
+// needs no invalidation: see spec §4.5 for the `{#key}` blocks that guarantee it.
+$effect(() => {
+  const provider = config.suggestionsProvider;
+  if (!provider || baselineRequested) {
+    return;
+  }
+  baselineRequested = true;
+
+  if (untrack(() => getActiveFilterCount(filters)) === 0) {
+    return;
+  }
+
+  void provider(createFilterState())
+    .then((result) => {
+      baseline = result;
+    })
+    .catch(() => {
+      // Leave it undefined. A section is never hidden on missing information.
+    });
+});
+```
+
+- [ ] **Step 5: Derive the verdicts**
+
+After `hasActiveFilter` (`:621-659`):
+
+```ts
+// Availability is derived, never persisted — the storage effect keeps writing `config.sections`.
+// Conflating the two would record a section as user-hidden the moment it went unavailable, and it
+// would never come back.
+let availability = $derived<Map<FilterSectionType, SectionAvailability>>(
+  new Map(
+    config.sections.map((section) => [
+      section,
+      config.suggestionsProvider && currentSuggestions
+        ? getSectionAvailability(section, {
+            current: currentSuggestions,
+            baseline,
+            hasActiveFilter: hasActiveFilter(section),
+            timeBucketCount: timeBuckets.length,
+          })
+        : 'available',
+    ]),
+  ),
+);
+
+let renderableSections = $derived(config.sections.filter((section) => availability.get(section) !== 'unavailable'));
+```
+
+The `config.suggestionsProvider && currentSuggestions` guard is what keeps the legacy path unchanged.
+
+- [ ] **Step 6: Use them in the template**
+
+Three edits. The toggle row (`:727`) and the section render loop (`:753`) both become:
+
+```svelte
+            {#each renderableSections as section (section)}
+```
+
+The `count` prop (`:761-771`):
+
+```svelte
+                count={config.suggestionsProvider
+                  ? availability.get(section) === 'empty'
+                    ? 0
+                    : undefined
+                  : filterContext
+                    ? section === 'people'
+                      ? people.length
+                      : section === 'location'
+                        ? countries.length
+                        : section === 'camera'
+                          ? cameraMakes.length
+                          : section === 'tags'
+                            ? tags.length
+                            : undefined
+                    : undefined}
+```
+
+`filterContext` stays for the legacy branch — do not delete it, and do not touch its #858 exclusion list.
+
+- [ ] **Step 7: Point the empty-state hint at renderable sections**
+
+Post-#926 the hint asks whether every section _this surface renders_ is hidden. Change that check to use
+`renderableSections`, so a user whose only available section is hidden still gets the hint. Read the
+post-#926 code for the exact expression before editing.
+
+- [ ] **Step 8: Run the whole panel suite**
+
+```bash
+cd web && pnpm test -- --run src/lib/components/filter-panel/
+```
+
+Expected: PASS, including `filter-panel.spec.ts:403` (`#858 §3.3`) with no edits — that test uses the
+legacy providers path and proves the carve-out still holds there.
+
+- [ ] **Step 9: Full web gate**
+
+```bash
+cd web && pnpm test && pnpm check:typescript && pnpm check:svelte && pnpm lint && pnpm format
+```
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add web/src/lib/components/filter-panel/
+git commit -m "feat(web): hide filter sections that cannot filter anything (#910)"
+```
+
+---
+
+## Task 3: Lock the `{#key}` remount invariant
+
+**Files:**
+
+- Test: the three query-mode page specs
+
+Baseline caching is correct only because each surface remounts the panel when its non-filter scope changes.
+Nothing in the panel enforces that, and deleting a `{#key}` would be a silent correctness regression.
+
+- [ ] **Step 1: Write the test**
+
+One per query-mode page. In `photos-page.spec.ts`:
+
+```ts
+it('remounts the filter panel when the committed query changes, so the baseline is re-fetched (#910)', async () => {
+  const before = sdkMock.searchSmartFacets.mock.calls.length;
+
+  await commitQuery('beach');
+
+  await waitFor(() => expect(sdkMock.searchSmartFacets.mock.calls.length).toBeGreaterThan(before));
+});
+```
+
+Read the neighbouring smart-search test in the same file for the actual query-commit mechanism and reuse it
+verbatim; do not invent a `commitQuery` helper if one does not exist.
+
+- [ ] **Step 2: Run and confirm green without source changes**
+
+```bash
+cd web && pnpm test -- --run "src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts"
+```
+
+Expected: PASS. If it fails, the `{#key}` block at `+page.svelte:600` has changed and the baseline design
+assumption is broken — stop and report rather than adjusting the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "web/src/routes/(user)/"
+git commit -m "test(web): lock the filter-panel remount that scopes the #910 baseline"
+```
+
+---
+
+## Done when
+
+- `pnpm test`, `pnpm check:typescript`, `pnpm check:svelte`, `pnpm lint`, `pnpm format` are all green in
+  `web/`.
+- `filter-panel.spec.ts:403` passes unmodified.
+- `git diff --name-only` for this slice lists **no** `rating-filter.svelte` or `media-type-filter.svelte`.
+- `grep -n "availableRatings =" web/src/lib/components/filter-panel/filter-panel.svelte` returns nothing.
+- `filterContext` still exists and still carries its #858 exclusion list.

--- a/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-5.md
+++ b/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-5.md
@@ -16,7 +16,9 @@ in the template. The legacy providers-only path is left byte-for-byte unchanged.
 - **Spec:** `docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md` §2.4, §4.2, §4.3.1, §4.5, §6.2, §6.3
 - **Branch:** `fix/910-interdependent-filter-sections`
 - **Depends on:** Slices 3 and 4. **Must not land without slice 4's sentinel removal** — gating on emptiness
-  while a failed fetch still resolves as "empty" would hide the whole panel on a network blip.
+  while a failed fetch still resolves as "empty" would hide the whole panel on a network blip. It also
+  consumes slice 4's `baselineProvider`; without it the panel simply never hides, which is safe but makes
+  every Task 2 hide/grey test fail for a reason that has nothing to do with this slice.
 - **Scope:** `filter-panel.svelte` and the panel's test directory. **Nothing else.**
 
 ## Global Constraints
@@ -66,8 +68,17 @@ three slice-1 booleans so existing tests keep their sections visible once Task 2
   hasAssetsNotInAlbum: true,
 ```
 
-Do the same for the fixtures in `contextual-refetch.spec.ts` and `filter-panel.spec.ts`. Skipping this
-makes Task 2 look like it broke a dozen unrelated tests.
+`unified-suggestions.spec.ts` and `contextual-refetch.spec.ts` are the only two panel specs that use
+`suggestionsProvider` (`grep -ln suggestionsProvider web/src/lib/components/filter-panel/__tests__/`),
+so they are the only two whose sections can go unavailable. Do not stop there, though: **~20 files
+across `web/src` carry `hasUnnamedPeople` literals** and slice 4 should already have repaired them —
+
+```bash
+cd web && grep -rln "hasUnnamedPeople" src | sort
+```
+
+Anything that list names and `pnpm check:typescript` does not is a fixture that type-checks but lies
+at runtime. Skipping this makes Task 2 look like it broke a dozen unrelated tests.
 
 - [ ] **Step 2: Write the failing test**
 
@@ -104,7 +115,7 @@ it('consumes the facets without dimming the controls (#910, feedback_no_dynamic_
 - [ ] **Step 3: Run it — it should pass**
 
 ```bash
-cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/unified-suggestions.spec.ts
+cd web && pnpm test --run src/lib/components/filter-panel/__tests__/unified-suggestions.spec.ts
 ```
 
 Expected: PASS. This is the rare guard-first case: the behaviour is already correct and the test exists to
@@ -154,7 +165,7 @@ asserting it.
 - [ ] **Step 5: Run the whole panel suite**
 
 ```bash
-cd web && pnpm test -- --run src/lib/components/filter-panel/
+cd web && pnpm test --run src/lib/components/filter-panel/
 ```
 
 Expected: PASS. `currentSuggestions` and `baseline` are captured but nothing reads them yet, so this task
@@ -265,41 +276,110 @@ describe('section availability (#910)', () => {
     await waitFor(() => expect(screen.getByTestId('filter-section-rating')).toBeInTheDocument());
   });
 
-  it('fetches a baseline separately when it mounts with filters applied', async () => {
+  it('calls baselineProvider once when it mounts with filters applied', async () => {
     const suggestionsProvider = vi.fn().mockResolvedValue(availableEverything);
-    const config = { sections: ['rating'] as FilterSection[], suggestionsProvider };
+    const baselineProvider = vi.fn().mockResolvedValue(availableEverything);
+    const config = { sections: ['rating'] as FilterSection[], suggestionsProvider, baselineProvider };
 
     render(FilterPanel, { props: { config, timeBuckets: [], filters: { ...createFilterState(), rating: 5 } } });
 
-    await waitFor(() => expect(suggestionsProvider).toHaveBeenCalledTimes(2));
-    expect(suggestionsProvider).toHaveBeenCalledWith(expect.objectContaining({ rating: undefined }));
+    await waitFor(() => expect(baselineProvider).toHaveBeenCalledTimes(1));
+    // The baseline is a SEPARATE hook, never a second suggestionsProvider call: spec §4.5 explains
+    // why reusing the provider corrupts the query-mode pages.
+    expect(suggestionsProvider).toHaveBeenCalledTimes(1);
   });
 
-  it('fetches no extra baseline when it mounts clean', async () => {
+  it('calls no baseline provider when it mounts clean', async () => {
     const suggestionsProvider = vi.fn().mockResolvedValue(availableEverything);
-    const config = { sections: ['rating'] as FilterSection[], suggestionsProvider };
+    const baselineProvider = vi.fn().mockResolvedValue(availableEverything);
+    const config = { sections: ['rating'] as FilterSection[], suggestionsProvider, baselineProvider };
 
     render(FilterPanel, { props: { config, timeBuckets: [] } });
 
     await waitFor(() => expect(suggestionsProvider).toHaveBeenCalledTimes(1));
-    // Give any stray second request time to land before asserting it did not.
+    // Give any stray request time to land before asserting it did not. The clean-mount response IS
+    // the baseline, so a second call would be pure waste.
     await new Promise((resolve) => setTimeout(resolve, 100));
-    expect(suggestionsProvider).toHaveBeenCalledTimes(1);
+    expect(baselineProvider).not.toHaveBeenCalled();
   });
 
-  it('hides nothing when the baseline request rejects', async () => {
+  // The filter is on `people`, NOT on `rating`. That distinction is the whole test: with the filter
+  // on the section under assertion, hasActiveFilter short-circuits to 'available' before the code
+  // ever reads `baseline`, and the test passes whether or not the failure path works at all.
+  it.each([
+    ['rejects', () => Promise.reject(new Error('baseline failed'))],
+    ['resolves undefined', () => Promise.resolve(undefined)],
+  ])('hides nothing when the baseline provider %s', async (_label, baseline) => {
+    const config = {
+      sections: ['rating', 'media'] as FilterSection[],
+      suggestionsProvider: vi.fn().mockResolvedValue({ ...availableEverything, ratings: [] }),
+      baselineProvider: vi.fn().mockImplementation(baseline),
+    };
+
+    render(FilterPanel, {
+      props: { config, timeBuckets: [], filters: { ...createFilterState(), personIds: ['p'] } },
+    });
+
+    await waitFor(() => expect(screen.getByTestId('filter-section-media')).toBeInTheDocument());
+    expect(screen.getByTestId('filter-section-rating')).toBeInTheDocument();
+  });
+
+  it('hides nothing when no baselineProvider is configured at all', async () => {
+    const config = {
+      sections: ['rating', 'media'] as FilterSection[],
+      suggestionsProvider: vi.fn().mockResolvedValue({ ...availableEverything, ratings: [] }),
+    };
+
+    render(FilterPanel, {
+      props: { config, timeBuckets: [], filters: { ...createFilterState(), personIds: ['p'] } },
+    });
+
+    await waitFor(() => expect(screen.getByTestId('filter-section-media')).toBeInTheDocument());
+    expect(screen.getByTestId('filter-section-rating')).toBeInTheDocument();
+  });
+
+  it('keeps the previous facets when a later refetch rejects', async () => {
     const suggestionsProvider = vi
       .fn()
-      .mockImplementation((next) =>
-        next.rating === undefined
-          ? Promise.reject(new Error('baseline failed'))
-          : Promise.resolve({ ...availableEverything, ratings: [] }),
-      );
-    const config = { sections: ['rating'] as FilterSection[], suggestionsProvider };
+      .mockResolvedValueOnce(availableEverything)
+      .mockRejectedValue(new Error('network blip'));
+    const config = { sections: ['rating', 'media'] as FilterSection[], suggestionsProvider };
+    const filters = { ...createFilterState() };
 
-    render(FilterPanel, { props: { config, timeBuckets: [], filters: { ...createFilterState(), rating: 5 } } });
-
+    const { rerender } = render(FilterPanel, { props: { config, timeBuckets: [], filters } });
     await waitFor(() => expect(screen.getByTestId('filter-section-rating')).toBeInTheDocument());
+
+    await rerender({ config, timeBuckets: [], filters: { ...filters, personIds: ['p'] } });
+    await waitFor(() => expect(suggestionsProvider).toHaveBeenCalledTimes(2));
+
+    // §4.6 at panel level: a rejection must leave `current` and `baseline` untouched, not blank the
+    // panel. Slice 4 made the surfaces reject instead of resolving empty precisely so this holds.
+    expect(screen.getByTestId('filter-section-rating')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-section-media')).toBeInTheDocument();
+  });
+
+  it('greys the timeline while it has no buckets, and restores it when they arrive', async () => {
+    const config = {
+      sections: ['timeline', 'media'] as FilterSection[],
+      suggestionsProvider: vi.fn().mockResolvedValue(availableEverything),
+    };
+
+    // Every query-mode surface passes through timeBuckets: [] before its first facet response.
+    const { rerender } = render(FilterPanel, { props: { config, timeBuckets: [] } });
+
+    await waitFor(() => {
+      const button = within(screen.getByTestId('filter-section-timeline')).getByRole('button');
+      expect(button).toBeDisabled();
+      expect(button.textContent).toContain('(0)');
+    });
+
+    await rerender({ config, timeBuckets: [{ timeBucket: '2024-01-01', count: 3 }] });
+
+    // `isOpen` is derived, not stored, so it must recover on its own.
+    await waitFor(() => {
+      const button = within(screen.getByTestId('filter-section-timeline')).getByRole('button');
+      expect(button).toBeEnabled();
+    });
   });
 
   it('keeps a section with an active filter visible even when its facet is empty', async () => {
@@ -311,6 +391,20 @@ describe('section availability (#910)', () => {
     render(FilterPanel, { props: { config, timeBuckets: [], filters: { ...createFilterState(), rating: 5 } } });
 
     await waitFor(() => expect(screen.getByTestId('filter-section-rating')).toBeInTheDocument());
+  });
+
+  it('offers the show-all hint when every AVAILABLE section is user-hidden', async () => {
+    // The user hid `media`; `rating` is unavailable. Nothing renders, so the hint must appear —
+    // but `visibleSections` still contains `rating`, so a `.size === 0` check would miss it.
+    localStorage.setItem('test-key', JSON.stringify({ selected: ['rating'], known: ['rating', 'media'] }));
+    const config = {
+      sections: ['rating', 'media'] as FilterSection[],
+      suggestionsProvider: vi.fn().mockResolvedValue({ ...availableEverything, ratings: [] }),
+    };
+
+    render(FilterPanel, { props: { config, timeBuckets: [], storageKey: 'test-key' } });
+
+    await waitFor(() => expect(screen.getByText('filter_show_all_sections')).toBeInTheDocument());
   });
 
   it('leaves the legacy providers path ungated', async () => {
@@ -327,14 +421,18 @@ describe('section availability (#910)', () => {
 });
 ```
 
+`$t()` returns raw keys under test (`feedback_web_vitest_no_clearmocks`), which is why the hint test
+matches the literal `filter_show_all_sections` rather than English copy.
+
 - [ ] **Step 2: Run them to verify they fail**
 
 ```bash
-cd web && pnpm test -- --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+cd web && pnpm test --run src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
 ```
 
-Expected: FAIL on hide, grey, re-show, and baseline-request. The ledger, reject, active-filter and legacy
-tests pass already — they are the guards against over-correcting.
+Expected: FAIL on hide, grey, re-show, baseline-provider (both), timeline-greying and the show-all
+hint. The ledger, no-baselineProvider, refetch-rejection, active-filter and legacy tests pass already —
+they are the guards against over-correcting.
 
 - [ ] **Step 3: Import the rule module**
 
@@ -356,15 +454,21 @@ if (getActiveFilterCount(currentFilters) === 0) {
 }
 ```
 
-Then add a one-shot effect next to the other `$effect`s:
+Then add a one-shot effect next to the other `$effect`s. **It must call `config.baselineProvider`, not
+`config.suggestionsProvider(createFilterState())`** — spec §4.5 has the full reasoning, and slice 4
+built the hook for exactly this. In short: the three query-mode pages keep one `smartFacetInFlight`
+slot and abort on key mismatch, so a second concurrent facet request would kill the first; and their
+`.then` writes `smartFacets`, which feeds the Timeline buckets and the result count, so an unfiltered
+baseline response would make the page render unfiltered data while filters are applied. Neither failure
+is visible from inside the panel.
 
 ```ts
 // Only fires when the panel mounts with filters already applied (a deep link, or restored state) —
 // otherwise the effect above captures the baseline for free. Scope changes remount the panel, so this
 // needs no invalidation: see spec §4.5 for the `{#key}` blocks that guarantee it.
 $effect(() => {
-  const provider = config.suggestionsProvider;
-  if (!provider || baselineRequested) {
+  const provider = config.baselineProvider;
+  if (!config.suggestionsProvider || !provider || baselineRequested) {
     return;
   }
   baselineRequested = true;
@@ -373,7 +477,9 @@ $effect(() => {
     return;
   }
 
-  void provider(createFilterState())
+  void provider()
+    // A surface with no cheap baseline resolves `undefined` (every query-mode branch does). Assigning
+    // it is a no-op that keeps the "never hidden on missing information" rule intact.
     .then((result) => {
       baseline = result;
     })
@@ -444,14 +550,25 @@ The `count` prop (`:761-771`):
 
 - [ ] **Step 7: Point the empty-state hint at renderable sections**
 
-Post-#926 the hint asks whether every section _this surface renders_ is hidden. Change that check to use
-`renderableSections`, so a user whose only available section is hidden still gets the hint. Read the
-post-#926 code for the exact expression before editing.
+This is the "offers the show-all hint" test from Step 1 — it is behaviour, not tidying, which is why it
+gets a failing test rather than a drive-by edit.
+
+Today the hint is gated on `{#if visibleSections.size === 0}` (`filter-panel.svelte:876`). That counts
+the user's _persisted_ choice, which still contains unavailable sections, so a panel rendering nothing
+can have `size > 0` and show no hint. Gate it on the intersection instead:
+
+```svelte
+{#if renderableSections.every((section) => !visibleSections.has(section))}
+```
+
+`showAllSections()` keeps setting `visibleSections = new SvelteSet(config.sections)` — availability must
+never be written into the ledger (§6.3), and an unavailable section that becomes available later has to
+come back already-selected. Read the post-#926 versions of both before editing; #926 rewrites this area.
 
 - [ ] **Step 8: Run the whole panel suite**
 
 ```bash
-cd web && pnpm test -- --run src/lib/components/filter-panel/
+cd web && pnpm test --run src/lib/components/filter-panel/
 ```
 
 Expected: PASS, including `filter-panel.spec.ts:403` (`#858 §3.3`) with no edits — that test uses the
@@ -481,12 +598,16 @@ git commit -m "feat(web): hide filter sections that cannot filter anything (#910
 Baseline caching is correct only because each surface remounts the panel when its non-filter scope changes.
 Nothing in the panel enforces that, and deleting a `{#key}` would be a silent correctness regression.
 
+Query mode returns no baseline (§4.5), so the remount matters here for `currentSuggestions`,
+the hydrated `visibleSections` and the expanded-section state rather than for the baseline itself — and
+for the browse↔query transition, where a browse-mode baseline must not survive into query mode.
+
 - [ ] **Step 1: Write the test**
 
 One per query-mode page. In `photos-page.spec.ts`:
 
 ```ts
-it('remounts the filter panel when the committed query changes, so the baseline is re-fetched (#910)', async () => {
+it('remounts the filter panel when the committed query changes, so its cached facets are dropped (#910)', async () => {
   const before = sdkMock.searchSmartFacets.mock.calls.length;
 
   await commitQuery('beach');
@@ -501,7 +622,7 @@ verbatim; do not invent a `commitQuery` helper if one does not exist.
 - [ ] **Step 2: Run and confirm green without source changes**
 
 ```bash
-cd web && pnpm test -- --run "src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts"
+cd web && pnpm test --run "src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts"
 ```
 
 Expected: PASS. If it fails, the `{#key}` block at `+page.svelte:600` has changed and the baseline design
@@ -518,9 +639,12 @@ git commit -m "test(web): lock the filter-panel remount that scopes the #910 bas
 
 ## Done when
 
-- `pnpm test`, `pnpm check:typescript`, `pnpm check:svelte`, `pnpm lint`, `pnpm format` are all green in
-  `web/`.
+- `pnpm test --run`, `pnpm check:typescript`, `pnpm check:svelte`, `pnpm lint`, `pnpm format` are all
+  green in `web/`.
 - `filter-panel.spec.ts:403` passes unmodified.
+- `grep -n "createFilterState()" web/src/lib/components/filter-panel/filter-panel.svelte` shows no call
+  handed to `suggestionsProvider` — the baseline goes through `config.baselineProvider` (spec §4.5).
+- The empty-state hint has a test, and it fails if the gate is reverted to `visibleSections.size === 0`.
 - `git diff --name-only` for this slice lists **no** `rating-filter.svelte` or `media-type-filter.svelte`.
 - `grep -n "availableRatings =" web/src/lib/components/filter-panel/filter-panel.svelte` returns nothing.
 - `filterContext` still exists and still carries its #858 exclusion list.

--- a/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-6.md
+++ b/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-6.md
@@ -33,47 +33,59 @@ must seed enough variety for that section to be available; the feature itself is
 
 ## File Structure
 
-| File                                                       | Responsibility                                    |
-| ---------------------------------------------------------- | ------------------------------------------------- |
-| `e2e/src/specs/web/photos-filter-panel.e2e-spec.ts`        | seed variety; People carve-out; new hide coverage |
-| `e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts`        | seed variety; People carve-out                    |
-| `e2e/src/specs/web/recently-added-filters.e2e-spec.ts`     | seed variety; People carve-out                    |
-| `e2e/src/specs/web/map-filter-panel.e2e-spec.ts`           | seeds **nothing** today — needs a fixture         |
-| `e2e/src/specs/rebase-smoke/permission-matrix.e2e-spec.ts` | one unconditional wait becomes conditional        |
+| File                                                       | Responsibility                                          |
+| ---------------------------------------------------------- | ------------------------------------------------------- |
+| `e2e/src/specs/web/photos-filter-panel.e2e-spec.ts`        | seed variety incl. a face for People; new hide coverage |
+| `e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts`        | seed variety incl. a space-scoped person for People     |
+| `e2e/src/specs/web/recently-added-filters.e2e-spec.ts`     | seed variety incl. a face for People                    |
+| `e2e/src/specs/web/map-filter-panel.e2e-spec.ts`           | seeds **nothing** today — needs a fixture               |
+| `e2e/src/specs/rebase-smoke/permission-matrix.e2e-spec.ts` | one unconditional wait becomes conditional              |
 
 ### The seeding recipes
 
-Verified against `e2e/test-assets` and `e2e/src/utils.ts`. Every section except People can be seeded.
+Verified against `e2e/test-assets` and `e2e/src/utils.ts`. Every section, People included, can be seeded.
 
-| Section   | Seed                                                                                                                                                                                 |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| media     | `utils.createAsset(token, { assetData: { filename: 'x.mp4' } })` — random bytes, typed from the extension (`recently-added-filters.e2e-spec.ts:102-110`)                             |
-| rating    | `updateAsset({ id, updateAssetDto: { rating: 5 } }, { headers: asBearerAuth(token) })`                                                                                               |
-| favorites | `updateAsset({ id, updateAssetDto: { isFavorite: true } }, …)`                                                                                                                       |
-| albums    | an album containing **some but not all** seeded assets — both booleans must be true                                                                                                  |
-| location  | upload `${testAssetDir}/metadata/gps-position/thompson-springs.jpg`, then `await utils.waitForQueueFinish(token, 'metadataExtraction')`                                              |
-| camera    | upload `${testAssetDir}/metadata/rating/mongolels.jpg` (EXIF `Make: Canon`). **`thompson-springs.jpg` has GPS but no `Make`** — confirmed with exiftool, so it does not cover Camera |
-| tags      | `const [tag] = await utils.upsertTags(token, ['e2e-tag']); await utils.tagAssets(token, tag.id, [assetId]);`                                                                         |
-| people    | **impossible here — see below**                                                                                                                                                      |
+| Section   | Seed                                                                                                                                                                                                                                              |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| media     | `utils.createAsset(token, { assetData: { filename: 'x.mp4' } })` — random bytes, typed from the extension (`recently-added-filters.e2e-spec.ts:102-110`)                                                                                          |
+| rating    | `updateAsset({ id, updateAssetDto: { rating: 5 } }, { headers: asBearerAuth(token) })`                                                                                                                                                            |
+| favorites | `updateAsset({ id, updateAssetDto: { isFavorite: true } }, …)`                                                                                                                                                                                    |
+| albums    | an album containing **some but not all** seeded assets — both booleans must be true                                                                                                                                                               |
+| location  | upload `${testAssetDir}/metadata/gps-position/thompson-springs.jpg`, then `await utils.waitForQueueFinish(token, 'metadataExtraction')`                                                                                                           |
+| camera    | upload `${testAssetDir}/metadata/rating/mongolels.jpg` (EXIF `Make: Canon`). **`thompson-springs.jpg` has GPS but no `Make`** — confirmed with exiftool, so it does not cover Camera                                                              |
+| tags      | `const [tag] = await utils.upsertTags(token, ['e2e-tag']); await utils.tagAssets(token, tag.id, [assetId]);`                                                                                                                                      |
+| people    | global scope: `const person = await utils.createPerson(token, { name }); await utils.createFace({ assetId, personId: person.id });`. Space scope: `utils.createSpacePerson(spaceId, name, ownerId, assetId)` — see "People is seedable too" below |
 
 `waitForQueueFinish` reports "done" while the queue is merely momentarily empty
 (`feedback_e2e_waitforqueuefinish_false_done`), so assert EXIF-derived sections with `expect.poll` or a
 Playwright web-first assertion rather than treating the drain as a barrier.
 
-### The People carve-out
+### People is seedable too
 
-A People facet needs a **face**, and face detection needs the ML stack the web e2e project does not
-run. `utils.createPerson` makes a person row with no face, which `getFilteredPeople`
-(`search.repository.ts:1502`) will not return — `e2e/src/utils.ts:989-991` already documents this for
-the command palette ("a bare API-created person won't surface in search results"). There is no seed that
-keeps the People section available in these suites.
+A People facet needs a **face**, but face detection does not: `utils.createFace({ assetId, personId })`
+(`e2e/src/utils.ts:490`) inserts `asset_face`, `face_identity` and `face_identity_face` directly by SQL —
+no ML involved. `utils.createPerson(token, { name })` + `createFace` satisfies every predicate
+`getFilteredPeople`'s global-scope query checks (`search.repository.ts:1646`: non-empty name, not
+hidden, a face on an asset in the filtered scope) and its identity-scoped variant
+(`search.repository.ts:1664`, which needs `person.identityId` plus a `face_identity_face` row —
+`createFace` writes both). It is already used this way by five web-project specs, including
+`global-search.e2e-spec.ts` and `cross-owner-people-merge.e2e-spec.ts`.
 
-So for `people` **only**, the assertion changes rather than the seed: drop it from the "all sections"
-lists and assert `filter-section-people` is **absent**, with a comment pointing here. This is not
-weakening an assertion to accommodate the feature — a library with no detected faces genuinely cannot
-filter by person, so asserting its absence is positive #910 coverage. If the suite ever runs with ML,
-seed a face chain (`feedback_e2e_space_person_face_chain`) and flip the assertion back; it will fail
-loudly rather than silently, which is the point.
+For a space's own People facet, use `utils.createSpacePerson(spaceId, name, ownerId, assetId)`
+(`e2e/src/utils.ts:573`) instead — it builds the whole `shared_space_person` chain in one transaction
+and satisfies `buildFilteredSpacePeopleQuery` (`search.repository.ts:1625`) exactly. It is already used
+by `spaces-albums.e2e-spec.ts:567`.
+
+So `people` follows the same rule as every other section: seed it, then assert it renders. There is no
+carve-out — every suite that lists "all sections" should include `people`, seeded like the rest.
+
+One environment-specific gotcha either seed needs: `asset_face.sourceType` defaults to
+`'machine-learning'` in the schema. On a stack that runs facial recognition (anything other than the
+e2e project's own ML-less docker-compose — e.g. a `make dev` stack), `person.service.ts`'s
+`handleDetectFaces` re-scans every newly uploaded asset, finds 0 real faces in these fixtures, and
+deletes every existing face it still sees tagged `machine-learning` as a stale detection — silently
+wiping a manually-seeded face. Both `createFace` and `createSpacePerson` insert their face row with
+`sourceType: 'manual'` for exactly this reason; do not drop it.
 
 ---
 
@@ -138,30 +150,41 @@ await updateAsset(
 
 // Albums needs BOTH sides — some filed, some not.
 const album = await utils.createAlbum(admin.accessToken, { albumName: '#910 album', assetIds: [video.id] });
+
+// People: createFace inserts asset_face + face_identity + face_identity_face directly, no ML needed.
+const person = await utils.createPerson(admin.accessToken, { name: '#910 Person' });
+await utils.createFace({ assetId: asset1.id, personId: person.id });
 ```
 
 `readFileSync` and `testAssetDir` need importing (`node:fs` and `src/utils`); `utils.createAlbum`'s exact
 signature is in `e2e/src/utils.ts` — read it rather than copying the line above verbatim.
 
-- [ ] **Step 2: Apply the People carve-out at `:63`**
+- [ ] **Step 2: Assert every section at `:63`, People included**
 
 ```ts
 test('should show every filter section its library can populate', async ({ context, page }) => {
   await gotoPhotos(context, page);
   await expect(page.locator('[data-testid="discovery-panel"]')).toBeVisible();
 
-  for (const section of ['timeline', 'location', 'camera', 'tags', 'rating', 'media']) {
+  for (const section of [
+    'timeline',
+    'people',
+    'location',
+    'camera',
+    'tags',
+    'rating',
+    'media',
+    'favorites',
+    'albums',
+    'text',
+  ]) {
     await expect(page.locator(`[data-testid="filter-section-${section}"]`)).toBeVisible();
   }
-
-  // #910: People needs a detected face and the web e2e project runs no ML, so this library
-  // genuinely cannot filter by person. Asserting the absence is the coverage, not a concession —
-  // see slice 6 "The People carve-out".
-  await expect(page.locator('[data-testid="filter-section-people"]')).toHaveCount(0);
 });
 ```
 
-Rename the test: "all 7 filter sections" is no longer what it checks.
+The list is `ALL_FILTER_SECTIONS` in full (`filter-panel.ts:46`) — every section the seed above
+populates, including `people` now that it is seeded like everything else.
 
 - [ ] **Step 3: Re-run and confirm every predicted failure is gone**
 
@@ -190,12 +213,19 @@ assertions at `:82-97`.
 
 Apply the same recipe set as Task 1, inside the helper so every caller benefits, and add the new assets
 to `utils.addSpaceAssets` alongside the existing four. **The space, not the library, is the scope** — an
-asset that is not in the space does not populate the space's facets.
+asset that is not in the space does not populate the space's facets. For People, use
+`utils.createSpacePerson(space.id, name, ownerId, assetId)` (not `createFace`) — People is space-scoped
+here, and `createSpacePerson` builds the `shared_space_person` chain the space's own facet query reads.
 
-- [ ] **Step 2: Apply the People carve-out at `:91`**
+- [ ] **Step 2: Assert every section at `:91`, People included**
 
-Same shape as Task 1 Step 2: drop `filter-section-people` from the visible list, assert `toHaveCount(0)`
-with the same comment.
+Same shape as Task 1 Step 2: add `people` to the visible-sections list, in `ALL_FILTER_SECTIONS` order.
+
+Three existing People tests in this file build their own bespoke space rather than reusing
+`createPopulatedSpace` ("should show only people present in the space (not global list)", "should
+update timeline when selecting a person", "should show photos containing either selected person (OR
+logic)"). Give each its own `utils.createSpacePerson` call too — they are the only web-suite coverage
+of space-scoped people versus the global list, and a seed exists for every one of them.
 
 - [ ] **Step 3: Re-run, then commit**
 
@@ -213,8 +243,8 @@ git commit -m "test(e2e): seed varied space assets so every filter section rende
 - [ ] **Step 1: Recently Added**
 
 Its `beforeAll` already seeds images, videos and ratings, so media and rating are fine. Add location,
-camera, tags, favourites and a partial album, then apply the People carve-out to the ten-section list at
-`:130`. Rename it — "renders all ten metadata filter sections" becomes nine plus an absence assertion.
+camera, tags, favourites, a partial album, and a face (`createPerson` + `createFace`, on an
+already-seeded asset so `TOTAL` stays exact) for People, then assert all ten sections at `:130`.
 
 - [ ] **Step 2: Map**
 
@@ -368,6 +398,6 @@ git commit -m "test(e2e): cover hiding and revealing unusable filter sections (#
 ## Done when
 
 - `make e2e-web-dev` is green for all four web filter suites, and `make e2e-rebase-smoke` for Test 9.
-- Every failure recorded in Task 0 is accounted for — fixed by seeding, or by the documented People
-  carve-out. Nothing was made to pass by deleting an assertion.
-- The only assertions that changed meaning are the four People ones, each carrying the carve-out comment.
+- Every failure recorded in Task 0 is accounted for, fixed by seeding. Nothing was made to pass by
+  deleting or weakening an assertion — People included, via `utils.createFace` /
+  `utils.createSpacePerson` (see "People is seedable too").

--- a/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-6.md
+++ b/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-6.md
@@ -1,0 +1,244 @@
+# Slice 6 — e2e seed data and coverage (#910)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for
+> tracking.
+
+**Goal:** The Playwright suites stop assuming every filter section is always rendered, and gain direct
+coverage for the new hide behaviour.
+
+**Architecture:** Seed data changes, not test-logic changes. Suites that click a control inside a section
+must seed enough variety for that section to be available; the feature itself is not weakened to suit them.
+
+**Tech Stack:** Playwright, Vitest (e2e runner), the fork's `utils` seeding helpers.
+
+- **Spec:** `docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md` §8.4
+- **Branch:** `fix/910-interdependent-filter-sections`
+- **Depends on:** Slice 5. Nothing is gated before it, so these tests cannot fail first without it.
+- **Scope:** `e2e/src/specs/web/`. No app source.
+
+## Global Constraints
+
+- Per `feedback_e2e_stack_port_2285_vs_dev_2283`, `make e2e` serves on **2285**; a `make dev` stack is 2283.
+  Run the web suites with `make e2e-web-dev` against a running dev stack, or the full `make e2e` stack.
+- Per `reference_e2e_web_playwright_2283_empty_body`, `make e2e-web-dev` on port 2283 can serve zero-byte
+  bodies. If every test fails on an empty page, that is the environment, not the change.
+- Per `feedback_no_flake_allowance`, never mark a failure as flaky and retry. Diagnose it.
+- Per `feedback_e2e_waitforqueuefinish_false_done`, `waitForQueueFinish` returns "done" while the queue is
+  merely momentarily empty. Rating and EXIF assertions must poll rather than trust it.
+
+## File Structure
+
+| File                                                | Responsibility                         |
+| --------------------------------------------------- | -------------------------------------- |
+| `e2e/src/specs/web/photos-filter-panel.e2e-spec.ts` | seed a video; new hide coverage        |
+| `e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts` | seed a video, a favourite and an album |
+
+---
+
+## Task 1: Seed the photos suite so its sections stay available
+
+**Files:**
+
+- Modify: `e2e/src/specs/web/photos-filter-panel.e2e-spec.ts:14-29` (`beforeAll`)
+
+The suite creates three assets, all images (`utils.createAsset` defaults to `makeRandomImage()` named
+`example.png`), and rates one. Rating therefore stays available; **Media does not** — `mediaTypes` is
+`['IMAGE']`, which is `< 2`. The `media-type-image` click at `:78` will fail.
+
+- [ ] **Step 1: Run the suite to see the failure**
+
+```bash
+make e2e-web-dev
+```
+
+Expected: FAIL in "should filter by media type" at `:78` — `media-type-image` never becomes visible,
+because the section is not rendered.
+
+This is the RED step. Do not skip it: seeing the exact failure confirms slice 5 gates what it should,
+and confirms the seed is the cause rather than something else.
+
+- [ ] **Step 2: Seed a video**
+
+The fork's pattern is a random-image body with a video extension — the server types the asset from the
+filename. Copy it from `recently-added-filters.e2e-spec.ts:102-110`:
+
+```ts
+// #910: the Media section only renders when both types are present. Without a video the section
+// is (correctly) hidden and every media-type assertion below has nothing to click.
+await utils.createAsset(admin.accessToken, {
+  fileCreatedAt: '2023-06-01T10:00:00.000Z',
+  fileModifiedAt: '2023-06-01T10:00:00.000Z',
+  assetData: { filename: 'example-video.mp4' },
+});
+```
+
+- [ ] **Step 3: Run the suite to verify it passes**
+
+```bash
+make e2e-web-dev
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/src/specs/web/photos-filter-panel.e2e-spec.ts
+git commit -m "test(e2e): seed a video so the media filter section renders (#910)"
+```
+
+---
+
+## Task 2: Seed the spaces suite
+
+**Files:**
+
+- Modify: `e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts` — `createPopulatedSpace`
+
+This suite asserts `filter-section-rating` and `filter-section-media` are visible (`:95-96`) and clicks
+`rating-star-N` / `media-type-*` around 25 times. `createPopulatedSpace` builds the fixture.
+
+- [ ] **Step 1: Run the suite to see the failures**
+
+```bash
+make e2e-web-dev
+```
+
+Expected: FAIL at `:95-96` and at every media-type and rating click, depending on what
+`createPopulatedSpace` currently seeds. Note the full list before changing anything.
+
+- [ ] **Step 2: Extend `createPopulatedSpace`**
+
+Read the whole helper first. Add whatever the Step 1 failures show is missing, from this set:
+
+```ts
+// #910: each of these keeps one filter section available. Without them the section is correctly
+// hidden and the assertions below have nothing to act on.
+// — a video, so Media has two types
+await utils.createAsset(admin.accessToken, {
+  fileCreatedAt: '2023-06-01T10:00:00.000Z',
+  fileModifiedAt: '2023-06-01T10:00:00.000Z',
+  assetData: { filename: 'space-video.mp4' },
+});
+// — a rating, so Rating is available
+await updateAsset({ id: asset1.id, updateAssetDto: { rating: 5 } }, { headers: asBearerAuth(admin.accessToken) });
+// — a favourite, so Favorites is available
+await updateAsset(
+  { id: asset2.id, updateAssetDto: { isFavorite: true } },
+  { headers: asBearerAuth(admin.accessToken) },
+);
+```
+
+`updateAsset` and `asBearerAuth` are already imported in `photos-filter-panel.e2e-spec.ts`; add the same
+imports here if absent.
+
+For the Albums section, the space needs both a filed and an un-filed asset. If the suite has an
+albums-section assertion, add an album containing exactly one of the seeded assets; if it does not, leave
+the section to be hidden and do not add an assertion for it.
+
+- [ ] **Step 3: Run the suite to verify it passes**
+
+```bash
+make e2e-web-dev
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts
+git commit -m "test(e2e): seed varied space assets so every filter section renders (#910)"
+```
+
+---
+
+## Task 3: Direct coverage for the hide behaviour
+
+**Files:**
+
+- Modify: `e2e/src/specs/web/photos-filter-panel.e2e-spec.ts`
+
+Tasks 1 and 2 prove the feature does not break existing flows. This proves it works.
+
+- [ ] **Step 1: Write the tests**
+
+These need a library **without** the seeded variety, so they get their own `test.describe` with its own
+`beforeAll` and a `utils.resetDatabase()`. Placing them in the existing describe would fight its fixture.
+
+```ts
+test.describe('Photos FilterPanel — unavailable sections (#910)', () => {
+  let admin: LoginResponseDto;
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+
+    // Images only, nothing rated, nothing favourited, no albums.
+    await utils.createAsset(admin.accessToken, {
+      fileCreatedAt: '2023-08-15T10:00:00.000Z',
+      fileModifiedAt: '2023-08-15T10:00:00.000Z',
+    });
+  });
+
+  test('hides the sections that cannot filter anything', async ({ context, page }) => {
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('/photos');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+    await page.waitForSelector('[data-testid="discovery-panel"]');
+
+    // The positive assertion first: the panel rendered, so the negatives below mean something.
+    await expect(page.locator('[data-testid="filter-section-timeline"]')).toBeVisible();
+
+    await expect(page.locator('[data-testid="filter-section-media"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="filter-section-rating"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="filter-section-favorites"]')).toHaveCount(0);
+    await expect(page.locator('[data-testid="section-toggle-rating"]')).toHaveCount(0);
+  });
+
+  test('shows the favorites section once something is favourited', async ({ context, page }) => {
+    const [asset] = await utils.getAssets(admin.accessToken);
+    await updateAsset(
+      { id: asset.id, updateAssetDto: { isFavorite: true } },
+      { headers: asBearerAuth(admin.accessToken) },
+    );
+
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('/photos');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+
+    await expect(page.locator('[data-testid="filter-section-favorites"]')).toBeVisible();
+  });
+});
+```
+
+`utils.getAssets` may not exist under that name — check `e2e/src/utils.ts` and either use the real helper
+or capture the asset id from `createAsset` in `beforeAll` into a suite-level variable.
+
+- [ ] **Step 2: Run them**
+
+```bash
+make e2e-web-dev
+```
+
+Expected: PASS. If "hides the sections" fails, slice 5's gating is not reaching the browser — check that
+the page provider forwards the new facets (slice 4) before touching this test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/src/specs/web/photos-filter-panel.e2e-spec.ts
+git commit -m "test(e2e): cover hiding and revealing unusable filter sections (#910)"
+```
+
+---
+
+## Done when
+
+- `make e2e-web-dev` is green for `photos-filter-panel` and `spaces-filter-panel`.
+- No assertion was deleted or weakened to accommodate the feature — only seed data was added, plus the new
+  describe block in Task 3.

--- a/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-6.md
+++ b/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-6.md
@@ -27,125 +27,177 @@ must seed enough variety for that section to be available; the feature itself is
 - Per `feedback_e2e_waitforqueuefinish_false_done`, `waitForQueueFinish` returns "done" while the queue is
   merely momentarily empty. Rating and EXIF assertions must poll rather than trust it.
 
+- **Five suites are affected, not two.** An earlier draft of this plan named only the photos and spaces
+  suites and mis-stated their failures as one assertion each. The real list, from
+  `grep -rln "filter-section-\|media-type-\|rating-star-\|section-toggle-" e2e/src`, is in Task 0.
+
 ## File Structure
 
-| File                                                | Responsibility                         |
-| --------------------------------------------------- | -------------------------------------- |
-| `e2e/src/specs/web/photos-filter-panel.e2e-spec.ts` | seed a video; new hide coverage        |
-| `e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts` | seed a video, a favourite and an album |
+| File                                                       | Responsibility                                    |
+| ---------------------------------------------------------- | ------------------------------------------------- |
+| `e2e/src/specs/web/photos-filter-panel.e2e-spec.ts`        | seed variety; People carve-out; new hide coverage |
+| `e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts`        | seed variety; People carve-out                    |
+| `e2e/src/specs/web/recently-added-filters.e2e-spec.ts`     | seed variety; People carve-out                    |
+| `e2e/src/specs/web/map-filter-panel.e2e-spec.ts`           | seeds **nothing** today — needs a fixture         |
+| `e2e/src/specs/rebase-smoke/permission-matrix.e2e-spec.ts` | one unconditional wait becomes conditional        |
+
+### The seeding recipes
+
+Verified against `e2e/test-assets` and `e2e/src/utils.ts`. Every section except People can be seeded.
+
+| Section   | Seed                                                                                                                                                                                 |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| media     | `utils.createAsset(token, { assetData: { filename: 'x.mp4' } })` — random bytes, typed from the extension (`recently-added-filters.e2e-spec.ts:102-110`)                             |
+| rating    | `updateAsset({ id, updateAssetDto: { rating: 5 } }, { headers: asBearerAuth(token) })`                                                                                               |
+| favorites | `updateAsset({ id, updateAssetDto: { isFavorite: true } }, …)`                                                                                                                       |
+| albums    | an album containing **some but not all** seeded assets — both booleans must be true                                                                                                  |
+| location  | upload `${testAssetDir}/metadata/gps-position/thompson-springs.jpg`, then `await utils.waitForQueueFinish(token, 'metadataExtraction')`                                              |
+| camera    | upload `${testAssetDir}/metadata/rating/mongolels.jpg` (EXIF `Make: Canon`). **`thompson-springs.jpg` has GPS but no `Make`** — confirmed with exiftool, so it does not cover Camera |
+| tags      | `const [tag] = await utils.upsertTags(token, ['e2e-tag']); await utils.tagAssets(token, tag.id, [assetId]);`                                                                         |
+| people    | **impossible here — see below**                                                                                                                                                      |
+
+`waitForQueueFinish` reports "done" while the queue is merely momentarily empty
+(`feedback_e2e_waitforqueuefinish_false_done`), so assert EXIF-derived sections with `expect.poll` or a
+Playwright web-first assertion rather than treating the drain as a barrier.
+
+### The People carve-out
+
+A People facet needs a **face**, and face detection needs the ML stack the web e2e project does not
+run. `utils.createPerson` makes a person row with no face, which `getFilteredPeople`
+(`search.repository.ts:1502`) will not return — `e2e/src/utils.ts:989-991` already documents this for
+the command palette ("a bare API-created person won't surface in search results"). There is no seed that
+keeps the People section available in these suites.
+
+So for `people` **only**, the assertion changes rather than the seed: drop it from the "all sections"
+lists and assert `filter-section-people` is **absent**, with a comment pointing here. This is not
+weakening an assertion to accommodate the feature — a library with no detected faces genuinely cannot
+filter by person, so asserting its absence is positive #910 coverage. If the suite ever runs with ML,
+seed a face chain (`feedback_e2e_space_person_face_chain`) and flip the assertion back; it will fail
+loudly rather than silently, which is the point.
 
 ---
 
-## Task 1: Seed the photos suite so its sections stay available
+## Task 0: Establish the real failure list before changing anything
 
-**Files:**
+**Files:** none — this is a measurement step.
 
-- Modify: `e2e/src/specs/web/photos-filter-panel.e2e-spec.ts:14-29` (`beforeAll`)
-
-The suite creates three assets, all images (`utils.createAsset` defaults to `makeRandomImage()` named
-`example.png`), and rates one. Rating therefore stays available; **Media does not** — `mediaTypes` is
-`['IMAGE']`, which is `< 2`. The `media-type-image` click at `:78` will fail.
-
-- [ ] **Step 1: Run the suite to see the failure**
+- [ ] **Step 1: Run every affected suite and record what fails**
 
 ```bash
 make e2e-web-dev
 ```
 
-Expected: FAIL in "should filter by media type" at `:78` — `media-type-image` never becomes visible,
-because the section is not rendered.
+Expected: FAIL, broadly. The predicted list, so you can tell a surprise from an expectation:
 
-This is the RED step. Do not skip it: seeing the exact failure confirms slice 5 gates what it should,
-and confirms the seed is the cause rather than something else.
+| Suite                                | Predicted failures                                                                                       |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| `photos-filter-panel.e2e-spec.ts`    | `:63` asserts 7 sections; only `timeline` + `rating` survive → **5 fail**. Then `:78` `media-type-image` |
+| `spaces-filter-panel.e2e-spec.ts`    | `:82` asserts 7 sections; only `timeline` survives → **6 fail**. Then ~25 rating/media clicks            |
+| `recently-added-filters.e2e-spec.ts` | `:130` asserts **all ten**; people/location/camera/tags/favorites/albums → **6 fail**                    |
+| `map-filter-panel.e2e-spec.ts`       | `beforeAll` seeds **zero assets**, so `:41` favorites and `:46` location fail                            |
 
-- [ ] **Step 2: Seed a video**
+`permission-matrix.e2e-spec.ts` is in the `rebase-smoke` project, not `web` — run it separately with
+`make e2e-rebase-smoke` if you want the confirmation; Task 4 fixes it either way.
 
-The fork's pattern is a random-image body with a video extension — the server types the asset from the
-filename. Copy it from `recently-added-filters.e2e-spec.ts:102-110`:
+**Write the actual list down before continuing.** If a suite fails in a way this table does not predict,
+stop: it means slice 5 gates something it should not, and that is a bug in slice 5, not a seed gap.
+
+---
+
+## Task 1: Photos suite
+
+**Files:** `e2e/src/specs/web/photos-filter-panel.e2e-spec.ts` — `beforeAll` at `:9-29`, assertions at `:63`.
+
+- [ ] **Step 1: Seed the missing variety**
+
+The suite creates three images and rates one. Add a video, a GPS asset, a Canon asset, a tag, a
+favourite and a partial album membership per the recipe table. Keep `asset1`'s rating.
 
 ```ts
-// #910: the Media section only renders when both types are present. Without a video the section
-// is (correctly) hidden and every media-type assertion below has nothing to click.
-await utils.createAsset(admin.accessToken, {
+// #910: each of these keeps one filter section available. Without them the section is correctly
+// hidden and the assertions below have nothing to act on. See slice 6's recipe table.
+const video = await utils.createAsset(admin.accessToken, {
   fileCreatedAt: '2023-06-01T10:00:00.000Z',
   fileModifiedAt: '2023-06-01T10:00:00.000Z',
   assetData: { filename: 'example-video.mp4' },
 });
+await utils.createAsset(admin.accessToken, {
+  assetData: { bytes: readFileSync(`${testAssetDir}/metadata/gps-position/thompson-springs.jpg`), filename: 'gps.jpg' },
+});
+await utils.createAsset(admin.accessToken, {
+  assetData: { bytes: readFileSync(`${testAssetDir}/metadata/rating/mongolels.jpg`), filename: 'canon.jpg' },
+});
+await utils.waitForQueueFinish(admin.accessToken, 'metadataExtraction');
+
+const [tag] = await utils.upsertTags(admin.accessToken, ['e2e-filter-tag']);
+await utils.tagAssets(admin.accessToken, tag.id, [asset1.id]);
+await updateAsset(
+  { id: asset1.id, updateAssetDto: { isFavorite: true } },
+  { headers: asBearerAuth(admin.accessToken) },
+);
+
+// Albums needs BOTH sides — some filed, some not.
+const album = await utils.createAlbum(admin.accessToken, { albumName: '#910 album', assetIds: [video.id] });
 ```
 
-- [ ] **Step 3: Run the suite to verify it passes**
+`readFileSync` and `testAssetDir` need importing (`node:fs` and `src/utils`); `utils.createAlbum`'s exact
+signature is in `e2e/src/utils.ts` — read it rather than copying the line above verbatim.
+
+- [ ] **Step 2: Apply the People carve-out at `:63`**
+
+```ts
+test('should show every filter section its library can populate', async ({ context, page }) => {
+  await gotoPhotos(context, page);
+  await expect(page.locator('[data-testid="discovery-panel"]')).toBeVisible();
+
+  for (const section of ['timeline', 'location', 'camera', 'tags', 'rating', 'media']) {
+    await expect(page.locator(`[data-testid="filter-section-${section}"]`)).toBeVisible();
+  }
+
+  // #910: People needs a detected face and the web e2e project runs no ML, so this library
+  // genuinely cannot filter by person. Asserting the absence is the coverage, not a concession —
+  // see slice 6 "The People carve-out".
+  await expect(page.locator('[data-testid="filter-section-people"]')).toHaveCount(0);
+});
+```
+
+Rename the test: "all 7 filter sections" is no longer what it checks.
+
+- [ ] **Step 3: Re-run and confirm every predicted failure is gone**
 
 ```bash
 make e2e-web-dev
 ```
-
-Expected: PASS.
 
 - [ ] **Step 4: Commit**
 
 ```bash
 git add e2e/src/specs/web/photos-filter-panel.e2e-spec.ts
-git commit -m "test(e2e): seed a video so the media filter section renders (#910)"
+git commit -m "test(e2e): seed the variety each filter section needs (#910)"
 ```
 
 ---
 
-## Task 2: Seed the spaces suite
+## Task 2: Spaces suite
 
-**Files:**
+**Files:** `e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts` — `createPopulatedSpace` at `:52-76`,
+assertions at `:82-97`.
 
-- Modify: `e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts` — `createPopulatedSpace`
+`createPopulatedSpace` seeds four plain images and nothing else, and the suite clicks `rating-star-N` /
+`media-type-*` around 25 times, so this is the largest fix.
 
-This suite asserts `filter-section-rating` and `filter-section-media` are visible (`:95-96`) and clicks
-`rating-star-N` / `media-type-*` around 25 times. `createPopulatedSpace` builds the fixture.
+- [ ] **Step 1: Extend `createPopulatedSpace`**
 
-- [ ] **Step 1: Run the suite to see the failures**
+Apply the same recipe set as Task 1, inside the helper so every caller benefits, and add the new assets
+to `utils.addSpaceAssets` alongside the existing four. **The space, not the library, is the scope** — an
+asset that is not in the space does not populate the space's facets.
 
-```bash
-make e2e-web-dev
-```
+- [ ] **Step 2: Apply the People carve-out at `:91`**
 
-Expected: FAIL at `:95-96` and at every media-type and rating click, depending on what
-`createPopulatedSpace` currently seeds. Note the full list before changing anything.
+Same shape as Task 1 Step 2: drop `filter-section-people` from the visible list, assert `toHaveCount(0)`
+with the same comment.
 
-- [ ] **Step 2: Extend `createPopulatedSpace`**
-
-Read the whole helper first. Add whatever the Step 1 failures show is missing, from this set:
-
-```ts
-// #910: each of these keeps one filter section available. Without them the section is correctly
-// hidden and the assertions below have nothing to act on.
-// — a video, so Media has two types
-await utils.createAsset(admin.accessToken, {
-  fileCreatedAt: '2023-06-01T10:00:00.000Z',
-  fileModifiedAt: '2023-06-01T10:00:00.000Z',
-  assetData: { filename: 'space-video.mp4' },
-});
-// — a rating, so Rating is available
-await updateAsset({ id: asset1.id, updateAssetDto: { rating: 5 } }, { headers: asBearerAuth(admin.accessToken) });
-// — a favourite, so Favorites is available
-await updateAsset(
-  { id: asset2.id, updateAssetDto: { isFavorite: true } },
-  { headers: asBearerAuth(admin.accessToken) },
-);
-```
-
-`updateAsset` and `asBearerAuth` are already imported in `photos-filter-panel.e2e-spec.ts`; add the same
-imports here if absent.
-
-For the Albums section, the space needs both a filed and an un-filed asset. If the suite has an
-albums-section assertion, add an album containing exactly one of the seeded assets; if it does not, leave
-the section to be hidden and do not add an assertion for it.
-
-- [ ] **Step 3: Run the suite to verify it passes**
-
-```bash
-make e2e-web-dev
-```
-
-Expected: PASS.
-
-- [ ] **Step 4: Commit**
+- [ ] **Step 3: Re-run, then commit**
 
 ```bash
 git add e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts
@@ -154,13 +206,71 @@ git commit -m "test(e2e): seed varied space assets so every filter section rende
 
 ---
 
-## Task 3: Direct coverage for the hide behaviour
+## Task 3: Recently Added and Map suites
 
-**Files:**
+**Files:** `recently-added-filters.e2e-spec.ts:130`, `map-filter-panel.e2e-spec.ts:9-12`.
 
-- Modify: `e2e/src/specs/web/photos-filter-panel.e2e-spec.ts`
+- [ ] **Step 1: Recently Added**
 
-Tasks 1 and 2 prove the feature does not break existing flows. This proves it works.
+Its `beforeAll` already seeds images, videos and ratings, so media and rating are fine. Add location,
+camera, tags, favourites and a partial album, then apply the People carve-out to the ten-section list at
+`:130`. Rename it — "renders all ten metadata filter sections" becomes nine plus an absence assertion.
+
+- [ ] **Step 2: Map**
+
+`map-filter-panel.e2e-spec.ts` seeds **nothing at all**, which is why its favorites (`:41`) and location
+(`:46`) tests fail: on an empty library every gated section is unavailable. Its `beforeAll` needs at
+minimum the GPS asset (for `filter-section-location`) and a favourite (for `favorites-filter`).
+
+This suite is also the cheapest place to prove the feature end to end, because it starts empty. Consider
+keeping one test that asserts the empty-library panel renders only `timeline` and `text` — but only if
+it can run before the seeding `beforeAll`, i.e. in its own `test.describe`.
+
+- [ ] **Step 3: Re-run, then commit**
+
+```bash
+git add e2e/src/specs/web/recently-added-filters.e2e-spec.ts e2e/src/specs/web/map-filter-panel.e2e-spec.ts
+git commit -m "test(e2e): seed the recently-added and map filter suites (#910)"
+```
+
+---
+
+## Task 4: The rebase-smoke camera wait
+
+**Files:** `e2e/src/specs/rebase-smoke/permission-matrix.e2e-spec.ts:220`.
+
+Test 9 waits unconditionally for `filter-section-camera`, while its own assertion at `:237` is guarded by
+`if (fullAsset.exifInfo?.make)` — the suite already assumes `make` may be absent. When it is, the section
+is now correctly hidden and the wait times out. The wait must take the same guard as the assertion.
+
+- [ ] **Step 1: Make the wait conditional**
+
+```ts
+// #910: an asset with no EXIF make gives an empty camera facet, so the section is not rendered.
+// The assertion below is already guarded on `make`; the wait has to be too.
+if (fullAsset.exifInfo?.make) {
+  await page.locator('[data-testid="filter-section-camera"]').waitFor({ timeout: 10_000 });
+}
+```
+
+Leave the location and tags waits alone: `test.skip` above already guarantees a country, and the suite
+seeds the tag itself.
+
+- [ ] **Step 2: Run the rebase-smoke project, then commit**
+
+```bash
+make e2e-rebase-smoke
+git add e2e/src/specs/rebase-smoke/permission-matrix.e2e-spec.ts
+git commit -m "test(e2e): guard the camera-section wait on EXIF make (#910)"
+```
+
+---
+
+## Task 5: Direct coverage for the hide behaviour
+
+**Files:** `e2e/src/specs/web/photos-filter-panel.e2e-spec.ts`
+
+Tasks 1–4 prove the feature does not break existing flows. This proves it works.
 
 - [ ] **Step 1: Write the tests**
 
@@ -170,17 +280,19 @@ These need a library **without** the seeded variety, so they get their own `test
 ```ts
 test.describe('Photos FilterPanel — unavailable sections (#910)', () => {
   let admin: LoginResponseDto;
+  let assetId: string;
 
   test.beforeAll(async () => {
     utils.initSdk();
     await utils.resetDatabase();
     admin = await utils.adminSetup();
 
-    // Images only, nothing rated, nothing favourited, no albums.
-    await utils.createAsset(admin.accessToken, {
+    // Images only, nothing rated, nothing favourited, no albums, no tags, no EXIF.
+    const asset = await utils.createAsset(admin.accessToken, {
       fileCreatedAt: '2023-08-15T10:00:00.000Z',
       fileModifiedAt: '2023-08-15T10:00:00.000Z',
     });
+    assetId = asset.id;
   });
 
   test('hides the sections that cannot filter anything', async ({ context, page }) => {
@@ -192,17 +304,17 @@ test.describe('Photos FilterPanel — unavailable sections (#910)', () => {
 
     // The positive assertion first: the panel rendered, so the negatives below mean something.
     await expect(page.locator('[data-testid="filter-section-timeline"]')).toBeVisible();
+    await expect(page.locator('[data-testid="filter-section-text"]')).toBeVisible();
 
-    await expect(page.locator('[data-testid="filter-section-media"]')).toHaveCount(0);
-    await expect(page.locator('[data-testid="filter-section-rating"]')).toHaveCount(0);
-    await expect(page.locator('[data-testid="filter-section-favorites"]')).toHaveCount(0);
-    await expect(page.locator('[data-testid="section-toggle-rating"]')).toHaveCount(0);
+    for (const section of ['media', 'rating', 'favorites', 'albums', 'people', 'location', 'camera', 'tags']) {
+      await expect(page.locator(`[data-testid="filter-section-${section}"]`)).toHaveCount(0);
+      await expect(page.locator(`[data-testid="section-toggle-${section}"]`)).toHaveCount(0);
+    }
   });
 
   test('shows the favorites section once something is favourited', async ({ context, page }) => {
-    const [asset] = await utils.getAssets(admin.accessToken);
     await updateAsset(
-      { id: asset.id, updateAssetDto: { isFavorite: true } },
+      { id: assetId, updateAssetDto: { isFavorite: true } },
       { headers: asBearerAuth(admin.accessToken) },
     );
 
@@ -213,11 +325,27 @@ test.describe('Photos FilterPanel — unavailable sections (#910)', () => {
 
     await expect(page.locator('[data-testid="filter-section-favorites"]')).toBeVisible();
   });
+
+  test('shows the media section once a video exists', async ({ context, page }) => {
+    await utils.createAsset(admin.accessToken, { assetData: { filename: 'late-video.mp4' } });
+
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('/photos');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+
+    await expect(page.locator('[data-testid="filter-section-media"]')).toBeVisible();
+  });
 });
 ```
 
-`utils.getAssets` may not exist under that name — check `e2e/src/utils.ts` and either use the real helper
-or capture the asset id from `createAsset` in `beforeAll` into a suite-level variable.
+The `assetId` capture replaces the earlier draft's `utils.getAssets`, which does not exist under that
+name — capture from `createAsset` instead of looking it up.
+
+Note the ordering dependency: the second test favourites the asset and the third adds a video, so the
+first must run before both. Playwright runs tests within a file in declaration order by default; if this
+project enables `fullyParallel`, split them into separate describes with their own resets rather than
+relying on it.
 
 - [ ] **Step 2: Run them**
 
@@ -239,6 +367,7 @@ git commit -m "test(e2e): cover hiding and revealing unusable filter sections (#
 
 ## Done when
 
-- `make e2e-web-dev` is green for `photos-filter-panel` and `spaces-filter-panel`.
-- No assertion was deleted or weakened to accommodate the feature — only seed data was added, plus the new
-  describe block in Task 3.
+- `make e2e-web-dev` is green for all four web filter suites, and `make e2e-rebase-smoke` for Test 9.
+- Every failure recorded in Task 0 is accounted for — fixed by seeding, or by the documented People
+  carve-out. Nothing was made to pass by deleting an assertion.
+- The only assertions that changed meaning are the four People ones, each carrying the carve-out comment.

--- a/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-7.md
+++ b/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-7.md
@@ -1,0 +1,498 @@
+# Slice 7 — Mobile filter-sheet gating (#910)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for
+> tracking.
+
+**Goal:** The mobile deep filter sheet stops rendering sections and toggles that cannot filter anything,
+using the facets slice 1 added — and, as a prerequisite, starts forwarding the not-in-album filter it
+currently drops.
+
+**Architecture:** A derived availability set, computed from `photosFilterSuggestionsProvider`, ANDed with
+the existing user-controlled `hiddenSectionsProvider` at render time. The two never merge: one is
+persisted, one is derived.
+
+**Tech Stack:** Flutter, Riverpod, mocktail, flutter_test.
+
+- **Spec:** `docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md` §7
+- **Branch:** `fix/910-interdependent-filter-sections`
+- **Depends on:** Slice 2 (the regenerated Dart client).
+- **Scope:** `mobile/lib/providers/photos_filter/`, `mobile/lib/presentation/widgets/filter_sheet/`, and
+  their tests. No server, no web.
+
+## Global Constraints
+
+- Flutter **3.44.8** — the pin is `mobile/mise.toml` (`"aqua:flutter/flutter" = "3.44.8"`). Read the pin
+  rather than trusting this line. If `mise install` symlinked an older patch, invoke the binaries directly
+  from `~/.local/share/mise/installs/aqua-flutter-flutter/<version>/flutter/bin/{flutter,dart}`.
+- Generate localisation and keys once before testing, from `mobile/`:
+  `flutter pub get`, then `dart run easy_localization:generate -S ../i18n && dart run bin/generate_keys.dart`.
+  The `lib/generated/*.g.dart` files are gitignored.
+- Per `feedback_mobile_dart_analyze_ci_fatal_infos`, CI has **two** separate gates:
+  `dart analyze --fatal-infos lib test` and `dart format`. Passing one is not passing the other.
+- `dart analyze` is not a substitute for `flutter test` — generated-code compile errors only surface when a
+  test actually compiles.
+- **Do not modify `rating_stars_section.widget.dart` or `media_type_section.widget.dart`.** The former's doc
+  comment cites `feedback_no_dynamic_rating_media_hiding` ("Always renders 5 stars"); spec §2.4 keeps that
+  true. Gate the sections as wholes, never their contents.
+
+## File Structure
+
+| File                                                                                  | Responsibility                 |
+| ------------------------------------------------------------------------------------- | ------------------------------ |
+| `mobile/lib/providers/photos_filter/filter_suggestions.provider.dart`                 | forward `isNotInAlbum`         |
+| `mobile/lib/providers/photos_filter/section_availability.provider.dart`               | **new** — the availability set |
+| `mobile/lib/presentation/widgets/filter_sheet/deep_content.widget.dart`               | gate the section list          |
+| `mobile/lib/presentation/widgets/filter_sheet/deep/toggles_section.widget.dart`       | gate two of the four switches  |
+| `mobile/lib/presentation/widgets/filter_sheet/deep/manage_sections_sheet.widget.dart` | gate the manage list           |
+
+---
+
+## Task 1: Forward `isNotInAlbum` to the facets request
+
+**Files:**
+
+- Modify: `mobile/lib/providers/photos_filter/filter_suggestions.provider.dart`
+- Test: `mobile/test/providers/photos_filter/filter_suggestions_provider_test.dart`
+
+`SearchDisplayFilters` carries `isNotInAlbum` (`search_filter.model.dart:182`) but the provider never sends
+it, so every facet ignores the not-in-album toggle. The albums facet would be computed against the wrong
+asset set without this.
+
+- [ ] **Step 1: Write the failing test**
+
+Follow the file's existing mocktail setup. Every named argument in the `when(...)` stub must be listed or
+mocktail will not match the call, so add `isNotInAlbum: any(named: 'isNotInAlbum')` to the existing stubs
+in this file at the same time.
+
+```dart
+test('forwards isNotInAlbum so the facets reflect it (#910)', () async {
+  when(
+    () => mockSearchApi.getFilterSuggestions(
+      city: any(named: 'city'),
+      country: any(named: 'country'),
+      isFavorite: any(named: 'isFavorite'),
+      isNotInAlbum: any(named: 'isNotInAlbum'),
+      make: any(named: 'make'),
+      mediaType: any(named: 'mediaType'),
+      model: any(named: 'model'),
+      personIds: any(named: 'personIds'),
+      rating: any(named: 'rating'),
+      spaceId: any(named: 'spaceId'),
+      tagIds: any(named: 'tagIds'),
+      takenAfter: any(named: 'takenAfter'),
+      takenBefore: any(named: 'takenBefore'),
+      withSharedSpaces: any(named: 'withSharedSpaces'),
+    ),
+  ).thenAnswer((_) async => emptySuggestions());
+
+  final filter = SearchFilter.empty().copyWith(
+    display: SearchFilter.empty().display.copyWith(isNotInAlbum: true),
+  );
+  await container.read(photosFilterSuggestionsProvider(filter).future);
+
+  verify(() => mockSearchApi.getFilterSuggestions(isNotInAlbum: true)).called(1);
+});
+```
+
+`verify` with a subset of named arguments does not match in mocktail — capture the call instead, following
+whatever the neighbouring `withSharedSpaces` test in this file does, and assert on the captured value.
+
+Per `feedback_searchfilter_copywith_cascade`, check how `copyWith` composes on `SearchFilter` before
+writing that line; the nested-display form above may need the file's own helper.
+
+- [ ] **Step 2: Add the shared fixture**
+
+Slice 2 made the three booleans required on the Dart DTO, so every
+`FilterSuggestionsResponseDto(hasUnnamedPeople: false)` in the test suite no longer compiles. Add one
+helper at the top of the file and replace each literal with it:
+
+```dart
+FilterSuggestionsResponseDto emptySuggestions() => FilterSuggestionsResponseDto(
+  hasUnnamedPeople: false,
+  hasFavorites: false,
+  hasAssetsInAlbum: false,
+  hasAssetsNotInAlbum: false,
+);
+```
+
+```bash
+cd mobile && grep -rn "FilterSuggestionsResponseDto(" test/ lib/
+```
+
+Fix every hit. If the generated constructor turns out to take these as optional, stop — that means slice 1
+wrote the Zod fields as `.optional()` and the contract is wrong.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+cd mobile && flutter test test/providers/photos_filter/filter_suggestions_provider_test.dart
+```
+
+Expected: FAIL — the captured call carries `isNotInAlbum: null`.
+
+- [ ] **Step 4: Forward the value**
+
+In `filter_suggestions.provider.dart`, add to the `getFilterSuggestions` call, next to `isFavorite`:
+
+```dart
+    // #910: the albums facet is computed with this filter excluded, but every OTHER facet must still
+    // honour it — dropping it here made all of them ignore the not-in-album toggle.
+    isNotInAlbum: filter.display.isNotInAlbum ? true : null,
+```
+
+`null` rather than `false` for the off state, matching the neighbouring `isFavorite` line: the server
+treats an explicit `false` as "only assets that ARE in an album".
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+cd mobile && flutter test test/providers/photos_filter/
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile/lib/providers/photos_filter/filter_suggestions.provider.dart mobile/test/
+git commit -m "fix(mobile): forward isNotInAlbum to the filter-suggestions request (#910)"
+```
+
+---
+
+## Task 2: The availability provider
+
+**Files:**
+
+- Create: `mobile/lib/providers/photos_filter/section_availability.provider.dart`
+- Create: `mobile/test/providers/photos_filter/section_availability_provider_test.dart`
+
+Mobile has no equivalent of web's baseline request, and adding one would mean a second network call on a
+mobile connection for a rarely-changing answer. Mobile therefore implements the simpler rule: a section is
+hidden when its facet is empty **and** the section holds no active filter. In practice the two coincide,
+because the mobile sheet's facets are refetched per filter change and the active-filter guard covers the
+transient case.
+
+- [ ] **Step 1: Write the failing tests**
+
+```dart
+void main() {
+  group('sectionAvailability (#910)', () {
+    test('hides a section whose facet is empty', () {
+      final available = availableSections(
+        emptySuggestions(),
+        SearchFilter.empty(),
+      );
+
+      expect(available.contains(FilterSectionId.rating), isFalse);
+      expect(available.contains(FilterSectionId.when), isTrue);
+    });
+
+    test('keeps a section available when its facet is populated', () {
+      final available = availableSections(
+        emptySuggestions().copyWithRatings([5]),
+        SearchFilter.empty(),
+      );
+
+      expect(available.contains(FilterSectionId.rating), isTrue);
+    });
+
+    test('keeps people available while unnamed faces exist', () {
+      final available = availableSections(
+        FilterSuggestionsResponseDto(
+          hasUnnamedPeople: true,
+          hasFavorites: false,
+          hasAssetsInAlbum: false,
+          hasAssetsNotInAlbum: false,
+        ),
+        SearchFilter.empty(),
+      );
+
+      expect(available.contains(FilterSectionId.people), isTrue);
+    });
+
+    test('needs two media types to keep media available', () {
+      expect(
+        availableSections(emptySuggestions().copyWithMediaTypes(['IMAGE']), SearchFilter.empty())
+            .contains(FilterSectionId.media),
+        isFalse,
+      );
+      expect(
+        availableSections(emptySuggestions().copyWithMediaTypes(['IMAGE', 'VIDEO']), SearchFilter.empty())
+            .contains(FilterSectionId.media),
+        isTrue,
+      );
+    });
+
+    test('never hides a section that holds an active filter', () {
+      // `Option<int?>`: none = no filter, some(null) = unrated, some(1-5) = that rating.
+      // See search_filter.model.dart:138-140.
+      final filter = SearchFilter.empty().copyWith(
+        rating: SearchRatingFilter(rating: const Option.some(5)),
+      );
+
+      expect(availableSections(emptySuggestions(), filter).contains(FilterSectionId.rating), isTrue);
+    });
+
+    test('always keeps when and toggles available', () {
+      final available = availableSections(emptySuggestions(), SearchFilter.empty());
+
+      expect(available.contains(FilterSectionId.when), isTrue);
+      expect(available.contains(FilterSectionId.toggles), isTrue);
+    });
+  });
+}
+```
+
+`copyWithRatings` / `copyWithMediaTypes` are shorthand — the generated DTO has no `copyWith`. Add two
+local helpers next to `emptySuggestions()` that construct the DTO with the field set, reading
+`mobile/openapi/lib/model/filter_suggestions_response_dto.dart` for the exact parameter names (list
+fields are typically named constructor parameters defaulting to `const []`):
+
+```dart
+FilterSuggestionsResponseDto withRatings(List<num> ratings) => FilterSuggestionsResponseDto(
+  hasUnnamedPeople: false,
+  hasFavorites: false,
+  hasAssetsInAlbum: false,
+  hasAssetsNotInAlbum: false,
+  ratings: ratings,
+);
+```
+
+`Option` and `SearchRatingFilter` come from `package:immich_mobile/utils/option.dart` and
+`search_filter.model.dart`. Per `feedback_searchfilter_copywith_cascade`, check how `copyWith` composes on
+`SearchFilter` before relying on the nested form.
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+cd mobile && flutter test test/providers/photos_filter/section_availability_provider_test.dart
+```
+
+Expected: FAIL — the file under test does not exist.
+
+- [ ] **Step 3: Write the provider**
+
+```dart
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/models/search/search_filter.model.dart';
+import 'package:immich_mobile/presentation/widgets/filter_sheet/filter_section_id.dart';
+import 'package:immich_mobile/providers/photos_filter/filter_suggestions.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
+import 'package:openapi/api.dart';
+
+/// Which deep-sheet sections can actually filter something right now (#910).
+///
+/// Mirrors web's `filter-availability.ts`, minus its structural/transient split: mobile has no
+/// baseline request, so an empty facet simply means "not offered". A section holding an active
+/// filter is always offered, so the user can never be stranded with a filter they cannot clear.
+///
+/// This is DERIVED. It is never written to [hiddenSectionsProvider], which is the user's own
+/// persisted choice — conflating them would record a section as deliberately hidden the moment its
+/// facet went empty, and it would never come back.
+Set<FilterSectionId> availableSections(FilterSuggestionsResponseDto facets, SearchFilter filter) {
+  bool offered(FilterSectionId id) {
+    switch (id) {
+      case FilterSectionId.people:
+        return facets.people.isNotEmpty || facets.hasUnnamedPeople;
+      case FilterSectionId.places:
+        return facets.countries.isNotEmpty;
+      case FilterSectionId.tags:
+        return facets.tags.isNotEmpty;
+      case FilterSectionId.camera:
+        return facets.cameraMakes.isNotEmpty;
+      case FilterSectionId.rating:
+        return facets.ratings.isNotEmpty;
+      case FilterSectionId.media:
+        // One type means "Photos" is a synonym for "All" and the other button is empty.
+        return facets.mediaTypes.length >= 2;
+      case FilterSectionId.when:
+      case FilterSectionId.toggles:
+        // `when` mirrors web's Timeline. `toggles` always renders — two of its four switches have no
+        // facet at all, so the section as a whole is never useless; see [availableToggles].
+        return true;
+    }
+  }
+
+  return {
+    for (final id in FilterSectionId.values)
+      if (offered(id) || hasActiveFilterFor(id, filter)) id,
+  };
+}
+
+final sectionAvailabilityProvider = Provider.autoDispose<Set<FilterSectionId>>((ref) {
+  final filter = ref.watch(photosFilterProvider);
+  final facets = ref.watch(photosFilterSuggestionsProvider(filter));
+
+  // While a request is in flight or has failed, offer everything. A section is never hidden on
+  // missing information.
+  return facets.maybeWhen(
+    data: (data) => availableSections(data, filter),
+    orElse: () => FilterSectionId.values.toSet(),
+  );
+});
+```
+
+`hasActiveFilterFor` does not exist yet. Check `mobile/lib/providers/photos_filter/active_chips.dart` and
+`filter_count.provider.dart` first — one of them almost certainly already maps a `SearchFilter` to the
+sections that hold values, and reusing it is better than writing a second mapping that can drift. If
+neither fits, add `hasActiveFilterFor` beside `availableSections` in this file.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd mobile && flutter test test/providers/photos_filter/section_availability_provider_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/providers/photos_filter/section_availability.provider.dart mobile/test/
+git commit -m "feat(mobile): derive which filter sections can filter anything (#910)"
+```
+
+---
+
+## Task 3: Gate the sheet, the manage list, and two toggles
+
+**Files:**
+
+- Modify: `mobile/lib/presentation/widgets/filter_sheet/deep_content.widget.dart:96-97`
+- Modify: `mobile/lib/presentation/widgets/filter_sheet/deep/manage_sections_sheet.widget.dart:32`
+- Modify: `mobile/lib/presentation/widgets/filter_sheet/deep/toggles_section.widget.dart`
+- Test: `mobile/test/presentation/widgets/filter_sheet/deep_content_visibility_test.dart`
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend `deep_content_visibility_test.dart`, which already covers the user-hidden path — follow its
+`ProviderScope` override setup rather than inventing one.
+
+```dart
+testWidgets('does not render a section with no facet (#910)', (tester) async {
+  await pumpDeepSheet(tester, availability: {FilterSectionId.when, FilterSectionId.media});
+
+  // Positive first, so a sheet that failed to render cannot pass the negatives.
+  expect(find.byKey(const Key('deep-section-media')), findsOneWidget);
+  expect(find.byKey(const Key('deep-section-rating')), findsNothing);
+});
+
+testWidgets('does not offer an unavailable section in manage sections (#910)', (tester) async {
+  await pumpManageSections(tester, availability: {FilterSectionId.when, FilterSectionId.media});
+
+  expect(find.byKey(const Key('manage-section-media')), findsOneWidget);
+  expect(find.byKey(const Key('manage-section-rating')), findsNothing);
+});
+
+testWidgets('hides the favourites and not-in-album switches when their facets are empty (#910)', (tester) async {
+  await pumpDeepSheet(tester, facets: emptySuggestions());
+
+  expect(find.byKey(const Key('toggle-favourites')), findsNothing);
+  expect(find.byKey(const Key('toggle-not-in-album')), findsNothing);
+  // These two have no facet and must always render — the section itself never disappears.
+  expect(find.byKey(const Key('toggle-archived')), findsOneWidget);
+  expect(find.byKey(const Key('toggle-untagged')), findsOneWidget);
+});
+
+testWidgets('never dims or drops a rating star (#910, feedback_no_dynamic_rating_media_hiding)', (tester) async {
+  await pumpDeepSheet(tester, facets: emptySuggestions().copyWithRatings([2]));
+
+  for (var i = 1; i <= 5; i++) {
+    expect(find.byKey(Key('rating-star-$i')), findsOneWidget);
+  }
+});
+```
+
+`pumpDeepSheet` / `pumpManageSections` with an `availability` override are shorthand for the file's
+existing pump helper plus a `sectionAvailabilityProvider.overrideWithValue(...)`. Read the existing helper
+and extend it rather than adding a parallel one.
+
+- [ ] **Step 2: Run them to verify they fail**
+
+```bash
+cd mobile && flutter test test/presentation/widgets/filter_sheet/deep_content_visibility_test.dart
+```
+
+Expected: FAIL on the first three. The rating-star test passes already — it is the guard.
+
+- [ ] **Step 3: Gate the deep sheet**
+
+`deep_content.widget.dart`, in `build`:
+
+```dart
+    final hidden = ref.watch(hiddenSectionsProvider);
+    final available = ref.watch(sectionAvailabilityProvider);
+```
+
+and the render loop at `:96`:
+
+```dart
+              for (final id in FilterSectionId.values)
+                // Two independent gates: `hidden` is the user's persisted choice, `available` is
+                // derived from the facets. Never merge them — see the provider's doc comment. #910
+                if (!hidden.contains(id) && available.contains(id)) _sectionFor(id),
+```
+
+- [ ] **Step 4: Gate the manage-sections list**
+
+`manage_sections_sheet.widget.dart:32`:
+
+```dart
+            for (final section in FilterSectionId.values)
+              if (available.contains(section))
+                SwitchListTile.adaptive(
+```
+
+with the same `ref.watch(sectionAvailabilityProvider)` above. A section the user cannot see is a switch
+that does nothing.
+
+- [ ] **Step 5: Gate the two toggles**
+
+`toggles_section.widget.dart` — wrap only the two switches that have a facet:
+
+```dart
+    final facets = ref.watch(photosFilterSuggestionsProvider(ref.watch(photosFilterProvider)));
+    // Offer everything while the request is in flight or failed.
+    final hasFavorites = facets.valueOrNull?.hasFavorites ?? true;
+    final hasUnfiled = facets.valueOrNull?.hasAssetsNotInAlbum ?? true;
+```
+
+then guard `toggle-favourites` with `if (hasFavorites || display.isFavorite)` and `toggle-not-in-album`
+with `if (hasUnfiled || display.isNotInAlbum)`. The `|| display.…` half is the active-filter rule: never
+remove the control that clears a filter the user has on.
+
+Mobile has no "has album" toggle, so `hasAssetsInAlbum` is unused here — that is expected, not an omission.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+cd mobile && flutter test test/presentation/widgets/filter_sheet/
+```
+
+Expected: PASS, including every pre-existing visibility test.
+
+- [ ] **Step 7: Full mobile gate**
+
+```bash
+cd mobile && flutter test && dart analyze --fatal-infos lib test && dart format --set-exit-if-changed lib test
+```
+
+Both analyze and format are separate CI gates; run both.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mobile/
+git commit -m "feat(mobile): hide filter sections and toggles that cannot filter anything (#910)"
+```
+
+---
+
+## Done when
+
+- `flutter test`, `dart analyze --fatal-infos lib test` and `dart format` are all green from `mobile/`.
+- `git diff --name-only` lists no `rating_stars_section.widget.dart` and no `media_type_section.widget.dart`.
+- `grep -rn "FilterSuggestionsResponseDto(" mobile/test` shows no literal missing the new fields.
+- `hiddenSectionsProvider` is read but never written by any code added in this slice.

--- a/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-7.md
+++ b/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-7.md
@@ -38,13 +38,13 @@ persisted, one is derived.
 
 ## File Structure
 
-| File                                                                                  | Responsibility                 |
-| ------------------------------------------------------------------------------------- | ------------------------------ |
-| `mobile/lib/providers/photos_filter/filter_suggestions.provider.dart`                 | forward `isNotInAlbum`         |
-| `mobile/lib/providers/photos_filter/section_availability.provider.dart`               | **new** — the availability set |
-| `mobile/lib/presentation/widgets/filter_sheet/deep_content.widget.dart`               | gate the section list          |
-| `mobile/lib/presentation/widgets/filter_sheet/deep/toggles_section.widget.dart`       | gate two of the four switches  |
-| `mobile/lib/presentation/widgets/filter_sheet/deep/manage_sections_sheet.widget.dart` | gate the manage list           |
+| File                                                                                  | Responsibility                                    |
+| ------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `mobile/lib/providers/photos_filter/filter_suggestions.provider.dart`                 | forward `isNotInAlbum`; delete the empty sentinel |
+| `mobile/lib/providers/photos_filter/section_availability.provider.dart`               | **new** — the availability set                    |
+| `mobile/lib/presentation/widgets/filter_sheet/deep_content.widget.dart`               | gate the section list                             |
+| `mobile/lib/presentation/widgets/filter_sheet/deep/toggles_section.widget.dart`       | gate two of the four switches                     |
+| `mobile/lib/presentation/widgets/filter_sheet/deep/manage_sections_sheet.widget.dart` | gate the manage list                              |
 
 ---
 
@@ -101,11 +101,11 @@ whatever the neighbouring `withSharedSpaces` test in this file does, and assert 
 Per `feedback_searchfilter_copywith_cascade`, check how `copyWith` composes on `SearchFilter` before
 writing that line; the nested-display form above may need the file's own helper.
 
-- [ ] **Step 2: Add the shared fixture**
+- [ ] **Step 2: Add the shared fixture — and do NOT "fix" the one hit in `lib/`**
 
 Slice 2 made the three booleans required on the Dart DTO, so every
 `FilterSuggestionsResponseDto(hasUnnamedPeople: false)` in the test suite no longer compiles. Add one
-helper at the top of the file and replace each literal with it:
+helper at the top of the file and replace each **test** literal with it:
 
 ```dart
 FilterSuggestionsResponseDto emptySuggestions() => FilterSuggestionsResponseDto(
@@ -120,8 +120,24 @@ FilterSuggestionsResponseDto emptySuggestions() => FilterSuggestionsResponseDto(
 cd mobile && grep -rn "FilterSuggestionsResponseDto(" test/ lib/
 ```
 
-Fix every hit. If the generated constructor turns out to take these as optional, stop — that means slice 1
-wrote the Zod fields as `.optional()` and the contract is wrong.
+> **⚠ The hit in `lib/` is a trap, and it is the same trap slice 4 exists to defuse on web.**
+>
+> `filter_suggestions.provider.dart` ends with:
+>
+> ```dart
+> return response ?? FilterSuggestionsResponseDto(hasUnnamedPeople: false);
+> ```
+>
+> That is spec §4.6's failure sentinel in Dart. Adding the three missing `false`s makes it compile and
+> **is precisely the bug**: a null response then
+> becomes indistinguishable from an empty library and Task 3 would hide six sections at once on a
+> transport hiccup. Slice 4 says the same thing about `emptyFilterSuggestions()` — "Do not satisfy
+> `tsc` by adding `hasFavorites: false` to the sentinel. That is the bug. Delete it instead."
+>
+> Delete it here too. Task 1b below does exactly that.
+
+If the generated constructor turns out to take these as optional, stop — that means slice 1 wrote the
+Zod fields as `.optional()` and the contract is wrong.
 
 - [ ] **Step 3: Run the test to verify it fails**
 
@@ -161,6 +177,59 @@ git commit -m "fix(mobile): forward isNotInAlbum to the filter-suggestions reque
 
 ---
 
+## Task 1b: Make a null facet response an error, not an empty library
+
+**Files:**
+
+- Modify: `mobile/lib/providers/photos_filter/filter_suggestions.provider.dart` (last line)
+- Test: `mobile/test/providers/photos_filter/filter_suggestions_provider_test.dart`
+
+Spec §4.6, mobile half. Until this lands, Task 3's gating is unsafe — exactly as web's slice 5 must not
+land without slice 4's sentinel removal.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+test('errors rather than reporting an empty library when the API returns null (#910)', () async {
+  when(() => mockSearchApi.getFilterSuggestions(/* …all named args… */)).thenAnswer((_) async => null);
+
+  final result = await container.read(photosFilterSuggestionsProvider(SearchFilter.empty()).future).then(
+        (value) => value,
+        onError: (Object e) => e,
+      );
+
+  expect(result, isA<Exception>());
+});
+```
+
+Prefer whatever error-assertion shape the neighbouring tests already use (`expectLater(..., throwsA(...))`
+against the future) over the `.then/onError` form above if one exists.
+
+- [ ] **Step 2: Run it — expect FAIL**
+
+It resolves with an all-false DTO instead of throwing.
+
+- [ ] **Step 3: Replace the sentinel with a throw**
+
+```dart
+  if (response == null) {
+    // #910: never fabricate an empty response. `sectionAvailabilityProvider` cannot tell a fabricated
+    // empty from a genuinely empty library and would hide six sections at once; an AsyncValue.error
+    // makes it fall back to offering everything. Mirrors web's slice-4 sentinel removal (spec §4.6).
+    throw Exception('filter suggestions unavailable');
+  }
+  return response;
+```
+
+- [ ] **Step 4: Run the provider tests, then commit**
+
+```bash
+cd mobile && flutter test test/providers/photos_filter/
+git commit -am "fix(mobile): error instead of faking empty filter facets (#910)"
+```
+
+---
+
 ## Task 2: The availability provider
 
 **Files:**
@@ -168,61 +237,87 @@ git commit -m "fix(mobile): forward isNotInAlbum to the filter-suggestions reque
 - Create: `mobile/lib/providers/photos_filter/section_availability.provider.dart`
 - Create: `mobile/test/providers/photos_filter/section_availability_provider_test.dart`
 
-Mobile has no equivalent of web's baseline request, and adding one would mean a second network call on a
-mobile connection for a rarely-changing answer. Mobile therefore implements the simpler rule: a section is
-hidden when its facet is empty **and** the section holds no active filter. In practice the two coincide,
-because the mobile sheet's facets are refetched per filter change and the active-filter guard covers the
-transient case.
+**Mobile takes the same baseline as web.** An earlier draft of this slice used the simpler rule "hidden
+when the facet is empty and the section holds no active filter", on the grounds that the active-filter
+guard covered the transient case. It does not, and this is worth understanding before writing the code:
+that guard only covers a section's **own** filter, while the case spec §4.4 rule 1 exists for is
+**cross-section** narrowing. Pick a person who has no rated photos and `ratings` comes back empty while
+`rating` holds no filter — so Rating would vanish from the sheet mid-session. That is the pop-in/pop-out
+behaviour §2.1 rejected, and a web/mobile divergence §2.3 exists to prevent.
+
+Parity is nearly free here, because the baseline is the _same family provider under a different key_:
+
+```dart
+final baselineKey = filter.isEmpty ? filter : SearchFilter.empty();
+final baseline = ref.watch(photosFilterSuggestionsProvider(baselineKey));
+```
+
+`SearchFilter` implements value equality (`search_filter.model.dart:362-402`), so when nothing is
+filtered `baselineKey == filter` and Riverpod hands back the _same_ cached future — zero extra requests
+in the common case, one `autoDispose`-cached request while filters are on.
+
+Mobile has no `(0)` grey treatment, so the three verdicts collapse to two renderings: `available` and
+`empty` both render the section normally, and only `unavailable` hides it. The rule is therefore
+"hidden when the facet is empty **in both** current and baseline, and the section holds no active
+filter" — the same predicate as web's, minus the middle rendering.
 
 - [ ] **Step 1: Write the failing tests**
 
 ```dart
 void main() {
   group('sectionAvailability (#910)', () {
-    test('hides a section whose facet is empty', () {
-      final available = availableSections(
-        emptySuggestions(),
-        SearchFilter.empty(),
-      );
+    test('hides a section whose facet is empty in both current and baseline', () {
+      final available = availableSections(emptySuggestions(), emptySuggestions(), SearchFilter.empty());
 
       expect(available.contains(FilterSectionId.rating), isFalse);
       expect(available.contains(FilterSectionId.when), isTrue);
     });
 
     test('keeps a section available when its facet is populated', () {
-      final available = availableSections(
-        emptySuggestions().copyWithRatings([5]),
-        SearchFilter.empty(),
-      );
+      final full = withRatings([5]);
+      expect(availableSections(full, full, SearchFilter.empty()).contains(FilterSectionId.rating), isTrue);
+    });
+
+    // The parity guard, and the reason mobile has a baseline at all. `rating` holds no filter, so
+    // the active-filter rule cannot save it; only the baseline can. Without the baseline watch this
+    // test fails and the Rating section vanishes mid-session on web-divergent behaviour (spec §7).
+    test('keeps a section whose facet a CROSS-SECTION filter emptied', () {
+      final personFilter = SearchFilter.empty().copyWith(people: {aPerson});
+
+      final available = availableSections(emptySuggestions(), withRatings([5]), personFilter);
 
       expect(available.contains(FilterSectionId.rating), isTrue);
     });
 
-    test('keeps people available while unnamed faces exist', () {
-      final available = availableSections(
-        FilterSuggestionsResponseDto(
-          hasUnnamedPeople: true,
-          hasFavorites: false,
-          hasAssetsInAlbum: false,
-          hasAssetsNotInAlbum: false,
-        ),
-        SearchFilter.empty(),
-      );
+    test('never hides anything while the baseline is unknown', () {
+      final available = availableSections(emptySuggestions(), null, SearchFilter.empty());
 
-      expect(available.contains(FilterSectionId.people), isTrue);
+      expect(available, containsAll(FilterSectionId.values));
     });
 
-    test('needs two media types to keep media available', () {
-      expect(
-        availableSections(emptySuggestions().copyWithMediaTypes(['IMAGE']), SearchFilter.empty())
-            .contains(FilterSectionId.media),
-        isFalse,
+    test('keeps people available while unnamed faces exist', () {
+      final unnamed = FilterSuggestionsResponseDto(
+        hasUnnamedPeople: true,
+        hasFavorites: false,
+        hasAssetsInAlbum: false,
+        hasAssetsNotInAlbum: false,
       );
-      expect(
-        availableSections(emptySuggestions().copyWithMediaTypes(['IMAGE', 'VIDEO']), SearchFilter.empty())
-            .contains(FilterSectionId.media),
-        isTrue,
-      );
+
+      expect(availableSections(unnamed, unnamed, SearchFilter.empty()).contains(FilterSectionId.people), isTrue);
+    });
+
+    test('needs BOTH photos and videos to keep media available', () {
+      bool mediaFor(List<String> types) {
+        final f = withMediaTypes(types);
+        return availableSections(f, f, SearchFilter.empty()).contains(FilterSectionId.media);
+      }
+
+      expect(mediaFor(['IMAGE']), isFalse);
+      expect(mediaFor(['VIDEO']), isFalse);
+      // A length>=2 rule would wrongly pass this one — AssetType includes AUDIO and OTHER.
+      expect(mediaFor(['IMAGE', 'OTHER']), isFalse);
+      expect(mediaFor(['IMAGE', 'VIDEO']), isTrue);
+      expect(mediaFor(['IMAGE', 'OTHER', 'VIDEO']), isTrue);
     });
 
     test('never hides a section that holds an active filter', () {
@@ -232,23 +327,39 @@ void main() {
         rating: SearchRatingFilter(rating: const Option.some(5)),
       );
 
-      expect(availableSections(emptySuggestions(), filter).contains(FilterSectionId.rating), isTrue);
+      expect(
+        availableSections(emptySuggestions(), emptySuggestions(), filter).contains(FilterSectionId.rating),
+        isTrue,
+      );
     });
 
     test('always keeps when and toggles available', () {
-      final available = availableSections(emptySuggestions(), SearchFilter.empty());
+      final available = availableSections(emptySuggestions(), emptySuggestions(), SearchFilter.empty());
 
       expect(available.contains(FilterSectionId.when), isTrue);
       expect(available.contains(FilterSectionId.toggles), isTrue);
     });
   });
+
+  group('sectionAvailabilityProvider (#910)', () {
+    // Locks the "same key when empty" optimisation: SearchFilter.empty() == an already-empty filter,
+    // so Riverpod serves one future, not two.
+    test('requests no second facet set when nothing is filtered', () async {
+      // …read the provider through a ProviderContainer with the API mocked, then:
+      verify(() => mockSearchApi.getFilterSuggestions(/* … */)).called(1);
+    });
+
+    test('offers every section while the facets are in error', () async {
+      // Task 1b makes a null response throw; the sheet must then show everything.
+    });
+  });
 }
 ```
 
-`copyWithRatings` / `copyWithMediaTypes` are shorthand — the generated DTO has no `copyWith`. Add two
-local helpers next to `emptySuggestions()` that construct the DTO with the field set, reading
-`mobile/openapi/lib/model/filter_suggestions_response_dto.dart` for the exact parameter names (list
-fields are typically named constructor parameters defaulting to `const []`):
+`withRatings` / `withMediaTypes` are local builders — the generated DTO has no `copyWith`. Add them next
+to `emptySuggestions()`, reading `mobile/openapi/lib/model/filter_suggestions_response_dto.dart` for the
+exact parameter names (list fields are typically named constructor parameters defaulting to `const []`).
+`aPerson` is any `PersonDto` fixture; the neighbouring picker tests already build one.
 
 ```dart
 FilterSuggestionsResponseDto withRatings(List<num> ratings) => FilterSuggestionsResponseDto(
@@ -291,33 +402,76 @@ import 'package:openapi/api.dart';
 /// This is DERIVED. It is never written to [hiddenSectionsProvider], which is the user's own
 /// persisted choice — conflating them would record a section as deliberately hidden the moment its
 /// facet went empty, and it would never come back.
-Set<FilterSectionId> availableSections(FilterSuggestionsResponseDto facets, SearchFilter filter) {
+/// Whether this section itself currently holds a filter value. Mirrors web's
+/// `hasActiveFilter` (`filter-panel.svelte:621-659`) section for section.
+bool hasActiveFilterFor(FilterSectionId id, SearchFilter filter) {
+  switch (id) {
+    case FilterSectionId.people:
+      return filter.people.isNotEmpty;
+    case FilterSectionId.places:
+      return filter.location.country != null || filter.location.state != null || filter.location.city != null;
+    case FilterSectionId.tags:
+      return (filter.tagIds ?? const []).isNotEmpty;
+    case FilterSectionId.camera:
+      return filter.camera.make != null || filter.camera.model != null;
+    case FilterSectionId.rating:
+      return filter.rating.rating.isSome;
+    case FilterSectionId.media:
+      return filter.mediaType != AssetType.other;
+    case FilterSectionId.when:
+      return filter.date.takenAfter != null || filter.date.takenBefore != null;
+    case FilterSectionId.toggles:
+      return filter.display.isFavorite ||
+          filter.display.isArchive ||
+          filter.display.isNotInAlbum ||
+          filter.display.isUntagged;
+  }
+}
+
+bool _facetEmpty(FilterSectionId id, FilterSuggestionsResponseDto facets) {
+  switch (id) {
+    case FilterSectionId.people:
+      return facets.people.isEmpty && !facets.hasUnnamedPeople;
+    case FilterSectionId.places:
+      return facets.countries.isEmpty;
+    case FilterSectionId.tags:
+      return facets.tags.isEmpty;
+    case FilterSectionId.camera:
+      return facets.cameraMakes.isEmpty;
+    case FilterSectionId.rating:
+      return facets.ratings.isEmpty;
+    case FilterSectionId.media:
+      // The control offers All / Photos / Videos, so it needs both of those to discriminate.
+      // NOT `length >= 2`: the server returns raw distinct asset.type and AssetType is
+      // IMAGE | VIDEO | AUDIO | OTHER, so a photo library with one OTHER asset would pass a
+      // length test while the Videos button stays dead. Same rule as web's filter-availability.ts.
+      return !(facets.mediaTypes.contains('IMAGE') && facets.mediaTypes.contains('VIDEO'));
+    case FilterSectionId.when:
+    case FilterSectionId.toggles:
+      // `when` mirrors web's Timeline. `toggles` always renders — two of its four switches have no
+      // facet at all, so the section as a whole is never useless; see [availableToggles].
+      return false;
+  }
+}
+
+Set<FilterSectionId> availableSections(
+  FilterSuggestionsResponseDto facets,
+  FilterSuggestionsResponseDto? baseline,
+  SearchFilter filter,
+) {
   bool offered(FilterSectionId id) {
-    switch (id) {
-      case FilterSectionId.people:
-        return facets.people.isNotEmpty || facets.hasUnnamedPeople;
-      case FilterSectionId.places:
-        return facets.countries.isNotEmpty;
-      case FilterSectionId.tags:
-        return facets.tags.isNotEmpty;
-      case FilterSectionId.camera:
-        return facets.cameraMakes.isNotEmpty;
-      case FilterSectionId.rating:
-        return facets.ratings.isNotEmpty;
-      case FilterSectionId.media:
-        // One type means "Photos" is a synonym for "All" and the other button is empty.
-        return facets.mediaTypes.length >= 2;
-      case FilterSectionId.when:
-      case FilterSectionId.toggles:
-        // `when` mirrors web's Timeline. `toggles` always renders — two of its four switches have no
-        // facet at all, so the section as a whole is never useless; see [availableToggles].
-        return true;
-    }
+    // Never strand a filter the user cannot then reach to clear.
+    if (hasActiveFilterFor(id, filter)) return true;
+    if (!_facetEmpty(id, facets)) return true;
+    // A section is never hidden on missing information.
+    if (baseline == null) return true;
+    // Empty under the current filters but not for the whole scope: transient, so keep it.
+    return !_facetEmpty(id, baseline);
   }
 
   return {
     for (final id in FilterSectionId.values)
-      if (offered(id) || hasActiveFilterFor(id, filter)) id,
+      if (offered(id)) id,
   };
 }
 
@@ -325,19 +479,26 @@ final sectionAvailabilityProvider = Provider.autoDispose<Set<FilterSectionId>>((
   final filter = ref.watch(photosFilterProvider);
   final facets = ref.watch(photosFilterSuggestionsProvider(filter));
 
+  // Same family, different key — and the SAME key when nothing is filtered, so the common case
+  // costs no extra request. SearchFilter has value equality, which is what makes that true.
+  final baselineKey = filter.isEmpty ? filter : SearchFilter.empty();
+  final baseline = ref.watch(photosFilterSuggestionsProvider(baselineKey));
+
   // While a request is in flight or has failed, offer everything. A section is never hidden on
-  // missing information.
+  // missing information — including when Task 1b's throw fires.
   return facets.maybeWhen(
-    data: (data) => availableSections(data, filter),
+    data: (data) => availableSections(data, baseline.valueOrNull, filter),
     orElse: () => FilterSectionId.values.toSet(),
   );
 });
 ```
 
-`hasActiveFilterFor` does not exist yet. Check `mobile/lib/providers/photos_filter/active_chips.dart` and
-`filter_count.provider.dart` first — one of them almost certainly already maps a `SearchFilter` to the
-sections that hold values, and reusing it is better than writing a second mapping that can drift. If
-neither fits, add `hasActiveFilterFor` beside `availableSections` in this file.
+`hasActiveFilterFor` is written out above rather than left to discovery: there is no existing mapping to
+reuse. `activeChipsFromFilter` (`active_chips.dart`) produces `ChipId`s, and that mapping is not 1:1 with
+`FilterSectionId` — `toggles` alone yields four chip ids, and `text` yields chips with no section at all.
+
+Check `filter.rating.rating.isSome` against `utils/option.dart` before relying on it; if the accessor is
+named differently, use `!filter.rating.rating.isNone` (`isNone` is used in `SearchFilter.isEmpty`).
 
 - [ ] **Step 4: Run the tests to verify they pass**
 
@@ -494,5 +655,11 @@ git commit -m "feat(mobile): hide filter sections and toggles that cannot filter
 
 - `flutter test`, `dart analyze --fatal-infos lib test` and `dart format` are all green from `mobile/`.
 - `git diff --name-only` lists no `rating_stars_section.widget.dart` and no `media_type_section.widget.dart`.
-- `grep -rn "FilterSuggestionsResponseDto(" mobile/test` shows no literal missing the new fields.
+- `grep -rn "FilterSuggestionsResponseDto(" mobile/test` shows no literal missing the new fields, and
+  `grep -rn "FilterSuggestionsResponseDto(" mobile/lib` shows **none at all** — Task 1b deleted the only
+  one, and re-adding it is the §4.6 bug.
 - `hiddenSectionsProvider` is read but never written by any code added in this slice.
+- The cross-section parity test in Task 2 passes, which is the only thing proving mobile behaves like web
+  rather than popping sections in and out (spec §2.1, §2.3, §7).
+- The media rule is `contains('IMAGE') && contains('VIDEO')`, not a length check —
+  `grep -n "mediaTypes.length" mobile/lib` returns nothing.

--- a/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-8.md
+++ b/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-8.md
@@ -1,0 +1,154 @@
+# Slice 8 — Documentation (#910)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for
+> tracking.
+
+**Goal:** `docs/docs/features/dynamic-filter-suggestions.md` describes what the app now does — including
+correcting three rows that were already wrong before this work started.
+
+**Architecture:** Documentation only. No source changes.
+
+**Tech Stack:** Docusaurus, Prettier.
+
+- **Spec:** `docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md` §2.1, §4.3, §2.4
+- **Branch:** `fix/910-interdependent-filter-sections`
+- **Depends on:** Slices 5 and 7 — document what shipped, not what was planned.
+- **Scope:** `docs/docs/features/dynamic-filter-suggestions.md`.
+
+## Global Constraints
+
+- Per `reference_docs_prettier_covers_superpowers_plans`, CI Docs Build runs Prettier over `docs/`
+  **including** `docs/plans/` and `docs/superpowers/`. Run `npx prettier --write` on every markdown file
+  touched, this plan file included, before committing.
+- User-facing docs describe behaviour, not implementation. The existing "Architecture" section is the one
+  exception and stays.
+
+---
+
+## Task 1: Correct the feature doc
+
+**Files:**
+
+- Modify: `docs/docs/features/dynamic-filter-suggestions.md`
+
+Three rows of the "What updates" table are wrong **today**, before this change:
+
+| Row        | Doc claims                                                 | Reality before #910                                     |
+| ---------- | ---------------------------------------------------------- | ------------------------------------------------------- |
+| Rating     | "Shows ratings that can still satisfy the current minimum" | Not dynamic — the client discards the facet             |
+| Media Type | "Photo/Video buttons hidden when no assets of that type"   | Not dynamic — and buttons are deliberately never hidden |
+| Favorites  | "Not dynamic. Simple toggle, always visible"               | Correct then; changes with this slice                   |
+
+- [ ] **Step 1: Rewrite the "What updates" table**
+
+```markdown
+## What updates
+
+| Filter     | Narrows with other filters? | Section hidden when it cannot filter?                  |
+| ---------- | --------------------------- | ------------------------------------------------------ |
+| People     | Yes                         | Yes, unless unnamed faces exist                        |
+| Location   | Yes (countries)             | Yes, when no photo has a location                      |
+| Camera     | Yes (makes)                 | Yes, when no photo has camera metadata                 |
+| Tags       | Yes                         | Yes, when nothing is tagged                            |
+| Rating     | Yes                         | Yes, when nothing is rated                             |
+| Media Type | Yes                         | Yes, unless you have both photos and videos            |
+| Favorites  | Yes                         | Yes, when nothing is favourited                        |
+| Albums     | Yes                         | Yes, unless some photos are in albums and some are not |
+| Timeline   | Drives filtering            | Never — it greys out instead                           |
+| Text       | No — free text              | Never                                                  |
+```
+
+- [ ] **Step 2: Add the section-visibility explanation**
+
+Insert after the table, before "Orphaned selections":
+
+```markdown
+## Sections you do not see
+
+A filter section only appears when it can change what you are looking at.
+
+- **Hidden.** Nothing in this library, album or space could ever populate the section — you have no
+  videos, so there is no Media Type section, and no way to filter by something you do not have. The
+  section reappears on its own as soon as the content does.
+- **Greyed out, with `(0)`.** The section could normally filter, but the filters you have applied right
+  now leave it nothing to offer. Clear or change a filter and it comes back.
+
+A section holding an active filter is never hidden or greyed, so you can always undo a selection.
+```
+
+- [ ] **Step 3: Correct the "Orphaned selections" section**
+
+It currently describes dimming as a general mechanism. It applies to the list-style filters — People,
+Location, Camera, Tags — and deliberately **not** to the rating stars or the media-type buttons, whose
+meaning is positional. Reword accordingly:
+
+```markdown
+## Orphaned selections
+
+If you select a value from a list — a person, country, camera or tag — and then apply another filter that
+removes it from the available options, the selected value stays visible but appears **dimmed**. This lets
+you see why your result set is empty and undo the selection with one click.
+
+Rating stars and the Photo/Video buttons never dim or disappear individually: their meaning comes from
+their position, so a gap in the row would be misleading. When they cannot help, the whole section is
+hidden or greyed instead.
+```
+
+- [ ] **Step 4: Update the "Architecture" paragraph**
+
+It says the endpoint "runs 6 parallel queries". After slice 1 it is eight. Correct the count and mention
+that the presence probes exist. Verify the number against
+`server/src/repositories/search.repository.ts`'s `getFilterSuggestions` rather than trusting this line.
+
+- [ ] **Step 5: Format and preview**
+
+```bash
+npx prettier --write docs/docs/features/dynamic-filter-suggestions.md
+npx prettier --check docs/
+```
+
+Expected: check passes. A failure here fails CI Docs Build.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/docs/features/dynamic-filter-suggestions.md
+git commit -m "docs: describe hidden and greyed filter sections (#910)"
+```
+
+---
+
+## Task 2: Decide on the README and marketing site
+
+**Files:** possibly none.
+
+CLAUDE.md requires the README's "What's Different from Upstream Immich" section to stay in feature parity
+with the marketing site, and the `launch-new-feature` skill covers launching a **new** feature.
+
+- [ ] **Step 1: Check whether anything is owed**
+
+```bash
+grep -n -i "dynamic filter" README.md
+```
+
+This work refines an existing shipped feature (`dynamic-filter-suggestions`) rather than adding one, so the
+expected answer is that the existing README entry already covers it and **no change is needed**. Confirm
+that, and if the README describes the old always-visible behaviour, correct that sentence only.
+
+Do **not** invoke `launch-new-feature`: there is no new feature and no new marketing page.
+
+- [ ] **Step 2: Commit only if something changed**
+
+```bash
+git add README.md && git commit -m "docs: note filter-section visibility in the README (#910)"
+```
+
+---
+
+## Done when
+
+- `npx prettier --check docs/` passes.
+- The "What updates" table matches what slices 5 and 7 actually shipped — re-read them rather than this
+  plan if the two disagree.
+- No claim in the doc says rating stars or media buttons are individually hidden or dimmed.

--- a/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-8.md
+++ b/docs/superpowers/plans/2026-08-04-interdependent-filters-slice-8.md
@@ -42,21 +42,27 @@ Three rows of the "What updates" table are wrong **today**, before this change:
 
 - [ ] **Step 1: Rewrite the "What updates" table**
 
+The "narrows" column must say **No** for Rating and Media Type. Per spec §2.4 and §4.3.1 their facets
+decide section visibility and are never handed to the controls: every star and every media button always
+renders. Saying "Yes" there would contradict §2.4 _and_ Step 3 of this same task, which states that stars
+and buttons never dim or disappear individually. Favorites and Albums are toggles with no list to narrow,
+so the column is n/a for them.
+
 ```markdown
 ## What updates
 
-| Filter     | Narrows with other filters? | Section hidden when it cannot filter?                  |
-| ---------- | --------------------------- | ------------------------------------------------------ |
-| People     | Yes                         | Yes, unless unnamed faces exist                        |
-| Location   | Yes (countries)             | Yes, when no photo has a location                      |
-| Camera     | Yes (makes)                 | Yes, when no photo has camera metadata                 |
-| Tags       | Yes                         | Yes, when nothing is tagged                            |
-| Rating     | Yes                         | Yes, when nothing is rated                             |
-| Media Type | Yes                         | Yes, unless you have both photos and videos            |
-| Favorites  | Yes                         | Yes, when nothing is favourited                        |
-| Albums     | Yes                         | Yes, unless some photos are in albums and some are not |
-| Timeline   | Drives filtering            | Never — it greys out instead                           |
-| Text       | No — free text              | Never                                                  |
+| Filter     | Options narrow with other filters? | Whole section hidden when it cannot filter?            |
+| ---------- | ---------------------------------- | ------------------------------------------------------ |
+| People     | Yes                                | Yes, unless unnamed faces exist                        |
+| Location   | Yes (countries)                    | Yes, when no photo has a location                      |
+| Camera     | Yes (makes)                        | Yes, when no photo has camera metadata                 |
+| Tags       | Yes                                | Yes, when nothing is tagged                            |
+| Rating     | No — all five stars always show    | Yes, when nothing is rated                             |
+| Media Type | No — all three buttons always show | Yes, unless you have both photos and videos            |
+| Favorites  | n/a — a toggle, not a list         | Yes, when nothing is favourited                        |
+| Albums     | n/a — a toggle, not a list         | Yes, unless some photos are in albums and some are not |
+| Timeline   | Drives filtering                   | Never — it greys out instead                           |
+| Text       | No — free text                     | Never                                                  |
 ```
 
 - [ ] **Step 2: Add the section-visibility explanation**
@@ -95,11 +101,24 @@ their position, so a gap in the row would be misleading. When they cannot help, 
 hidden or greyed instead.
 ```
 
-- [ ] **Step 4: Update the "Architecture" paragraph**
+- [ ] **Step 4: Correct the query count in all three places it appears**
 
-It says the endpoint "runs 6 parallel queries". After slice 1 it is eight. Correct the count and mention
-that the presence probes exist. Verify the number against
-`server/src/repositories/search.repository.ts`'s `getFilterSuggestions` rather than trusting this line.
+"6" is stated three times, and Step 4 of an earlier draft caught only the first:
+
+```bash
+grep -n "6 parallel\|6 queries\|All 6" docs/docs/features/dynamic-filter-suggestions.md
+```
+
+1. the **Architecture** paragraph — "The server runs 6 parallel queries"
+2. the **Server flow** code block — "3. Run 6 queries in parallel:" plus the six-item list under it,
+   which needs the favourites and album-membership probes added
+3. the **Shared query helper** paragraph — "All 6 extraction queries share a common
+   `buildFilteredAssetIds` helper"
+
+The `Promise.all` gains two entries (favourites, album membership) for **eight**, but album membership
+issues two SQL probes, so nine queries run. Say "eight parallel facet queries" in the prose and let the
+Server flow list show the album row as two probes. Verify both numbers against
+`getFilterSuggestions` in `server/src/repositories/search.repository.ts` rather than trusting this line.
 
 - [ ] **Step 5: Format and preview**
 
@@ -151,4 +170,8 @@ git add README.md && git commit -m "docs: note filter-section visibility in the 
 - `npx prettier --check docs/` passes.
 - The "What updates" table matches what slices 5 and 7 actually shipped — re-read them rather than this
   plan if the two disagree.
-- No claim in the doc says rating stars or media buttons are individually hidden or dimmed.
+- No claim in the doc says rating stars or media buttons are individually hidden or dimmed, **or that
+  their options narrow**. That last one is the easy mistake: their facets exist and are consulted, but
+  only for section visibility (spec §4.3.1).
+- `grep -n "6 parallel\|6 queries\|All 6" docs/docs/features/dynamic-filter-suggestions.md` returns
+  nothing.

--- a/docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md
+++ b/docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md
@@ -169,8 +169,33 @@ Notes on the three non-obvious rows:
 discoverability path to making the filter useful at all. Hiding the section would remove the only
 prompt to name a face.
 
-**timeline** never hides: the panel is already suppressed wholesale via its `hidden` prop when the
-scope has no assets, so a structurally empty Timeline means an empty page, not a useless section.
+**timeline** never hides. Its bucket list is the page's own data rather than a server facet, and it is
+the one section whose emptiness means "this page has no assets" rather than "this control is
+useless" — a state the surfaces already handle with the panel's `hidden` prop (photos `:609`,
+recently-added `:509`, spaces `:829`, albums `:523`/`:535`, space-albums `:349`/`:527`; the map passes
+no `hidden` and simply greys).
+
+### 4.3.1 The rating stars need a different rule from the rating section
+
+The section-level rule above is correct — no rated asset means no `rating >= N` can match, for any N.
+The **star-level** rule inside the section is not, and turning `availableRatings` on activates a
+latent bug.
+
+The rating filter is a **minimum**, not an equality: `asset_exif.rating >= options.rating`
+(`asset.repository.ts:309`, and `database.ts:897` via `ratingIsMinimum` on the smart path). But
+`rating-filter.svelte:27` computes:
+
+```ts
+const isOrphaned = availableRatings !== undefined && !availableRatings.includes(star);
+```
+
+With `ratings: [2]` — a library whose only rated assets are 2-star — stars 1 _and_ 2 both return
+results, yet star 1 would be dimmed as unavailable. The prop is dead code today, so nobody has hit
+this. Slice 5 makes it live. The correct rule follows the `>=` semantics:
+
+```ts
+const isOrphaned = availableRatings !== undefined && star > Math.max(0, ...availableRatings);
+```
 
 ### 4.4 Three overriding rules
 
@@ -179,7 +204,7 @@ scope has no assets, so a structurally empty Timeline means an empty page, not a
    photos, empties the ratings facet while `rating: 5` is applied. Greying Rating there would trap the
    user with a filter they cannot reach to clear. `hasActiveFilter(section)`
    (`filter-panel.svelte:621-659`) already exists and is the guard.
-2. **Availability is never persisted.** §5.3.
+2. **Availability is never persisted.** §6.3.
 3. **A section absent from `config.sections` is untouched** — album detail's documented omission of
    `albums` (`filter-section-parity.spec.ts`) is unrelated and stays.
 
@@ -191,13 +216,71 @@ Client-side, cached per panel instance:
   `getActiveFilterCount(filters) === 0`, that response **is** the baseline — captured for free.
 - When the panel mounts with filters already applied (a deep link such as `/photos?rating=5`, or
   restored space filters), one extra `suggestionsProvider(createFilterState())` call fires alongside.
-- The baseline is held for the component's lifetime. Scope changes — a different album, a different
-  space — remount the panel, so component lifetime **is** the cache scope. No invalidation logic.
+- The baseline is held for the component's lifetime.
 
 Rejected: a server-side `scopeFacets` block returned with every response. It adds ~8 `EXISTS`
 subqueries to every suggestions request, including the debounced refetch that fires on each filter
 tweak, to answer a question whose answer changes when the library changes. The expensive path is the
 one that repeats.
+
+#### The `{#key}` invariant this depends on
+
+"Component lifetime is the cache scope" is only true because every surface already remounts the panel
+whenever its **non-filter** scope changes — the album, the space, or the committed smart-search query,
+none of which the panel can see:
+
+| Surface        | `{#key}` expression                                                                           |
+| -------------- | --------------------------------------------------------------------------------------------- |
+| photos         | `showSearchResults ? \`photos-search-${committedQuery}:${$lang}\` : 'photos-browse'` (`:600`) |
+| spaces         | `` `${space.id}:${showSearchResults ? …search… : 'spaces-browse'}` `` (`:822`)                |
+| recently-added | `showSearchResults ? \`recently-added-search-…\` : 'recently-added-browse'` (`:501`)          |
+| albums         | `` `picker-${album.id}` `` / `` `album-${album.id}` `` (`:517`, `:527`)                       |
+| space-albums   | `` `space-album-${album.id}` `` / `` `space-album-picker-${album.id}` `` (`:341`, `:521`)     |
+| map            | no query mode; route change remounts                                                          |
+
+This is load-bearing and invisible: deleting a `{#key}` in a later refactor would leave a stale
+baseline behind with no compile error and no failing test. §8.3 adds a guard.
+
+Even a stale baseline fails safe, which is why no `scopeKey` prop is needed. A committed query can
+only **narrow** the scope, so `facet(query) ⊆ facet(browse)`. Hiding requires _both_ the current and
+the baseline facet to be empty; a baseline from a wider scope can therefore only fail to hide, never
+hide wrongly. The same argument covers the `withSharedSpaces` coupling in §4.6.
+
+### 4.6 Degenerate inputs that must not read as "structurally empty"
+
+An all-empty facet response is currently produced by three paths that do **not** mean "this scope has
+none of these". Each has to be handled or the panel will hide every section at once.
+
+**A failed facet fetch returns an empty sentinel.** All three query-mode surfaces resolve their
+provider with `emptyFilterSuggestions()` — every array empty, `hasUnnamedPeople: false` — when the
+smart-facets request fails or is aborted:
+
+- `photos/…/+page.svelte:271-273`
+- `spaces/[spaceId]/…/+page.svelte:305-307`
+- `recently-added/…/+page.svelte:266-269`
+
+Today that renders empty pickers, which is harmless. Under this model it is indistinguishable from a
+genuinely empty scope and would hide **every** section. The `baseline === undefined` safeguard in §6.1
+does not catch it, because the sentinel is a defined object.
+
+**Fix:** the sentinel becomes a rejection. Each of the three sites throws instead of returning
+`emptyFilterSuggestions()`, so the panel's existing `.catch` (`filter-panel.svelte:167-171`) runs and
+neither `current` nor `baseline` is overwritten — the panel keeps showing the last good facets, which
+is also better behaviour than blanking the pickers. `emptyFilterSuggestions()` is then deleted from
+all three surfaces. This belongs to slice 4, not to slice 5: the gating is unsafe until it lands.
+
+**`forceEmptyResult` deliberately empties everything.** `buildFilteredAssetIds` honours it
+(`search.repository.ts:1402`); `SearchService.getSearchSuggestions` sets it when a scoped person token
+is inaccessible (#858 §2.1). Every facet then comes back empty **for the current filters only** — the
+baseline, built from an empty filter state, carries no person token and is unaffected. The sections
+grey rather than hide, which is the correct outcome. Needs a test, not a code change.
+
+**Favourites narrows the scope, not just the filter.** The photos page couples `withSharedSpaces` to
+the favourites filter (`:200`, `:230`, `:282`, `:289`) because favourites are per-user (#763): with
+`isFavorite` set, suggestions are computed over own+partner assets only, while the baseline (no
+filters) includes shared spaces. Current and baseline therefore span different scopes. By the subset
+argument above this can only produce a grey where a hide might have been justified — never a wrong
+hide. Documented and tested, not changed.
 
 ## 5. Server
 
@@ -293,7 +376,9 @@ baseline and never calls it.
 
 - Delete the `filter-panel.svelte:160-164` discard; assign `availableRatings = result.ratings` and
   `availableMediaTypes = result.mediaTypes`. Both props already exist and are already consumed
-  (`rating-filter.svelte:27`, `media-type-filter.svelte:18-24`) — nothing downstream changes.
+  (`rating-filter.svelte:27`, `media-type-filter.svelte:18-24`).
+- Fix `rating-filter.svelte:27` to the `>=` orphan rule per §4.3.1. The two changes must land in the
+  same slice: assigning `availableRatings` without the fix ships the dimming bug.
 - Capture `baseline` per §4.5.
 - Derive `availability` per section and gate **both** the render loop (`filter-panel.svelte:753`) and
   the section-toggle icon row (`filter-panel.svelte:727`) on `!== 'unavailable'`.
@@ -331,11 +416,16 @@ Six config/mapper sites forward the three new fields:
 - `web/src/lib/utils/album-filter-config.ts` (both builders)
 - `web/src/lib/utils/recently-added-filter-config.ts`
 - `web/src/lib/utils/space-search.ts` (`mapSmartSearchFacetsToFilterSuggestions`)
-- `routes/(user)/photos/[[assetId=id]]/+page.svelte` — including `emptyFilterSuggestions()`
+- `routes/(user)/photos/[[assetId=id]]/+page.svelte`
 - `routes/(user)/spaces/[spaceId]/…/+page.svelte` and `routes/(user)/albums/[albumId=id]/…/+page.svelte`
 
 Widening `FilterSuggestionsResponse` (`filter-panel.ts:80-90`) with three required booleans makes
 `tsc` name every site that has not been updated — the compiler is the checklist.
+
+The same slice removes `emptyFilterSuggestions()` from the three query-mode surfaces in favour of a
+rejection, per §4.6. Note that `tsc` will **not** catch this one: the sentinel is a plain object
+literal, so widening the type flags it as missing the new fields, and the tempting fix is to add
+`hasFavorites: false` to it — which is precisely the bug. Delete it instead.
 
 ## 7. Mobile
 
@@ -388,6 +478,12 @@ database:
 | smart-search path, each of the above                    | same verdicts via `getSmartSearchFacets`                                                                          |
 | smart-search with `isFavorite` set                      | `hasFavorites` unaffected — regression guard for the `exclude !== 'favorites'` fix                                |
 | smart-search with `isNotInAlbum` set                    | other facets (`ratings`, `tags`, …) still reflect it — proves the candidate-query move did not drop the predicate |
+| `forceEmptyResult` set                                  | all three false — §4.6, so the client greys rather than hides                                                     |
+| `withSharedSpaces` with a shared-space favourite        | `hasFavorites` true; false without the flag — locks the §4.6 scope coupling                                       |
+
+The two rows above the last are the ones that fail loudest if the §5.3 candidate-query move is done
+wrong: dropping the album predicate entirely makes the second pass trivially, so it must be paired
+with an assertion that a **non**-album facet still reflects `isNotInAlbum`.
 
 Plus unit-level fixture updates in `search.service.spec.ts` and `search.controller.spec.ts`.
 
@@ -404,6 +500,13 @@ of §4.1, plus:
 - `hasAssetsInAlbum: true, hasAssetsNotInAlbum: false` → `unavailable`, and the mirror
 - timeline and text never `unavailable`, for any input
 
+Separately, `rating-filter.svelte`'s star-level rule (§4.3.1), which is not part of the module:
+
+- `availableRatings: [2]` → stars 1 and 2 live, stars 3–5 dimmed. **This is the test that fails
+  against today's `!includes(star)` implementation** and is the reason the fix is in scope.
+- `availableRatings: [2, 5]` → stars 1–5 all live (5 is the max, everything below it matches `>=`)
+- `availableRatings: []` → all five dimmed; `availableRatings: undefined` → none dimmed (legacy path)
+
 ### 8.3 Web — panel integration
 
 In `web/src/lib/components/filter-panel/__tests__/`:
@@ -412,13 +515,26 @@ In `web/src/lib/components/filter-panel/__tests__/`:
 - an `empty` section renders `(0)`, is collapsed and is disabled
 - a section that goes unavailable is **not** written to `localStorage`, and reappears when the next
   response reports it available — the §6.3 regression guard
+- an unavailable section still appears in the stored `known` array, so PR #926's
+  "introduced since the ledger" logic cannot mistake it for a new section on the next load
 - the panel mounts with filters active → a second `suggestionsProvider` call with an empty filter
   state; mounts clean → exactly one call
 - baseline request rejects → no section is hidden
+- **a later `suggestionsProvider` rejection leaves the previous facets and baseline in place** — the
+  §4.6 sentinel guard, at panel level
 - `showAllSections` and the empty-state hint count only available sections
 - a section with an active filter survives an empty facet
 - **the legacy providers path is unaffected** — `filter-panel.spec.ts:403` (`#858 §3.3`) stays green
   without edits, and no section is ever hidden when `config.suggestionsProvider` is absent
+
+At surface level, one test per query-mode page (photos, spaces, recently-added) that a failing
+`searchSmartFacets` makes `suggestionsProvider` **reject** rather than resolve with empty arrays
+(§4.6). These fail against today's `emptyFilterSuggestions()` and are what makes slice 4 TDD rather
+than a refactor.
+
+A guard for the `{#key}` invariant in §4.5: one test per surface that changing the committed query (or
+album/space id) mounts a fresh panel — asserted by the panel re-issuing its baseline request. Without
+it, deleting a `{#key}` is a silent correctness regression.
 
 `filter-section-parity.spec.ts` guards `config.sections` parity, which this change does not touch, so
 it must stay green. Widen its `getFilterSuggestions` mock with the three new fields so the mocked
@@ -455,19 +571,22 @@ and `dart format` as separate gates:
 
 ## 9. Slices
 
-| #   | Slice                                                                               | Gate                             |
-| --- | ----------------------------------------------------------------------------------- | -------------------------------- |
-| 1   | Server facets, DTOs, `SmartFacetExclude`, candidate-query move, `make sql`          | server unit + medium             |
-| 2   | OpenAPI regen — TypeScript SDK + Dart client                                        | build                            |
-| 3   | `filter-availability.ts` + its tests, no wiring                                     | web unit                         |
-| 4   | Widen `FilterSuggestionsResponse`; six surface configs/mappers                      | web unit + `check:typescript`    |
-| 5   | Panel wiring: consume facets, baseline capture, gating, ledger separation           | web unit + `check:svelte` + lint |
-| 6   | e2e seed and assertion updates                                                      | e2e web                          |
-| 7   | Mobile: `isNotInAlbum` forwarding, section and toggle gating, manage-sections sheet | flutter test, analyze, format    |
-| 8   | Docs                                                                                | docs prettier                    |
+Each row names the test that must fail first, so the slice cannot be started implementation-first.
+
+| #   | Slice                                                                                     | First failing test                                                                | Gate                             |
+| --- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------- |
+| 1   | Server facets, DTOs, `SmartFacetExclude`, candidate-query move, `make sql`                | medium: `hasFavorites` on a library with one favourite (§8.1)                     | server unit + medium             |
+| 2   | OpenAPI regen — TypeScript SDK + Dart client                                              | none — generated output, covered by slice 1 and 4                                 | build                            |
+| 3   | `filter-availability.ts` + its tests, no wiring                                           | the §4.3 table, driven as data (§8.2)                                             | web unit                         |
+| 4   | Widen `FilterSuggestionsResponse`; six configs/mappers; delete `emptyFilterSuggestions()` | per-surface: a failing facet fetch **rejects** rather than resolving empty (§8.3) | web unit + `check:typescript`    |
+| 5   | Panel wiring: consume facets, `>=` star rule, baseline capture, gating, ledger separation | `availableRatings: [2]` keeps star 1 live (§8.2)                                  | web unit + `check:svelte` + lint |
+| 6   | e2e seed and assertion updates                                                            | a library with no videos does not render `filter-section-media`                   | e2e web                          |
+| 7   | Mobile: `isNotInAlbum` forwarding, section and toggle gating, manage-sections sheet       | provider forwards `isNotInAlbum` (§8.5)                                           | flutter test, analyze, format    |
+| 8   | Docs                                                                                      | none                                                                              | docs prettier                    |
 
 Slice 4 precedes slice 5 because widening the response type breaks every config until they are
-updated; `tsc` then enumerates the work.
+updated; `tsc` then enumerates the work. It also carries the §4.6 sentinel removal, which slice 5's
+gating depends on for safety — slice 5 must not land without it.
 
 ## 10. Sequencing and risks
 

--- a/docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md
+++ b/docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md
@@ -25,8 +25,9 @@ faceted data the panel already fetches, and either hides or greys itself out acc
 
 ## 2. Decisions taken
 
-Four product decisions were settled before design. They are recorded here because two of them
-**reverse decisions previously made deliberately in code**, and a future reader needs the reason.
+Four product decisions were settled before design. They are recorded here because the work sits on top
+of two earlier deliberate decisions — §2.4 keeps one, §4.2 supersedes the other — and a future reader
+needs to know which is which, and why.
 
 ### 2.1 Hide structural, grey transient
 
@@ -50,24 +51,42 @@ Mobile's filter sheet consumes the same `/search/filter-suggestions` endpoint
 (`mobile/lib/providers/photos_filter/filter_suggestions.provider.dart`) and has the same
 always-visible sections. Both clients change in this spec so they cannot drift.
 
-### 2.4 What this reverses
+### 2.4 What this does **not** reverse: no per-star or per-button dimming
 
-**`filter-panel.svelte:160-164`** — the client currently discards the `ratings` and `mediaTypes` the
-server already sends:
+`filter-panel.svelte:160-164` discards the `ratings` and `mediaTypes` the server already sends:
 
 > Note: availableRatings and availableMediaTypes are intentionally NOT set from suggestionsProvider.
 > Hiding rating stars and media type buttons based on the current result set is too aggressive — it
 > breaks existing E2E tests and confuses users who expect these fixed options to always be visible.
 
-Two claims, handled separately. "Breaks existing E2E tests" was true and is still true — §8.4 fixes
-the seed data rather than the feature. "Confuses users who expect these fixed options to always be
-visible" is the claim #910 contradicts: the reporter is confused by the _opposite_. The comment is
-deleted, and this section is the replacement record.
+That is a **standing decision**, not an incidental comment — recorded in
+`feedback_no_dynamic_rating_media_hiding` and load-bearing on `rating_stars_section.widget.dart`,
+which cites it. Its three grounds still hold:
+
+1. **A real bug (PR #261).** Filtering `visibleStars` by `availableRatings` made the stars positional
+   liars: with `[1, 2, 3, 5]` available, clicking the fourth visible star selected rating 5. Stars
+   derive their meaning from position, unlike labelled values such as countries or tags.
+2. **It breaks e2e.** Suites click `rating-star-5` and `media-type-video` directly; hidden elements
+   time out.
+3. **Dimming specifically was rejected too**, not only hiding.
+
+**#910 does not require reversing any of it.** The issue is about _sections_ — "hide the complete
+section" — not about individual stars and buttons. This spec therefore reads `ratings` and
+`mediaTypes` **only** to decide section availability, and never assigns `availableRatings` /
+`availableMediaTypes`. All five stars keep rendering uniformly whenever the Rating section renders at
+all; all three media buttons keep rendering whenever Media does.
+
+A useful corollary: because the props stay unset, the latent `>=` mismatch inside
+`rating-filter.svelte:27` stays dead. The rating filter is a **minimum**
+(`asset.repository.ts:309`, `database.ts:897` via `ratingIsMinimum`), so `!availableRatings.includes(star)`
+would have dimmed star 1 on a library whose only rated assets are 2-star — a fourth reason the
+standing decision is the right one. §6.2 leaves that code untouched and documents why.
 
 **The #858 §3.3 carve-out** (`filter-panel.svelte:92`) excludes `country`, `city`, `make`, `model`
 and `mediaType` from `filterContext` so that a section-local filter cannot grey out its own section.
 It stops applying on every production surface — see §4.2 — while remaining in force on the legacy
-path it was written for.
+path it was written for. This is the one prior decision the spec does supersede, and only because the
+condition that motivated it becomes structurally impossible (§4.2).
 
 ## 3. Current state
 
@@ -175,27 +194,19 @@ useless" — a state the surfaces already handle with the panel's `hidden` prop 
 recently-added `:509`, spaces `:829`, albums `:523`/`:535`, space-albums `:349`/`:527`; the map passes
 no `hidden` and simply greys).
 
-### 4.3.1 The rating stars need a different rule from the rating section
+### 4.3.1 Section-level only — the facets never reach the controls
 
-The section-level rule above is correct — no rated asset means no `rating >= N` can match, for any N.
-The **star-level** rule inside the section is not, and turning `availableRatings` on activates a
-latent bug.
+`ratings` and `mediaTypes` feed `getSectionAvailability` and nothing else. Per §2.4,
+`availableRatings` and `availableMediaTypes` stay unset, so:
 
-The rating filter is a **minimum**, not an equality: `asset_exif.rating >= options.rating`
-(`asset.repository.ts:309`, and `database.ts:897` via `ratingIsMinimum` on the smart path). But
-`rating-filter.svelte:27` computes:
+- whenever the Rating section renders, all five stars render uniformly;
+- whenever the Media section renders, all three buttons render;
+- `rating-filter.svelte` and `media-type-filter.svelte` are not modified by this work at all.
 
-```ts
-const isOrphaned = availableRatings !== undefined && !availableRatings.includes(star);
-```
-
-With `ratings: [2]` — a library whose only rated assets are 2-star — stars 1 _and_ 2 both return
-results, yet star 1 would be dimmed as unavailable. The prop is dead code today, so nobody has hit
-this. Slice 5 makes it live. The correct rule follows the `>=` semantics:
-
-```ts
-const isOrphaned = availableRatings !== undefined && star > Math.max(0, ...availableRatings);
-```
+The section rules remain sound without the controls participating. `ratings: []` means no
+`rating >= N` can match for any N, so the whole section is dead. `mediaTypes.length < 2` means the
+one present type is a synonym for _All_ and the other button is empty, so the control cannot
+discriminate. Both verdicts are about the section, which is exactly what #910 asks about.
 
 ### 4.4 Three overriding rules
 
@@ -374,12 +385,11 @@ baseline and never calls it.
 
 `filter-panel.svelte`:
 
-- Delete the `filter-panel.svelte:160-164` discard; assign `availableRatings = result.ratings` and
-  `availableMediaTypes = result.mediaTypes`. Both props already exist and are already consumed
-  (`rating-filter.svelte:27`, `media-type-filter.svelte:18-24`).
-- Fix `rating-filter.svelte:27` to the `>=` orphan rule per §4.3.1. The two changes must land in the
-  same slice: assigning `availableRatings` without the fix ships the dimming bug.
-- Capture `baseline` per §4.5.
+- Capture the whole response into `currentSuggestions`, and `baseline` per §4.5. `ratings` and
+  `mediaTypes` reach `getSectionAvailability` through that object.
+- **Leave `availableRatings` and `availableMediaTypes` unset**, and leave the
+  `filter-panel.svelte:160-164` comment in place with a pointer to §2.4 — it records a standing
+  decision this spec does not overturn. Do not "tidy" it away.
 - Derive `availability` per section and gate **both** the render loop (`filter-panel.svelte:753`) and
   the section-toggle icon row (`filter-panel.svelte:727`) on `!== 'unavailable'`.
 - Feed `count = 0` on `'empty'`. The `filterContext ? … : undefined` ladder at
@@ -452,8 +462,10 @@ Mobile has no `isInAlbum` ("has album") equivalent, so only `hasAssetsNotInAlbum
 from §6.3. `manage_sections_sheet.widget.dart` iterates `FilterSectionId.values` and must not offer a
 switch for an unavailable section.
 
-`rating_stars_section.widget.dart` and `media_type_section.widget.dart` get the same available-value
-dimming web already has.
+`rating_stars_section.widget.dart` and `media_type_section.widget.dart` are **not modified**. The
+former's doc comment already cites `feedback_no_dynamic_rating_media_hiding` ("Always renders 5
+stars"); §2.4 keeps that true on both clients. Mobile gates the `rating` and `media` sections as
+wholes, exactly like web, and leaves their contents alone.
 
 ## 8. Test plan
 
@@ -500,12 +512,15 @@ of §4.1, plus:
 - `hasAssetsInAlbum: true, hasAssetsNotInAlbum: false` → `unavailable`, and the mirror
 - timeline and text never `unavailable`, for any input
 
-Separately, `rating-filter.svelte`'s star-level rule (§4.3.1), which is not part of the module:
+Separately, a guard that §2.4's standing decision survives this work — the panel must reach
+`getSectionAvailability` without ever handing the facets to the controls:
 
-- `availableRatings: [2]` → stars 1 and 2 live, stars 3–5 dimmed. **This is the test that fails
-  against today's `!includes(star)` implementation** and is the reason the fix is in scope.
-- `availableRatings: [2, 5]` → stars 1–5 all live (5 is the max, everything below it matches `>=`)
-- `availableRatings: []` → all five dimmed; `availableRatings: undefined` → none dimmed (legacy path)
+- with `ratings: [2]` and the Rating section available, all five stars render and none carries the
+  `opacity-50` dimming class
+- with `mediaTypes: ['IMAGE', 'VIDEO']`, all three media buttons render undimmed
+
+Both fail if a later change re-introduces `availableRatings` / `availableMediaTypes` assignment, which
+is the point: `feedback_no_dynamic_rating_media_hiding` has been re-litigated twice already.
 
 ### 8.3 Web — panel integration
 
@@ -579,7 +594,7 @@ Each row names the test that must fail first, so the slice cannot be started imp
 | 2   | OpenAPI regen — TypeScript SDK + Dart client                                              | none — generated output, covered by slice 1 and 4                                 | build                            |
 | 3   | `filter-availability.ts` + its tests, no wiring                                           | the §4.3 table, driven as data (§8.2)                                             | web unit                         |
 | 4   | Widen `FilterSuggestionsResponse`; six configs/mappers; delete `emptyFilterSuggestions()` | per-surface: a failing facet fetch **rejects** rather than resolving empty (§8.3) | web unit + `check:typescript`    |
-| 5   | Panel wiring: consume facets, `>=` star rule, baseline capture, gating, ledger separation | `availableRatings: [2]` keeps star 1 live (§8.2)                                  | web unit + `check:svelte` + lint |
+| 5   | Panel wiring: capture facets, baseline capture, section gating, ledger separation         | an unavailable section renders neither its body nor its toggle icon (§8.3)        | web unit + `check:svelte` + lint |
 | 6   | e2e seed and assertion updates                                                            | a library with no videos does not render `filter-section-media`                   | e2e web                          |
 | 7   | Mobile: `isNotInAlbum` forwarding, section and toggle gating, manage-sections sheet       | provider forwards `isNotInAlbum` (§8.5)                                           | flutter test, analyze, format    |
 | 8   | Docs                                                                                      | none                                                                              | docs prettier                    |

--- a/docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md
+++ b/docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md
@@ -167,7 +167,7 @@ test suite — a refactor #910 does not justify.
 | camera    | `cameraMakes`                             | `cameraMakes` empty                             |
 | tags      | `tags`                                    | `tags` empty                                    |
 | rating    | `ratings`                                 | `ratings` empty                                 |
-| media     | `mediaTypes`                              | `mediaTypes.length < 2`                         |
+| media     | `mediaTypes`                              | not **both** `IMAGE` and `VIDEO` present        |
 | favorites | `hasFavorites`                            | `hasFavorites` false                            |
 | albums    | `hasAssetsInAlbum`, `hasAssetsNotInAlbum` | either is false                                 |
 | timeline  | `timeBuckets`                             | never — greys when `timeBuckets` empty          |
@@ -175,8 +175,13 @@ test suite — a refactor #910 does not justify.
 
 Notes on the three non-obvious rows:
 
-- **media** uses `< 2`, not "empty". The section offers All / Photos / Videos; with only images
-  present, _Photos_ is identical to _All_ and _Videos_ is empty, so the control cannot discriminate.
+- **media** tests for the two types the control actually offers, not for list length. The section
+  offers All / Photos / Videos; with only images present, _Photos_ is identical to _All_ and _Videos_
+  is empty, so the control cannot discriminate. A length test looks equivalent and is not:
+  `getFilteredMediaTypes` (`search.repository.ts:1737`) returns raw `distinct asset.type`, and
+  `AssetType` is `IMAGE | VIDEO | AUDIO | OTHER` (`enum.ts:38`). A library of photos plus one `OTHER`
+  asset yields `['IMAGE', 'OTHER']` — length 2, but the Videos button is still dead. The rule is
+  `mediaTypes.includes('IMAGE') && mediaTypes.includes('VIDEO')`.
 - **albums** needs both booleans for the same reason. With no albums, _Has album_ → 0 and _Has no
   album_ → everything; with a fully-filed library, the reverse.
 - **favorites** takes one boolean, deliberately asymmetric with albums. "Nothing favourited" is the
@@ -196,7 +201,8 @@ no `hidden` and simply greys).
 
 ### 4.3.1 Section-level only — the facets never reach the controls
 
-`ratings` and `mediaTypes` feed `getSectionAvailability` and nothing else. Per §2.4,
+`ratings` and `mediaTypes` feed `getSectionAvailability` and nothing else — including the
+`IMAGE`/`VIDEO` presence test above, which never reaches the three media buttons. Per §2.4,
 `availableRatings` and `availableMediaTypes` stay unset, so:
 
 - whenever the Rating section renders, all five stars render uniformly;
@@ -204,9 +210,9 @@ no `hidden` and simply greys).
 - `rating-filter.svelte` and `media-type-filter.svelte` are not modified by this work at all.
 
 The section rules remain sound without the controls participating. `ratings: []` means no
-`rating >= N` can match for any N, so the whole section is dead. `mediaTypes.length < 2` means the
-one present type is a synonym for _All_ and the other button is empty, so the control cannot
-discriminate. Both verdicts are about the section, which is exactly what #910 asks about.
+`rating >= N` can match for any N, so the whole section is dead. A `mediaTypes` missing either `IMAGE`
+or `VIDEO` means the present type is a synonym for _All_ and the other button is empty, so the control
+cannot discriminate. Both verdicts are about the section, which is exactly what #910 asks about.
 
 ### 4.4 Three overriding rules
 
@@ -223,11 +229,50 @@ discriminate. Both verdicts are about the section, which is exactly what #910 as
 
 Client-side, cached per panel instance:
 
-- The panel's mount effect (`filter-panel.svelte:100-184`) already fires one request. When
+- The panel's mount effect (`filter-panel.svelte:96-181`) already fires one request. When
   `getActiveFilterCount(filters) === 0`, that response **is** the baseline — captured for free.
 - When the panel mounts with filters already applied (a deep link such as `/photos?rating=5`, or
-  restored space filters), one extra `suggestionsProvider(createFilterState())` call fires alongside.
+  restored space filters), the panel calls a **separate** `config.baselineProvider` once, after the
+  first ordinary response has settled.
 - The baseline is held for the component's lifetime.
+
+#### Why `baselineProvider` and not `suggestionsProvider(createFilterState())`
+
+The obvious implementation — reuse the existing provider with an empty filter state — is wrong on
+the three query-mode surfaces, in two independent ways. Both were found by reading
+`loadPhotoSmartFacets` (`photos/…/+page.svelte:224-274`; `spaces/…:239-247` and
+`recently-added/…:210-247` are the same shape):
+
+1. **The requests abort each other.** Each page keeps a _single_ `smartFacetInFlight` slot and calls
+   `smartFacetInFlight?.controller.abort()` whenever the incoming key differs. A filtered mount would
+   issue the current-filters request and the baseline request concurrently under different keys, so
+   one kills the other. Whichever loses falls into the `.catch`, which returns the stale `smartFacets`
+   — `undefined` on a first load — and after §4.6 that becomes a rejection. The panel then has either
+   no `current` or no `baseline`. It fails safe (nothing is wrongly hidden) but #910 is silently dead
+   on every filtered deep link into query mode.
+2. **The baseline response would clobber the page's own state.** On resolve the page assigns
+   `smartFacets = result; smartFacetKey = key`, and `smartFacets` drives `smartFacetBuckets` (the
+   Timeline section) and `smartFacetTotal` (the result count). An unfiltered baseline response landing
+   in that slot makes the timeline and the count show _unfiltered_ data while filters are applied.
+
+Sequencing the two requests fixes (1) but not (2). The panel cannot fix (2) at all, because the
+coupling lives in the page. So the baseline becomes the surface's own decision:
+
+```ts
+baselineProvider?: () => Promise<FilterSuggestionsResponse | undefined>;
+```
+
+- Returning a response sets the baseline.
+- Returning `undefined` means "this surface has no cheap baseline here" — the panel keeps
+  `baseline === undefined` and therefore never hides anything, which is the same fail-safe as a
+  rejection (§6.1).
+- Omitting the field entirely has the same effect, so a surface can adopt the suggestions path
+  without opting into hiding.
+
+The query-mode branches return `undefined` for exactly this reason: a smart-search result set is a
+deliberately narrow scope where an empty facet means "this query has none", which is what greying
+already communicates. Browse-mode branches call their ordinary loader with `createFilterState()`,
+which touches no cache and no page state.
 
 Rejected: a server-side `scopeFacets` block returned with every response. It adds ~8 `EXISTS`
 subqueries to every suggestions request, including the debounced refetch that fires on each filter
@@ -256,6 +301,11 @@ Even a stale baseline fails safe, which is why no `scopeKey` prop is needed. A c
 only **narrow** the scope, so `facet(query) ⊆ facet(browse)`. Hiding requires _both_ the current and
 the baseline facet to be empty; a baseline from a wider scope can therefore only fail to hide, never
 hide wrongly. The same argument covers the `withSharedSpaces` coupling in §4.6.
+
+Note that the `{#key}` invariant is still load-bearing even though query mode returns no baseline:
+without the remount, a baseline captured in browse mode would survive into query mode. That is the
+benign direction by the subset argument above, but the guard in §8.3 stays because the invariant also
+protects `currentSuggestions`, `visibleSections` hydration and the expanded-section state.
 
 ### 4.6 Degenerate inputs that must not read as "structurally empty"
 
@@ -350,9 +400,21 @@ dimension; the album predicate is an `EXISTS` over `album_asset`, cheap per row.
 
 ### 5.4 Ripple
 
-`make sql` to regenerate `server/src/queries/search.repository.sql` — **requires a running database;
-it deletes every query file otherwise** — then `pnpm build`, `pnpm sync:open-api`, and `make open-api`
-for the TypeScript SDK and the Dart client (Java required).
+Regenerate `server/src/queries/search.repository.sql`, then the spec and both clients. **The commands
+CLAUDE.md documents for this no longer exist** — `make sql`, `make open-api` and `pnpm sync:open-api`
+are removed stubs or absent (verified against `Makefile` and `server/package.json`; see
+`feedback_local_verify_command_traps` §2). The real sequence, from the repo root:
+
+```bash
+cd server && pnpm build          # mise sql and sync-open-api both run out of dist/
+mise sql                         # node ./dist/bin/sync-sql.js — needs a running database
+node server/dist/bin/sync-open-api.js
+mise open-api                    # TypeScript SDK + Dart client (Java required)
+```
+
+`mise sql` still **requires a running database and deletes every file in `server/src/queries/`
+without one**. Use the bare `mise sql` form, never `mise run //:sql`: from a worktree the `//:` prefix
+resolves to the **main** checkout (`reference_mise_run_from_worktree_wrong_dir`).
 
 ## 6. Web
 
@@ -420,7 +482,7 @@ The empty-state hint ("all sections hidden — show all") must count only sectio
 
 ### 6.4 Surfaces
 
-Six config/mapper sites forward the three new fields:
+Six config/mapper sites forward the three new fields **and gain a `baselineProvider`** (§4.5):
 
 - `web/src/lib/utils/map-filter-config.ts`
 - `web/src/lib/utils/album-filter-config.ts` (both builders)
@@ -430,7 +492,10 @@ Six config/mapper sites forward the three new fields:
 - `routes/(user)/spaces/[spaceId]/…/+page.svelte` and `routes/(user)/albums/[albumId=id]/…/+page.svelte`
 
 Widening `FilterSuggestionsResponse` (`filter-panel.ts:80-90`) with three required booleans makes
-`tsc` name every site that has not been updated — the compiler is the checklist.
+`tsc` name every site that has not been updated — the compiler is the checklist. It will **not** name
+the missing `baselineProvider`, which is optional by design (§4.5): a surface that forgets it simply
+never hides. That is safe but silent, so slice 4 enumerates the six sites by hand and slice 5's
+per-surface tests assert the baseline call actually happens.
 
 The same slice removes `emptyFilterSuggestions()` from the three query-mode surfaces in favour of a
 rejection, per §4.6. Note that `tsc` will **not** catch this one: the sentinel is a plain object
@@ -457,6 +522,40 @@ facets therefore ignore the not-in-album toggle today. Slice 7 forwards it; with
 albums facet would be computed against the wrong asset set.
 
 Mobile has no `isInAlbum` ("has album") equivalent, so only `hasAssetsNotInAlbum` is consulted there.
+
+**Mobile has the same empty sentinel web is deleting, and it is the same bug.**
+`filter_suggestions.provider.dart` ends with:
+
+```dart
+return response ?? FilterSuggestionsResponseDto(hasUnnamedPeople: false);
+```
+
+That is §4.6's failure sentinel in Dart. Widening the DTO makes this line stop compiling, and the
+tempting fix — adding `hasFavorites: false, hasAssetsInAlbum: false, hasAssetsNotInAlbum: false` — is
+precisely the bug: a null response would then be indistinguishable from an empty library and would
+hide six sections at once. It becomes a `throw` (slice 7 task 1), so the provider surfaces
+`AsyncValue.error` and the gating falls back to "offer everything".
+
+**Mobile gets a baseline too.** An earlier draft gave mobile the simpler rule "hidden when the facet
+is empty", on the grounds that the active-filter guard covered the transient case. It does not: that
+guard only covers a section's _own_ filter, and the case §4.4 rule 1 exists for is **cross-section**
+narrowing. Select a person with no rated photos and `ratings` empties while `rating` holds no filter,
+so the Rating section would vanish from the sheet — the pop-in/pop-out behaviour §2.1 rejected, and a
+web/mobile divergence §2.3 exists to prevent.
+
+Mobile pays almost nothing for parity, because the baseline is the same family provider under a
+different key:
+
+```dart
+final baselineKey = filter.isEmpty ? filter : SearchFilter.empty();
+final baseline = ref.watch(photosFilterSuggestionsProvider(baselineKey));
+```
+
+`SearchFilter` implements value equality (`search_filter.model.dart:362-402`), so when no filter is
+applied `baselineKey == filter` and Riverpod serves the _same_ cached future — zero extra requests in
+the common case, one `autoDispose`-cached request while filters are on. Mobile therefore takes the
+full three-verdict model, minus the grey rendering: it has no `(0)` treatment, so `empty` and
+`available` both render the section normally and only `unavailable` hides it.
 
 **`hidden_sections.provider.dart`** is mobile's user ledger and takes the identical separation rule
 from §6.3. `manage_sections_sheet.widget.dart` iterates `FilterSectionId.values` and must not offer a
@@ -532,9 +631,12 @@ In `web/src/lib/components/filter-panel/__tests__/`:
   response reports it available — the §6.3 regression guard
 - an unavailable section still appears in the stored `known` array, so PR #926's
   "introduced since the ledger" logic cannot mistake it for a new section on the next load
-- the panel mounts with filters active → a second `suggestionsProvider` call with an empty filter
-  state; mounts clean → exactly one call
-- baseline request rejects → no section is hidden
+- the panel mounts with filters active → exactly one `baselineProvider` call, and **no** second
+  `suggestionsProvider` call; mounts clean → neither fires
+- `baselineProvider` rejects, resolves `undefined`, or is absent → no section is hidden, in all three
+  cases, and with a filter active on a _different_ section so the §4.4 rule-1 guard cannot mask it
+- Timeline renders `(0)`, collapsed and disabled while `timeBuckets` is empty, and re-expands when
+  buckets arrive — the state every query-mode surface passes through before its first facet response
 - **a later `suggestionsProvider` rejection leaves the previous facets and baseline in place** — the
   §4.6 sentinel guard, at panel level
 - `showAllSections` and the empty-state hint count only available sections
@@ -545,7 +647,8 @@ In `web/src/lib/components/filter-panel/__tests__/`:
 At surface level, one test per query-mode page (photos, spaces, recently-added) that a failing
 `searchSmartFacets` makes `suggestionsProvider` **reject** rather than resolve with empty arrays
 (§4.6). These fail against today's `emptyFilterSuggestions()` and are what makes slice 4 TDD rather
-than a refactor.
+than a refactor. Plus, per surface, one test that `baselineProvider` returns `undefined` in query mode
+and a real response in browse mode — the §4.5 guard against re-introducing the cache collision.
 
 A guard for the `{#key}` invariant in §4.5: one test per surface that changing the committed query (or
 album/space id) mounts a fresh panel — asserted by the panel re-issuing its baseline request. Without
@@ -557,18 +660,44 @@ response matches the runtime shape.
 
 ### 8.4 e2e
 
-Both suites click controls that will now be gated:
+**Five suites are affected, not two.** Every suite that asserts a filter section is visible, or clicks
+a control inside one, is now seed-dependent. Enumerated by
+`grep -rln "filter-section-\|media-type-\|rating-star-\|section-toggle-" e2e/src`:
 
-- `photos-filter-panel.e2e-spec.ts` already rates an asset (`:28`) so Rating stays available, but
-  seeds **only images** — the Media section becomes unavailable and the `media-type-image` click at
-  `:78` fails.
-- `spaces-filter-panel.e2e-spec.ts` asserts `filter-section-rating` and `filter-section-media` are
-  visible (`:95-96`) and clicks `rating-star-N` / `media-type-*` ~25 times.
+| Suite                                        | Seeds today               | Breaks                                                                                     |
+| -------------------------------------------- | ------------------------- | ------------------------------------------------------------------------------------------ |
+| `web/photos-filter-panel.e2e-spec.ts`        | 3 plain images, 1 rating  | `:63` asserts 7 sections → **5 fail**; `:78` media click                                   |
+| `web/spaces-filter-panel.e2e-spec.ts`        | 4 plain images            | `:82` asserts 7 sections → **6 fail**; ~25 control clicks                                  |
+| `web/recently-added-filters.e2e-spec.ts`     | images + videos + ratings | `:130` asserts **all ten** → **6 fail**                                                    |
+| `web/map-filter-panel.e2e-spec.ts`           | **nothing at all**        | `:41` favorites, `:46` location                                                            |
+| `rebase-smoke/permission-matrix.e2e-spec.ts` | GPS asset + tag           | `:220` waits for camera unconditionally, but `:237` already guards on `make` being present |
 
-Fix the seed data, not the feature. `recently-added-filters.e2e-spec.ts:102-110` shows the existing
-pattern: `utils.createAsset(token, { assetData: { filename: 'example-0.mp4' } })` — random image bytes
-with an `.mp4` name, typed from the extension. Add a video and, where absent, a rating, a favourite
-and an album membership to each suite's `beforeAll`.
+Fix the seed data, not the feature — with one documented exception below. The seeding recipes, all
+verified against `e2e/test-assets` and `e2e/src/utils.ts`:
+
+| Section   | Seed                                                                                                                                                                        |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| media     | `utils.createAsset(token, { assetData: { filename: 'x.mp4' } })` — random bytes, typed from the extension (`recently-added-filters.e2e-spec.ts:102-110`)                    |
+| rating    | `updateAsset({ id, updateAssetDto: { rating: 5 } }, …)`                                                                                                                     |
+| favorites | `updateAsset({ id, updateAssetDto: { isFavorite: true } }, …)`                                                                                                              |
+| albums    | an album containing **some but not all** seeded assets                                                                                                                      |
+| location  | upload `${testAssetDir}/metadata/gps-position/thompson-springs.jpg`, then `waitForQueueFinish(token, 'metadataExtraction')`                                                 |
+| camera    | upload a fixture that carries an EXIF `Make` — `metadata/rating/mongolels.jpg` or `metadata/tags/picasa.jpg` (both Canon); **`thompson-springs.jpg` has GPS but no `Make`** |
+| tags      | `utils.upsertTags(token, ['x'])` then `utils.tagAssets(token, tagId, [assetId])`                                                                                            |
+| people    | **not seedable** — see below                                                                                                                                                |
+
+**The People carve-out.** A People facet requires a _face_, and face detection needs the ML stack that
+the web e2e project does not run. `utils.createPerson` makes a person row with no face, which
+`getFilteredPeople` (`search.repository.ts:1502`) will not return — `utils.ts:989-991` already
+documents this for the command palette ("a bare API-created person won't surface in search results").
+There is no seed that keeps People available in these suites.
+
+So for `people` only, the assertion changes rather than the seed: the three suites that list `people`
+among "all sections" drop it from the list and instead assert `filter-section-people` is **absent**,
+with a comment naming this paragraph. That is not weakening an assertion to accommodate the feature —
+a library with no detected faces genuinely cannot filter by person, so asserting its absence is
+positive #910 coverage. Any suite that later runs with ML can seed a face chain
+(`feedback_e2e_space_person_face_chain`) and flip the assertion back.
 
 New e2e coverage: a library with no videos does not render `filter-section-media`; favouriting an
 asset makes `filter-section-favorites` appear on reload.
@@ -583,25 +712,36 @@ and `dart format` as separate gates:
   always render
 - availability is never written to `hiddenSectionsProvider`
 - `photosFilterSuggestionsProvider` forwards `isNotInAlbum`
+- a facet emptied by a **cross-section** filter keeps its section rendered, because the baseline still
+  has it — the §7 parity guard, and the test that fails if the baseline watch is dropped
+- `SearchFilter.empty()` is not re-requested when the current filter is already empty (one provider
+  key, not two)
+- a null API response makes the provider **error** rather than resolve with an all-false DTO, and the
+  sheet then renders every section
 
 ## 9. Slices
 
 Each row names the test that must fail first, so the slice cannot be started implementation-first.
 
-| #   | Slice                                                                                     | First failing test                                                                | Gate                             |
-| --- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------- |
-| 1   | Server facets, DTOs, `SmartFacetExclude`, candidate-query move, `make sql`                | medium: `hasFavorites` on a library with one favourite (§8.1)                     | server unit + medium             |
-| 2   | OpenAPI regen — TypeScript SDK + Dart client                                              | none — generated output, covered by slice 1 and 4                                 | build                            |
-| 3   | `filter-availability.ts` + its tests, no wiring                                           | the §4.3 table, driven as data (§8.2)                                             | web unit                         |
-| 4   | Widen `FilterSuggestionsResponse`; six configs/mappers; delete `emptyFilterSuggestions()` | per-surface: a failing facet fetch **rejects** rather than resolving empty (§8.3) | web unit + `check:typescript`    |
-| 5   | Panel wiring: capture facets, baseline capture, section gating, ledger separation         | an unavailable section renders neither its body nor its toggle icon (§8.3)        | web unit + `check:svelte` + lint |
-| 6   | e2e seed and assertion updates                                                            | a library with no videos does not render `filter-section-media`                   | e2e web                          |
-| 7   | Mobile: `isNotInAlbum` forwarding, section and toggle gating, manage-sections sheet       | provider forwards `isNotInAlbum` (§8.5)                                           | flutter test, analyze, format    |
-| 8   | Docs                                                                                      | none                                                                              | docs prettier                    |
+| #   | Slice                                                                                                         | First failing test                                                                | Gate                             |
+| --- | ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | -------------------------------- |
+| 1   | Server facets, DTOs, `SmartFacetExclude`, candidate-query move, `mise sql`                                    | medium: `hasFavorites` on a library with one favourite (§8.1)                     | server unit + medium             |
+| 2   | OpenAPI regen — TypeScript SDK + Dart client                                                                  | none — generated output, covered by slice 1 and 4                                 | build                            |
+| 3   | `filter-availability.ts` + its tests, no wiring                                                               | the §4.3 table, driven as data (§8.2)                                             | web unit                         |
+| 4   | Widen `FilterSuggestionsResponse`; six configs/mappers; `baselineProvider`; delete `emptyFilterSuggestions()` | per-surface: a failing facet fetch **rejects** rather than resolving empty (§8.3) | web unit + `check:typescript`    |
+| 5   | Panel wiring: capture facets, baseline capture, section gating, ledger separation                             | an unavailable section renders neither its body nor its toggle icon (§8.3)        | web unit + `check:svelte` + lint |
+| 6   | e2e seed and assertion updates                                                                                | a library with no videos does not render `filter-section-media`                   | e2e web                          |
+| 7   | Mobile: `isNotInAlbum` forwarding, section and toggle gating, manage-sections sheet                           | provider forwards `isNotInAlbum` (§8.5)                                           | flutter test, analyze, format    |
+| 8   | Docs                                                                                                          | none                                                                              | docs prettier                    |
 
 Slice 4 precedes slice 5 because widening the response type breaks every config until they are
 updated; `tsc` then enumerates the work. It also carries the §4.6 sentinel removal, which slice 5's
 gating depends on for safety — slice 5 must not land without it.
+
+**The slice order is strict, including 2 before 3.** Slice 3 knowingly leaves `check:typescript` red
+until slice 4 repairs it, and slice 2's gate asserts that a clean `check:typescript` proves the
+generated SDK is well-formed. Running 3 first invalidates that gate. Slice 3's "depends on: nothing at
+runtime" refers to its imports, not to its position.
 
 ## 10. Sequencing and risks
 
@@ -615,8 +755,21 @@ GPS, no tags, no albums and no favourites will show Timeline, People (unnamed hi
 only. This is the intended behaviour per §2.2 — the hidden sections genuinely cannot filter anything —
 but it is a visible change for new users and should be called out in the PR description.
 
-**Risk: one extra request on filtered mount.** Deep links carrying filters pay one additional
-suggestions request. Measured against the alternative in §4.5, this is the cheaper side.
+**Risk: one extra request on filtered mount.** Browse-mode deep links carrying filters pay one
+additional suggestions request. Query mode pays none (§4.5 returns no baseline there). Measured
+against the server-side alternative in §4.5, this is the cheaper side.
+
+**Risk: Timeline greys during smart-search loading.** `timeBuckets` is `[]` until the first facet
+response lands, so on query-mode surfaces the Timeline section renders `(0)`, collapsed and disabled
+for the duration of every committed query. `filter-section.svelte:21` derives `isOpen` rather than
+storing it, so it re-expands on its own — but it is a visible flicker on the hot path that did not
+exist before, because the suggestions path previously passed no count for `timeline` at all. Called
+out in the PR description; §8.3 locks the re-expansion.
+
+**Risk: the e2e People carve-out is permanent until ML runs in e2e.** §8.4 replaces three
+"all sections are visible" assertions with "People is absent". If the web e2e project ever gains face
+detection, those assertions become wrong in the other direction and will fail loudly, which is the
+intended outcome.
 
 **Non-goal: the Text section.** Description, filename and OCR are free text with no enumerable
 domain. Gating them would need `hasDescription` / `hasOcrText` probes over columns not indexed for

--- a/docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md
+++ b/docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md
@@ -1,0 +1,489 @@
+# Do not offer unusable filters — interdependent filter sections (#910)
+
+- **Issue:** [#910](https://github.com/open-noodle/gallery/issues/910) — "Do not offer unusable/unnecessary filters"
+- **Reported on:** Gallery 5.2.2
+- **Branch:** `fix/910-interdependent-filter-sections`
+- **Status:** ready for `/impl-loop`
+
+---
+
+## 1. Goal
+
+A filter section must not be offered when using it cannot change what the user sees. The reporter's
+words:
+
+> The filters on the left side are always displayed, even though filtering would lead into zero
+> results. [...] do not offer filtering and hide the complete section:
+>
+> - for media types if there isn't at least one photo of each type
+> - for favorites if there are no photos favorized
+> - for rating if there are no photos with a rating
+> - ... and so on
+
+After this change, every filter section on web and mobile derives its own usability from the same
+faceted data the panel already fetches, and either hides or greys itself out accordingly.
+
+## 2. Decisions taken
+
+Four product decisions were settled before design. They are recorded here because two of them
+**reverse decisions previously made deliberately in code**, and a future reader needs the reason.
+
+### 2.1 Hide structural, grey transient
+
+A section that is empty **for the whole scope regardless of filters** is hidden outright. A section
+that is empty **only because of the filters the user currently has applied** keeps today's treatment:
+50% opacity, a `(0)` suffix, collapsed and disabled (`filter-section.svelte:21-36`).
+
+Rejected: hiding in both cases (sections would pop in and out on every filter change, and the
+section-toggle row would shift under the cursor); greying in both cases (does not do what the issue
+asks — the unusable section is still listed).
+
+### 2.2 All eight enumerable sections, not just the four always-on ones
+
+Rating, Media, Favorites and Albums are the sections named in the issue, but People, Location, Camera
+and Tags are equally unusable on a library with no faces, no GPS, no EXIF or no tags. All eight take
+the rule. Timeline and Text are exempt (§4.3).
+
+### 2.3 Web **and** mobile
+
+Mobile's filter sheet consumes the same `/search/filter-suggestions` endpoint
+(`mobile/lib/providers/photos_filter/filter_suggestions.provider.dart`) and has the same
+always-visible sections. Both clients change in this spec so they cannot drift.
+
+### 2.4 What this reverses
+
+**`filter-panel.svelte:160-164`** — the client currently discards the `ratings` and `mediaTypes` the
+server already sends:
+
+> Note: availableRatings and availableMediaTypes are intentionally NOT set from suggestionsProvider.
+> Hiding rating stars and media type buttons based on the current result set is too aggressive — it
+> breaks existing E2E tests and confuses users who expect these fixed options to always be visible.
+
+Two claims, handled separately. "Breaks existing E2E tests" was true and is still true — §8.4 fixes
+the seed data rather than the feature. "Confuses users who expect these fixed options to always be
+visible" is the claim #910 contradicts: the reporter is confused by the _opposite_. The comment is
+deleted, and this section is the replacement record.
+
+**The #858 §3.3 carve-out** (`filter-panel.svelte:92`) excludes `country`, `city`, `make`, `model`
+and `mediaType` from `filterContext` so that a section-local filter cannot grey out its own section.
+It stops applying on every production surface — see §4.2 — while remaining in force on the legacy
+path it was written for.
+
+## 3. Current state
+
+The interdependency machinery exists and is half-wired. `getFilterSuggestions`
+(`search.repository.ts:1254-1273`) already computes every facet **with that facet's own filter
+excluded**:
+
+```ts
+const [countries, cameraMakes, tags, peopleResult, ratings, mediaTypes] = await Promise.all([
+  this.getFilteredCountries(userIds, without(options, 'country', 'city')),
+  this.getFilteredCameraMakes(userIds, without(options, 'make', 'model')),
+  this.getFilteredTags(userIds, without(options, 'tagIds')),
+  this.getFilteredPeople(userIds, without(options, 'personIds', 'identityIds')),
+  this.getFilteredRatings(userIds, without(options, 'rating')),
+  this.getFilteredMediaTypes(userIds, without(options, 'mediaType')),
+]);
+```
+
+| Section   | Narrowed by the other filters?                         | Disabled when it would yield 0?               |
+| --------- | ------------------------------------------------------ | --------------------------------------------- |
+| timeline  | yes — timeline-manager buckets, or smart-search facets | never                                         |
+| people    | yes                                                    | only while a _cross-section_ filter is active |
+| location  | yes                                                    | only while a _cross-section_ filter is active |
+| camera    | yes                                                    | only while a _cross-section_ filter is active |
+| tags      | yes                                                    | only while a _cross-section_ filter is active |
+| rating    | **no** — server sends `ratings`, client discards it    | never                                         |
+| media     | **no** — server sends `mediaTypes`, client discards it | never                                         |
+| favorites | **no** — no facet exists                               | never                                         |
+| albums    | **no** — no facet exists                               | never                                         |
+| text      | n/a — free text, no enumerable domain                  | never                                         |
+
+Two gaps, then: four sections whose facet is computed but ignored or missing, and a disable gate
+(`filter-panel.svelte:761-771`) that only fires when `filterContext` is truthy — so a library with
+zero tags shows a fully-enabled, permanently empty Tags section.
+
+## 4. The availability model
+
+### 4.1 One signal, two verdicts
+
+Each section resolves against its own facet under two filter states:
+
+| Facet under **current** filters | Facet under **no** filters (baseline) | Verdict                                                  |
+| ------------------------------- | ------------------------------------- | -------------------------------------------------------- |
+| non-empty                       | —                                     | `available` — render normally                            |
+| empty                           | non-empty                             | `empty` — `(0)`, collapsed, disabled (today's grey)      |
+| empty                           | empty                                 | `unavailable` — section and its toggle icon not rendered |
+
+### 4.2 Two panel paths, and what happens to the #858 carve-out
+
+`FilterPanel` has two data paths. The **suggestions path** (`config.suggestionsProvider` set) fetches
+one faceted response per filter change. The **legacy providers path** (`config.providers` only) fires
+per-dimension fetches and has no `ratings` / `mediaTypes` / favourites / albums data at all.
+
+**Every production surface sets `suggestionsProvider`** — verified across all six mount sites in §6.4.
+The legacy path survives only as the fallback that the panel's own unit tests exercise.
+
+Availability therefore applies **on the suggestions path only**. On the legacy path the panel keeps
+today's behaviour byte for byte, including `filterContext` and the #858 §3.3 carve-out, and including
+the test that locks it (`filter-panel.spec.ts:403`, which must stay green untouched).
+
+On the suggestions path the carve-out is moot rather than removed. It exists because `filterContext`
+was a proxy for "did something narrow the panel?", so a section-local filter — a selected camera make
+— would have made Camera grey itself out. That is structurally impossible under the new gate: each
+verdict reads the facet the **server already computed with that section's own filter excluded**, so
+selecting a make cannot empty the makes facet. The gate becomes facet length directly.
+
+`filterContext` (`filter-panel.svelte:92`) is **not** deleted: `filter-panel.svelte:761` is its only
+consumer, and that consumer still exists for the legacy path. Removing the legacy path altogether
+would mean deleting four mount effects, the temporal re-fetch effect and a large share of the panel's
+test suite — a refactor #910 does not justify.
+
+### 4.3 Per-section rules
+
+| Section   | Facet consulted                           | `unavailable` when                              |
+| --------- | ----------------------------------------- | ----------------------------------------------- |
+| people    | `people`, `hasUnnamedPeople`              | `people` empty **and** `hasUnnamedPeople` false |
+| location  | `countries`                               | `countries` empty                               |
+| camera    | `cameraMakes`                             | `cameraMakes` empty                             |
+| tags      | `tags`                                    | `tags` empty                                    |
+| rating    | `ratings`                                 | `ratings` empty                                 |
+| media     | `mediaTypes`                              | `mediaTypes.length < 2`                         |
+| favorites | `hasFavorites`                            | `hasFavorites` false                            |
+| albums    | `hasAssetsInAlbum`, `hasAssetsNotInAlbum` | either is false                                 |
+| timeline  | `timeBuckets`                             | never — greys when `timeBuckets` empty          |
+| text      | none                                      | never                                           |
+
+Notes on the three non-obvious rows:
+
+- **media** uses `< 2`, not "empty". The section offers All / Photos / Videos; with only images
+  present, _Photos_ is identical to _All_ and _Videos_ is empty, so the control cannot discriminate.
+- **albums** needs both booleans for the same reason. With no albums, _Has album_ → 0 and _Has no
+  album_ → everything; with a fully-filed library, the reverse.
+- **favorites** takes one boolean, deliberately asymmetric with albums. "Nothing favourited" is the
+  common state worth detecting. "Everything favourited" is not a state real libraries reach, and
+  hiding the section for it would be more surprising than the degenerate control.
+
+**people** keeps the carve-out because `PeopleFilter`'s empty state renders
+`$t('filter_name_people_hint')` when `hasUnnamedPeople` is true (`filter-panel.svelte:790`) — the
+discoverability path to making the filter useful at all. Hiding the section would remove the only
+prompt to name a face.
+
+**timeline** never hides: the panel is already suppressed wholesale via its `hidden` prop when the
+scope has no assets, so a structurally empty Timeline means an empty page, not a useless section.
+
+### 4.4 Three overriding rules
+
+1. **A section with an active filter is never `unavailable` and never `empty`.** Cross-section
+   narrowing can empty a facet whose own filter is set — person X plus rating 5, where X has no rated
+   photos, empties the ratings facet while `rating: 5` is applied. Greying Rating there would trap the
+   user with a filter they cannot reach to clear. `hasActiveFilter(section)`
+   (`filter-panel.svelte:621-659`) already exists and is the guard.
+2. **Availability is never persisted.** §5.3.
+3. **A section absent from `config.sections` is untouched** — album detail's documented omission of
+   `albums` (`filter-section-parity.spec.ts`) is unrelated and stays.
+
+### 4.5 Where the baseline comes from
+
+Client-side, cached per panel instance:
+
+- The panel's mount effect (`filter-panel.svelte:100-184`) already fires one request. When
+  `getActiveFilterCount(filters) === 0`, that response **is** the baseline — captured for free.
+- When the panel mounts with filters already applied (a deep link such as `/photos?rating=5`, or
+  restored space filters), one extra `suggestionsProvider(createFilterState())` call fires alongside.
+- The baseline is held for the component's lifetime. Scope changes — a different album, a different
+  space — remount the panel, so component lifetime **is** the cache scope. No invalidation logic.
+
+Rejected: a server-side `scopeFacets` block returned with every response. It adds ~8 `EXISTS`
+subqueries to every suggestions request, including the debounced refetch that fires on each filter
+tweak, to answer a question whose answer changes when the library changes. The expensive path is the
+one that repeats.
+
+## 5. Server
+
+### 5.1 New facets
+
+Three booleans on both `FilterSuggestionsResponseSchema` (`search.dto.ts:248`) and
+`SmartSearchFacetsResponseSchema` (`search.dto.ts:260`), and on the matching
+`FilterSuggestionsResult` / `SmartSearchFacetsResult` interfaces:
+
+```ts
+hasFavorites: boolean; // ignores isFavorite
+hasAssetsInAlbum: boolean; // ─ both ignore isInAlbum / isNotInAlbum
+hasAssetsNotInAlbum: boolean; // ─
+```
+
+### 5.2 Browse path — mechanical
+
+Three more entries in `getFilterSuggestions`' `Promise.all`, reusing `buildFilteredAssetIds`
+(`search.repository.ts:1385-1457`):
+
+```ts
+this.getFilteredHasFavorites(userIds, without(options, 'isFavorite')),
+this.getFilteredAlbumMembership(userIds, without(options, 'isInAlbum', 'isNotInAlbum')),
+```
+
+Each probe is shaped `select exists(select 1 from asset where id in (<filteredIds>) and <predicate>)`
+so Postgres short-circuits on the first matching row instead of aggregating the filtered set.
+`getFilteredAlbumMembership` issues two such probes and returns both booleans.
+
+`@GenerateSqlQueries`' `sortQueries` list (`search.repository.ts:1245-1252`) gains the new prefixes.
+
+**No album-scope special case.** Inside album detail the probes naturally return
+`hasAssetsInAlbum: true, hasAssetsNotInAlbum: false`, hiding the section by the ordinary rule — the
+same outcome `asset.repository.ts`'s `&& !options.albumId` guards already produce, reached without a
+branch.
+
+### 5.3 Smart-search path — one structural change
+
+Smart-search facets read a per-transaction temp table, `smart_search_facet_candidates`
+(`search.repository.ts:628-637`). Only predicates applied **outside** that table, in
+`buildSmartFacetFilteredAssetIds` (`search.repository.ts:639-709`), can be excluded per-facet.
+
+- `isFavorite` is already in the candidate query's `without(...)` list
+  (`search.repository.ts:597-616`) and re-applied at `search.repository.ts:666` — but
+  **unconditionally**, with no `exclude` guard. Adding `exclude !== 'favorites'` is a one-line change
+  and also corrects a latent asymmetry: every other dimension there is guarded.
+- `isInAlbum` / `isNotInAlbum` are **not** in that list, so they bake into the temp table and cannot
+  be excluded. They move into `without(...)` and get re-applied in `buildSmartFacetFilteredAssetIds`
+  behind `exclude !== 'albums'`, mirroring exactly how favourites already works.
+
+`SmartFacetExclude` (`search.repository.ts:187-188`) gains `'favorites' | 'albums'`.
+
+**Cost.** The candidate table is no longer pruned by album membership, so each facet query filters it
+instead. This is the same trade already accepted for favourites and for every other excludable
+dimension; the album predicate is an `EXISTS` over `album_asset`, cheap per row.
+
+### 5.4 Ripple
+
+`make sql` to regenerate `server/src/queries/search.repository.sql` — **requires a running database;
+it deletes every query file otherwise** — then `pnpm build`, `pnpm sync:open-api`, and `make open-api`
+for the TypeScript SDK and the Dart client (Java required).
+
+## 6. Web
+
+### 6.1 A pure rule module
+
+New `web/src/lib/components/filter-panel/filter-availability.ts`:
+
+```ts
+export type SectionAvailability = 'available' | 'empty' | 'unavailable';
+
+export interface AvailabilityInput {
+  current: FilterSuggestionsResponse;
+  baseline: FilterSuggestionsResponse | undefined;
+  hasActiveFilter: boolean;
+  timeBucketCount: number;
+}
+
+export function getSectionAvailability(section: FilterSection, input: AvailabilityInput): SectionAvailability;
+```
+
+No component, no DOM, no fetch. The whole of §4.3 and §4.4 is data in, verdict out — which is what
+makes the TDD loop in §8.2 cheap and exhaustive. `baseline === undefined` (still in flight, or the
+extra request failed) resolves to `available` or `empty`, never `unavailable`: a section is never
+hidden on missing information.
+
+The module is only consulted on the suggestions path (§4.2). The legacy path never captures a
+baseline and never calls it.
+
+### 6.2 Panel wiring
+
+`filter-panel.svelte`:
+
+- Delete the `filter-panel.svelte:160-164` discard; assign `availableRatings = result.ratings` and
+  `availableMediaTypes = result.mediaTypes`. Both props already exist and are already consumed
+  (`rating-filter.svelte:27`, `media-type-filter.svelte:18-24`) — nothing downstream changes.
+- Capture `baseline` per §4.5.
+- Derive `availability` per section and gate **both** the render loop (`filter-panel.svelte:753`) and
+  the section-toggle icon row (`filter-panel.svelte:727`) on `!== 'unavailable'`.
+- Feed `count = 0` on `'empty'`. The `filterContext ? … : undefined` ladder at
+  `filter-panel.svelte:761-771` stays as the legacy-path branch:
+
+  ```
+  count = config.suggestionsProvider
+    ? (availability(section) === 'empty' ? 0 : undefined)
+    : <existing filterContext ladder, unchanged>
+  ```
+
+`filter-section.svelte` is unchanged — it already renders `(0)`, collapses and disables on
+`count === 0`.
+
+### 6.3 Availability is not user-hiding
+
+`visibleSections` is a persisted per-browser ledger, `{ selected, known }` in `localStorage`.
+Availability is derived state and **must never be written to it**. If it were, a section that goes
+unavailable would be recorded as deliberately hidden and would not come back when the library gains
+its first video. Two independent gates, ANDed at render:
+
+```
+rendered = visibleSections.has(section) && availability(section) !== 'unavailable'
+```
+
+The empty-state hint ("all sections hidden — show all") must count only sections that are
+**available**, or a user whose available sections are all hidden gets no hint.
+
+### 6.4 Surfaces
+
+Six config/mapper sites forward the three new fields:
+
+- `web/src/lib/utils/map-filter-config.ts`
+- `web/src/lib/utils/album-filter-config.ts` (both builders)
+- `web/src/lib/utils/recently-added-filter-config.ts`
+- `web/src/lib/utils/space-search.ts` (`mapSmartSearchFacetsToFilterSuggestions`)
+- `routes/(user)/photos/[[assetId=id]]/+page.svelte` — including `emptyFilterSuggestions()`
+- `routes/(user)/spaces/[spaceId]/…/+page.svelte` and `routes/(user)/albums/[albumId=id]/…/+page.svelte`
+
+Widening `FilterSuggestionsResponse` (`filter-panel.ts:80-90`) with three required booleans makes
+`tsc` name every site that has not been updated — the compiler is the checklist.
+
+## 7. Mobile
+
+Mobile's taxonomy differs, so the same rules land at a different granularity. Its sections
+(`filter_section_id.dart`) are `people, places, tags, camera, when, rating, media, toggles` — no
+`text`, and no standalone `favorites` or `albums`.
+
+**Six sections take the section-level rule:** `people` (with the unnamed carve-out), `places`, `tags`,
+`camera`, `rating`, `media`. `when` never hides, matching web's Timeline.
+
+**`toggles` is gated per switch, not per section.** `toggles_section.widget.dart` renders four
+independent switches — favourites, archived, not-in-album, untagged. Favourites gates on
+`hasFavorites`; not-in-album gates on `hasAssetsNotInAlbum`. Archived and untagged have no facet and
+stay on, so the section itself never hides.
+
+**A prerequisite gap.** `filter_suggestions.provider.dart` forwards `isFavorite` but **not**
+`isNotInAlbum`, although `SearchDisplayFilters` carries it (`search_filter.model.dart:182`). The
+facets therefore ignore the not-in-album toggle today. Slice 7 forwards it; without that, the
+albums facet would be computed against the wrong asset set.
+
+Mobile has no `isInAlbum` ("has album") equivalent, so only `hasAssetsNotInAlbum` is consulted there.
+
+**`hidden_sections.provider.dart`** is mobile's user ledger and takes the identical separation rule
+from §6.3. `manage_sections_sheet.widget.dart` iterates `FilterSectionId.values` and must not offer a
+switch for an unavailable section.
+
+`rating_stars_section.widget.dart` and `media_type_section.widget.dart` get the same available-value
+dimming web already has.
+
+## 8. Test plan
+
+TDD throughout: each slice writes the failing test first and records why it failed.
+
+### 8.1 Server
+
+Medium tests in `server/test/medium/specs/repositories/search.repository.spec.ts`, against a real
+database:
+
+| Case                                                    | Asserts                                                                                                           |
+| ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| library with no favourites                              | `hasFavorites` false                                                                                              |
+| library with one favourite                              | `hasFavorites` true                                                                                               |
+| `isFavorite: true` applied                              | `hasFavorites` still true — own filter excluded                                                                   |
+| favourite exists but only outside the active tag filter | `hasFavorites` false — other dimensions honoured                                                                  |
+| no albums                                               | `hasAssetsInAlbum` false, `hasAssetsNotInAlbum` true                                                              |
+| every asset filed                                       | `hasAssetsInAlbum` true, `hasAssetsNotInAlbum` false                                                              |
+| mixed                                                   | both true                                                                                                         |
+| `isNotInAlbum: true` applied                            | both unchanged — own filter excluded                                                                              |
+| `albumId` scope                                         | `hasAssetsInAlbum` true, `hasAssetsNotInAlbum` false                                                              |
+| smart-search path, each of the above                    | same verdicts via `getSmartSearchFacets`                                                                          |
+| smart-search with `isFavorite` set                      | `hasFavorites` unaffected — regression guard for the `exclude !== 'favorites'` fix                                |
+| smart-search with `isNotInAlbum` set                    | other facets (`ratings`, `tags`, …) still reflect it — proves the candidate-query move did not drop the predicate |
+
+Plus unit-level fixture updates in `search.service.spec.ts` and `search.controller.spec.ts`.
+
+### 8.2 Web — the rule module
+
+Exhaustive table-driven tests over `getSectionAvailability`, one case per row of §4.3 × each verdict
+of §4.1, plus:
+
+- every override in §4.4 — active filter beats both `empty` and `unavailable`, for each of the eight
+  sections
+- `baseline === undefined` never yields `unavailable`
+- `mediaTypes: ['IMAGE']` → `unavailable`; `['IMAGE', 'VIDEO']` → `available`
+- `people: [], hasUnnamedPeople: true` → `available`; `hasUnnamedPeople: false` → `unavailable`
+- `hasAssetsInAlbum: true, hasAssetsNotInAlbum: false` → `unavailable`, and the mirror
+- timeline and text never `unavailable`, for any input
+
+### 8.3 Web — panel integration
+
+In `web/src/lib/components/filter-panel/__tests__/`:
+
+- an unavailable section renders neither `filter-section-<id>` nor `section-toggle-<id>`
+- an `empty` section renders `(0)`, is collapsed and is disabled
+- a section that goes unavailable is **not** written to `localStorage`, and reappears when the next
+  response reports it available — the §6.3 regression guard
+- the panel mounts with filters active → a second `suggestionsProvider` call with an empty filter
+  state; mounts clean → exactly one call
+- baseline request rejects → no section is hidden
+- `showAllSections` and the empty-state hint count only available sections
+- a section with an active filter survives an empty facet
+- **the legacy providers path is unaffected** — `filter-panel.spec.ts:403` (`#858 §3.3`) stays green
+  without edits, and no section is ever hidden when `config.suggestionsProvider` is absent
+
+`filter-section-parity.spec.ts` guards `config.sections` parity, which this change does not touch, so
+it must stay green. Widen its `getFilterSuggestions` mock with the three new fields so the mocked
+response matches the runtime shape.
+
+### 8.4 e2e
+
+Both suites click controls that will now be gated:
+
+- `photos-filter-panel.e2e-spec.ts` already rates an asset (`:28`) so Rating stays available, but
+  seeds **only images** — the Media section becomes unavailable and the `media-type-image` click at
+  `:78` fails.
+- `spaces-filter-panel.e2e-spec.ts` asserts `filter-section-rating` and `filter-section-media` are
+  visible (`:95-96`) and clicks `rating-star-N` / `media-type-*` ~25 times.
+
+Fix the seed data, not the feature. `recently-added-filters.e2e-spec.ts:102-110` shows the existing
+pattern: `utils.createAsset(token, { assetData: { filename: 'example-0.mp4' } })` — random image bytes
+with an `.mp4` name, typed from the extension. Add a video and, where absent, a rating, a favourite
+and an album membership to each suite's `beforeAll`.
+
+New e2e coverage: a library with no videos does not render `filter-section-media`; favouriting an
+asset makes `filter-section-favorites` appear on reload.
+
+### 8.5 Mobile
+
+Widget tests under Flutter **3.44.8** (`mobile/mise.toml`), with `dart analyze --fatal-infos lib test`
+and `dart format` as separate gates:
+
+- an unavailable section is absent from the deep sheet and from `manage_sections_sheet`
+- the favourites and not-in-album switches disappear when their facet is false; archived and untagged
+  always render
+- availability is never written to `hiddenSectionsProvider`
+- `photosFilterSuggestionsProvider` forwards `isNotInAlbum`
+
+## 9. Slices
+
+| #   | Slice                                                                               | Gate                             |
+| --- | ----------------------------------------------------------------------------------- | -------------------------------- |
+| 1   | Server facets, DTOs, `SmartFacetExclude`, candidate-query move, `make sql`          | server unit + medium             |
+| 2   | OpenAPI regen — TypeScript SDK + Dart client                                        | build                            |
+| 3   | `filter-availability.ts` + its tests, no wiring                                     | web unit                         |
+| 4   | Widen `FilterSuggestionsResponse`; six surface configs/mappers                      | web unit + `check:typescript`    |
+| 5   | Panel wiring: consume facets, baseline capture, gating, ledger separation           | web unit + `check:svelte` + lint |
+| 6   | e2e seed and assertion updates                                                      | e2e web                          |
+| 7   | Mobile: `isNotInAlbum` forwarding, section and toggle gating, manage-sections sheet | flutter test, analyze, format    |
+| 8   | Docs                                                                                | docs prettier                    |
+
+Slice 4 precedes slice 5 because widening the response type breaks every config until they are
+updated; `tsc` then enumerates the work.
+
+## 10. Sequencing and risks
+
+**PR #926 conflicts directly.** It rewrites the `{ selected, known }` ledger in
+`filter-panel.svelte` and `filter-panel.ts` — the same files slice 5 edits heavily, and the same
+concern §6.3 depends on. Branch off #926, or land #926 first. Do not develop the two in parallel on
+`main`.
+
+**Risk: a near-empty panel on a fresh library.** A freshly imported library with no faces named, no
+GPS, no tags, no albums and no favourites will show Timeline, People (unnamed hint), Media and Text
+only. This is the intended behaviour per §2.2 — the hidden sections genuinely cannot filter anything —
+but it is a visible change for new users and should be called out in the PR description.
+
+**Risk: one extra request on filtered mount.** Deep links carrying filters pay one additional
+suggestions request. Measured against the alternative in §4.5, this is the cheaper side.
+
+**Non-goal: the Text section.** Description, filename and OCR are free text with no enumerable
+domain. Gating them would need `hasDescription` / `hasOcrText` probes over columns not indexed for
+it, on the hot suggestions path. Out of scope; if it is ever wanted it belongs in its own issue.

--- a/docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md
+++ b/docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md
@@ -170,8 +170,13 @@ test suite — a refactor #910 does not justify.
 | media     | `mediaTypes`                              | not **both** `IMAGE` and `VIDEO` present        |
 | favorites | `hasFavorites`                            | `hasFavorites` false                            |
 | albums    | `hasAssetsInAlbum`, `hasAssetsNotInAlbum` | either is false                                 |
-| timeline  | `timeBuckets`                             | never — greys when `timeBuckets` empty          |
+| timeline  | `timeBuckets`                             | never — greys when `timeBuckets` empty†         |
 | text      | none                                      | never                                           |
+
+† Not unconditionally: §4.4 rule 1 outranks this row. A Timeline holding an active date filter stays
+`available` even with no buckets, because greying the one control that could clear that filter would
+strand the user. The implementation takes rule 1 first, which is correct — read this row as "timeline
+never becomes `unavailable`, and greys when empty _unless_ rule 1 applies".
 
 Notes on the three non-obvious rows:
 
@@ -684,20 +689,24 @@ verified against `e2e/test-assets` and `e2e/src/utils.ts`:
 | location  | upload `${testAssetDir}/metadata/gps-position/thompson-springs.jpg`, then `waitForQueueFinish(token, 'metadataExtraction')`                                                 |
 | camera    | upload a fixture that carries an EXIF `Make` — `metadata/rating/mongolels.jpg` or `metadata/tags/picasa.jpg` (both Canon); **`thompson-springs.jpg` has GPS but no `Make`** |
 | tags      | `utils.upsertTags(token, ['x'])` then `utils.tagAssets(token, tagId, [assetId])`                                                                                            |
-| people    | **not seedable** — see below                                                                                                                                                |
+| people    | `utils.createPerson` + `utils.createFace({ assetId, personId })` (global), or `utils.createSpacePerson(...)` (space-scoped)                                                 |
 
-**The People carve-out.** A People facet requires a _face_, and face detection needs the ML stack that
-the web e2e project does not run. `utils.createPerson` makes a person row with no face, which
-`getFilteredPeople` (`search.repository.ts:1502`) will not return — `utils.ts:989-991` already
-documents this for the command palette ("a bare API-created person won't surface in search results").
-There is no seed that keeps People available in these suites.
+**People is seedable too — an earlier draft of this spec said otherwise and was wrong.** That draft
+reasoned from `utils.createPerson`, which creates a person row with no face and therefore never
+reaches `getFilteredPeople`, and concluded that a People facet needs the ML stack the web e2e project
+does not run. It then sanctioned changing People assertions to assert **absence**.
 
-So for `people` only, the assertion changes rather than the seed: the three suites that list `people`
-among "all sections" drop it from the list and instead assert `filter-section-people` is **absent**,
-with a comment naming this paragraph. That is not weakening an assertion to accommodate the feature —
-a library with no detected faces genuinely cannot filter by person, so asserting its absence is
-positive #910 coverage. Any suite that later runs with ML can seed a face chain
-(`feedback_e2e_space_person_face_chain`) and flip the assertion back.
+That was a mistake. `utils.createFace({ assetId, personId })` (`e2e/src/utils.ts:490`) inserts the
+face row directly in SQL with no ML involved, and more than twenty specs already use it;
+`utils.createSpacePerson` (`:573`) does the same for space-scoped people. So People takes the ordinary
+rule — fix the seed, never the assertion — exactly like every other section, and the suites assert
+`filter-section-people` is **visible**.
+
+One trap that made this look impossible, now fixed in the helpers themselves: `asset_face.sourceType`
+defaults to `machine-learning`, and on any stack with facial recognition enabled `handleDetectFaces`
+treats such a face as a prior detection, re-runs detection, finds no real face in a synthetic fixture,
+and deletes it — so a manually seeded face vanished seconds after creation. Both helpers now insert
+`sourceType: 'manual'`, which is also what the app's own manual-face endpoint writes.
 
 New e2e coverage: a library with no videos does not render `filter-section-media`; favouriting an
 asset makes `filter-section-favorites` appear on reload.
@@ -766,10 +775,9 @@ storing it, so it re-expands on its own — but it is a visible flicker on the h
 exist before, because the suggestions path previously passed no count for `timeline` at all. Called
 out in the PR description; §8.3 locks the re-expansion.
 
-**Risk: the e2e People carve-out is permanent until ML runs in e2e.** §8.4 replaces three
-"all sections are visible" assertions with "People is absent". If the web e2e project ever gains face
-detection, those assertions become wrong in the other direction and will fail loudly, which is the
-intended outcome.
+**Retired risk: the e2e People carve-out.** An earlier draft listed a standing risk here on the premise
+that People could not be seeded without ML. It can (§8.4), the carve-out was removed, and the suites
+assert People is visible like every other section. Nothing is outstanding.
 
 **Non-goal: the Text section.** Description, filename and OCR are free text with no enumerable
 domain. Gating them would need `hasDescription` / `hasOcrText` probes over columns not indexed for

--- a/e2e/src/specs/rebase-smoke/permission-matrix.e2e-spec.ts
+++ b/e2e/src/specs/rebase-smoke/permission-matrix.e2e-spec.ts
@@ -216,7 +216,11 @@ test.describe('Rebase Smoke — UI Permission Matrix', () => {
 
     // FilterPanel is open by default on /photos. Wait for all 3 sections to mount.
     await page.locator('[data-testid="filter-section-location"]').waitFor({ timeout: 10_000 });
-    await page.locator('[data-testid="filter-section-camera"]').waitFor({ timeout: 10_000 });
+    // #910: an asset with no EXIF make gives an empty camera facet, so the section is not rendered.
+    // The assertion below is already guarded on `make`; the wait has to be too.
+    if (fullAsset.exifInfo?.make) {
+      await page.locator('[data-testid="filter-section-camera"]').waitFor({ timeout: 10_000 });
+    }
     await page.locator('[data-testid="filter-section-tags"]').waitFor({ timeout: 10_000 });
 
     // Tags: the owner's "rebase-smoke" tag must appear.

--- a/e2e/src/specs/web/map-filter-panel.e2e-spec.ts
+++ b/e2e/src/specs/web/map-filter-panel.e2e-spec.ts
@@ -1,6 +1,31 @@
 import type { LoginResponseDto } from '@immich/sdk';
+import { updateAsset } from '@immich/sdk';
 import { expect, test } from '@playwright/test';
-import { utils } from 'src/utils';
+import { readFileSync } from 'node:fs';
+import { asBearerAuth, testAssetDir, utils } from 'src/utils';
+
+test.describe('Map FilterPanel — empty library (#910)', () => {
+  let admin: LoginResponseDto;
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+  });
+
+  test('hides every gated section on an empty library, keeping timeline and text', async ({ context, page }) => {
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('/map');
+    await page.waitForSelector('[data-testid="discovery-panel"], [data-testid="filter-toggle-btn"]');
+
+    await expect(page.getByTestId('filter-section-timeline')).toBeVisible();
+    await expect(page.getByTestId('filter-section-text')).toBeVisible();
+
+    for (const section of ['people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites', 'albums']) {
+      await expect(page.getByTestId(`filter-section-${section}`)).toHaveCount(0);
+    }
+  });
+});
 
 test.describe('Map FilterPanel', () => {
   let admin: LoginResponseDto;
@@ -9,6 +34,22 @@ test.describe('Map FilterPanel', () => {
     utils.initSdk();
     await utils.resetDatabase();
     admin = await utils.adminSetup();
+
+    // #910: favorites and location need real data or their sections hide — this suite seeded
+    // nothing before, so both were unreachable. See slice 6's recipe table.
+    const favoriteAsset = await utils.createAsset(admin.accessToken);
+    await updateAsset(
+      { id: favoriteAsset.id, updateAssetDto: { isFavorite: true } },
+      { headers: asBearerAuth(admin.accessToken) },
+    );
+
+    await utils.createAsset(admin.accessToken, {
+      assetData: {
+        bytes: readFileSync(`${testAssetDir}/metadata/gps-position/thompson-springs.jpg`),
+        filename: 'gps.jpg',
+      },
+    });
+    await utils.waitForQueueFinish(admin.accessToken, 'metadataExtraction');
   });
 
   async function gotoMap(context: import('@playwright/test').BrowserContext, page: import('@playwright/test').Page) {

--- a/e2e/src/specs/web/photos-filter-panel.e2e-spec.ts
+++ b/e2e/src/specs/web/photos-filter-panel.e2e-spec.ts
@@ -59,6 +59,12 @@ test.describe('Photos FilterPanel', () => {
 
     // Albums needs BOTH sides — some filed, some not.
     await utils.createAlbum(admin.accessToken, { albumName: '#910 album', assetIds: [video.id] });
+
+    // People: createFace inserts asset_face + face_identity + face_identity_face directly, so it
+    // needs no ML — getFilteredPeople's global-scope query only requires a named, non-hidden person
+    // with a face on an asset in scope. See e2e/src/utils.ts:490.
+    const person = await utils.createPerson(admin.accessToken, { name: '#910 Person' });
+    await utils.createFace({ assetId: asset1.id, personId: person.id });
   });
 
   async function gotoPhotos(context: import('@playwright/test').BrowserContext, page: import('@playwright/test').Page) {
@@ -94,17 +100,25 @@ test.describe('Photos FilterPanel', () => {
   test('should show every filter section its library can populate', async ({ context, page }) => {
     await gotoPhotos(context, page);
 
-    // Panel starts expanded — all sections should be visible
+    // Panel starts expanded — every section the library populates should be visible. `timeline` and
+    // `text` are always available (filter-availability.ts); the rest each need the seed data added
+    // in beforeAll above.
     await expect(page.locator('[data-testid="discovery-panel"]')).toBeVisible();
 
-    for (const section of ['timeline', 'location', 'camera', 'tags', 'rating', 'media']) {
+    for (const section of [
+      'timeline',
+      'people',
+      'location',
+      'camera',
+      'tags',
+      'rating',
+      'media',
+      'favorites',
+      'albums',
+      'text',
+    ]) {
       await expect(page.locator(`[data-testid="filter-section-${section}"]`)).toBeVisible();
     }
-
-    // #910: People needs a detected face and the web e2e project runs no ML, so this library
-    // genuinely cannot filter by person. Asserting the absence is the coverage, not a concession —
-    // see slice 6 "The People carve-out".
-    await expect(page.locator('[data-testid="filter-section-people"]')).toHaveCount(0);
   });
 
   test('should filter by media type and show result count', async ({ context, page }) => {

--- a/e2e/src/specs/web/photos-filter-panel.e2e-spec.ts
+++ b/e2e/src/specs/web/photos-filter-panel.e2e-spec.ts
@@ -64,7 +64,9 @@ test.describe('Photos FilterPanel', () => {
     // needs no ML — getFilteredPeople's global-scope query only requires a named, non-hidden person
     // with a face on an asset in scope. See e2e/src/utils.ts:490.
     const person = await utils.createPerson(admin.accessToken, { name: '#910 Person' });
-    await utils.createFace({ assetId: asset1.id, personId: person.id });
+    // sourceType: 'manual' — this spec uploads real assets, so detection runs and would delete a
+    // machine-learning-sourced seed (see utils.createFace).
+    await utils.createFace({ assetId: asset1.id, personId: person.id, sourceType: 'manual' });
   });
 
   async function gotoPhotos(context: import('@playwright/test').BrowserContext, page: import('@playwright/test').Page) {

--- a/e2e/src/specs/web/photos-filter-panel.e2e-spec.ts
+++ b/e2e/src/specs/web/photos-filter-panel.e2e-spec.ts
@@ -1,7 +1,8 @@
 import type { LoginResponseDto } from '@immich/sdk';
 import { updateAsset } from '@immich/sdk';
 import { expect, test } from '@playwright/test';
-import { asBearerAuth, utils } from 'src/utils';
+import { readFileSync } from 'node:fs';
+import { asBearerAuth, testAssetDir, utils } from 'src/utils';
 
 test.describe('Photos FilterPanel', () => {
   let admin: LoginResponseDto;
@@ -27,6 +28,37 @@ test.describe('Photos FilterPanel', () => {
 
     // Rate an asset so the rating filter has a visible star
     await updateAsset({ id: asset1.id, updateAssetDto: { rating: 5 } }, { headers: asBearerAuth(admin.accessToken) });
+
+    // #910: each of these keeps one filter section available. Without them the section is correctly
+    // hidden and the assertions below have nothing to act on. See slice 6's recipe table.
+    const video = await utils.createAsset(admin.accessToken, {
+      fileCreatedAt: '2023-06-01T10:00:00.000Z',
+      fileModifiedAt: '2023-06-01T10:00:00.000Z',
+      assetData: { filename: 'example-video.mp4' },
+    });
+    await utils.createAsset(admin.accessToken, {
+      assetData: {
+        bytes: readFileSync(`${testAssetDir}/metadata/gps-position/thompson-springs.jpg`),
+        filename: 'gps.jpg',
+      },
+    });
+    await utils.createAsset(admin.accessToken, {
+      assetData: {
+        bytes: readFileSync(`${testAssetDir}/metadata/rating/mongolels.jpg`),
+        filename: 'canon.jpg',
+      },
+    });
+    await utils.waitForQueueFinish(admin.accessToken, 'metadataExtraction');
+
+    const [tag] = await utils.upsertTags(admin.accessToken, ['e2e-filter-tag']);
+    await utils.tagAssets(admin.accessToken, tag.id, [asset1.id]);
+    await updateAsset(
+      { id: asset1.id, updateAssetDto: { isFavorite: true } },
+      { headers: asBearerAuth(admin.accessToken) },
+    );
+
+    // Albums needs BOTH sides — some filed, some not.
+    await utils.createAlbum(admin.accessToken, { albumName: '#910 album', assetIds: [video.id] });
   });
 
   async function gotoPhotos(context: import('@playwright/test').BrowserContext, page: import('@playwright/test').Page) {
@@ -59,15 +91,20 @@ test.describe('Photos FilterPanel', () => {
     await expect(page.locator('[data-testid="filter-toggle-btn"]')).toBeVisible();
   });
 
-  test('should show all 7 filter sections when expanded', async ({ context, page }) => {
+  test('should show every filter section its library can populate', async ({ context, page }) => {
     await gotoPhotos(context, page);
 
     // Panel starts expanded — all sections should be visible
     await expect(page.locator('[data-testid="discovery-panel"]')).toBeVisible();
 
-    for (const section of ['timeline', 'people', 'location', 'camera', 'tags', 'rating', 'media']) {
+    for (const section of ['timeline', 'location', 'camera', 'tags', 'rating', 'media']) {
       await expect(page.locator(`[data-testid="filter-section-${section}"]`)).toBeVisible();
     }
+
+    // #910: People needs a detected face and the web e2e project runs no ML, so this library
+    // genuinely cannot filter by person. Asserting the absence is the coverage, not a concession —
+    // see slice 6 "The People carve-out".
+    await expect(page.locator('[data-testid="filter-section-people"]')).toHaveCount(0);
   });
 
   test('should filter by media type and show result count', async ({ context, page }) => {
@@ -110,5 +147,65 @@ test.describe('Photos FilterPanel', () => {
 
     // ActiveFiltersBar should disappear, full timeline restored
     await expect(page.locator('[data-testid="active-filters-bar"]')).not.toBeVisible();
+  });
+});
+
+test.describe('Photos FilterPanel — unavailable sections (#910)', () => {
+  let admin: LoginResponseDto;
+  let assetId: string;
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+
+    // Images only, nothing rated, nothing favourited, no albums, no tags, no EXIF.
+    const asset = await utils.createAsset(admin.accessToken, {
+      fileCreatedAt: '2023-08-15T10:00:00.000Z',
+      fileModifiedAt: '2023-08-15T10:00:00.000Z',
+    });
+    assetId = asset.id;
+  });
+
+  test('hides the sections that cannot filter anything', async ({ context, page }) => {
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('/photos');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+    await page.waitForSelector('[data-testid="discovery-panel"]');
+
+    // The positive assertion first: the panel rendered, so the negatives below mean something.
+    await expect(page.locator('[data-testid="filter-section-timeline"]')).toBeVisible();
+    await expect(page.locator('[data-testid="filter-section-text"]')).toBeVisible();
+
+    for (const section of ['media', 'rating', 'favorites', 'albums', 'people', 'location', 'camera', 'tags']) {
+      await expect(page.locator(`[data-testid="filter-section-${section}"]`)).toHaveCount(0);
+      await expect(page.locator(`[data-testid="section-toggle-${section}"]`)).toHaveCount(0);
+    }
+  });
+
+  test('shows the favorites section once something is favourited', async ({ context, page }) => {
+    await updateAsset(
+      { id: assetId, updateAssetDto: { isFavorite: true } },
+      { headers: asBearerAuth(admin.accessToken) },
+    );
+
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('/photos');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+
+    await expect(page.locator('[data-testid="filter-section-favorites"]')).toBeVisible();
+  });
+
+  test('shows the media section once a video exists', async ({ context, page }) => {
+    await utils.createAsset(admin.accessToken, { assetData: { filename: 'late-video.mp4' } });
+
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto('/photos');
+    await page.evaluate(() => localStorage.clear());
+    await page.reload();
+
+    await expect(page.locator('[data-testid="filter-section-media"]')).toBeVisible();
   });
 });

--- a/e2e/src/specs/web/recently-added-filters.e2e-spec.ts
+++ b/e2e/src/specs/web/recently-added-filters.e2e-spec.ts
@@ -153,6 +153,11 @@ test.describe('Recently Added filters', () => {
       albumName: '#910 recently-added album',
       assetIds: [images[4].id],
     });
+
+    // People: createFace inserts asset_face + face_identity + face_identity_face directly, so it
+    // needs no ML — see e2e/src/utils.ts:490. No new asset, so TOTAL stays exact.
+    const person = await utils.createPerson(admin.accessToken, { name: '#910 Person' });
+    await utils.createFace({ assetId: images[0].id, personId: person.id });
   });
 
   async function gotoRecentlyAdded(
@@ -168,12 +173,13 @@ test.describe('Recently Added filters', () => {
     await page.waitForSelector('[data-testid="discovery-panel"], [data-testid="filter-toggle-btn"]');
   }
 
-  test('renders nine metadata filter sections and hides People (#910)', async ({ context, page }) => {
+  test('renders every metadata filter section its library can populate (#910)', async ({ context, page }) => {
     await gotoRecentlyAdded(context, page);
 
     await expect(page.getByTestId('discovery-panel')).toBeVisible();
     for (const section of [
       'timeline',
+      'people',
       'location',
       'camera',
       'tags',
@@ -185,11 +191,6 @@ test.describe('Recently Added filters', () => {
     ]) {
       await expect(page.getByTestId(`filter-section-${section}`)).toBeVisible();
     }
-
-    // #910: People needs a detected face and the web e2e project runs no ML, so this library
-    // genuinely cannot filter by person. Asserting the absence is the coverage, not a concession —
-    // see slice 6 "The People carve-out".
-    await expect(page.getByTestId('filter-section-people')).toHaveCount(0);
   });
 
   // Spec scenario: Filtering by media type updates grid, URL, and count

--- a/e2e/src/specs/web/recently-added-filters.e2e-spec.ts
+++ b/e2e/src/specs/web/recently-added-filters.e2e-spec.ts
@@ -157,7 +157,8 @@ test.describe('Recently Added filters', () => {
     // People: createFace inserts asset_face + face_identity + face_identity_face directly, so it
     // needs no ML — see e2e/src/utils.ts:490. No new asset, so TOTAL stays exact.
     const person = await utils.createPerson(admin.accessToken, { name: '#910 Person' });
-    await utils.createFace({ assetId: images[0].id, personId: person.id });
+    // sourceType: 'manual' — see utils.createFace; detection runs on these uploads.
+    await utils.createFace({ assetId: images[0].id, personId: person.id, sourceType: 'manual' });
   });
 
   async function gotoRecentlyAdded(

--- a/e2e/src/specs/web/recently-added-filters.e2e-spec.ts
+++ b/e2e/src/specs/web/recently-added-filters.e2e-spec.ts
@@ -1,8 +1,9 @@
 import type { LoginResponseDto } from '@immich/sdk';
 import { updateAsset } from '@immich/sdk';
 import { expect, test } from '@playwright/test';
+import { readFileSync } from 'node:fs';
 import { thumbnailUtils } from 'src/ui/specs/timeline/utils';
-import { asBearerAuth, utils } from 'src/utils';
+import { asBearerAuth, testAssetDir, utils } from 'src/utils';
 
 test.describe('Recently Added', () => {
   let admin: LoginResponseDto;
@@ -84,16 +85,42 @@ test.describe('Recently Added filters', () => {
 
     // Seed with *taken* dates deliberately unrelated to upload order, so "ordered by added date"
     // is a meaningful assertion: taken dates run backwards while added order runs forwards.
+    // #910: two of the images carry real EXIF instead of synthetic bytes, so location/camera have
+    // something to populate their facets with — without real data those sections are correctly
+    // hidden. Swapping into the existing loop (not adding new assets) keeps TOTAL accurate for every
+    // header-count assertion below. See slice 6's recipe table.
     const images = [];
     for (let i = 0; i < TOTAL - VIDEOS; i++) {
       const day = String(TOTAL - VIDEOS - i).padStart(2, '0');
-      images.push(
-        await utils.createAsset(admin.accessToken, {
-          fileCreatedAt: `2023-09-${day}T10:00:00.000Z`,
-          fileModifiedAt: `2023-09-${day}T10:00:00.000Z`,
-        }),
-      );
+      const fileCreatedAt = `2023-09-${day}T10:00:00.000Z`;
+      const fileModifiedAt = fileCreatedAt;
+      if (i === 0) {
+        images.push(
+          await utils.createAsset(admin.accessToken, {
+            fileCreatedAt,
+            fileModifiedAt,
+            assetData: {
+              bytes: readFileSync(`${testAssetDir}/metadata/gps-position/thompson-springs.jpg`),
+              filename: 'gps.jpg',
+            },
+          }),
+        );
+      } else if (i === 1) {
+        images.push(
+          await utils.createAsset(admin.accessToken, {
+            fileCreatedAt,
+            fileModifiedAt,
+            assetData: {
+              bytes: readFileSync(`${testAssetDir}/metadata/rating/mongolels.jpg`),
+              filename: 'canon.jpg',
+            },
+          }),
+        );
+      } else {
+        images.push(await utils.createAsset(admin.accessToken, { fileCreatedAt, fileModifiedAt }));
+      }
     }
+    await utils.waitForQueueFinish(admin.accessToken, 'metadataExtraction');
 
     // Videos' taken dates run *opposite* to their upload order, so within the video-filtered set
     // "newest added first" and "newest taken first" disagree. That disagreement is the whole point
@@ -112,6 +139,20 @@ test.describe('Recently Added filters', () => {
     for (const asset of images.slice(0, RATED)) {
       await updateAsset({ id: asset.id, updateAssetDto: { rating: 5 } }, { headers: asBearerAuth(admin.accessToken) });
     }
+
+    // #910: tag/favorite/album metadata on already-seeded assets — no new assets, so TOTAL stays
+    // exact. See slice 6's recipe table.
+    const [tag] = await utils.upsertTags(admin.accessToken, ['e2e-recently-added-tag']);
+    await utils.tagAssets(admin.accessToken, tag.id, [images[2].id]);
+    await updateAsset(
+      { id: images[3].id, updateAssetDto: { isFavorite: true } },
+      { headers: asBearerAuth(admin.accessToken) },
+    );
+    // Albums needs BOTH sides — some filed, some not.
+    await utils.createAlbum(admin.accessToken, {
+      albumName: '#910 recently-added album',
+      assetIds: [images[4].id],
+    });
   });
 
   async function gotoRecentlyAdded(
@@ -127,13 +168,12 @@ test.describe('Recently Added filters', () => {
     await page.waitForSelector('[data-testid="discovery-panel"], [data-testid="filter-toggle-btn"]');
   }
 
-  test('renders all ten metadata filter sections, including text', async ({ context, page }) => {
+  test('renders nine metadata filter sections and hides People (#910)', async ({ context, page }) => {
     await gotoRecentlyAdded(context, page);
 
     await expect(page.getByTestId('discovery-panel')).toBeVisible();
     for (const section of [
       'timeline',
-      'people',
       'location',
       'camera',
       'tags',
@@ -145,6 +185,11 @@ test.describe('Recently Added filters', () => {
     ]) {
       await expect(page.getByTestId(`filter-section-${section}`)).toBeVisible();
     }
+
+    // #910: People needs a detected face and the web e2e project runs no ML, so this library
+    // genuinely cannot filter by person. Asserting the absence is the coverage, not a concession —
+    // see slice 6 "The People carve-out".
+    await expect(page.getByTestId('filter-section-people')).toHaveCount(0);
   });
 
   // Spec scenario: Filtering by media type updates grid, URL, and count

--- a/e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts
+++ b/e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts
@@ -361,7 +361,8 @@ test.describe('Spaces FilterPanel', () => {
       // ever regressed to the global people list, this person would leak into it.
       const outsideAsset = await utils.createAsset(admin.accessToken);
       const outsidePerson = await utils.createPerson(admin.accessToken, { name: 'Outside The Space' });
-      await utils.createFace({ assetId: outsideAsset.id, personId: outsidePerson.id });
+      // sourceType: 'manual' — see utils.createFace; detection runs on these uploads.
+      await utils.createFace({ assetId: outsideAsset.id, personId: outsidePerson.id, sourceType: 'manual' });
 
       await gotoSpace(context, page, space.id);
 

--- a/e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts
+++ b/e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts
@@ -123,7 +123,12 @@ test.describe('Spaces FilterPanel', () => {
     // Albums needs BOTH sides — some filed, some not.
     await utils.createAlbum(admin.accessToken, { albumName: `#910 space album ${space.id}`, assetIds: [video.id] });
 
-    return { space, assets: [asset1, asset2, asset3, asset4] };
+    // People is space-scoped (buildFilteredSpacePeopleQuery), so a global createPerson+createFace
+    // would not surface here — utils.createSpacePerson builds the shared_space_person +
+    // shared_space_person_face chain directly. See e2e/src/utils.ts:573.
+    const person = await utils.createSpacePerson(space.id, '#910 Space Person', admin.userId, asset1.id);
+
+    return { space, assets: [asset1, asset2, asset3, asset4], person };
   }
 
   // ────────────────────────────────────────────────────────────────────────────
@@ -137,18 +142,22 @@ test.describe('Spaces FilterPanel', () => {
       const panel = page.locator('[data-testid="discovery-panel"]');
       await expect(panel).toBeVisible();
 
-      // Verify all configured sections are present
-      await expect(page.locator('[data-testid="filter-section-timeline"]')).toBeVisible();
-      await expect(page.locator('[data-testid="filter-section-location"]')).toBeVisible();
-      await expect(page.locator('[data-testid="filter-section-camera"]')).toBeVisible();
-      await expect(page.locator('[data-testid="filter-section-tags"]')).toBeVisible();
-      await expect(page.locator('[data-testid="filter-section-rating"]')).toBeVisible();
-      await expect(page.locator('[data-testid="filter-section-media"]')).toBeVisible();
-
-      // #910: People needs a detected face and the web e2e project runs no ML, so this space
-      // genuinely cannot filter by person. Asserting the absence is the coverage, not a concession —
-      // see slice 6 "The People carve-out".
-      await expect(page.locator('[data-testid="filter-section-people"]')).toHaveCount(0);
+      // Verify every section the space populates is present. `timeline` and `text` are always
+      // available (filter-availability.ts); the rest each need the seed data in createPopulatedSpace.
+      for (const section of [
+        'timeline',
+        'people',
+        'location',
+        'camera',
+        'tags',
+        'rating',
+        'media',
+        'favorites',
+        'albums',
+        'text',
+      ]) {
+        await expect(page.locator(`[data-testid="filter-section-${section}"]`)).toBeVisible();
+      }
     });
 
     test('should show temporal picker with year/month data from space photos', async ({ context, page }) => {
@@ -311,6 +320,13 @@ test.describe('Spaces FilterPanel', () => {
 
       await expect(page.locator('[data-testid="filter-section-timeline"]')).toBeVisible();
       await expect(page.locator('[data-testid="temporal-picker"]')).toHaveCount(0);
+
+      // The invariant this test is named for: the section wrapper stays mounted but greys out
+      // (filter-section.svelte's `isEmpty` branch) rather than merely losing its content.
+      const timelineHeader = page.locator('[data-testid="filter-section-timeline"] button');
+      await expect(timelineHeader).toBeDisabled();
+      await expect(timelineHeader).toHaveClass(/opacity-50/);
+      await expect(timelineHeader).toContainText('(0)');
     });
 
     test('should grey out months with zero photos after filtering', async ({ context, page }) => {
@@ -333,29 +349,57 @@ test.describe('Spaces FilterPanel', () => {
   // People filter (9 tests)
   // ────────────────────────────────────────────────────────────────────────────
   test.describe('People filter', () => {
-    // #910: People needs a detected face and the web e2e project runs no ML, so a space with no
-    // face-recognition data genuinely cannot filter by person — the section hides rather than
-    // showing an empty scoped list. Asserting the absence is the coverage, not a concession — see
-    // slice 6 "The People carve-out".
-    test('hides the people section when the space has no face-recognition data', async ({ context, page }) => {
-      const { space } = await createPopulatedSpace('People Scoped');
+    // #910: People is now seedable via utils.createSpacePerson (see createPopulatedSpace above),
+    // which builds the shared_space_person chain directly — no ML required. The space-scoped
+    // section is the only web-suite coverage of "space people, not the global list", so it must
+    // actually seed a global person outside the space to prove the scoping, not just that the
+    // section renders.
+    test('should show only people present in the space (not global list)', async ({ context, page }) => {
+      const { space, person } = await createPopulatedSpace('People Scoped');
+
+      // A person who exists globally but has no face on any asset in this space. If the section
+      // ever regressed to the global people list, this person would leak into it.
+      const outsideAsset = await utils.createAsset(admin.accessToken);
+      const outsidePerson = await utils.createPerson(admin.accessToken, { name: 'Outside The Space' });
+      await utils.createFace({ assetId: outsideAsset.id, personId: outsidePerson.id });
+
       await gotoSpace(context, page, space.id);
 
-      await expect(page.locator('[data-testid="filter-section-people"]')).toHaveCount(0);
-      await expect(page.locator('[data-testid="people-filter"]')).toHaveCount(0);
+      const peopleSection = page.locator('[data-testid="filter-section-people"]');
+      await expect(peopleSection).toBeVisible();
+
+      const peopleFilter = page.locator('[data-testid="people-filter"]');
+      await expect(peopleFilter).toBeVisible();
+
+      // The space-scoped person is listed...
+      await expect(page.locator(`[data-testid="people-item-${person.spacePersonId}"]`)).toBeVisible();
+      // ...but the global person outside the space is not.
+      await expect(page.locator(`[data-testid="people-item-${outsidePerson.id}"]`)).toHaveCount(0);
     });
 
-    // #910: same carve-out as above — this space has no face-recognition data (createPerson-less,
-    // ML-less e2e project), so the section is absent rather than offering a selectable (or even
-    // empty) people list. See slice 6 "The People carve-out".
-    test('hides the people section for a space with no detected people', async ({ context, page }) => {
+    // #910: seeded via utils.createSpacePerson so the people-item-* branch is the live one —
+    // nothing about ML blocked this, only the plan's now-corrected People carve-out did.
+    test('should update timeline when selecting a person', async ({ context, page }) => {
       const space = await utils.createSpace(admin.accessToken, { name: 'Person Select' });
       const asset = await utils.createAsset(admin.accessToken);
       await utils.addSpaceAssets(admin.accessToken, space.id, [asset.id]);
+      const { spacePersonId } = await utils.createSpacePerson(space.id, 'Person Select Person', admin.userId, asset.id);
 
       await gotoSpace(context, page, space.id);
 
-      await expect(page.locator('[data-testid="filter-section-people"]')).toHaveCount(0);
+      const personItem = page.locator(`[data-testid="people-item-${spacePersonId}"]`);
+      await expect(personItem).toBeVisible();
+
+      // Selecting the person should trigger a filter change and show a result count.
+      const bucketResponse = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
+      await personItem.click();
+      await bucketResponse;
+
+      await expect(page.locator('[data-testid="active-filters-bar"]')).toBeVisible();
+      const resultCount = page.locator('[data-testid="result-count"]');
+      await expect(resultCount).toBeVisible();
+      const countText = await resultCount.textContent();
+      expect(countText).toMatch(/\d+\s*result/);
     });
 
     test('should support multi-select for people (both remain selected)', async ({ context, page }) => {
@@ -380,20 +424,15 @@ test.describe('Spaces FilterPanel', () => {
       // If fewer than 2 people, test passes trivially (no multi-select to verify)
     });
 
-    // #910: same carve-out — OR-logic selection needs at least one real person to select, which this
-    // ML-less e2e project cannot seed. The server-side OR-logic behavior itself is covered by
-    // search.e2e-spec.ts; this only confirms the section hides. See slice 6 "The People carve-out".
-    test('hides the people section rather than offering an OR-logic selection with no people', async ({
-      context,
-      page,
-    }) => {
-      const space = await utils.createSpace(admin.accessToken, { name: 'People OR' });
-      const asset = await utils.createAsset(admin.accessToken);
-      await utils.addSpaceAssets(admin.accessToken, space.id, [asset.id]);
-
+    test('should show photos containing either selected person (OR logic)', async ({ context, page }) => {
+      const { space } = await createPopulatedSpace('People OR');
       await gotoSpace(context, page, space.id);
 
-      await expect(page.locator('[data-testid="filter-section-people"]')).toHaveCount(0);
+      // Verify people filter exists and is populated (utils.createSpacePerson in createPopulatedSpace
+      // — see the helper above). OR logic itself is a server-side behavior; this UI test verifies the
+      // interaction works.
+      await expect(page.locator('[data-testid="filter-section-people"]')).toBeVisible();
+      await expect(page.locator('[data-testid="people-filter"]')).toBeVisible();
     });
 
     test('should keep only remaining person filter after deselecting one', async ({ context, page }) => {
@@ -854,11 +893,19 @@ test.describe('Spaces FilterPanel', () => {
 
       await gotoSpace(context, page, space.id);
 
+      // Wait for the tag filter to take effect before interacting with its chip — without this the
+      // chip-close click can land mid-refetch, while the ActiveFiltersBar is still reflowing, and
+      // silently miss (this is what "may be obscured by layout overlap" below is guarding against).
+      const tagResponse = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
       await page.locator(`[data-testid="tags-item-${tags[0].id}"]`).click();
+      await tagResponse;
+      await expect(page.locator('[data-testid="active-chip"]')).toHaveCount(1);
 
       // Remove via chip close button — use force:true because the button may be obscured by layout overlap
+      const clearResponse = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
       const chipClose = page.locator('[data-testid="chip-close"]');
       await chipClose.first().click({ force: true });
+      await clearResponse;
 
       // No chips should remain
       await expect(page.locator('[data-testid="active-chip"]')).toHaveCount(0);
@@ -910,20 +957,14 @@ test.describe('Spaces FilterPanel', () => {
       await page.locator('[data-testid="rating-star-3"]').click();
       await bucketResponse;
 
-      // Active filter bar should appear with rating chip and result count
+      // Active filter bar should appear with rating chip and result count.
+      // #910: createPopulatedSpace explicitly rates TWO assets (asset1 the image, and video) at 3
+      // stars — see the helper above — and cameraAsset (mongolels.jpg) carries its own embedded
+      // EXIF Rating of 3 (confirmed with exiftool), which metadata extraction applies automatically.
+      // A >=3 filter therefore matches exactly those three, and the empty state never appears.
       await expect(page.locator('[data-testid="active-filters-bar"]')).toBeVisible();
       const resultCount = page.locator('[data-testid="result-count"]');
-      await expect(resultCount).toBeVisible();
-      const countText = await resultCount.textContent();
-      expect(countText).toMatch(/\d+\s*result/);
-
-      // #910: createPopulatedSpace rates one asset at 3 stars (see the helper above), so a >=3
-      // filter matches it and the empty state should NOT appear — this only guards the case where
-      // it unexpectedly does.
-      const emptyState = page.locator('[data-testid="empty-state-message"]');
-      if (await isVisibleOrFalse(emptyState, 2000)) {
-        await expect(emptyState).toContainText('No photos match your filters');
-      }
+      await expect(resultCount).toContainText('3 results');
     });
 
     test('should show only 5-star photos when clicking 5th star', async ({ context, page }) => {
@@ -969,13 +1010,12 @@ test.describe('Spaces FilterPanel', () => {
 
       await expect(page.locator('[data-testid="active-filters-bar"]')).toBeVisible();
 
-      // #910: createPopulatedSpace rates one asset at 3 stars (see the helper above), so a >=1
-      // filter matches it; the point here is just that the result count renders in the active
-      // filters bar, which the assertion below checks without pinning an exact value.
+      // #910: createPopulatedSpace explicitly rates asset1 and video at 3 stars, and cameraAsset
+      // (mongolels.jpg) carries its own embedded EXIF Rating of 3 — see "should show only 3+ star
+      // rated photos" above. Nothing else in the space's 7 assets is rated. A >=1 filter matches
+      // exactly those three, proving the other four (unrated) assets are excluded.
       const resultCount = page.locator('[data-testid="result-count"]');
-      await expect(resultCount).toBeVisible();
-      const countText = await resultCount.textContent();
-      expect(countText).toMatch(/\d+\s*result/);
+      await expect(resultCount).toContainText('3 results');
     });
 
     test('should show chip in star format with minimum rating', async ({ context, page }) => {
@@ -1367,13 +1407,23 @@ test.describe('Spaces FilterPanel', () => {
       const { space } = await createPopulatedSpace('Remove One Combined');
       await gotoSpace(context, page, space.id);
 
-      // Apply two filters
+      // Apply two filters, waiting for each refetch before the next interaction — without this the
+      // chip-close click below can land mid-refetch, while the ActiveFiltersBar is still reflowing
+      // from the second filter, and silently miss its target (the pre-existing "may be obscured by
+      // layout overlap" hazard the force:true click is already guarding against).
+      const mediaResponse = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
       await page.locator('[data-testid="media-type-image"]').click();
+      await mediaResponse;
+
+      const ratingResponse = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
       await page.locator('[data-testid="rating-star-3"]').click();
+      await ratingResponse;
       await expect(page.locator('[data-testid="active-chip"]')).toHaveCount(2);
 
       // Remove one via chip close — use force:true because the button may be obscured by layout overlap
+      const removeResponse = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
       await page.locator('[data-testid="chip-close"]').first().click({ force: true });
+      await removeResponse;
       await expect(page.locator('[data-testid="active-chip"]')).toHaveCount(1);
     });
 
@@ -1381,13 +1431,21 @@ test.describe('Spaces FilterPanel', () => {
       const { space } = await createPopulatedSpace('Combined Temporal');
       await gotoSpace(context, page, space.id);
 
-      // Apply filters
+      // Apply filters — no seeded asset reaches 5 stars, so image + rating-5 combined always
+      // empties the current view. That is precisely the state the "collapses the temporal picker"
+      // test above exercises: the section wrapper stays mounted but its content unmounts
+      // (filter-section.svelte's isEmpty/isOpen). Await both bucket refetches so the assertion
+      // below observes the settled state rather than racing the first poll.
+      const mediaResponse = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
       await page.locator('[data-testid="media-type-image"]').click();
-      await page.locator('[data-testid="rating-star-5"]').click();
+      await mediaResponse;
 
-      // Temporal picker should still be in the DOM (it may have zero height when
-      // combined filters produce zero timeBuckets, so check attachment not visibility)
-      await expect(page.locator('[data-testid="temporal-picker"]')).toBeAttached();
+      const ratingResponse = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
+      await page.locator('[data-testid="rating-star-5"]').click();
+      await ratingResponse;
+
+      await expect(page.locator('[data-testid="filter-section-timeline"]')).toBeVisible();
+      await expect(page.locator('[data-testid="temporal-picker"]')).toHaveCount(0);
     });
   });
 
@@ -1571,8 +1629,8 @@ test.describe('Spaces FilterPanel', () => {
     // shared helper. Under slice 5 that scope hides the sections outright instead of showing an
     // "-empty" placeholder inside them (there are no active filters, so "current" and "baseline"
     // facets are identical — an always-empty scope is 'unavailable', never merely 'empty'). Asserting
-    // the absence is the coverage, not a concession — see slice 6 "The People carve-out" for the same
-    // principle applied to People.
+    // the absence is the coverage here: a scope with genuinely no location/camera data cannot filter
+    // by either, and that is a fact about the seed, not a concession to a missing seed.
     test('hides location and camera sections when space has no EXIF data', async ({ context, page }) => {
       const space = await utils.createSpace(admin.accessToken, { name: 'No EXIF Data' });
       const asset1 = await utils.createAsset(admin.accessToken);

--- a/e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts
+++ b/e2e/src/specs/web/spaces-filter-panel.e2e-spec.ts
@@ -1,7 +1,9 @@
 import type { LoginResponseDto } from '@immich/sdk';
+import { updateAsset } from '@immich/sdk';
 import type { Locator } from '@playwright/test';
 import { expect, test } from '@playwright/test';
-import { utils } from 'src/utils';
+import { readFileSync } from 'node:fs';
+import { asBearerAuth, testAssetDir, utils } from 'src/utils';
 
 // isVisible() rejects if the locator resolution races with a navigation; the
 // empty-state probes below treat that the same as "not visible".
@@ -70,7 +72,56 @@ test.describe('Spaces FilterPanel', () => {
       fileModifiedAt: '2023-08-20T10:00:00.000Z',
     });
 
-    await utils.addSpaceAssets(admin.accessToken, space.id, [asset1.id, asset2.id, asset3.id, asset4.id]);
+    // #910: each of these keeps one filter section available within the SPACE's own scope — the
+    // space, not the library, is what facets are scoped to, so they must be added to the space
+    // alongside the four plain assets above. See slice 6's recipe table.
+    const video = await utils.createAsset(admin.accessToken, {
+      fileCreatedAt: '2023-06-01T10:00:00.000Z',
+      fileModifiedAt: '2023-06-01T10:00:00.000Z',
+      assetData: { filename: 'example-video.mp4' },
+    });
+    const gpsAsset = await utils.createAsset(admin.accessToken, {
+      assetData: {
+        bytes: readFileSync(`${testAssetDir}/metadata/gps-position/thompson-springs.jpg`),
+        filename: 'gps.jpg',
+      },
+    });
+    const cameraAsset = await utils.createAsset(admin.accessToken, {
+      assetData: {
+        bytes: readFileSync(`${testAssetDir}/metadata/rating/mongolels.jpg`),
+        filename: 'canon.jpg',
+      },
+    });
+    await utils.waitForQueueFinish(admin.accessToken, 'metadataExtraction');
+
+    await utils.addSpaceAssets(admin.accessToken, space.id, [
+      asset1.id,
+      asset2.id,
+      asset3.id,
+      asset4.id,
+      video.id,
+      gpsAsset.id,
+      cameraAsset.id,
+    ]);
+
+    const [tag] = await utils.upsertTags(admin.accessToken, ['e2e-space-filter-tag']);
+    await utils.tagAssets(admin.accessToken, tag.id, [asset1.id]);
+    // Rating 3, not 5: some existing tests hard-assert "0 results" at the 5-star filter, so the
+    // seeded rating must clear the 3-star threshold without also clearing 5.
+    //
+    // Rate BOTH asset1 (image) and video: rating ONLY an image means a >=3 rating filter narrows
+    // the space down to a single media type, which empties the Media facet mid-interaction and
+    // detaches media-type-image/-video while a combined rating+media test is still clicking — rating
+    // both keeps at least one image AND one video in every rating-filtered view, so Media stays
+    // available throughout.
+    await updateAsset(
+      { id: asset1.id, updateAssetDto: { rating: 3, isFavorite: true } },
+      { headers: asBearerAuth(admin.accessToken) },
+    );
+    await updateAsset({ id: video.id, updateAssetDto: { rating: 3 } }, { headers: asBearerAuth(admin.accessToken) });
+
+    // Albums needs BOTH sides — some filed, some not.
+    await utils.createAlbum(admin.accessToken, { albumName: `#910 space album ${space.id}`, assetIds: [video.id] });
 
     return { space, assets: [asset1, asset2, asset3, asset4] };
   }
@@ -79,7 +130,7 @@ test.describe('Spaces FilterPanel', () => {
   // Page load and basic rendering (3 tests)
   // ────────────────────────────────────────────────────────────────────────────
   test.describe('Page load and basic rendering', () => {
-    test('should render filter panel with all sections on space page', async ({ context, page }) => {
+    test('should render filter panel with every section the space can populate', async ({ context, page }) => {
       const { space } = await createPopulatedSpace('Render All Sections');
       await gotoSpace(context, page, space.id);
 
@@ -88,12 +139,16 @@ test.describe('Spaces FilterPanel', () => {
 
       // Verify all configured sections are present
       await expect(page.locator('[data-testid="filter-section-timeline"]')).toBeVisible();
-      await expect(page.locator('[data-testid="filter-section-people"]')).toBeVisible();
       await expect(page.locator('[data-testid="filter-section-location"]')).toBeVisible();
       await expect(page.locator('[data-testid="filter-section-camera"]')).toBeVisible();
       await expect(page.locator('[data-testid="filter-section-tags"]')).toBeVisible();
       await expect(page.locator('[data-testid="filter-section-rating"]')).toBeVisible();
       await expect(page.locator('[data-testid="filter-section-media"]')).toBeVisible();
+
+      // #910: People needs a detected face and the web e2e project runs no ML, so this space
+      // genuinely cannot filter by person. Asserting the absence is the coverage, not a concession —
+      // see slice 6 "The People carve-out".
+      await expect(page.locator('[data-testid="filter-section-people"]')).toHaveCount(0);
     });
 
     test('should show temporal picker with year/month data from space photos', async ({ context, page }) => {
@@ -236,31 +291,26 @@ test.describe('Spaces FilterPanel', () => {
       expect(countText).toMatch(/\d+\s*result/);
     });
 
-    test('should grey out years with zero photos after filtering', async ({ context, page }) => {
+    // #910: filtering to zero results puts Timeline in the same "empty" state every other section
+    // gets when the CURRENT filters (not the whole scope) empty it — greyed, `(0)` suffix, content
+    // collapsed (filter-section.svelte's isEmpty/isOpen; see filter-availability.ts's `count`
+    // wiring for suggestionsProvider pages). The temporal picker content — including year-grid —
+    // unmounts entirely rather than rendering with zero height, which is what this test originally
+    // assumed (predating #910, when Timeline never received a `count` prop at all). The section
+    // wrapper itself is never removed from the DOM — getSectionAvailability never returns
+    // 'unavailable' for Timeline — so that wrapper is the actual "greys but never hides" invariant
+    // to assert on.
+    test('collapses the temporal picker content with zero photos after filtering', async ({ context, page }) => {
       const { space } = await createPopulatedSpace('Year Greyed Out');
       await gotoSpace(context, page, space.id);
 
-      // Apply a very restrictive filter that may cause some years to have zero photos
-      // Click rating 5 — likely no photos have 5-star rating
+      // Click rating 5 — no seeded asset reaches 5 stars, so this always empties the current view.
+      const bucketResponse = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
       await page.locator('[data-testid="rating-star-5"]').click();
+      await bucketResponse;
 
-      // Wait for TimelineManager to re-fetch timeBuckets with the rating filter applied
-      await page.waitForTimeout(2000);
-
-      // The temporal picker div is always in the DOM but may have zero height when
-      // timeBuckets is empty (no year chips to render). Check it exists in the DOM
-      // rather than asserting visibility, which fails when the div has no content.
-      await expect(page.locator('[data-testid="temporal-picker"]')).toBeAttached();
-
-      // When the filter produces zero results, timeBuckets may be empty so year-grid
-      // may have no children (invisible). If year chips exist, verify they have opacity-30.
-      const yearChips = page.locator('[data-testid="year-grid"] .year-chip');
-      if ((await yearChips.count()) > 0) {
-        // All year buttons should have opacity-30 class when count is 0
-        for (let i = 0; i < (await yearChips.count()); i++) {
-          await expect(yearChips.nth(i)).toHaveClass(/opacity-30/);
-        }
-      }
+      await expect(page.locator('[data-testid="filter-section-timeline"]')).toBeVisible();
+      await expect(page.locator('[data-testid="temporal-picker"]')).toHaveCount(0);
     });
 
     test('should grey out months with zero photos after filtering', async ({ context, page }) => {
@@ -283,52 +333,29 @@ test.describe('Spaces FilterPanel', () => {
   // People filter (9 tests)
   // ────────────────────────────────────────────────────────────────────────────
   test.describe('People filter', () => {
-    test('should show only people present in the space (not global list)', async ({ context, page }) => {
+    // #910: People needs a detected face and the web e2e project runs no ML, so a space with no
+    // face-recognition data genuinely cannot filter by person — the section hides rather than
+    // showing an empty scoped list. Asserting the absence is the coverage, not a concession — see
+    // slice 6 "The People carve-out".
+    test('hides the people section when the space has no face-recognition data', async ({ context, page }) => {
       const { space } = await createPopulatedSpace('People Scoped');
       await gotoSpace(context, page, space.id);
 
-      // People section should be visible
-      const peopleSection = page.locator('[data-testid="filter-section-people"]');
-      await expect(peopleSection).toBeVisible();
-
-      // Since our test space has no face recognition data, it should show the empty state
-      // or the people loaded from the space's people endpoint
-      const peopleFilter = page.locator('[data-testid="people-filter"]');
-      await expect(peopleFilter).toBeVisible();
+      await expect(page.locator('[data-testid="filter-section-people"]')).toHaveCount(0);
+      await expect(page.locator('[data-testid="people-filter"]')).toHaveCount(0);
     });
 
-    test('should update timeline when selecting a person', async ({ context, page }) => {
-      // Create space with face recognition enabled and people
+    // #910: same carve-out as above — this space has no face-recognition data (createPerson-less,
+    // ML-less e2e project), so the section is absent rather than offering a selectable (or even
+    // empty) people list. See slice 6 "The People carve-out".
+    test('hides the people section for a space with no detected people', async ({ context, page }) => {
       const space = await utils.createSpace(admin.accessToken, { name: 'Person Select' });
       const asset = await utils.createAsset(admin.accessToken);
       await utils.addSpaceAssets(admin.accessToken, space.id, [asset.id]);
 
       await gotoSpace(context, page, space.id);
 
-      // Check people filter renders
-      const peopleFilter = page.locator('[data-testid="people-filter"]');
-      await expect(peopleFilter).toBeVisible();
-
-      // If people exist, clicking one should work; if empty, the empty state message shows
-      const emptyMsg = page.locator('[data-testid="people-empty"]');
-      const personItems = page.locator('[data-testid^="people-item-"]');
-      const hasItems = (await personItems.count()) > 0;
-
-      if (hasItems) {
-        // Wait for the timeline/buckets API to be called with the person filter
-        const bucketResponse = page.waitForResponse((r) => r.url().includes('/timeline/buckets'));
-        await personItems.first().click();
-        await bucketResponse;
-
-        // Should trigger filter change and show result count
-        await expect(page.locator('[data-testid="active-filters-bar"]')).toBeVisible();
-        const resultCount = page.locator('[data-testid="result-count"]');
-        await expect(resultCount).toBeVisible();
-        const countText = await resultCount.textContent();
-        expect(countText).toMatch(/\d+\s*result/);
-      } else {
-        await expect(emptyMsg).toBeVisible();
-      }
+      await expect(page.locator('[data-testid="filter-section-people"]')).toHaveCount(0);
     });
 
     test('should support multi-select for people (both remain selected)', async ({ context, page }) => {
@@ -353,16 +380,20 @@ test.describe('Spaces FilterPanel', () => {
       // If fewer than 2 people, test passes trivially (no multi-select to verify)
     });
 
-    test('should show photos containing either selected person (OR logic)', async ({ context, page }) => {
+    // #910: same carve-out — OR-logic selection needs at least one real person to select, which this
+    // ML-less e2e project cannot seed. The server-side OR-logic behavior itself is covered by
+    // search.e2e-spec.ts; this only confirms the section hides. See slice 6 "The People carve-out".
+    test('hides the people section rather than offering an OR-logic selection with no people', async ({
+      context,
+      page,
+    }) => {
       const space = await utils.createSpace(admin.accessToken, { name: 'People OR' });
       const asset = await utils.createAsset(admin.accessToken);
       await utils.addSpaceAssets(admin.accessToken, space.id, [asset.id]);
 
       await gotoSpace(context, page, space.id);
 
-      // Verify people filter exists
-      await expect(page.locator('[data-testid="people-filter"]')).toBeVisible();
-      // OR logic is a server-side behavior; UI test verifies the interaction works
+      await expect(page.locator('[data-testid="filter-section-people"]')).toHaveCount(0);
     });
 
     test('should keep only remaining person filter after deselecting one', async ({ context, page }) => {
@@ -886,8 +917,9 @@ test.describe('Spaces FilterPanel', () => {
       const countText = await resultCount.textContent();
       expect(countText).toMatch(/\d+\s*result/);
 
-      // Since our test assets have no ratings, the filtered count should be 0
-      // and the empty state should appear
+      // #910: createPopulatedSpace rates one asset at 3 stars (see the helper above), so a >=3
+      // filter matches it and the empty state should NOT appear — this only guards the case where
+      // it unexpectedly does.
       const emptyState = page.locator('[data-testid="empty-state-message"]');
       if (await isVisibleOrFalse(emptyState, 2000)) {
         await expect(emptyState).toContainText('No photos match your filters');
@@ -937,8 +969,9 @@ test.describe('Spaces FilterPanel', () => {
 
       await expect(page.locator('[data-testid="active-filters-bar"]')).toBeVisible();
 
-      // Our test assets are unrated, so even rating >= 1 should yield 0 results
-      // Verify result count shows in the active filters bar
+      // #910: createPopulatedSpace rates one asset at 3 stars (see the helper above), so a >=1
+      // filter matches it; the point here is just that the result count renders in the active
+      // filters bar, which the assertion below checks without pinning an exact value.
       const resultCount = page.locator('[data-testid="result-count"]');
       await expect(resultCount).toBeVisible();
       const countText = await resultCount.textContent();
@@ -1532,17 +1565,24 @@ test.describe('Spaces FilterPanel', () => {
       await expect(page.locator('[data-testid="filter-toggle-btn"]')).toHaveCount(0);
     });
 
-    test('should show empty messages in location and camera sections when space has no EXIF data', async ({
-      context,
-      page,
-    }) => {
-      // Create space with test images (random PNGs without real EXIF)
-      const { space } = await createPopulatedSpace('No EXIF Data');
+    // #910: createPopulatedSpace now seeds real GPS/camera EXIF (see the helper above) so every
+    // OTHER test in this file gets a populated location/camera facet. This test needs the opposite —
+    // a space that structurally has none — so it builds its own bare fixture rather than reusing the
+    // shared helper. Under slice 5 that scope hides the sections outright instead of showing an
+    // "-empty" placeholder inside them (there are no active filters, so "current" and "baseline"
+    // facets are identical — an always-empty scope is 'unavailable', never merely 'empty'). Asserting
+    // the absence is the coverage, not a concession — see slice 6 "The People carve-out" for the same
+    // principle applied to People.
+    test('hides location and camera sections when space has no EXIF data', async ({ context, page }) => {
+      const space = await utils.createSpace(admin.accessToken, { name: 'No EXIF Data' });
+      const asset1 = await utils.createAsset(admin.accessToken);
+      const asset2 = await utils.createAsset(admin.accessToken);
+      await utils.addSpaceAssets(admin.accessToken, space.id, [asset1.id, asset2.id]);
+
       await gotoSpace(context, page, space.id);
 
-      // Location and camera should show empty messages since our random images lack EXIF
-      await expect(page.locator('[data-testid="location-empty"]')).toBeVisible();
-      await expect(page.locator('[data-testid="camera-empty"]')).toBeVisible();
+      await expect(page.locator('[data-testid="filter-section-location"]')).toHaveCount(0);
+      await expect(page.locator('[data-testid="filter-section-camera"]')).toHaveCount(0);
     });
 
     test('should handle rapid filter toggling without race conditions', async ({ context, page }) => {

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -514,11 +514,16 @@ export const utils = {
       throw new Error('Database client not connected');
     }
 
+    // sourceType must be 'manual', NOT left at its schema default ('machine-learning'). On any
+    // stack with facial recognition enabled, person.service.ts's handleDetectFaces treats every
+    // existing MachineLearning-sourced face on an asset as a prior ML detection: it re-runs
+    // detection, finds 0 real faces in these test fixtures, and deletes every face whose id wasn't
+    // re-confirmed — silently wiping a manually-seeded face that defaulted to that sourceType.
     const result = await client.query(
       `
       WITH inserted_face AS (
-        INSERT INTO asset_face ("assetId", "personId")
-        VALUES ($1, $2)
+        INSERT INTO asset_face ("assetId", "personId", "sourceType")
+        VALUES ($1, $2, 'manual')
         RETURNING id
       ),
       person_row AS (
@@ -625,9 +630,11 @@ export const utils = {
       );
       const globalPersonId = personResult.rows[0].id as string;
 
-      // 2. Create a face row linking the asset to the global person.
+      // 2. Create a face row linking the asset to the global person. sourceType: 'manual' — see the
+      // comment on utils.createFace above; left at the default it gets silently deleted by
+      // handleDetectFaces on any stack with facial recognition enabled.
       const faceResult = await client.query(
-        `INSERT INTO "asset_face" ("assetId", "personId") VALUES ($1, $2) RETURNING id`,
+        `INSERT INTO "asset_face" ("assetId", "personId", "sourceType") VALUES ($1, $2, 'manual') RETURNING id`,
         [assetId, globalPersonId],
       );
       const faceId = faceResult.rows[0].id as string;

--- a/e2e/src/utils.ts
+++ b/e2e/src/utils.ts
@@ -509,21 +509,35 @@ export const utils = {
     return person;
   },
 
-  createFace: async ({ assetId, personId }: { assetId: string; personId: string }): Promise<string> => {
+  createFace: async ({
+    assetId,
+    personId,
+    sourceType = 'machine-learning',
+  }: {
+    assetId: string;
+    personId: string;
+    /**
+     * Defaults to the schema default, `machine-learning`, because that is what the face-repair
+     * surfaces require: getScanFlaggedFaces (and the cross-engine console) join `face_search` on
+     * `sourceType = MachineLearning`, so a face seeded any other way is invisible to them and the
+     * scan silently finds nothing — see face-cleanup / face-review-cross-engine.
+     *
+     * Pass `'manual'` from specs that upload real assets and let detection run: on a stack with
+     * facial recognition enabled, `handleDetectFaces` treats an existing MachineLearning-sourced
+     * face as a prior ML detection, re-runs detection, finds 0 real faces in these fixtures, and
+     * deletes every face whose id was not re-confirmed — wiping the seeded face.
+     */
+    sourceType?: 'machine-learning' | 'manual';
+  }): Promise<string> => {
     if (!client) {
       throw new Error('Database client not connected');
     }
 
-    // sourceType must be 'manual', NOT left at its schema default ('machine-learning'). On any
-    // stack with facial recognition enabled, person.service.ts's handleDetectFaces treats every
-    // existing MachineLearning-sourced face on an asset as a prior ML detection: it re-runs
-    // detection, finds 0 real faces in these test fixtures, and deletes every face whose id wasn't
-    // re-confirmed — silently wiping a manually-seeded face that defaulted to that sourceType.
     const result = await client.query(
       `
       WITH inserted_face AS (
         INSERT INTO asset_face ("assetId", "personId", "sourceType")
-        VALUES ($1, $2, 'manual')
+        VALUES ($1, $2, $3)
         RETURNING id
       ),
       person_row AS (
@@ -557,7 +571,7 @@ export const utils = {
       SELECT (SELECT id FROM inserted_face), (SELECT id FROM resolved_identity), 'manual'
       RETURNING "assetFaceId" AS id
       `,
-      [assetId, personId],
+      [assetId, personId, sourceType],
     );
     return result.rows[0].id as string;
   },

--- a/mobile/lib/presentation/widgets/filter_sheet/deep/manage_sections_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/filter_sheet/deep/manage_sections_sheet.widget.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/filter_section_id.dart';
 import 'package:immich_mobile/providers/photos_filter/hidden_sections.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/section_availability.provider.dart';
 
 Future<void> showManageSectionsSheet(BuildContext context) => showModalBottomSheet<void>(
   context: context,
@@ -19,6 +20,7 @@ class ManageSectionsSheet extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final hidden = ref.watch(hiddenSectionsProvider);
+    final available = ref.watch(sectionAvailabilityProvider);
     return SafeArea(
       child: SingleChildScrollView(
         child: Column(
@@ -30,15 +32,17 @@ class ManageSectionsSheet extends ConsumerWidget {
               child: Text('filter_sheet_deep_manage_sections'.tr(), style: theme.textTheme.titleMedium),
             ),
             for (final section in FilterSectionId.values)
-              SwitchListTile.adaptive(
-                key: Key('manage-section-${section.storageId}'),
-                title: Text(section.titleKey.tr()),
-                value: !hidden.contains(section),
-                onChanged: (visible) {
-                  HapticFeedback.selectionClick();
-                  ref.read(hiddenSectionsProvider.notifier).setVisible(section, visible);
-                },
-              ),
+              // A section the user cannot see is a switch that does nothing. #910
+              if (available.contains(section))
+                SwitchListTile.adaptive(
+                  key: Key('manage-section-${section.storageId}'),
+                  title: Text(section.titleKey.tr()),
+                  value: !hidden.contains(section),
+                  onChanged: (visible) {
+                    HapticFeedback.selectionClick();
+                    ref.read(hiddenSectionsProvider.notifier).setVisible(section, visible);
+                  },
+                ),
             const SizedBox(height: 8),
           ],
         ),

--- a/mobile/lib/presentation/widgets/filter_sheet/deep/toggles_section.widget.dart
+++ b/mobile/lib/presentation/widgets/filter_sheet/deep/toggles_section.widget.dart
@@ -4,8 +4,10 @@ import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/deep/collapsible_section.widget.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/filter_section_id.dart';
+import 'package:immich_mobile/providers/photos_filter/filter_debounce.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/filter_suggestions.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/section_availability.provider.dart';
 
 /// Adaptive toggles: Favourites, Archived, Not-in-album, Untagged.
 /// Each toggle flips independently and its initial state reflects the provider.
@@ -14,13 +16,29 @@ class TogglesSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // Immediate: the active-filter escape below must react the instant a filter is set or
+    // cleared, not 250 ms later (#910 fix-wave finding 1).
     final display = ref.watch(photosFilterProvider.select((f) => f.display));
     final notifier = ref.read(photosFilterProvider.notifier);
 
-    final facets = ref.watch(photosFilterSuggestionsProvider(ref.watch(photosFilterProvider)));
-    // Offer everything while the request is in flight or failed. #910
-    final hasFavorites = facets.valueOrNull?.hasFavorites ?? true;
-    final hasUnfiled = facets.valueOrNull?.hasAssetsNotInAlbum ?? true;
+    // Debounced: shares its family key with every other deep-sheet facets consumer, so a burst of
+    // taps coalesces into one request instead of firing one per tap (#910 fix-wave finding 1).
+    final debouncedFilter = ref.watch(photosFilterDebouncedProvider);
+    final facets = ref.watch(photosFilterSuggestionsProvider(debouncedFilter));
+    // The whole-scope baseline, shared with sectionAvailabilityProvider (#910 fix-wave finding 2):
+    // a facet emptied only by a CROSS-SECTION filter must not pop its switch out mid-session — same
+    // rule as the gated sections, generalised in `toggleAvailable`.
+    final baseline = ref.watch(baselineFacetsProvider);
+    final showFavorites = toggleAvailable(
+      activeFilter: display.isFavorite,
+      currentFacet: facets.valueOrNull?.hasFavorites,
+      baselineFacet: baseline.valueOrNull?.hasFavorites,
+    );
+    final showNotInAlbum = toggleAvailable(
+      activeFilter: display.isNotInAlbum,
+      currentFacet: facets.valueOrNull?.hasAssetsNotInAlbum,
+      baselineFacet: baseline.valueOrNull?.hasAssetsNotInAlbum,
+    );
 
     return CollapsibleSection(
       sectionId: FilterSectionId.toggles,
@@ -31,7 +49,7 @@ class TogglesSection extends ConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // Never remove the control that clears a filter the user has on. #910
-            if (hasFavorites || display.isFavorite)
+            if (showFavorites)
               SwitchListTile.adaptive(
                 key: const Key('toggle-favourites'),
                 contentPadding: EdgeInsets.zero,
@@ -52,7 +70,7 @@ class TogglesSection extends ConsumerWidget {
                 notifier.setArchivedIncluded(v);
               },
             ),
-            if (hasUnfiled || display.isNotInAlbum)
+            if (showNotInAlbum)
               SwitchListTile.adaptive(
                 key: const Key('toggle-not-in-album'),
                 contentPadding: EdgeInsets.zero,

--- a/mobile/lib/presentation/widgets/filter_sheet/deep/toggles_section.widget.dart
+++ b/mobile/lib/presentation/widgets/filter_sheet/deep/toggles_section.widget.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/deep/collapsible_section.widget.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/filter_section_id.dart';
+import 'package:immich_mobile/providers/photos_filter/filter_suggestions.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
 
 /// Adaptive toggles: Favourites, Archived, Not-in-album, Untagged.
@@ -16,6 +17,11 @@ class TogglesSection extends ConsumerWidget {
     final display = ref.watch(photosFilterProvider.select((f) => f.display));
     final notifier = ref.read(photosFilterProvider.notifier);
 
+    final facets = ref.watch(photosFilterSuggestionsProvider(ref.watch(photosFilterProvider)));
+    // Offer everything while the request is in flight or failed. #910
+    final hasFavorites = facets.valueOrNull?.hasFavorites ?? true;
+    final hasUnfiled = facets.valueOrNull?.hasAssetsNotInAlbum ?? true;
+
     return CollapsibleSection(
       sectionId: FilterSectionId.toggles,
       titleKey: 'filter_sheet_deep_toggles_section',
@@ -24,16 +30,18 @@ class TogglesSection extends ConsumerWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            SwitchListTile.adaptive(
-              key: const Key('toggle-favourites'),
-              contentPadding: EdgeInsets.zero,
-              title: Text('filter_sheet_favourites'.tr()),
-              value: display.isFavorite,
-              onChanged: (v) {
-                HapticFeedback.selectionClick();
-                notifier.setFavouritesOnly(v);
-              },
-            ),
+            // Never remove the control that clears a filter the user has on. #910
+            if (hasFavorites || display.isFavorite)
+              SwitchListTile.adaptive(
+                key: const Key('toggle-favourites'),
+                contentPadding: EdgeInsets.zero,
+                title: Text('filter_sheet_favourites'.tr()),
+                value: display.isFavorite,
+                onChanged: (v) {
+                  HapticFeedback.selectionClick();
+                  notifier.setFavouritesOnly(v);
+                },
+              ),
             SwitchListTile.adaptive(
               key: const Key('toggle-archived'),
               contentPadding: EdgeInsets.zero,
@@ -44,16 +52,17 @@ class TogglesSection extends ConsumerWidget {
                 notifier.setArchivedIncluded(v);
               },
             ),
-            SwitchListTile.adaptive(
-              key: const Key('toggle-not-in-album'),
-              contentPadding: EdgeInsets.zero,
-              title: Text('filter_sheet_not_in_album'.tr()),
-              value: display.isNotInAlbum,
-              onChanged: (v) {
-                HapticFeedback.selectionClick();
-                notifier.setNotInAlbum(v);
-              },
-            ),
+            if (hasUnfiled || display.isNotInAlbum)
+              SwitchListTile.adaptive(
+                key: const Key('toggle-not-in-album'),
+                contentPadding: EdgeInsets.zero,
+                title: Text('filter_sheet_not_in_album'.tr()),
+                value: display.isNotInAlbum,
+                onChanged: (v) {
+                  HapticFeedback.selectionClick();
+                  notifier.setNotInAlbum(v);
+                },
+              ),
             SwitchListTile.adaptive(
               key: const Key('toggle-untagged'),
               contentPadding: EdgeInsets.zero,

--- a/mobile/lib/presentation/widgets/filter_sheet/deep_content.widget.dart
+++ b/mobile/lib/presentation/widgets/filter_sheet/deep_content.widget.dart
@@ -14,6 +14,7 @@ import 'package:immich_mobile/presentation/widgets/filter_sheet/filter_section_i
 import 'package:immich_mobile/presentation/widgets/filter_sheet/match_count_footer.widget.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/search_bar.widget.dart';
 import 'package:immich_mobile/providers/photos_filter/hidden_sections.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/section_availability.provider.dart';
 import 'package:immich_mobile/routing/router.dart';
 
 /// The Deep snap body. Owns the scroll view, the sticky Done bar, and the
@@ -77,6 +78,7 @@ class DeepContent extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final hidden = ref.watch(hiddenSectionsProvider);
+    final available = ref.watch(sectionAvailabilityProvider);
     return Material(
       color: theme.colorScheme.surface,
       elevation: 3,
@@ -95,7 +97,9 @@ class DeepContent extends ConsumerWidget {
                 child: KeyedSubtree(key: Key('deep-search'), child: FilterSheetSearchBar()),
               ),
               for (final id in FilterSectionId.values)
-                if (!hidden.contains(id)) _sectionFor(id),
+                // Two independent gates: `hidden` is the user's persisted choice, `available` is
+                // derived from the facets. Never merge them — see the provider's doc comment. #910
+                if (!hidden.contains(id) && available.contains(id)) _sectionFor(id),
             ],
           ),
           const Positioned(

--- a/mobile/lib/providers/photos_filter/filter_suggestions.provider.dart
+++ b/mobile/lib/providers/photos_filter/filter_suggestions.provider.dart
@@ -19,6 +19,9 @@ final photosFilterSuggestionsProvider = FutureProvider.autoDispose.family<Filter
     city: filter.location.city,
     country: filter.location.country,
     isFavorite: filter.display.isFavorite ? true : null,
+    // #910: the albums facet is computed with this filter excluded, but every OTHER facet must still
+    // honour it — dropping it here made all of them ignore the not-in-album toggle.
+    isNotInAlbum: filter.display.isNotInAlbum ? true : null,
     make: filter.camera.make,
     mediaType: mapAssetType(filter.mediaType),
     model: filter.camera.model,

--- a/mobile/lib/providers/photos_filter/filter_suggestions.provider.dart
+++ b/mobile/lib/providers/photos_filter/filter_suggestions.provider.dart
@@ -36,5 +36,11 @@ final photosFilterSuggestionsProvider = FutureProvider.autoDispose.family<Filter
     // server RBAC-projects the result. See issue #727 family (#737 / #738).
     withSharedSpaces: true,
   );
-  return response ?? FilterSuggestionsResponseDto(hasUnnamedPeople: false);
+  if (response == null) {
+    // #910: never fabricate an empty response. `sectionAvailabilityProvider` cannot tell a fabricated
+    // empty from a genuinely empty library and would hide six sections at once; an AsyncValue.error
+    // makes it fall back to offering everything. Mirrors web's slice-4 sentinel removal (spec §4.6).
+    throw Exception('filter suggestions unavailable');
+  }
+  return response;
 });

--- a/mobile/lib/providers/photos_filter/section_availability.provider.dart
+++ b/mobile/lib/providers/photos_filter/section_availability.provider.dart
@@ -110,6 +110,33 @@ bool toggleAvailable({required bool activeFilter, required bool? currentFacet, r
   return baselineFacet ?? true;
 }
 
+/// Whether [filter] is empty with respect to the fields the facets request actually forwards.
+///
+/// This is deliberately narrower than [SearchFilter.isEmpty]: that getter also counts fields the
+/// facets call in filter_suggestions.provider.dart never sends — `context` (the sheet's search-bar
+/// text) foremost, plus `filename`/`description`/`ocr`/`language`/`assetId`/`location.state`/
+/// `display.isArchive`/`display.isUntagged`. Using [SearchFilter.isEmpty] for the baseline-key
+/// decision below meant setting only one of those unforwarded fields (typically the search bar)
+/// made the baseline key diverge from the main key even though the outgoing HTTP request for both
+/// was byte-identical — firing a second request that told the server nothing new.
+///
+/// Keep the field list here in lockstep with the parameters passed to `getFilterSuggestions` in
+/// filter_suggestions.provider.dart — that's the contract this predicate exists to mirror.
+bool _isEmptyForFacets(SearchFilter filter) {
+  return filter.location.city == null &&
+      filter.location.country == null &&
+      filter.camera.make == null &&
+      filter.camera.model == null &&
+      filter.mediaType == AssetType.other &&
+      filter.people.isEmpty &&
+      filter.rating.rating.isNone &&
+      (filter.tagIds ?? const []).isEmpty &&
+      filter.date.takenAfter == null &&
+      filter.date.takenBefore == null &&
+      filter.display.isFavorite == false &&
+      filter.display.isNotInAlbum == false;
+}
+
 /// The scope-wide baseline (no filters applied) facets — "could this ever populate?". Keyed on
 /// [photosFilterDebouncedProvider] like every other facets lookup (finding 1), and shared by
 /// [sectionAvailabilityProvider] and the toggles' gated switches (finding 2) so both consult the
@@ -117,9 +144,11 @@ bool toggleAvailable({required bool activeFilter, required bool? currentFacet, r
 final baselineFacetsProvider = Provider.autoDispose<AsyncValue<FilterSuggestionsResponseDto>>((ref) {
   final filter = ref.watch(photosFilterDebouncedProvider);
 
-  // Same family, different key — and the SAME key when nothing is filtered, so the common case
-  // costs no extra request. SearchFilter has value equality, which is what makes that true.
-  final baselineKey = filter.isEmpty ? filter : SearchFilter.empty();
+  // Same family, different key — and the SAME key when nothing FACETS-RELEVANT is filtered, so the
+  // common case costs no extra request. SearchFilter has value equality, which is what makes that
+  // true; [_isEmptyForFacets] (rather than [SearchFilter.isEmpty]) is what makes it true even when
+  // an unforwarded field like the search-bar `context` is set.
+  final baselineKey = _isEmptyForFacets(filter) ? filter : SearchFilter.empty();
   return ref.watch(photosFilterSuggestionsProvider(baselineKey));
 });
 

--- a/mobile/lib/providers/photos_filter/section_availability.provider.dart
+++ b/mobile/lib/providers/photos_filter/section_availability.provider.dart
@@ -2,6 +2,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/models/search/search_filter.model.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/filter_section_id.dart';
+import 'package:immich_mobile/providers/photos_filter/filter_debounce.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/filter_suggestions.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
 import 'package:openapi/api.dart';
@@ -15,6 +16,14 @@ import 'package:openapi/api.dart';
 /// This is DERIVED. It is never written to [hiddenSectionsProvider], which is the user's own
 /// persisted choice — conflating them would record a section as deliberately hidden the moment its
 /// facet went empty, and it would never come back.
+///
+/// Facets vs. active-filter state (#910 fix-wave finding 1): every facets lookup here is keyed on
+/// [photosFilterDebouncedProvider] (250 ms), the same key every other deep-sheet consumer shares —
+/// so a burst of discrete taps coalesces into one request instead of firing one per tap on a family
+/// key nobody else holds. [hasActiveFilterFor] and any raw `display`/filter read, by contrast, MUST
+/// stay on the immediate [photosFilterProvider]: the active-filter escape hatch has to react the
+/// instant the user sets or clears a filter, or the control it guards would flicker away for 250 ms
+/// before coming back.
 
 /// Whether this section itself currently holds a filter value. Mirrors web's
 /// `hasActiveFilter` (`filter-panel.svelte:621-659`) section for section.
@@ -89,14 +98,40 @@ Set<FilterSectionId> availableSections(
   };
 }
 
-final sectionAvailabilityProvider = Provider.autoDispose<Set<FilterSectionId>>((ref) {
-  final filter = ref.watch(photosFilterProvider);
-  final facets = ref.watch(photosFilterSuggestionsProvider(filter));
+/// Whether a single facet-gated control (e.g. a toggle switch, as opposed to a whole
+/// [FilterSectionId] section) should render. Same rule as [availableSections]'s `offered`,
+/// generalised down to one boolean facet: never hide a control that clears a filter the user
+/// already has on, and otherwise hide it only when the facet is empty under BOTH the current
+/// filters and the whole-scope baseline. Missing information (loading/error, i.e. `null`) fails
+/// open on both sides, matching `availableSections`'s `baseline == null` early return.
+bool toggleAvailable({required bool activeFilter, required bool? currentFacet, required bool? baselineFacet}) {
+  if (activeFilter) return true;
+  if (currentFacet ?? true) return true;
+  return baselineFacet ?? true;
+}
+
+/// The scope-wide baseline (no filters applied) facets — "could this ever populate?". Keyed on
+/// [photosFilterDebouncedProvider] like every other facets lookup (finding 1), and shared by
+/// [sectionAvailabilityProvider] and the toggles' gated switches (finding 2) so both consult the
+/// same fetch rather than each computing — and requesting — their own.
+final baselineFacetsProvider = Provider.autoDispose<AsyncValue<FilterSuggestionsResponseDto>>((ref) {
+  final filter = ref.watch(photosFilterDebouncedProvider);
 
   // Same family, different key — and the SAME key when nothing is filtered, so the common case
   // costs no extra request. SearchFilter has value equality, which is what makes that true.
   final baselineKey = filter.isEmpty ? filter : SearchFilter.empty();
-  final baseline = ref.watch(photosFilterSuggestionsProvider(baselineKey));
+  return ref.watch(photosFilterSuggestionsProvider(baselineKey));
+});
+
+final sectionAvailabilityProvider = Provider.autoDispose<Set<FilterSectionId>>((ref) {
+  // Immediate: hasActiveFilterFor must react the instant a filter is set or cleared (see the file
+  // doc comment) — never debounced.
+  final filter = ref.watch(photosFilterProvider);
+
+  // Debounced: shares its family key with every other deep-sheet facets consumer (finding 1).
+  final debouncedFilter = ref.watch(photosFilterDebouncedProvider);
+  final facets = ref.watch(photosFilterSuggestionsProvider(debouncedFilter));
+  final baseline = ref.watch(baselineFacetsProvider);
 
   // While a request is in flight or has failed, offer everything. A section is never hidden on
   // missing information — including when Task 1b's throw fires.

--- a/mobile/lib/providers/photos_filter/section_availability.provider.dart
+++ b/mobile/lib/providers/photos_filter/section_availability.provider.dart
@@ -1,0 +1,107 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/models/search/search_filter.model.dart';
+import 'package:immich_mobile/presentation/widgets/filter_sheet/filter_section_id.dart';
+import 'package:immich_mobile/providers/photos_filter/filter_suggestions.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
+import 'package:openapi/api.dart';
+
+/// Which deep-sheet sections can actually filter something right now (#910).
+///
+/// Mirrors web's `filter-availability.ts`, minus its structural/transient split: mobile has no
+/// `(0)` grey treatment, so the three verdicts (`available` / `empty` / `unavailable`) collapse to
+/// two renderings here — a section is either offered or it isn't.
+///
+/// This is DERIVED. It is never written to [hiddenSectionsProvider], which is the user's own
+/// persisted choice — conflating them would record a section as deliberately hidden the moment its
+/// facet went empty, and it would never come back.
+
+/// Whether this section itself currently holds a filter value. Mirrors web's
+/// `hasActiveFilter` (`filter-panel.svelte:621-659`) section for section.
+bool hasActiveFilterFor(FilterSectionId id, SearchFilter filter) {
+  switch (id) {
+    case FilterSectionId.people:
+      return filter.people.isNotEmpty;
+    case FilterSectionId.places:
+      return filter.location.country != null || filter.location.state != null || filter.location.city != null;
+    case FilterSectionId.tags:
+      return (filter.tagIds ?? const []).isNotEmpty;
+    case FilterSectionId.camera:
+      return filter.camera.make != null || filter.camera.model != null;
+    case FilterSectionId.rating:
+      return filter.rating.rating.isSome;
+    case FilterSectionId.media:
+      return filter.mediaType != AssetType.other;
+    case FilterSectionId.when:
+      return filter.date.takenAfter != null || filter.date.takenBefore != null;
+    case FilterSectionId.toggles:
+      return filter.display.isFavorite ||
+          filter.display.isArchive ||
+          filter.display.isNotInAlbum ||
+          filter.display.isUntagged;
+  }
+}
+
+bool _facetEmpty(FilterSectionId id, FilterSuggestionsResponseDto facets) {
+  switch (id) {
+    case FilterSectionId.people:
+      return facets.people.isEmpty && !facets.hasUnnamedPeople;
+    case FilterSectionId.places:
+      return facets.countries.isEmpty;
+    case FilterSectionId.tags:
+      return facets.tags.isEmpty;
+    case FilterSectionId.camera:
+      return facets.cameraMakes.isEmpty;
+    case FilterSectionId.rating:
+      return facets.ratings.isEmpty;
+    case FilterSectionId.media:
+      // The control offers All / Photos / Videos, so it needs both of those to discriminate.
+      // NOT `length >= 2`: the server returns raw distinct asset.type and AssetType is
+      // IMAGE | VIDEO | AUDIO | OTHER, so a photo library with one OTHER asset would pass a
+      // length test while the Videos button stays dead. Same rule as web's filter-availability.ts.
+      return !(facets.mediaTypes.contains('IMAGE') && facets.mediaTypes.contains('VIDEO'));
+    case FilterSectionId.when:
+    case FilterSectionId.toggles:
+      // `when` mirrors web's Timeline. `toggles` always renders — two of its four switches have no
+      // facet at all, so the section as a whole is never useless; per-switch gating is Task 3's.
+      return false;
+  }
+}
+
+Set<FilterSectionId> availableSections(
+  FilterSuggestionsResponseDto facets,
+  FilterSuggestionsResponseDto? baseline,
+  SearchFilter filter,
+) {
+  bool offered(FilterSectionId id) {
+    // Never strand a filter the user cannot then reach to clear.
+    if (hasActiveFilterFor(id, filter)) return true;
+    if (!_facetEmpty(id, facets)) return true;
+    // A section is never hidden on missing information.
+    if (baseline == null) return true;
+    // Empty under the current filters but not for the whole scope: transient, so keep it.
+    return !_facetEmpty(id, baseline);
+  }
+
+  return {
+    for (final id in FilterSectionId.values)
+      if (offered(id)) id,
+  };
+}
+
+final sectionAvailabilityProvider = Provider.autoDispose<Set<FilterSectionId>>((ref) {
+  final filter = ref.watch(photosFilterProvider);
+  final facets = ref.watch(photosFilterSuggestionsProvider(filter));
+
+  // Same family, different key — and the SAME key when nothing is filtered, so the common case
+  // costs no extra request. SearchFilter has value equality, which is what makes that true.
+  final baselineKey = filter.isEmpty ? filter : SearchFilter.empty();
+  final baseline = ref.watch(photosFilterSuggestionsProvider(baselineKey));
+
+  // While a request is in flight or has failed, offer everything. A section is never hidden on
+  // missing information — including when Task 1b's throw fires.
+  return facets.maybeWhen(
+    data: (data) => availableSections(data, baseline.valueOrNull, filter),
+    orElse: () => FilterSectionId.values.toSet(),
+  );
+});

--- a/mobile/openapi/lib/model/filter_suggestions_response_dto.dart
+++ b/mobile/openapi/lib/model/filter_suggestions_response_dto.dart
@@ -15,6 +15,9 @@ class FilterSuggestionsResponseDto {
   FilterSuggestionsResponseDto({
     this.cameraMakes = const [],
     this.countries = const [],
+    required this.hasAssetsInAlbum,
+    required this.hasAssetsNotInAlbum,
+    required this.hasFavorites,
     required this.hasUnnamedPeople,
     this.mediaTypes = const [],
     this.people = const [],
@@ -27,6 +30,15 @@ class FilterSuggestionsResponseDto {
 
   /// Available countries
   List<String> countries;
+
+  /// Whether any filtered asset belongs to an album
+  bool hasAssetsInAlbum;
+
+  /// Whether any filtered asset belongs to no album
+  bool hasAssetsNotInAlbum;
+
+  /// Whether any favourite exists in the filtered set, ignoring isFavorite
+  bool hasFavorites;
 
   /// Whether unnamed people exist in the filtered set
   bool hasUnnamedPeople;
@@ -47,6 +59,9 @@ class FilterSuggestionsResponseDto {
   bool operator ==(Object other) => identical(this, other) || other is FilterSuggestionsResponseDto &&
     _deepEquality.equals(other.cameraMakes, cameraMakes) &&
     _deepEquality.equals(other.countries, countries) &&
+    other.hasAssetsInAlbum == hasAssetsInAlbum &&
+    other.hasAssetsNotInAlbum == hasAssetsNotInAlbum &&
+    other.hasFavorites == hasFavorites &&
     other.hasUnnamedPeople == hasUnnamedPeople &&
     _deepEquality.equals(other.mediaTypes, mediaTypes) &&
     _deepEquality.equals(other.people, people) &&
@@ -58,6 +73,9 @@ class FilterSuggestionsResponseDto {
     // ignore: unnecessary_parenthesis
     (cameraMakes.hashCode) +
     (countries.hashCode) +
+    (hasAssetsInAlbum.hashCode) +
+    (hasAssetsNotInAlbum.hashCode) +
+    (hasFavorites.hashCode) +
     (hasUnnamedPeople.hashCode) +
     (mediaTypes.hashCode) +
     (people.hashCode) +
@@ -65,12 +83,15 @@ class FilterSuggestionsResponseDto {
     (tags.hashCode);
 
   @override
-  String toString() => 'FilterSuggestionsResponseDto[cameraMakes=$cameraMakes, countries=$countries, hasUnnamedPeople=$hasUnnamedPeople, mediaTypes=$mediaTypes, people=$people, ratings=$ratings, tags=$tags]';
+  String toString() => 'FilterSuggestionsResponseDto[cameraMakes=$cameraMakes, countries=$countries, hasAssetsInAlbum=$hasAssetsInAlbum, hasAssetsNotInAlbum=$hasAssetsNotInAlbum, hasFavorites=$hasFavorites, hasUnnamedPeople=$hasUnnamedPeople, mediaTypes=$mediaTypes, people=$people, ratings=$ratings, tags=$tags]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
       json[r'cameraMakes'] = this.cameraMakes;
       json[r'countries'] = this.countries;
+      json[r'hasAssetsInAlbum'] = this.hasAssetsInAlbum;
+      json[r'hasAssetsNotInAlbum'] = this.hasAssetsNotInAlbum;
+      json[r'hasFavorites'] = this.hasFavorites;
       json[r'hasUnnamedPeople'] = this.hasUnnamedPeople;
       json[r'mediaTypes'] = this.mediaTypes;
       json[r'people'] = this.people;
@@ -94,6 +115,9 @@ class FilterSuggestionsResponseDto {
         countries: json[r'countries'] is Iterable
             ? (json[r'countries'] as Iterable).cast<String>().toList(growable: false)
             : const [],
+        hasAssetsInAlbum: mapValueOfType<bool>(json, r'hasAssetsInAlbum')!,
+        hasAssetsNotInAlbum: mapValueOfType<bool>(json, r'hasAssetsNotInAlbum')!,
+        hasFavorites: mapValueOfType<bool>(json, r'hasFavorites')!,
         hasUnnamedPeople: mapValueOfType<bool>(json, r'hasUnnamedPeople')!,
         mediaTypes: json[r'mediaTypes'] is Iterable
             ? (json[r'mediaTypes'] as Iterable).cast<String>().toList(growable: false)
@@ -152,6 +176,9 @@ class FilterSuggestionsResponseDto {
   static const requiredKeys = <String>{
     'cameraMakes',
     'countries',
+    'hasAssetsInAlbum',
+    'hasAssetsNotInAlbum',
+    'hasFavorites',
     'hasUnnamedPeople',
     'mediaTypes',
     'people',

--- a/mobile/openapi/lib/model/smart_search_facets_response_dto.dart
+++ b/mobile/openapi/lib/model/smart_search_facets_response_dto.dart
@@ -17,6 +17,9 @@ class SmartSearchFacetsResponseDto {
     this.cameraModels = const [],
     this.cities = const [],
     this.countries = const [],
+    required this.hasAssetsInAlbum,
+    required this.hasAssetsNotInAlbum,
+    required this.hasFavorites,
     required this.hasUnnamedPeople,
     this.mediaTypes = const [],
     this.people = const [],
@@ -37,6 +40,15 @@ class SmartSearchFacetsResponseDto {
 
   /// Available countries
   List<String> countries;
+
+  /// Whether any filtered asset belongs to an album
+  bool hasAssetsInAlbum;
+
+  /// Whether any filtered asset belongs to no album
+  bool hasAssetsNotInAlbum;
+
+  /// Whether any favourite exists in the filtered set, ignoring isFavorite
+  bool hasFavorites;
 
   /// Whether unnamed people exist in the filtered smart-search set
   bool hasUnnamedPeople;
@@ -68,6 +80,9 @@ class SmartSearchFacetsResponseDto {
     _deepEquality.equals(other.cameraModels, cameraModels) &&
     _deepEquality.equals(other.cities, cities) &&
     _deepEquality.equals(other.countries, countries) &&
+    other.hasAssetsInAlbum == hasAssetsInAlbum &&
+    other.hasAssetsNotInAlbum == hasAssetsNotInAlbum &&
+    other.hasFavorites == hasFavorites &&
     other.hasUnnamedPeople == hasUnnamedPeople &&
     _deepEquality.equals(other.mediaTypes, mediaTypes) &&
     _deepEquality.equals(other.people, people) &&
@@ -83,6 +98,9 @@ class SmartSearchFacetsResponseDto {
     (cameraModels.hashCode) +
     (cities.hashCode) +
     (countries.hashCode) +
+    (hasAssetsInAlbum.hashCode) +
+    (hasAssetsNotInAlbum.hashCode) +
+    (hasFavorites.hashCode) +
     (hasUnnamedPeople.hashCode) +
     (mediaTypes.hashCode) +
     (people.hashCode) +
@@ -92,7 +110,7 @@ class SmartSearchFacetsResponseDto {
     (total.hashCode);
 
   @override
-  String toString() => 'SmartSearchFacetsResponseDto[cameraMakes=$cameraMakes, cameraModels=$cameraModels, cities=$cities, countries=$countries, hasUnnamedPeople=$hasUnnamedPeople, mediaTypes=$mediaTypes, people=$people, ratings=$ratings, tags=$tags, timeBuckets=$timeBuckets, total=$total]';
+  String toString() => 'SmartSearchFacetsResponseDto[cameraMakes=$cameraMakes, cameraModels=$cameraModels, cities=$cities, countries=$countries, hasAssetsInAlbum=$hasAssetsInAlbum, hasAssetsNotInAlbum=$hasAssetsNotInAlbum, hasFavorites=$hasFavorites, hasUnnamedPeople=$hasUnnamedPeople, mediaTypes=$mediaTypes, people=$people, ratings=$ratings, tags=$tags, timeBuckets=$timeBuckets, total=$total]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
@@ -100,6 +118,9 @@ class SmartSearchFacetsResponseDto {
       json[r'cameraModels'] = this.cameraModels;
       json[r'cities'] = this.cities;
       json[r'countries'] = this.countries;
+      json[r'hasAssetsInAlbum'] = this.hasAssetsInAlbum;
+      json[r'hasAssetsNotInAlbum'] = this.hasAssetsNotInAlbum;
+      json[r'hasFavorites'] = this.hasFavorites;
       json[r'hasUnnamedPeople'] = this.hasUnnamedPeople;
       json[r'mediaTypes'] = this.mediaTypes;
       json[r'people'] = this.people;
@@ -131,6 +152,9 @@ class SmartSearchFacetsResponseDto {
         countries: json[r'countries'] is Iterable
             ? (json[r'countries'] as Iterable).cast<String>().toList(growable: false)
             : const [],
+        hasAssetsInAlbum: mapValueOfType<bool>(json, r'hasAssetsInAlbum')!,
+        hasAssetsNotInAlbum: mapValueOfType<bool>(json, r'hasAssetsNotInAlbum')!,
+        hasFavorites: mapValueOfType<bool>(json, r'hasFavorites')!,
         hasUnnamedPeople: mapValueOfType<bool>(json, r'hasUnnamedPeople')!,
         mediaTypes: AssetTypeEnum.listFromJson(json[r'mediaTypes']),
         people: FilterSuggestionsPersonDto.listFromJson(json[r'people']),
@@ -191,6 +215,9 @@ class SmartSearchFacetsResponseDto {
     'cameraModels',
     'cities',
     'countries',
+    'hasAssetsInAlbum',
+    'hasAssetsNotInAlbum',
+    'hasFavorites',
     'hasUnnamedPeople',
     'mediaTypes',
     'people',

--- a/mobile/test/presentation/pages/photos_filter/camera_picker_test.dart
+++ b/mobile/test/presentation/pages/photos_filter/camera_picker_test.dart
@@ -10,8 +10,13 @@ import 'package:openapi/api.dart';
 
 import '../../../widget_tester_extensions.dart';
 
-FilterSuggestionsResponseDto _sugg(List<String> cameraMakes) =>
-    FilterSuggestionsResponseDto(hasUnnamedPeople: false, cameraMakes: cameraMakes);
+FilterSuggestionsResponseDto _sugg(List<String> cameraMakes) => FilterSuggestionsResponseDto(
+  hasUnnamedPeople: false,
+  hasFavorites: true,
+  hasAssetsInAlbum: true,
+  hasAssetsNotInAlbum: true,
+  cameraMakes: cameraMakes,
+);
 
 List<Override> _overrideMakes(List<String> cameraMakes) => [
   photosFilterSuggestionsProvider.overrideWith((ref, filter) async => _sugg(cameraMakes)),

--- a/mobile/test/presentation/pages/photos_filter/places_picker_test.dart
+++ b/mobile/test/presentation/pages/photos_filter/places_picker_test.dart
@@ -10,8 +10,13 @@ import 'package:openapi/api.dart';
 
 import '../../../widget_tester_extensions.dart';
 
-FilterSuggestionsResponseDto _sugg(List<String> countries) =>
-    FilterSuggestionsResponseDto(hasUnnamedPeople: false, countries: countries);
+FilterSuggestionsResponseDto _sugg(List<String> countries) => FilterSuggestionsResponseDto(
+  hasUnnamedPeople: false,
+  hasFavorites: true,
+  hasAssetsInAlbum: true,
+  hasAssetsNotInAlbum: true,
+  countries: countries,
+);
 
 List<Override> _overrideCountries(List<String> countries) => [
   photosFilterSuggestionsProvider.overrideWith((ref, filter) async => _sugg(countries)),

--- a/mobile/test/presentation/pages/photos_filter/widgets/camera_picker_make_accordion_test.dart
+++ b/mobile/test/presentation/pages/photos_filter/widgets/camera_picker_make_accordion_test.dart
@@ -11,8 +11,13 @@ import 'package:openapi/api.dart';
 
 import '../../../../widget_tester_extensions.dart';
 
-FilterSuggestionsResponseDto _sugg(List<String> cameraMakes) =>
-    FilterSuggestionsResponseDto(hasUnnamedPeople: false, cameraMakes: cameraMakes);
+FilterSuggestionsResponseDto _sugg(List<String> cameraMakes) => FilterSuggestionsResponseDto(
+  hasUnnamedPeople: false,
+  hasFavorites: true,
+  hasAssetsInAlbum: true,
+  hasAssetsNotInAlbum: true,
+  cameraMakes: cameraMakes,
+);
 
 List<Override> _overrideMakes(List<String> cameraMakes) => [
   photosFilterSuggestionsProvider.overrideWith((ref, filter) async => _sugg(cameraMakes)),
@@ -36,10 +41,7 @@ void main() {
     });
 
     testWidgets('empty makes -> hidden (SizedBox.shrink)', (tester) async {
-      await tester.pumpConsumerWidget(
-        _harness(expandedMake: null, onExpand: (_) {}),
-        overrides: _overrideMakes([]),
-      );
+      await tester.pumpConsumerWidget(_harness(expandedMake: null, onExpand: (_) {}), overrides: _overrideMakes([]));
       await tester.pumpAndSettle();
       expect(find.byKey(const Key('camera-picker-make-Canon')), findsNothing);
     });
@@ -64,8 +66,13 @@ void main() {
     testWidgets('tapping an already-expanded make calls onExpandMake(null)', (tester) async {
       String? expanded = 'Canon';
       await tester.pumpConsumerWidget(
-        SingleChildScrollView(child: _harness(expandedMake: 'Canon', onExpand: (m) => expanded = m)),
-        overrides: [..._overrideMakes(['Canon']), cameraModelSuggestionsProvider.overrideWith((ref, m) async => [])],
+        SingleChildScrollView(
+          child: _harness(expandedMake: 'Canon', onExpand: (m) => expanded = m),
+        ),
+        overrides: [
+          ..._overrideMakes(['Canon']),
+          cameraModelSuggestionsProvider.overrideWith((ref, m) async => []),
+        ],
       );
       await tester.pumpAndSettle();
 
@@ -77,7 +84,9 @@ void main() {
     testWidgets('expanding a make fetches its models only — other makes are not fetched', (tester) async {
       final fetchedFor = <String?>[];
       await tester.pumpConsumerWidget(
-        SingleChildScrollView(child: _harness(expandedMake: 'Canon', onExpand: (_) {})),
+        SingleChildScrollView(
+          child: _harness(expandedMake: 'Canon', onExpand: (_) {}),
+        ),
         overrides: [
           ..._overrideMakes(['Canon', 'Sony']),
           cameraModelSuggestionsProvider.overrideWith((ref, make) async {
@@ -96,7 +105,9 @@ void main() {
 
     testWidgets('tapping a model selects make + model via setCamera', (tester) async {
       await tester.pumpConsumerWidget(
-        SingleChildScrollView(child: _harness(expandedMake: 'Canon', onExpand: (_) {})),
+        SingleChildScrollView(
+          child: _harness(expandedMake: 'Canon', onExpand: (_) {}),
+        ),
         overrides: [
           ..._overrideMakes(['Canon']),
           cameraModelSuggestionsProvider.overrideWith((ref, make) async => ['EOS R5', 'EOS R6']),
@@ -116,7 +127,9 @@ void main() {
     testWidgets('selecting a different make replaces the prior make/model selection', (tester) async {
       String? expanded = 'Canon';
       await tester.pumpConsumerWidget(
-        SingleChildScrollView(child: _harness(expandedMake: expanded, onExpand: (m) => expanded = m)),
+        SingleChildScrollView(
+          child: _harness(expandedMake: expanded, onExpand: (m) => expanded = m),
+        ),
         overrides: [
           ..._overrideMakes(['Canon', 'Sony']),
           cameraModelSuggestionsProvider.overrideWith((ref, make) async => make == 'Canon' ? ['EOS R5'] : []),
@@ -138,7 +151,9 @@ void main() {
 
     testWidgets('search query filters the already-loaded model list for the expanded make', (tester) async {
       await tester.pumpConsumerWidget(
-        SingleChildScrollView(child: _harness(expandedMake: 'Canon', onExpand: (_) {})),
+        SingleChildScrollView(
+          child: _harness(expandedMake: 'Canon', onExpand: (_) {}),
+        ),
         overrides: [
           ..._overrideMakes(['Canon']),
           cameraModelSuggestionsProvider.overrideWith((ref, make) async => ['EOS R5', 'EOS R6']),
@@ -158,7 +173,9 @@ void main() {
 
     testWidgets('per-make fetch error shows an inline retry for that make only', (tester) async {
       await tester.pumpConsumerWidget(
-        SingleChildScrollView(child: _harness(expandedMake: 'Leica', onExpand: (_) {})),
+        SingleChildScrollView(
+          child: _harness(expandedMake: 'Leica', onExpand: (_) {}),
+        ),
         overrides: [
           ..._overrideMakes(['Leica']),
           cameraModelSuggestionsProvider.overrideWith((ref, make) async => throw Exception('boom')),

--- a/mobile/test/presentation/pages/photos_filter/widgets/places_picker_country_accordion_test.dart
+++ b/mobile/test/presentation/pages/photos_filter/widgets/places_picker_country_accordion_test.dart
@@ -11,8 +11,13 @@ import 'package:openapi/api.dart';
 
 import '../../../../widget_tester_extensions.dart';
 
-FilterSuggestionsResponseDto _sugg(List<String> countries) =>
-    FilterSuggestionsResponseDto(hasUnnamedPeople: false, countries: countries);
+FilterSuggestionsResponseDto _sugg(List<String> countries) => FilterSuggestionsResponseDto(
+  hasUnnamedPeople: false,
+  hasFavorites: true,
+  hasAssetsInAlbum: true,
+  hasAssetsNotInAlbum: true,
+  countries: countries,
+);
 
 List<Override> _overrideCountries(List<String> countries) => [
   photosFilterSuggestionsProvider.overrideWith((ref, filter) async => _sugg(countries)),
@@ -52,9 +57,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      final container = ProviderScope.containerOf(
-        tester.element(find.byType(PlacesPickerCountryAccordion)),
-      );
+      final container = ProviderScope.containerOf(tester.element(find.byType(PlacesPickerCountryAccordion)));
       await tester.tap(find.byKey(const Key('places-picker-country-France')));
       await tester.pumpAndSettle();
 
@@ -66,8 +69,13 @@ void main() {
     testWidgets('tapping an already-expanded country calls onExpandCountry(null)', (tester) async {
       String? expanded = 'France';
       await tester.pumpConsumerWidget(
-        SingleChildScrollView(child: _harness(expandedCountry: 'France', onExpand: (c) => expanded = c)),
-        overrides: [..._overrideCountries(['France']), citySuggestionsProvider.overrideWith((ref, c) async => [])],
+        SingleChildScrollView(
+          child: _harness(expandedCountry: 'France', onExpand: (c) => expanded = c),
+        ),
+        overrides: [
+          ..._overrideCountries(['France']),
+          citySuggestionsProvider.overrideWith((ref, c) async => []),
+        ],
       );
       await tester.pumpAndSettle();
 
@@ -79,7 +87,9 @@ void main() {
     testWidgets('expanding a country fetches its cities only — other countries are not fetched', (tester) async {
       final fetchedFor = <String?>[];
       await tester.pumpConsumerWidget(
-        SingleChildScrollView(child: _harness(expandedCountry: 'France', onExpand: (_) {})),
+        SingleChildScrollView(
+          child: _harness(expandedCountry: 'France', onExpand: (_) {}),
+        ),
         overrides: [
           ..._overrideCountries(['France', 'Spain']),
           citySuggestionsProvider.overrideWith((ref, country) async {
@@ -98,7 +108,9 @@ void main() {
 
     testWidgets('tapping a city selects country + city via setLocation', (tester) async {
       await tester.pumpConsumerWidget(
-        SingleChildScrollView(child: _harness(expandedCountry: 'France', onExpand: (_) {})),
+        SingleChildScrollView(
+          child: _harness(expandedCountry: 'France', onExpand: (_) {}),
+        ),
         overrides: [
           ..._overrideCountries(['France']),
           citySuggestionsProvider.overrideWith((ref, country) async => ['Paris', 'Lyon']),
@@ -106,9 +118,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      final container = ProviderScope.containerOf(
-        tester.element(find.byType(PlacesPickerCountryAccordion)),
-      );
+      final container = ProviderScope.containerOf(tester.element(find.byType(PlacesPickerCountryAccordion)));
       await tester.tap(find.byKey(const Key('places-picker-city-Paris')));
       await tester.pumpAndSettle();
 
@@ -120,7 +130,9 @@ void main() {
     testWidgets('selecting a different country replaces the prior country/city selection', (tester) async {
       String? expanded = 'France';
       await tester.pumpConsumerWidget(
-        SingleChildScrollView(child: _harness(expandedCountry: expanded, onExpand: (c) => expanded = c)),
+        SingleChildScrollView(
+          child: _harness(expandedCountry: expanded, onExpand: (c) => expanded = c),
+        ),
         overrides: [
           ..._overrideCountries(['France', 'Spain']),
           citySuggestionsProvider.overrideWith((ref, country) async => country == 'France' ? ['Paris'] : []),
@@ -128,9 +140,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      final container = ProviderScope.containerOf(
-        tester.element(find.byType(PlacesPickerCountryAccordion)),
-      );
+      final container = ProviderScope.containerOf(tester.element(find.byType(PlacesPickerCountryAccordion)));
       container.read(photosFilterProvider.notifier).setLocation(SearchLocationFilter(country: 'France', city: 'Paris'));
       await tester.pumpAndSettle();
 
@@ -144,7 +154,9 @@ void main() {
 
     testWidgets('search query filters the already-loaded city list for the expanded country', (tester) async {
       await tester.pumpConsumerWidget(
-        SingleChildScrollView(child: _harness(expandedCountry: 'France', onExpand: (_) {})),
+        SingleChildScrollView(
+          child: _harness(expandedCountry: 'France', onExpand: (_) {}),
+        ),
         overrides: [
           ..._overrideCountries(['France']),
           citySuggestionsProvider.overrideWith((ref, country) async => ['Paris', 'Lyon']),
@@ -154,9 +166,7 @@ void main() {
       expect(find.byKey(const Key('places-picker-city-Paris')), findsOneWidget);
       expect(find.byKey(const Key('places-picker-city-Lyon')), findsOneWidget);
 
-      final container = ProviderScope.containerOf(
-        tester.element(find.byType(PlacesPickerCountryAccordion)),
-      );
+      final container = ProviderScope.containerOf(tester.element(find.byType(PlacesPickerCountryAccordion)));
       container.read(placesPickerQueryProvider.notifier).state = 'par';
       await tester.pumpAndSettle();
 
@@ -166,7 +176,9 @@ void main() {
 
     testWidgets('per-country fetch error shows an inline retry for that country only', (tester) async {
       await tester.pumpConsumerWidget(
-        SingleChildScrollView(child: _harness(expandedCountry: 'Italy', onExpand: (_) {})),
+        SingleChildScrollView(
+          child: _harness(expandedCountry: 'Italy', onExpand: (_) {}),
+        ),
         overrides: [
           ..._overrideCountries(['Italy']),
           citySuggestionsProvider.overrideWith((ref, country) async => throw Exception('boom')),

--- a/mobile/test/presentation/widgets/filter_sheet/deep/camera_cascade_section_test.dart
+++ b/mobile/test/presentation/widgets/filter_sheet/deep/camera_cascade_section_test.dart
@@ -23,8 +23,13 @@ class _FakePrefs implements FilterSectionPrefs {
 
 Override _noCollapsed() => filterSectionPrefsProvider.overrideWithValue(_FakePrefs({}));
 
-FilterSuggestionsResponseDto _sugg({List<String>? cameraMakes}) =>
-    FilterSuggestionsResponseDto(hasUnnamedPeople: false, cameraMakes: cameraMakes ?? const []);
+FilterSuggestionsResponseDto _sugg({List<String>? cameraMakes}) => FilterSuggestionsResponseDto(
+  hasUnnamedPeople: false,
+  hasFavorites: true,
+  hasAssetsInAlbum: true,
+  hasAssetsNotInAlbum: true,
+  cameraMakes: cameraMakes ?? const [],
+);
 
 void main() {
   group('CameraCascadeSection', () {

--- a/mobile/test/presentation/widgets/filter_sheet/deep/people_section_test.dart
+++ b/mobile/test/presentation/widgets/filter_sheet/deep/people_section_test.dart
@@ -18,8 +18,13 @@ import 'package:openapi/api.dart';
 
 import '../../../../widget_tester_extensions.dart';
 
-FilterSuggestionsResponseDto _sugg({List<FilterSuggestionsPersonDto>? people}) =>
-    FilterSuggestionsResponseDto(hasUnnamedPeople: false, people: people ?? const []);
+FilterSuggestionsResponseDto _sugg({List<FilterSuggestionsPersonDto>? people}) => FilterSuggestionsResponseDto(
+  hasUnnamedPeople: false,
+  hasFavorites: true,
+  hasAssetsInAlbum: true,
+  hasAssetsNotInAlbum: true,
+  people: people ?? const [],
+);
 
 void main() {
   late Drift db;
@@ -200,9 +205,7 @@ void main() {
       final people = [for (var i = 0; i < 10; i++) FilterSuggestionsPersonDto(id: 'p$i', name: 'P$i')];
       await tester.pumpConsumerWidget(
         const Material(child: PeopleSectionDeep(onOpenPicker: null)),
-        overrides: [
-          photosFilterSuggestionsProvider.overrideWith((ref, filter) => Future.value(_sugg(people: people))),
-        ],
+        overrides: [photosFilterSuggestionsProvider.overrideWith((ref, filter) => Future.value(_sugg(people: people)))],
       );
       await tester.pumpAndSettle();
 
@@ -233,16 +236,14 @@ void main() {
       final people = [for (var i = 0; i < 10; i++) FilterSuggestionsPersonDto(id: 'p$i', name: 'P$i')];
       await tester.pumpConsumerWidget(
         const Material(child: PeopleSectionDeep(onOpenPicker: null)),
-        overrides: [
-          photosFilterSuggestionsProvider.overrideWith((ref, filter) => Future.value(_sugg(people: people))),
-        ],
+        overrides: [photosFilterSuggestionsProvider.overrideWith((ref, filter) => Future.value(_sugg(people: people)))],
       );
       await tester.pumpAndSettle();
 
       final container = ProviderScope.containerOf(tester.element(find.byType(PeopleSectionDeep)));
-      container.read(photosFilterProvider.notifier).togglePerson(
-        const PersonDto(id: 'p7', name: 'P7', isHidden: false, thumbnailPath: ''),
-      );
+      container
+          .read(photosFilterProvider.notifier)
+          .togglePerson(const PersonDto(id: 'p7', name: 'P7', isHidden: false, thumbnailPath: ''));
       await tester.pumpAndSettle();
 
       // Pinned beyond the cap because it's selected.
@@ -260,9 +261,7 @@ void main() {
       final people = [for (var i = 0; i < 4; i++) FilterSuggestionsPersonDto(id: 'p$i', name: 'P$i')];
       await tester.pumpConsumerWidget(
         const Material(child: PeopleSectionDeep(onOpenPicker: null)),
-        overrides: [
-          photosFilterSuggestionsProvider.overrideWith((ref, filter) => Future.value(_sugg(people: people))),
-        ],
+        overrides: [photosFilterSuggestionsProvider.overrideWith((ref, filter) => Future.value(_sugg(people: people)))],
       );
       await tester.pumpAndSettle();
 

--- a/mobile/test/presentation/widgets/filter_sheet/deep/places_cascade_section_test.dart
+++ b/mobile/test/presentation/widgets/filter_sheet/deep/places_cascade_section_test.dart
@@ -23,8 +23,13 @@ class _FakePrefs implements FilterSectionPrefs {
 
 Override _noCollapsed() => filterSectionPrefsProvider.overrideWithValue(_FakePrefs({}));
 
-FilterSuggestionsResponseDto _sugg({List<String>? countries}) =>
-    FilterSuggestionsResponseDto(hasUnnamedPeople: false, countries: countries ?? const []);
+FilterSuggestionsResponseDto _sugg({List<String>? countries}) => FilterSuggestionsResponseDto(
+  hasUnnamedPeople: false,
+  hasFavorites: true,
+  hasAssetsInAlbum: true,
+  hasAssetsNotInAlbum: true,
+  countries: countries ?? const [],
+);
 
 void main() {
   group('PlacesCascadeSection', () {

--- a/mobile/test/presentation/widgets/filter_sheet/deep/tags_section_test.dart
+++ b/mobile/test/presentation/widgets/filter_sheet/deep/tags_section_test.dart
@@ -22,8 +22,13 @@ class _FakePrefs implements FilterSectionPrefs {
 
 Override _noCollapsed() => filterSectionPrefsProvider.overrideWithValue(_FakePrefs({}));
 
-FilterSuggestionsResponseDto _sugg({List<FilterSuggestionsTagDto>? tags}) =>
-    FilterSuggestionsResponseDto(hasUnnamedPeople: false, tags: tags ?? const []);
+FilterSuggestionsResponseDto _sugg({List<FilterSuggestionsTagDto>? tags}) => FilterSuggestionsResponseDto(
+  hasUnnamedPeople: false,
+  hasFavorites: true,
+  hasAssetsInAlbum: true,
+  hasAssetsNotInAlbum: true,
+  tags: tags ?? const [],
+);
 
 void main() {
   group('TagsSectionDeep', () {

--- a/mobile/test/presentation/widgets/filter_sheet/deep/toggles_section_test.dart
+++ b/mobile/test/presentation/widgets/filter_sheet/deep/toggles_section_test.dart
@@ -1,11 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/person.model.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/deep/toggles_section.widget.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/filter_section_id.dart';
+import 'package:immich_mobile/providers/api.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/collapsed_sections.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/filter_suggestions.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openapi/api.dart';
 
+import '../../../../service.mocks.dart';
 import '../../../../widget_tester_extensions.dart';
 
 class _FakePrefs implements FilterSectionPrefs {
@@ -77,6 +83,60 @@ void main() {
       expect(container.read(photosFilterProvider).display.isNotInAlbum, isFalse);
     });
 
+    // The escape hatch that keeps a switch reachable while it holds a filter, even when its facet
+    // says the library has nothing left to match — otherwise the user could set the filter but never
+    // clear it. Untested before #910's fix-wave (deleting `|| display.isFavorite` kept the suite
+    // green).
+    testWidgets('keeps the favourites switch when its facet is empty but the filter is already active', (tester) async {
+      await tester.pumpConsumerWidget(
+        const Material(child: TogglesSection()),
+        overrides: [
+          ..._prefs(),
+          photosFilterSuggestionsProvider.overrideWith(
+            (ref, filter) => Future.value(
+              FilterSuggestionsResponseDto(
+                hasUnnamedPeople: false,
+                hasFavorites: false,
+                hasAssetsInAlbum: false,
+                hasAssetsNotInAlbum: false,
+              ),
+            ),
+          ),
+        ],
+      );
+      final container = ProviderScope.containerOf(tester.element(find.byType(TogglesSection)));
+      container.read(photosFilterProvider.notifier).setFavouritesOnly(true);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('toggle-favourites')), findsOneWidget);
+    });
+
+    testWidgets('keeps the not-in-album switch when its facet is empty but the filter is already active', (
+      tester,
+    ) async {
+      await tester.pumpConsumerWidget(
+        const Material(child: TogglesSection()),
+        overrides: [
+          ..._prefs(),
+          photosFilterSuggestionsProvider.overrideWith(
+            (ref, filter) => Future.value(
+              FilterSuggestionsResponseDto(
+                hasUnnamedPeople: false,
+                hasFavorites: false,
+                hasAssetsInAlbum: false,
+                hasAssetsNotInAlbum: false,
+              ),
+            ),
+          ),
+        ],
+      );
+      final container = ProviderScope.containerOf(tester.element(find.byType(TogglesSection)));
+      container.read(photosFilterProvider.notifier).setNotInAlbum(true);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('toggle-not-in-album')), findsOneWidget);
+    });
+
     testWidgets('initial switch state reflects provider', (tester) async {
       await tester.pumpConsumerWidget(const Material(child: TogglesSection()), overrides: _prefs());
       final container = ProviderScope.containerOf(tester.element(find.byType(TogglesSection)));
@@ -103,6 +163,101 @@ void main() {
       expect(find.byKey(const Key('toggle-archived')), findsOneWidget);
       expect(find.byKey(const Key('toggle-not-in-album')), findsOneWidget);
       expect(find.byKey(const Key('toggle-untagged')), findsOneWidget);
+    });
+
+    // #910 fix-wave finding 1: this widget's own facets watch must key on the debounced filter too
+    // (sectionAvailabilityProvider is only one of the two flagged call sites). A burst of rapid,
+    // discrete filter changes settles to exactly one NEW facets request, not one per change.
+    testWidgets('coalesces a burst of rapid filter changes into a single new facets request', (tester) async {
+      final mockApiService = MockApiService();
+      final mockSearchApi = MockSearchApi();
+      when(() => mockApiService.searchApi).thenReturn(mockSearchApi);
+      when(
+        () => mockSearchApi.getFilterSuggestions(
+          city: any(named: 'city'),
+          country: any(named: 'country'),
+          isFavorite: any(named: 'isFavorite'),
+          isNotInAlbum: any(named: 'isNotInAlbum'),
+          make: any(named: 'make'),
+          mediaType: any(named: 'mediaType'),
+          model: any(named: 'model'),
+          personIds: any(named: 'personIds'),
+          rating: any(named: 'rating'),
+          spaceId: any(named: 'spaceId'),
+          tagIds: any(named: 'tagIds'),
+          takenAfter: any(named: 'takenAfter'),
+          takenBefore: any(named: 'takenBefore'),
+          withSharedSpaces: any(named: 'withSharedSpaces'),
+        ),
+      ).thenAnswer(
+        (_) async => FilterSuggestionsResponseDto(
+          hasUnnamedPeople: false,
+          hasFavorites: true,
+          hasAssetsInAlbum: true,
+          hasAssetsNotInAlbum: true,
+        ),
+      );
+
+      await tester.pumpConsumerWidget(
+        const Material(child: TogglesSection()),
+        overrides: [..._prefs(), apiServiceProvider.overrideWithValue(mockApiService)],
+      );
+      final container = ProviderScope.containerOf(tester.element(find.byType(TogglesSection)));
+      // The initial (empty-filter) mount request is not what this test is about; only the burst is.
+      clearInteractions(mockSearchApi);
+
+      // Three discrete taps in quick succession — each well inside the 250 ms debounce window
+      // measured from the previous one.
+      final notifier = container.read(photosFilterProvider.notifier);
+      notifier.togglePerson(const PersonDto(id: 'p1', name: 'A', isHidden: false, thumbnailPath: ''));
+      await tester.pump(const Duration(milliseconds: 50));
+      notifier.togglePerson(const PersonDto(id: 'p2', name: 'B', isHidden: false, thumbnailPath: ''));
+      await tester.pump(const Duration(milliseconds: 50));
+      notifier.togglePerson(const PersonDto(id: 'p3', name: 'C', isHidden: false, thumbnailPath: ''));
+
+      // Still within the window measured from the last change: no new request yet.
+      await tester.pump(const Duration(milliseconds: 100));
+      verifyNever(
+        () => mockSearchApi.getFilterSuggestions(
+          city: any(named: 'city'),
+          country: any(named: 'country'),
+          isFavorite: any(named: 'isFavorite'),
+          isNotInAlbum: any(named: 'isNotInAlbum'),
+          make: any(named: 'make'),
+          mediaType: any(named: 'mediaType'),
+          model: any(named: 'model'),
+          personIds: any(named: 'personIds'),
+          rating: any(named: 'rating'),
+          spaceId: any(named: 'spaceId'),
+          tagIds: any(named: 'tagIds'),
+          takenAfter: any(named: 'takenAfter'),
+          takenBefore: any(named: 'takenBefore'),
+          withSharedSpaces: any(named: 'withSharedSpaces'),
+        ),
+      );
+
+      // Past the debounce window: the burst settles to exactly ONE new request.
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => mockSearchApi.getFilterSuggestions(
+          city: any(named: 'city'),
+          country: any(named: 'country'),
+          isFavorite: any(named: 'isFavorite'),
+          isNotInAlbum: any(named: 'isNotInAlbum'),
+          make: any(named: 'make'),
+          mediaType: any(named: 'mediaType'),
+          model: any(named: 'model'),
+          personIds: any(named: 'personIds'),
+          rating: any(named: 'rating'),
+          spaceId: any(named: 'spaceId'),
+          tagIds: any(named: 'tagIds'),
+          takenAfter: any(named: 'takenAfter'),
+          takenBefore: any(named: 'takenBefore'),
+          withSharedSpaces: any(named: 'withSharedSpaces'),
+        ),
+      ).called(1);
     });
   });
 }

--- a/mobile/test/presentation/widgets/filter_sheet/deep_content_test.dart
+++ b/mobile/test/presentation/widgets/filter_sheet/deep_content_test.dart
@@ -109,6 +109,9 @@ void main() {
             (ref, filter) => Future.value(
               FilterSuggestionsResponseDto(
                 hasUnnamedPeople: false,
+                hasFavorites: true,
+                hasAssetsInAlbum: true,
+                hasAssetsNotInAlbum: true,
                 people: [FilterSuggestionsPersonDto(id: 'p1', name: 'Emma')],
               ),
             ),
@@ -132,7 +135,15 @@ void main() {
       final scope = ProviderContainer(
         overrides: [
           photosFilterSuggestionsProvider.overrideWith(
-            (ref, filter) => Future.value(FilterSuggestionsResponseDto(hasUnnamedPeople: false, people: const [])),
+            (ref, filter) => Future.value(
+              FilterSuggestionsResponseDto(
+                hasUnnamedPeople: false,
+                hasFavorites: true,
+                hasAssetsInAlbum: true,
+                hasAssetsNotInAlbum: true,
+                people: const [],
+              ),
+            ),
           ),
           timeBucketsProvider.overrideWith((ref, filter) => Future.value(const <BucketLite>[])),
         ],
@@ -194,7 +205,14 @@ void main() {
         DeepContent(scrollController: controller),
         overrides: [
           photosFilterSuggestionsProvider.overrideWith(
-            (ref, filter) => Future.value(FilterSuggestionsResponseDto(hasUnnamedPeople: false)),
+            (ref, filter) => Future.value(
+              FilterSuggestionsResponseDto(
+                hasUnnamedPeople: false,
+                hasFavorites: true,
+                hasAssetsInAlbum: true,
+                hasAssetsNotInAlbum: true,
+              ),
+            ),
           ),
           timeBucketsProvider.overrideWith(
             (ref, filter) => Future.value(const <BucketLite>[(timeBucket: '2024-06-01', count: 10)]),
@@ -219,7 +237,15 @@ void main() {
         DeepContent(scrollController: controller),
         overrides: [
           photosFilterSuggestionsProvider.overrideWith(
-            (ref, filter) => Future.value(FilterSuggestionsResponseDto(hasUnnamedPeople: false, countries: ['France'])),
+            (ref, filter) => Future.value(
+              FilterSuggestionsResponseDto(
+                hasUnnamedPeople: false,
+                hasFavorites: true,
+                hasAssetsInAlbum: true,
+                hasAssetsNotInAlbum: true,
+                countries: ['France'],
+              ),
+            ),
           ),
           timeBucketsProvider.overrideWith((ref, filter) => Future.value(const <BucketLite>[])),
         ],

--- a/mobile/test/presentation/widgets/filter_sheet/deep_content_visibility_test.dart
+++ b/mobile/test/presentation/widgets/filter_sheet/deep_content_visibility_test.dart
@@ -5,6 +5,7 @@ import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/person.model.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/domain/services/store.service.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
@@ -15,6 +16,7 @@ import 'package:immich_mobile/presentation/widgets/filter_sheet/deep_content.wid
 import 'package:immich_mobile/presentation/widgets/filter_sheet/filter_section_id.dart';
 import 'package:immich_mobile/providers/photos_filter/filter_sheet.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/filter_suggestions.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/section_availability.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/time_buckets.provider.dart';
 import 'package:openapi/api.dart';
@@ -145,6 +147,44 @@ void main() {
     // These two have no facet and must always render — the section itself never disappears.
     expect(find.byKey(const Key('toggle-archived')), findsOneWidget);
     expect(find.byKey(const Key('toggle-untagged')), findsOneWidget);
+  });
+
+  // #910 fix-wave finding 2: the gated toggles need the SAME baseline treatment as the sections —
+  // a facet emptied only by a CROSS-SECTION filter (here: selecting a person with no favourited
+  // photos) must not pop the switch out mid-session, because the whole-scope baseline still has it.
+  // Mirrors the provider-level `keeps a section whose facet a CROSS-SECTION filter emptied` test.
+  testWidgets('keeps the favourites switch when a CROSS-SECTION filter emptied its facet, because the '
+      'baseline still has it (#910)', (tester) async {
+    const aPerson = PersonDto(id: 'p1', name: 'Alice', isHidden: false, thumbnailPath: '');
+    final controller = ScrollController();
+    addTearDown(controller.dispose);
+
+    await pumpDeep(
+      tester,
+      controller,
+      overrides: [
+        photosFilterSuggestionsProvider.overrideWith((ref, filter) {
+          // Current facets (person filter applied): no favourites in that person's photos.
+          // Baseline facets (SearchFilter.empty()): the library does have favourites.
+          return Future.value(
+            FilterSuggestionsResponseDto(
+              hasUnnamedPeople: false,
+              hasFavorites: filter.isEmpty,
+              hasAssetsInAlbum: false,
+              hasAssetsNotInAlbum: true,
+            ),
+          );
+        }),
+      ],
+    );
+
+    final container = ProviderScope.containerOf(tester.element(find.byType(DeepContent)));
+    container.read(photosFilterProvider.notifier).togglePerson(aPerson);
+    // Past the 250 ms debounce so the person filter's facets settle in.
+    await tester.pump(const Duration(milliseconds: 260));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('toggle-favourites')), findsOneWidget);
   });
 
   testWidgets('never dims or drops a rating star (#910, feedback_no_dynamic_rating_media_hiding)', (tester) async {

--- a/mobile/test/presentation/widgets/filter_sheet/deep_content_visibility_test.dart
+++ b/mobile/test/presentation/widgets/filter_sheet/deep_content_visibility_test.dart
@@ -4,16 +4,46 @@ import 'package:drift/drift.dart' as drift;
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
 import 'package:immich_mobile/domain/services/store.service.dart';
 import 'package:immich_mobile/entities/store.entity.dart';
 import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
 import 'package:immich_mobile/infrastructure/repositories/store.repository.dart';
+import 'package:immich_mobile/presentation/widgets/filter_sheet/deep/manage_sections_sheet.widget.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/deep_content.widget.dart';
+import 'package:immich_mobile/presentation/widgets/filter_sheet/filter_section_id.dart';
 import 'package:immich_mobile/providers/photos_filter/filter_sheet.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/filter_suggestions.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/section_availability.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/time_buckets.provider.dart';
+import 'package:openapi/api.dart';
 
 import '../../../widget_tester_extensions.dart';
+
+FilterSuggestionsResponseDto emptySuggestions() => FilterSuggestionsResponseDto(
+  hasUnnamedPeople: false,
+  hasFavorites: false,
+  hasAssetsInAlbum: false,
+  hasAssetsNotInAlbum: false,
+);
+
+extension _CopyWithRatings on FilterSuggestionsResponseDto {
+  /// Test-only helper: returns a copy with [ratings] substituted. #910's rating-star guard needs a
+  /// populated ratings facet without hand-rolling every other field.
+  FilterSuggestionsResponseDto copyWithRatings(List<num> ratings) => FilterSuggestionsResponseDto(
+    cameraMakes: cameraMakes,
+    countries: countries,
+    hasAssetsInAlbum: hasAssetsInAlbum,
+    hasAssetsNotInAlbum: hasAssetsNotInAlbum,
+    hasFavorites: hasFavorites,
+    hasUnnamedPeople: hasUnnamedPeople,
+    mediaTypes: mediaTypes,
+    people: people,
+    ratings: ratings,
+    tags: tags,
+  );
+}
 
 void main() {
   late Drift db;
@@ -29,7 +59,7 @@ void main() {
   });
   setUp(() async => Store.put(StoreKey.filterSheetHiddenSections, '[]'));
 
-  Future<void> pumpDeep(WidgetTester tester, ScrollController controller) async {
+  Future<void> pumpDeep(WidgetTester tester, ScrollController controller, {List<Override> overrides = const []}) async {
     await tester.binding.setSurfaceSize(const Size(400, 2400));
     addTearDown(() => tester.binding.setSurfaceSize(null));
     await tester.pumpConsumerWidget(
@@ -37,9 +67,38 @@ void main() {
       overrides: [
         photosFilterSheetProvider.overrideWith((ref) => FilterSheetSnap.deep),
         timeBucketsProvider.overrideWith((ref, filter) => Future.value(const [])),
+        ...overrides,
       ],
     );
     await tester.pumpAndSettle();
+  }
+
+  /// Shorthand: [pumpDeep] plus an optional `sectionAvailabilityProvider` override
+  /// ([availability]) and/or a `photosFilterSuggestionsProvider` override ([facets]) (#910).
+  Future<void> pumpDeepSheet(
+    WidgetTester tester, {
+    Set<FilterSectionId>? availability,
+    FilterSuggestionsResponseDto? facets,
+  }) async {
+    final controller = ScrollController();
+    addTearDown(controller.dispose);
+    await pumpDeep(
+      tester,
+      controller,
+      overrides: [
+        if (availability != null) sectionAvailabilityProvider.overrideWithValue(availability),
+        if (facets != null) photosFilterSuggestionsProvider.overrideWith((ref, filter) => Future.value(facets)),
+      ],
+    );
+  }
+
+  /// Shorthand: pumps [ManageSectionsSheet] with an optional `sectionAvailabilityProvider`
+  /// override (#910).
+  Future<void> pumpManageSections(WidgetTester tester, {Set<FilterSectionId>? availability}) async {
+    await tester.pumpConsumerWidget(
+      const ManageSectionsSheet(),
+      overrides: [if (availability != null) sectionAvailabilityProvider.overrideWithValue(availability)],
+    );
   }
 
   testWidgets('hidden sections are not rendered; visible ones are', (tester) async {
@@ -61,5 +120,38 @@ void main() {
 
     expect(find.byKey(const Key('deep-section-people')), findsOneWidget);
     expect(find.byKey(const Key('deep-section-toggles')), findsOneWidget);
+  });
+
+  testWidgets('does not render a section with no facet (#910)', (tester) async {
+    await pumpDeepSheet(tester, availability: {FilterSectionId.when, FilterSectionId.media});
+
+    // Positive first, so a sheet that failed to render cannot pass the negatives.
+    expect(find.byKey(const Key('deep-section-media')), findsOneWidget);
+    expect(find.byKey(const Key('deep-section-rating')), findsNothing);
+  });
+
+  testWidgets('does not offer an unavailable section in manage sections (#910)', (tester) async {
+    await pumpManageSections(tester, availability: {FilterSectionId.when, FilterSectionId.media});
+
+    expect(find.byKey(const Key('manage-section-media')), findsOneWidget);
+    expect(find.byKey(const Key('manage-section-rating')), findsNothing);
+  });
+
+  testWidgets('hides the favourites and not-in-album switches when their facets are empty (#910)', (tester) async {
+    await pumpDeepSheet(tester, facets: emptySuggestions());
+
+    expect(find.byKey(const Key('toggle-favourites')), findsNothing);
+    expect(find.byKey(const Key('toggle-not-in-album')), findsNothing);
+    // These two have no facet and must always render — the section itself never disappears.
+    expect(find.byKey(const Key('toggle-archived')), findsOneWidget);
+    expect(find.byKey(const Key('toggle-untagged')), findsOneWidget);
+  });
+
+  testWidgets('never dims or drops a rating star (#910, feedback_no_dynamic_rating_media_hiding)', (tester) async {
+    await pumpDeepSheet(tester, facets: emptySuggestions().copyWithRatings([2]));
+
+    for (var i = 1; i <= 5; i++) {
+      expect(find.byKey(Key('rating-star-$i')), findsOneWidget);
+    }
   });
 }

--- a/mobile/test/presentation/widgets/filter_sheet/deep_flow_test.dart
+++ b/mobile/test/presentation/widgets/filter_sheet/deep_flow_test.dart
@@ -51,6 +51,9 @@ void main() {
                 people: [FilterSuggestionsPersonDto(id: 'p1', name: 'Emma')],
                 tags: [FilterSuggestionsTagDto(id: 't1', value: 'Travel')],
                 countries: ['France'],
+                // #910: the rating section only renders when its facet is non-empty — this flow
+                // taps rating-star-4, so the mocked facets must include a rating.
+                ratings: [4],
               ),
             ),
           ),

--- a/mobile/test/presentation/widgets/filter_sheet/deep_flow_test.dart
+++ b/mobile/test/presentation/widgets/filter_sheet/deep_flow_test.dart
@@ -45,6 +45,9 @@ void main() {
             (ref, filter) => Future.value(
               FilterSuggestionsResponseDto(
                 hasUnnamedPeople: false,
+                hasFavorites: true,
+                hasAssetsInAlbum: true,
+                hasAssetsNotInAlbum: true,
                 people: [FilterSuggestionsPersonDto(id: 'p1', name: 'Emma')],
                 tags: [FilterSuggestionsTagDto(id: 't1', value: 'Travel')],
                 countries: ['France'],
@@ -107,6 +110,9 @@ void main() {
             (ref, filter) => Future.value(
               FilterSuggestionsResponseDto(
                 hasUnnamedPeople: false,
+                hasFavorites: true,
+                hasAssetsInAlbum: true,
+                hasAssetsNotInAlbum: true,
                 people: [FilterSuggestionsPersonDto(id: 'p1', name: 'Emma')],
                 tags: [FilterSuggestionsTagDto(id: 't1', value: 'Travel')],
               ),

--- a/mobile/test/presentation/widgets/filter_sheet/strips/strips_test.dart
+++ b/mobile/test/presentation/widgets/filter_sheet/strips/strips_test.dart
@@ -74,6 +74,9 @@ FilterSuggestionsResponseDto _suggestions({
   List<String> cameraMakes = const [],
 }) => FilterSuggestionsResponseDto(
   hasUnnamedPeople: false,
+  hasFavorites: true,
+  hasAssetsInAlbum: true,
+  hasAssetsNotInAlbum: true,
   people: people,
   tags: tags,
   countries: countries,
@@ -338,7 +341,9 @@ void main() {
     testWidgets('caps to 10 chips + a trailing "+N" tile when there are more than 10 tags', (tester) async {
       await tester.binding.setSurfaceSize(const Size(2400, 200));
       addTearDown(() => tester.binding.setSurfaceSize(null));
-      final s = _suggestions(tags: [for (var i = 0; i < 15; i++) FilterSuggestionsTagDto(id: 't$i', value: 'Tag$i')]);
+      final s = _suggestions(
+        tags: [for (var i = 0; i < 15; i++) FilterSuggestionsTagDto(id: 't$i', value: 'Tag$i')],
+      );
       await tester.pumpConsumerWidget(const TagsStrip(), overrides: _overrideSuggestions(s));
       await tester.pumpAndSettle();
 
@@ -359,7 +364,9 @@ void main() {
     testWidgets('no "+N" tile when there are 10 or fewer tags', (tester) async {
       await tester.binding.setSurfaceSize(const Size(2400, 200));
       addTearDown(() => tester.binding.setSurfaceSize(null));
-      final s = _suggestions(tags: [for (var i = 0; i < 10; i++) FilterSuggestionsTagDto(id: 't$i', value: 'Tag$i')]);
+      final s = _suggestions(
+        tags: [for (var i = 0; i < 10; i++) FilterSuggestionsTagDto(id: 't$i', value: 'Tag$i')],
+      );
       await tester.pumpConsumerWidget(const TagsStrip(), overrides: _overrideSuggestions(s));
       await tester.pumpAndSettle();
 
@@ -372,7 +379,9 @@ void main() {
     testWidgets('tapping the "+N" tile navigates to the tags picker', (tester) async {
       await tester.binding.setSurfaceSize(const Size(2400, 200));
       addTearDown(() => tester.binding.setSurfaceSize(null));
-      final s = _suggestions(tags: [for (var i = 0; i < 15; i++) FilterSuggestionsTagDto(id: 't$i', value: 'Tag$i')]);
+      final s = _suggestions(
+        tags: [for (var i = 0; i < 15; i++) FilterSuggestionsTagDto(id: 't$i', value: 'Tag$i')],
+      );
       final router = _TagsStripTestRouter();
       await tester.pumpWidget(
         EasyLocalization(

--- a/mobile/test/providers/photos_filter/active_chips_test.dart
+++ b/mobile/test/providers/photos_filter/active_chips_test.dart
@@ -111,6 +111,9 @@ void main() {
       final f = _base()..tagIds = ['t1'];
       final suggestions = FilterSuggestionsResponseDto(
         hasUnnamedPeople: false,
+        hasFavorites: false,
+        hasAssetsInAlbum: false,
+        hasAssetsNotInAlbum: false,
         tags: [FilterSuggestionsTagDto(id: 't1', value: 'wedding')],
       );
       final chips = activeChipsFromFilter(f, suggestions: suggestions);
@@ -274,7 +277,12 @@ void main() {
 
     test('person in state but absent from current suggestions still emits (id + state name)', () {
       final f = _base()..people.add(_person('p1', 'Alice'));
-      final suggestions = FilterSuggestionsResponseDto(hasUnnamedPeople: false); // no people field
+      final suggestions = FilterSuggestionsResponseDto(
+        hasUnnamedPeople: false,
+        hasFavorites: false,
+        hasAssetsInAlbum: false,
+        hasAssetsNotInAlbum: false,
+      ); // no people field
       final chips = activeChipsFromFilter(f, suggestions: suggestions);
       expect(chips.single.label, 'Alice');
     });

--- a/mobile/test/providers/photos_filter/camera_picker_provider_test.dart
+++ b/mobile/test/providers/photos_filter/camera_picker_provider_test.dart
@@ -5,8 +5,13 @@ import 'package:immich_mobile/providers/photos_filter/filter_debounce.provider.d
 import 'package:immich_mobile/providers/photos_filter/filter_suggestions.provider.dart';
 import 'package:openapi/api.dart';
 
-FilterSuggestionsResponseDto _sugg(List<String> cameraMakes) =>
-    FilterSuggestionsResponseDto(hasUnnamedPeople: false, cameraMakes: cameraMakes);
+FilterSuggestionsResponseDto _sugg(List<String> cameraMakes) => FilterSuggestionsResponseDto(
+  hasUnnamedPeople: false,
+  hasFavorites: true,
+  hasAssetsInAlbum: true,
+  hasAssetsNotInAlbum: true,
+  cameraMakes: cameraMakes,
+);
 
 ProviderContainer _containerWith(List<String> cameraMakes) {
   return ProviderContainer(

--- a/mobile/test/providers/photos_filter/filter_suggestions_provider_test.dart
+++ b/mobile/test/providers/photos_filter/filter_suggestions_provider_test.dart
@@ -10,6 +10,13 @@ import 'package:openapi/api.dart';
 
 import '../../service.mocks.dart';
 
+FilterSuggestionsResponseDto emptySuggestions() => FilterSuggestionsResponseDto(
+  hasUnnamedPeople: false,
+  hasFavorites: false,
+  hasAssetsInAlbum: false,
+  hasAssetsNotInAlbum: false,
+);
+
 void main() {
   late MockApiService mockApiService;
   late MockSearchApi mockSearchApi;
@@ -38,6 +45,7 @@ void main() {
           city: any(named: 'city'),
           country: any(named: 'country'),
           isFavorite: any(named: 'isFavorite'),
+          isNotInAlbum: any(named: 'isNotInAlbum'),
           make: any(named: 'make'),
           mediaType: any(named: 'mediaType'),
           model: any(named: 'model'),
@@ -49,7 +57,7 @@ void main() {
           takenBefore: any(named: 'takenBefore'),
           withSharedSpaces: any(named: 'withSharedSpaces'),
         ),
-      ).thenAnswer((_) async => FilterSuggestionsResponseDto(hasUnnamedPeople: false));
+      ).thenAnswer((_) async => emptySuggestions());
 
       await container.read(photosFilterSuggestionsProvider(SearchFilter.empty()).future);
 
@@ -58,6 +66,7 @@ void main() {
           city: any(named: 'city'),
           country: any(named: 'country'),
           isFavorite: any(named: 'isFavorite'),
+          isNotInAlbum: any(named: 'isNotInAlbum'),
           make: any(named: 'make'),
           mediaType: any(named: 'mediaType'),
           model: any(named: 'model'),
@@ -72,13 +81,66 @@ void main() {
       ).called(1);
     });
 
-    test('returns the FilterSuggestionsResponseDto returned by the API', () async {
-      final dto = FilterSuggestionsResponseDto(hasUnnamedPeople: false, countries: ['France']);
+    // #910: the albums facet is computed with this filter excluded, but every OTHER facet must
+    // still honour it — forwarding it here is what lets a not-in-album toggle narrow the other
+    // five facets instead of being silently dropped.
+    test('forwards isNotInAlbum so the facets reflect it (#910)', () async {
       when(
         () => mockSearchApi.getFilterSuggestions(
           city: any(named: 'city'),
           country: any(named: 'country'),
           isFavorite: any(named: 'isFavorite'),
+          isNotInAlbum: any(named: 'isNotInAlbum'),
+          make: any(named: 'make'),
+          mediaType: any(named: 'mediaType'),
+          model: any(named: 'model'),
+          personIds: any(named: 'personIds'),
+          rating: any(named: 'rating'),
+          spaceId: any(named: 'spaceId'),
+          tagIds: any(named: 'tagIds'),
+          takenAfter: any(named: 'takenAfter'),
+          takenBefore: any(named: 'takenBefore'),
+          withSharedSpaces: any(named: 'withSharedSpaces'),
+        ),
+      ).thenAnswer((_) async => emptySuggestions());
+
+      final filter = SearchFilter.empty().copyWith(display: SearchFilter.empty().display.copyWith(isNotInAlbum: true));
+      await container.read(photosFilterSuggestionsProvider(filter).future);
+
+      verify(
+        () => mockSearchApi.getFilterSuggestions(
+          city: any(named: 'city'),
+          country: any(named: 'country'),
+          isFavorite: any(named: 'isFavorite'),
+          isNotInAlbum: true,
+          make: any(named: 'make'),
+          mediaType: any(named: 'mediaType'),
+          model: any(named: 'model'),
+          personIds: any(named: 'personIds'),
+          rating: any(named: 'rating'),
+          spaceId: any(named: 'spaceId'),
+          tagIds: any(named: 'tagIds'),
+          takenAfter: any(named: 'takenAfter'),
+          takenBefore: any(named: 'takenBefore'),
+          withSharedSpaces: any(named: 'withSharedSpaces'),
+        ),
+      ).called(1);
+    });
+
+    test('returns the FilterSuggestionsResponseDto returned by the API', () async {
+      final dto = FilterSuggestionsResponseDto(
+        hasUnnamedPeople: false,
+        hasFavorites: false,
+        hasAssetsInAlbum: false,
+        hasAssetsNotInAlbum: false,
+        countries: ['France'],
+      );
+      when(
+        () => mockSearchApi.getFilterSuggestions(
+          city: any(named: 'city'),
+          country: any(named: 'country'),
+          isFavorite: any(named: 'isFavorite'),
+          isNotInAlbum: any(named: 'isNotInAlbum'),
           make: any(named: 'make'),
           mediaType: any(named: 'mediaType'),
           model: any(named: 'model'),
@@ -103,6 +165,7 @@ void main() {
           city: any(named: 'city'),
           country: any(named: 'country'),
           isFavorite: any(named: 'isFavorite'),
+          isNotInAlbum: any(named: 'isNotInAlbum'),
           make: any(named: 'make'),
           mediaType: any(named: 'mediaType'),
           model: any(named: 'model'),
@@ -127,6 +190,7 @@ void main() {
           city: any(named: 'city'),
           country: any(named: 'country'),
           isFavorite: any(named: 'isFavorite'),
+          isNotInAlbum: any(named: 'isNotInAlbum'),
           make: any(named: 'make'),
           mediaType: any(named: 'mediaType'),
           model: any(named: 'model'),
@@ -138,7 +202,7 @@ void main() {
           takenBefore: any(named: 'takenBefore'),
           withSharedSpaces: any(named: 'withSharedSpaces'),
         ),
-      ).thenAnswer((_) async => FilterSuggestionsResponseDto(hasUnnamedPeople: false));
+      ).thenAnswer((_) async => emptySuggestions());
 
       final after = DateTime.utc(2024, 1, 1);
       final before = DateTime.utc(2024, 12, 31);
@@ -158,6 +222,7 @@ void main() {
           city: 'Paris',
           country: 'France',
           isFavorite: null,
+          isNotInAlbum: null,
           make: 'Canon',
           mediaType: AssetTypeEnum.IMAGE,
           model: 'EOS R5',
@@ -177,6 +242,7 @@ void main() {
           city: any(named: 'city'),
           country: any(named: 'country'),
           isFavorite: any(named: 'isFavorite'),
+          isNotInAlbum: any(named: 'isNotInAlbum'),
           make: any(named: 'make'),
           mediaType: any(named: 'mediaType'),
           model: any(named: 'model'),
@@ -188,7 +254,7 @@ void main() {
           takenBefore: any(named: 'takenBefore'),
           withSharedSpaces: any(named: 'withSharedSpaces'),
         ),
-      ).thenAnswer((_) async => FilterSuggestionsResponseDto(hasUnnamedPeople: false));
+      ).thenAnswer((_) async => emptySuggestions());
 
       await container.read(photosFilterSuggestionsProvider(SearchFilter.empty()).future);
 
@@ -197,6 +263,7 @@ void main() {
           city: any(named: 'city'),
           country: any(named: 'country'),
           isFavorite: any(named: 'isFavorite'),
+          isNotInAlbum: any(named: 'isNotInAlbum'),
           make: any(named: 'make'),
           mediaType: captureAny(named: 'mediaType'),
           model: any(named: 'model'),
@@ -218,6 +285,7 @@ void main() {
           city: any(named: 'city'),
           country: any(named: 'country'),
           isFavorite: any(named: 'isFavorite'),
+          isNotInAlbum: any(named: 'isNotInAlbum'),
           make: any(named: 'make'),
           mediaType: any(named: 'mediaType'),
           model: any(named: 'model'),
@@ -229,7 +297,7 @@ void main() {
           takenBefore: any(named: 'takenBefore'),
           withSharedSpaces: any(named: 'withSharedSpaces'),
         ),
-      ).thenAnswer((_) async => FilterSuggestionsResponseDto(hasUnnamedPeople: false));
+      ).thenAnswer((_) async => emptySuggestions());
 
       await container.read(photosFilterSuggestionsProvider(SearchFilter.empty()).future);
 
@@ -238,6 +306,7 @@ void main() {
           city: any(named: 'city'),
           country: any(named: 'country'),
           isFavorite: captureAny(named: 'isFavorite'),
+          isNotInAlbum: any(named: 'isNotInAlbum'),
           make: any(named: 'make'),
           mediaType: any(named: 'mediaType'),
           model: any(named: 'model'),

--- a/mobile/test/providers/photos_filter/filter_suggestions_provider_test.dart
+++ b/mobile/test/providers/photos_filter/filter_suggestions_provider_test.dart
@@ -159,7 +159,10 @@ void main() {
       expect(result, dto);
     });
 
-    test('returns a fallback empty DTO when api returns null', () async {
+    // #910 / spec §4.6: a null API response must surface as AsyncValue.error, not a fabricated
+    // all-empty DTO. sectionAvailabilityProvider (Task 3) cannot tell a fabricated empty response
+    // from a genuinely empty library, and would hide six filter sections on a transient failure.
+    test('errors rather than reporting an empty library when the API returns null (#910)', () async {
       when(
         () => mockSearchApi.getFilterSuggestions(
           city: any(named: 'city'),
@@ -179,9 +182,10 @@ void main() {
         ),
       ).thenAnswer((_) async => null);
 
-      final result = await container.read(photosFilterSuggestionsProvider(SearchFilter.empty()).future);
-
-      expect(result.hasUnnamedPeople, false);
+      expect(
+        () => container.read(photosFilterSuggestionsProvider(SearchFilter.empty()).future),
+        throwsA(isA<Exception>()),
+      );
     });
 
     test('forwards filter fields to getFilterSuggestions', () async {

--- a/mobile/test/providers/photos_filter/places_picker_provider_test.dart
+++ b/mobile/test/providers/photos_filter/places_picker_provider_test.dart
@@ -5,8 +5,13 @@ import 'package:immich_mobile/providers/photos_filter/filter_suggestions.provide
 import 'package:immich_mobile/providers/photos_filter/places_picker.provider.dart';
 import 'package:openapi/api.dart';
 
-FilterSuggestionsResponseDto _sugg(List<String> countries) =>
-    FilterSuggestionsResponseDto(hasUnnamedPeople: false, countries: countries);
+FilterSuggestionsResponseDto _sugg(List<String> countries) => FilterSuggestionsResponseDto(
+  hasUnnamedPeople: false,
+  hasFavorites: true,
+  hasAssetsInAlbum: true,
+  hasAssetsNotInAlbum: true,
+  countries: countries,
+);
 
 ProviderContainer _containerWith(List<String> countries) {
   return ProviderContainer(

--- a/mobile/test/providers/photos_filter/section_availability_provider_test.dart
+++ b/mobile/test/providers/photos_filter/section_availability_provider_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/person.model.dart';
+import 'package:immich_mobile/models/search/search_filter.model.dart';
+import 'package:immich_mobile/presentation/widgets/filter_sheet/filter_section_id.dart';
+import 'package:immich_mobile/providers/api.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/filter_suggestions.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/section_availability.provider.dart';
+import 'package:immich_mobile/utils/option.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openapi/api.dart';
+
+import '../../service.mocks.dart';
+
+FilterSuggestionsResponseDto emptySuggestions() => FilterSuggestionsResponseDto(
+  hasUnnamedPeople: false,
+  hasFavorites: false,
+  hasAssetsInAlbum: false,
+  hasAssetsNotInAlbum: false,
+);
+
+FilterSuggestionsResponseDto withRatings(List<num> ratings) => FilterSuggestionsResponseDto(
+  hasUnnamedPeople: false,
+  hasFavorites: false,
+  hasAssetsInAlbum: false,
+  hasAssetsNotInAlbum: false,
+  ratings: ratings,
+);
+
+FilterSuggestionsResponseDto withMediaTypes(List<String> mediaTypes) => FilterSuggestionsResponseDto(
+  hasUnnamedPeople: false,
+  hasFavorites: false,
+  hasAssetsInAlbum: false,
+  hasAssetsNotInAlbum: false,
+  mediaTypes: mediaTypes,
+);
+
+const aPerson = PersonDto(id: 'p1', name: 'Alice', isHidden: false, thumbnailPath: '');
+
+void main() {
+  group('sectionAvailability (#910)', () {
+    test('hides a section whose facet is empty in both current and baseline', () {
+      final available = availableSections(emptySuggestions(), emptySuggestions(), SearchFilter.empty());
+
+      expect(available.contains(FilterSectionId.rating), isFalse);
+      expect(available.contains(FilterSectionId.when), isTrue);
+    });
+
+    test('keeps a section available when its facet is populated', () {
+      final full = withRatings([5]);
+      expect(availableSections(full, full, SearchFilter.empty()).contains(FilterSectionId.rating), isTrue);
+    });
+
+    // The parity guard, and the reason mobile has a baseline at all. `rating` holds no filter, so
+    // the active-filter rule cannot save it; only the baseline can. Without the baseline watch this
+    // test fails and the Rating section vanishes mid-session on web-divergent behaviour (spec §7).
+    test('keeps a section whose facet a CROSS-SECTION filter emptied', () {
+      final personFilter = SearchFilter.empty().copyWith(people: {aPerson});
+
+      final available = availableSections(emptySuggestions(), withRatings([5]), personFilter);
+
+      expect(available.contains(FilterSectionId.rating), isTrue);
+    });
+
+    test('never hides anything while the baseline is unknown', () {
+      final available = availableSections(emptySuggestions(), null, SearchFilter.empty());
+
+      expect(available, containsAll(FilterSectionId.values));
+    });
+
+    test('keeps people available while unnamed faces exist', () {
+      final unnamed = FilterSuggestionsResponseDto(
+        hasUnnamedPeople: true,
+        hasFavorites: false,
+        hasAssetsInAlbum: false,
+        hasAssetsNotInAlbum: false,
+      );
+
+      expect(availableSections(unnamed, unnamed, SearchFilter.empty()).contains(FilterSectionId.people), isTrue);
+    });
+
+    test('needs BOTH photos and videos to keep media available', () {
+      bool mediaFor(List<String> types) {
+        final f = withMediaTypes(types);
+        return availableSections(f, f, SearchFilter.empty()).contains(FilterSectionId.media);
+      }
+
+      expect(mediaFor(['IMAGE']), isFalse);
+      expect(mediaFor(['VIDEO']), isFalse);
+      // A length>=2 rule would wrongly pass this one — AssetType includes AUDIO and OTHER.
+      expect(mediaFor(['IMAGE', 'OTHER']), isFalse);
+      expect(mediaFor(['IMAGE', 'VIDEO']), isTrue);
+      expect(mediaFor(['IMAGE', 'OTHER', 'VIDEO']), isTrue);
+    });
+
+    test('never hides a section that holds an active filter', () {
+      // `Option<int?>`: none = no filter, some(null) = unrated, some(1-5) = that rating.
+      // See search_filter.model.dart:138-140.
+      final filter = SearchFilter.empty().copyWith(rating: SearchRatingFilter(rating: const Option.some(5)));
+
+      expect(
+        availableSections(emptySuggestions(), emptySuggestions(), filter).contains(FilterSectionId.rating),
+        isTrue,
+      );
+    });
+
+    test('always keeps when and toggles available', () {
+      final available = availableSections(emptySuggestions(), emptySuggestions(), SearchFilter.empty());
+
+      expect(available.contains(FilterSectionId.when), isTrue);
+      expect(available.contains(FilterSectionId.toggles), isTrue);
+    });
+  });
+
+  group('sectionAvailabilityProvider (#910)', () {
+    late MockApiService mockApiService;
+    late MockSearchApi mockSearchApi;
+
+    setUp(() {
+      mockApiService = MockApiService();
+      mockSearchApi = MockSearchApi();
+      when(() => mockApiService.searchApi).thenReturn(mockSearchApi);
+    });
+
+    // Locks the "same key when empty" optimisation: SearchFilter.empty() == an already-empty filter,
+    // so Riverpod serves one future, not two.
+    test('requests no second facet set when nothing is filtered', () async {
+      when(
+        () => mockSearchApi.getFilterSuggestions(
+          city: any(named: 'city'),
+          country: any(named: 'country'),
+          isFavorite: any(named: 'isFavorite'),
+          isNotInAlbum: any(named: 'isNotInAlbum'),
+          make: any(named: 'make'),
+          mediaType: any(named: 'mediaType'),
+          model: any(named: 'model'),
+          personIds: any(named: 'personIds'),
+          rating: any(named: 'rating'),
+          spaceId: any(named: 'spaceId'),
+          tagIds: any(named: 'tagIds'),
+          takenAfter: any(named: 'takenAfter'),
+          takenBefore: any(named: 'takenBefore'),
+          withSharedSpaces: any(named: 'withSharedSpaces'),
+        ),
+      ).thenAnswer((_) async => emptySuggestions());
+
+      final container = ProviderContainer(overrides: [apiServiceProvider.overrideWithValue(mockApiService)]);
+      addTearDown(container.dispose);
+
+      container.read(sectionAvailabilityProvider);
+
+      verify(
+        () => mockSearchApi.getFilterSuggestions(
+          city: any(named: 'city'),
+          country: any(named: 'country'),
+          isFavorite: any(named: 'isFavorite'),
+          isNotInAlbum: any(named: 'isNotInAlbum'),
+          make: any(named: 'make'),
+          mediaType: any(named: 'mediaType'),
+          model: any(named: 'model'),
+          personIds: any(named: 'personIds'),
+          rating: any(named: 'rating'),
+          spaceId: any(named: 'spaceId'),
+          tagIds: any(named: 'tagIds'),
+          takenAfter: any(named: 'takenAfter'),
+          takenBefore: any(named: 'takenBefore'),
+          withSharedSpaces: any(named: 'withSharedSpaces'),
+        ),
+      ).called(1);
+    });
+
+    // Task 1b makes a null response throw; the sheet must then show everything rather than
+    // interpreting the failure as a genuinely empty library.
+    test('offers every section while the facets are in error', () async {
+      when(
+        () => mockSearchApi.getFilterSuggestions(
+          city: any(named: 'city'),
+          country: any(named: 'country'),
+          isFavorite: any(named: 'isFavorite'),
+          isNotInAlbum: any(named: 'isNotInAlbum'),
+          make: any(named: 'make'),
+          mediaType: any(named: 'mediaType'),
+          model: any(named: 'model'),
+          personIds: any(named: 'personIds'),
+          rating: any(named: 'rating'),
+          spaceId: any(named: 'spaceId'),
+          tagIds: any(named: 'tagIds'),
+          takenAfter: any(named: 'takenAfter'),
+          takenBefore: any(named: 'takenBefore'),
+          withSharedSpaces: any(named: 'withSharedSpaces'),
+        ),
+      ).thenAnswer((_) async => null);
+
+      final container = ProviderContainer(overrides: [apiServiceProvider.overrideWithValue(mockApiService)]);
+      addTearDown(container.dispose);
+
+      // Let the underlying request settle to AsyncError before reading the derived provider —
+      // mirrors cameraPickerMakesProvider's test pattern for synchronous derived providers.
+      try {
+        await container.read(photosFilterSuggestionsProvider(SearchFilter.empty()).future);
+      } catch (_) {
+        // expected: Task 1b throws on a null response.
+      }
+
+      final available = container.read(sectionAvailabilityProvider);
+
+      expect(available, FilterSectionId.values.toSet());
+    });
+  });
+}

--- a/mobile/test/providers/photos_filter/section_availability_provider_test.dart
+++ b/mobile/test/providers/photos_filter/section_availability_provider_test.dart
@@ -1,3 +1,4 @@
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/person.model.dart';
@@ -5,6 +6,7 @@ import 'package:immich_mobile/models/search/search_filter.model.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/filter_section_id.dart';
 import 'package:immich_mobile/providers/api.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/filter_suggestions.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/section_availability.provider.dart';
 import 'package:immich_mobile/utils/option.dart';
 import 'package:mocktail/mocktail.dart';
@@ -167,6 +169,94 @@ void main() {
           withSharedSpaces: any(named: 'withSharedSpaces'),
         ),
       ).called(1);
+    });
+
+    // #910 fix-wave finding 1: the facets lookup must key on photosFilterDebouncedProvider (250 ms),
+    // not the raw filter — otherwise every discrete tap fires its own request on a family key nobody
+    // else shares. This is the strong form: a burst of rapid, discrete changes settles to exactly one
+    // NEW request, not one per change.
+    test('coalesces a burst of rapid filter changes into a single new facets request', () {
+      fakeAsync((async) {
+        when(
+          () => mockSearchApi.getFilterSuggestions(
+            city: any(named: 'city'),
+            country: any(named: 'country'),
+            isFavorite: any(named: 'isFavorite'),
+            isNotInAlbum: any(named: 'isNotInAlbum'),
+            make: any(named: 'make'),
+            mediaType: any(named: 'mediaType'),
+            model: any(named: 'model'),
+            personIds: any(named: 'personIds'),
+            rating: any(named: 'rating'),
+            spaceId: any(named: 'spaceId'),
+            tagIds: any(named: 'tagIds'),
+            takenAfter: any(named: 'takenAfter'),
+            takenBefore: any(named: 'takenBefore'),
+            withSharedSpaces: any(named: 'withSharedSpaces'),
+          ),
+        ).thenAnswer((_) async => emptySuggestions());
+
+        final container = ProviderContainer(overrides: [apiServiceProvider.overrideWithValue(mockApiService)]);
+        addTearDown(container.dispose);
+
+        // Mount and let the at-rest (empty-filter) request settle before starting the burst.
+        container.listen(sectionAvailabilityProvider, (_, __) {});
+        async.flushMicrotasks();
+        clearInteractions(mockSearchApi);
+
+        // Three discrete taps in quick succession — each well inside the 250 ms debounce window
+        // measured from the previous one.
+        final notifier = container.read(photosFilterProvider.notifier);
+        notifier.togglePerson(const PersonDto(id: 'p1', name: 'A', isHidden: false, thumbnailPath: ''));
+        async.elapse(const Duration(milliseconds: 50));
+        notifier.togglePerson(const PersonDto(id: 'p2', name: 'B', isHidden: false, thumbnailPath: ''));
+        async.elapse(const Duration(milliseconds: 50));
+        notifier.togglePerson(const PersonDto(id: 'p3', name: 'C', isHidden: false, thumbnailPath: ''));
+
+        // Still within the window measured from the last change: no new request yet.
+        async.elapse(const Duration(milliseconds: 100));
+        verifyNever(
+          () => mockSearchApi.getFilterSuggestions(
+            city: any(named: 'city'),
+            country: any(named: 'country'),
+            isFavorite: any(named: 'isFavorite'),
+            isNotInAlbum: any(named: 'isNotInAlbum'),
+            make: any(named: 'make'),
+            mediaType: any(named: 'mediaType'),
+            model: any(named: 'model'),
+            personIds: any(named: 'personIds'),
+            rating: any(named: 'rating'),
+            spaceId: any(named: 'spaceId'),
+            tagIds: any(named: 'tagIds'),
+            takenAfter: any(named: 'takenAfter'),
+            takenBefore: any(named: 'takenBefore'),
+            withSharedSpaces: any(named: 'withSharedSpaces'),
+          ),
+        );
+
+        // Past the debounce window: the burst settles to exactly ONE new request.
+        async.elapse(const Duration(milliseconds: 200));
+        async.flushMicrotasks();
+
+        verify(
+          () => mockSearchApi.getFilterSuggestions(
+            city: any(named: 'city'),
+            country: any(named: 'country'),
+            isFavorite: any(named: 'isFavorite'),
+            isNotInAlbum: any(named: 'isNotInAlbum'),
+            make: any(named: 'make'),
+            mediaType: any(named: 'mediaType'),
+            model: any(named: 'model'),
+            personIds: any(named: 'personIds'),
+            rating: any(named: 'rating'),
+            spaceId: any(named: 'spaceId'),
+            tagIds: any(named: 'tagIds'),
+            takenAfter: any(named: 'takenAfter'),
+            takenBefore: any(named: 'takenBefore'),
+            withSharedSpaces: any(named: 'withSharedSpaces'),
+          ),
+        ).called(1);
+      });
     });
 
     // Task 1b makes a null response throw; the sheet must then show everything rather than

--- a/mobile/test/providers/photos_filter/section_availability_provider_test.dart
+++ b/mobile/test/providers/photos_filter/section_availability_provider_test.dart
@@ -259,6 +259,67 @@ void main() {
       });
     });
 
+    // filter_suggestions.provider.dart never forwards the search-bar `context` field to the server,
+    // so a session that opens with only the search text set must not diverge the baseline key from
+    // the main key: that would fire a second facets request whose actual HTTP params are
+    // byte-identical to the first. Setting the text BEFORE anything reads the derived providers is
+    // deliberate: it's the case that matters, because it's the only one where neither key has a
+    // chance to reuse an already-resolved "empty" cache entry from an earlier at-rest render — a
+    // burst starting from an at-rest mount (like the test above) would prime that cache and mask
+    // the bug regardless of which baseline-key predicate is used.
+    test(
+      'requests one facets set, not two, when the sheet opens with only search text set (#910 fix-wave finding 3)',
+      () {
+        fakeAsync((async) {
+          when(
+            () => mockSearchApi.getFilterSuggestions(
+              city: any(named: 'city'),
+              country: any(named: 'country'),
+              isFavorite: any(named: 'isFavorite'),
+              isNotInAlbum: any(named: 'isNotInAlbum'),
+              make: any(named: 'make'),
+              mediaType: any(named: 'mediaType'),
+              model: any(named: 'model'),
+              personIds: any(named: 'personIds'),
+              rating: any(named: 'rating'),
+              spaceId: any(named: 'spaceId'),
+              tagIds: any(named: 'tagIds'),
+              takenAfter: any(named: 'takenAfter'),
+              takenBefore: any(named: 'takenBefore'),
+              withSharedSpaces: any(named: 'withSharedSpaces'),
+            ),
+          ).thenAnswer((_) async => emptySuggestions());
+
+          final container = ProviderContainer(overrides: [apiServiceProvider.overrideWithValue(mockApiService)]);
+          addTearDown(container.dispose);
+
+          container.read(photosFilterProvider.notifier).setText('sunset');
+
+          container.listen(sectionAvailabilityProvider, (_, __) {});
+          async.flushMicrotasks();
+
+          verify(
+            () => mockSearchApi.getFilterSuggestions(
+              city: any(named: 'city'),
+              country: any(named: 'country'),
+              isFavorite: any(named: 'isFavorite'),
+              isNotInAlbum: any(named: 'isNotInAlbum'),
+              make: any(named: 'make'),
+              mediaType: any(named: 'mediaType'),
+              model: any(named: 'model'),
+              personIds: any(named: 'personIds'),
+              rating: any(named: 'rating'),
+              spaceId: any(named: 'spaceId'),
+              tagIds: any(named: 'tagIds'),
+              takenAfter: any(named: 'takenAfter'),
+              takenBefore: any(named: 'takenBefore'),
+              withSharedSpaces: any(named: 'withSharedSpaces'),
+            ),
+          ).called(1);
+        });
+      },
+    );
+
     // Task 1b makes a null response throw; the sheet must then show everything rather than
     // interpreting the failure as a genuinely empty library.
     test('offers every section while the facets are in error', () async {

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -27758,6 +27758,18 @@
             },
             "type": "array"
           },
+          "hasAssetsInAlbum": {
+            "description": "Whether any filtered asset belongs to an album",
+            "type": "boolean"
+          },
+          "hasAssetsNotInAlbum": {
+            "description": "Whether any filtered asset belongs to no album",
+            "type": "boolean"
+          },
+          "hasFavorites": {
+            "description": "Whether any favourite exists in the filtered set, ignoring isFavorite",
+            "type": "boolean"
+          },
           "hasUnnamedPeople": {
             "description": "Whether unnamed people exist in the filtered set",
             "type": "boolean"
@@ -27794,6 +27806,9 @@
         "required": [
           "cameraMakes",
           "countries",
+          "hasAssetsInAlbum",
+          "hasAssetsNotInAlbum",
+          "hasFavorites",
           "hasUnnamedPeople",
           "mediaTypes",
           "people",
@@ -33989,6 +34004,18 @@
             },
             "type": "array"
           },
+          "hasAssetsInAlbum": {
+            "description": "Whether any filtered asset belongs to an album",
+            "type": "boolean"
+          },
+          "hasAssetsNotInAlbum": {
+            "description": "Whether any filtered asset belongs to no album",
+            "type": "boolean"
+          },
+          "hasFavorites": {
+            "description": "Whether any favourite exists in the filtered set, ignoring isFavorite",
+            "type": "boolean"
+          },
           "hasUnnamedPeople": {
             "description": "Whether unnamed people exist in the filtered smart-search set",
             "type": "boolean"
@@ -34040,6 +34067,9 @@
           "cameraModels",
           "cities",
           "countries",
+          "hasAssetsInAlbum",
+          "hasAssetsNotInAlbum",
+          "hasFavorites",
           "hasUnnamedPeople",
           "mediaTypes",
           "people",

--- a/packages/sdk/src/fetch-client.ts
+++ b/packages/sdk/src/fetch-client.ts
@@ -2402,6 +2402,12 @@ export type SmartSearchFacetsResponseDto = {
     cities: string[];
     /** Available countries */
     countries: string[];
+    /** Whether any filtered asset belongs to an album */
+    hasAssetsInAlbum: boolean;
+    /** Whether any filtered asset belongs to no album */
+    hasAssetsNotInAlbum: boolean;
+    /** Whether any favourite exists in the filtered set, ignoring isFavorite */
+    hasFavorites: boolean;
     /** Whether unnamed people exist in the filtered smart-search set */
     hasUnnamedPeople: boolean;
     /** Available media types */
@@ -2492,6 +2498,12 @@ export type FilterSuggestionsResponseDto = {
     cameraMakes: string[];
     /** Available countries */
     countries: string[];
+    /** Whether any filtered asset belongs to an album */
+    hasAssetsInAlbum: boolean;
+    /** Whether any filtered asset belongs to no album */
+    hasAssetsNotInAlbum: boolean;
+    /** Whether any favourite exists in the filtered set, ignoring isFavorite */
+    hasFavorites: boolean;
     /** Whether unnamed people exist in the filtered set */
     hasUnnamedPeople: boolean;
     /** Available media types */

--- a/server/src/controllers/search.controller.spec.ts
+++ b/server/src/controllers/search.controller.spec.ts
@@ -614,6 +614,9 @@ describe(SearchController.name, () => {
           ratings: [],
           mediaTypes: [],
           hasUnnamedPeople: false,
+          hasFavorites: false,
+          hasAssetsInAlbum: false,
+          hasAssetsNotInAlbum: false,
         });
 
         const { status } = await request(ctx.getHttpServer())

--- a/server/src/controllers/search.controller.spec.ts
+++ b/server/src/controllers/search.controller.spec.ts
@@ -175,6 +175,9 @@ describe(SearchController.name, () => {
           ratings: [4, 5],
           mediaTypes: [AssetType.Image],
           hasUnnamedPeople: false,
+          hasFavorites: true,
+          hasAssetsInAlbum: true,
+          hasAssetsNotInAlbum: true,
         });
       });
 
@@ -506,6 +509,9 @@ describe(SearchController.name, () => {
           ratings: [],
           mediaTypes: [],
           hasUnnamedPeople: false,
+          hasFavorites: false,
+          hasAssetsInAlbum: false,
+          hasAssetsNotInAlbum: false,
         });
 
         const { status, body } = await request(ctx.getHttpServer())
@@ -521,6 +527,9 @@ describe(SearchController.name, () => {
           ratings: [],
           mediaTypes: [],
           hasUnnamedPeople: false,
+          hasFavorites: false,
+          hasAssetsInAlbum: false,
+          hasAssetsNotInAlbum: false,
         });
         expect(service.getFilterSuggestions).toHaveBeenCalledWith(
           expect.anything(),
@@ -575,6 +584,9 @@ describe(SearchController.name, () => {
           ratings: [],
           mediaTypes: [],
           hasUnnamedPeople: false,
+          hasFavorites: false,
+          hasAssetsInAlbum: false,
+          hasAssetsNotInAlbum: false,
         });
 
         const { status } = await request(ctx.getHttpServer())

--- a/server/src/dtos/search.dto.ts
+++ b/server/src/dtos/search.dto.ts
@@ -262,6 +262,9 @@ const FilterSuggestionsResponseSchema = z
     ratings: z.array(z.number()).describe('Available ratings'),
     mediaTypes: z.array(z.string()).describe('Available media types'),
     hasUnnamedPeople: z.boolean().describe('Whether unnamed people exist in the filtered set'),
+    hasFavorites: z.boolean().describe('Whether any favourite exists in the filtered set, ignoring isFavorite'),
+    hasAssetsInAlbum: z.boolean().describe('Whether any filtered asset belongs to an album'),
+    hasAssetsNotInAlbum: z.boolean().describe('Whether any filtered asset belongs to no album'),
   })
   .meta({ id: 'FilterSuggestionsResponseDto' });
 
@@ -280,6 +283,9 @@ const SmartSearchFacetsResponseSchema = z
     ratings: z.array(z.number()).describe('Available ratings'),
     mediaTypes: z.array(AssetTypeSchema).describe('Available media types'),
     hasUnnamedPeople: z.boolean().describe('Whether unnamed people exist in the filtered smart-search set'),
+    hasFavorites: z.boolean().describe('Whether any favourite exists in the filtered set, ignoring isFavorite'),
+    hasAssetsInAlbum: z.boolean().describe('Whether any filtered asset belongs to an album'),
+    hasAssetsNotInAlbum: z.boolean().describe('Whether any filtered asset belongs to no album'),
   })
   .meta({ id: 'SmartSearchFacetsResponseDto' });
 

--- a/server/src/queries/search.repository.sql
+++ b/server/src/queries/search.repository.sql
@@ -987,6 +987,141 @@ where
   )
 order by
   "type"
+select
+  "asset"."id"
+from
+  "asset"
+where
+  "asset"."id" in (
+    select
+      "asset"."id"
+    from
+      "asset"
+      inner join "asset_exif" on "asset_exif"."assetId" = "asset"."id"
+      inner join (
+        select
+          "assetId"
+        from
+          "tag_asset"
+          inner join "tag_closure" on "tag_asset"."tagId" = "tag_closure"."id_descendant"
+        where
+          "tag_closure"."id_ancestor" = any ($1::uuid[])
+        group by
+          "assetId"
+        having
+          count(distinct "tag_closure"."id_ancestor") >= $2
+      ) as "has_tags" on "has_tags"."assetId" = "asset"."id"
+    where
+      "asset"."id" in (
+        select
+          "candidates"."id"
+        from
+          smart_search_facet_candidates as "candidates"
+      )
+      and "asset"."fileCreatedAt" >= $3
+      and "asset"."fileCreatedAt" <= $4
+      and "asset"."type" = $5
+      and "asset_exif"."country" = $6
+      and "asset_exif"."make" = $7
+      and "asset_exif"."rating" >= $8
+  )
+  and "asset"."isFavorite" = $9
+limit
+  $10
+select
+  "asset"."id"
+from
+  "asset"
+where
+  "asset"."id" in (
+    select
+      "asset"."id"
+    from
+      "asset"
+      inner join "asset_exif" on "asset_exif"."assetId" = "asset"."id"
+      inner join (
+        select
+          "assetId"
+        from
+          "tag_asset"
+          inner join "tag_closure" on "tag_asset"."tagId" = "tag_closure"."id_descendant"
+        where
+          "tag_closure"."id_ancestor" = any ($1::uuid[])
+        group by
+          "assetId"
+        having
+          count(distinct "tag_closure"."id_ancestor") >= $2
+      ) as "has_tags" on "has_tags"."assetId" = "asset"."id"
+    where
+      "asset"."id" in (
+        select
+          "candidates"."id"
+        from
+          smart_search_facet_candidates as "candidates"
+      )
+      and "asset"."fileCreatedAt" >= $3
+      and "asset"."fileCreatedAt" <= $4
+      and "asset"."type" = $5
+      and "asset_exif"."country" = $6
+      and "asset_exif"."make" = $7
+      and "asset_exif"."rating" >= $8
+  )
+  and exists (
+    select
+    from
+      "album_asset"
+    where
+      "album_asset"."assetId" = "asset"."id"
+  )
+limit
+  $9
+select
+  "asset"."id"
+from
+  "asset"
+where
+  "asset"."id" in (
+    select
+      "asset"."id"
+    from
+      "asset"
+      inner join "asset_exif" on "asset_exif"."assetId" = "asset"."id"
+      inner join (
+        select
+          "assetId"
+        from
+          "tag_asset"
+          inner join "tag_closure" on "tag_asset"."tagId" = "tag_closure"."id_descendant"
+        where
+          "tag_closure"."id_ancestor" = any ($1::uuid[])
+        group by
+          "assetId"
+        having
+          count(distinct "tag_closure"."id_ancestor") >= $2
+      ) as "has_tags" on "has_tags"."assetId" = "asset"."id"
+    where
+      "asset"."id" in (
+        select
+          "candidates"."id"
+        from
+          smart_search_facet_candidates as "candidates"
+      )
+      and "asset"."fileCreatedAt" >= $3
+      and "asset"."fileCreatedAt" <= $4
+      and "asset"."type" = $5
+      and "asset_exif"."country" = $6
+      and "asset_exif"."make" = $7
+      and "asset_exif"."rating" >= $8
+  )
+  and not exists (
+    select
+    from
+      "album_asset"
+    where
+      "album_asset"."assetId" = "asset"."id"
+  )
+limit
+  $9
 commit
 
 -- SearchRepository.searchFaces (owner)
@@ -3153,3 +3288,264 @@ where
   )
 order by
   "type"
+select
+  "asset"."id"
+from
+  "asset"
+where
+  "asset"."id" in (
+    select
+      "asset"."id"
+    from
+      "asset"
+    where
+      "asset"."deletedAt" is null
+      and (
+        "asset"."ownerId" = any ($1::uuid[])
+        or (
+          "asset"."visibility" = $2
+          and (
+            exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_asset"
+              where
+                "shared_space_asset"."assetId" = "asset"."id"
+                and "shared_space_asset"."spaceId" = any ($3::uuid[])
+            )
+            or exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_library"
+              where
+                "shared_space_library"."libraryId" = "asset"."libraryId"
+                and "shared_space_library"."spaceId" = any ($4::uuid[])
+            )
+            or (
+              exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_album"
+                  inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+                  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                  and "album"."deletedAt" is null
+                where
+                  "album_asset"."assetId" = "asset"."id"
+                  and "shared_space_album"."spaceId" = any ($5::uuid[])
+                  and "shared_space_album"."showInTimeline" = $6
+              )
+              or exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_album"
+                  inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+                  and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+                  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                  and "album"."deletedAt" is null
+                where
+                  "album_space_asset"."assetId" = "asset"."id"
+                  and "shared_space_album"."spaceId" = any ($7::uuid[])
+                  and "shared_space_album"."showInTimeline" = $8
+              )
+            )
+          )
+        )
+      )
+      and "asset"."fileCreatedAt" >= $9
+      and exists (
+        select
+        from
+          "asset_face"
+          inner join "face_identity_face" on "face_identity_face"."assetFaceId" = "asset_face"."id"
+        where
+          "asset_face"."assetId" = "asset"."id"
+          and "asset_face"."deletedAt" is null
+          and "asset_face"."isVisible" is true
+          and "face_identity_face"."identityId" = $10::uuid
+      )
+  )
+  and "asset"."isFavorite" = $11
+limit
+  $12
+select
+  "asset"."id"
+from
+  "asset"
+where
+  "asset"."id" in (
+    select
+      "asset"."id"
+    from
+      "asset"
+    where
+      "asset"."deletedAt" is null
+      and (
+        "asset"."ownerId" = any ($1::uuid[])
+        or (
+          "asset"."visibility" = $2
+          and (
+            exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_asset"
+              where
+                "shared_space_asset"."assetId" = "asset"."id"
+                and "shared_space_asset"."spaceId" = any ($3::uuid[])
+            )
+            or exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_library"
+              where
+                "shared_space_library"."libraryId" = "asset"."libraryId"
+                and "shared_space_library"."spaceId" = any ($4::uuid[])
+            )
+            or (
+              exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_album"
+                  inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+                  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                  and "album"."deletedAt" is null
+                where
+                  "album_asset"."assetId" = "asset"."id"
+                  and "shared_space_album"."spaceId" = any ($5::uuid[])
+                  and "shared_space_album"."showInTimeline" = $6
+              )
+              or exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_album"
+                  inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+                  and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+                  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                  and "album"."deletedAt" is null
+                where
+                  "album_space_asset"."assetId" = "asset"."id"
+                  and "shared_space_album"."spaceId" = any ($7::uuid[])
+                  and "shared_space_album"."showInTimeline" = $8
+              )
+            )
+          )
+        )
+      )
+      and "asset"."fileCreatedAt" >= $9
+      and exists (
+        select
+        from
+          "asset_face"
+          inner join "face_identity_face" on "face_identity_face"."assetFaceId" = "asset_face"."id"
+        where
+          "asset_face"."assetId" = "asset"."id"
+          and "asset_face"."deletedAt" is null
+          and "asset_face"."isVisible" is true
+          and "face_identity_face"."identityId" = $10::uuid
+      )
+  )
+  and exists (
+    select
+    from
+      "album_asset"
+    where
+      "album_asset"."assetId" = "asset"."id"
+  )
+limit
+  $11
+select
+  "asset"."id"
+from
+  "asset"
+where
+  "asset"."id" in (
+    select
+      "asset"."id"
+    from
+      "asset"
+    where
+      "asset"."deletedAt" is null
+      and (
+        "asset"."ownerId" = any ($1::uuid[])
+        or (
+          "asset"."visibility" = $2
+          and (
+            exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_asset"
+              where
+                "shared_space_asset"."assetId" = "asset"."id"
+                and "shared_space_asset"."spaceId" = any ($3::uuid[])
+            )
+            or exists (
+              select
+                1 as "exists"
+              from
+                "shared_space_library"
+              where
+                "shared_space_library"."libraryId" = "asset"."libraryId"
+                and "shared_space_library"."spaceId" = any ($4::uuid[])
+            )
+            or (
+              exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_album"
+                  inner join "album_asset" on "album_asset"."albumId" = "shared_space_album"."albumId"
+                  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                  and "album"."deletedAt" is null
+                where
+                  "album_asset"."assetId" = "asset"."id"
+                  and "shared_space_album"."spaceId" = any ($5::uuid[])
+                  and "shared_space_album"."showInTimeline" = $6
+              )
+              or exists (
+                select
+                  1 as "exists"
+                from
+                  "shared_space_album"
+                  inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+                  and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+                  inner join "album" on "album"."id" = "shared_space_album"."albumId"
+                  and "album"."deletedAt" is null
+                where
+                  "album_space_asset"."assetId" = "asset"."id"
+                  and "shared_space_album"."spaceId" = any ($7::uuid[])
+                  and "shared_space_album"."showInTimeline" = $8
+              )
+            )
+          )
+        )
+      )
+      and "asset"."fileCreatedAt" >= $9
+      and exists (
+        select
+        from
+          "asset_face"
+          inner join "face_identity_face" on "face_identity_face"."assetFaceId" = "asset_face"."id"
+        where
+          "asset_face"."assetId" = "asset"."id"
+          and "asset_face"."deletedAt" is null
+          and "asset_face"."isVisible" is true
+          and "face_identity_face"."identityId" = $10::uuid
+      )
+  )
+  and not exists (
+    select
+    from
+      "album_asset"
+    where
+      "album_asset"."assetId" = "asset"."id"
+  )
+limit
+  $11

--- a/server/src/repositories/search.repository.spec.ts
+++ b/server/src/repositories/search.repository.spec.ts
@@ -626,9 +626,10 @@ describe(SearchRepository.name, () => {
 
       await repository.getFilterSuggestions([userId], { ...allDimensions });
 
-      // countries, cameraMakes, tags, people, ratings, mediaTypes — in construction order.
+      // countries, cameraMakes, tags, people, ratings, mediaTypes, hasFavorites, then the two
+      // album-membership probes (filed / unfiled) — in construction order.
       const [countries, ...rest] = options();
-      expect(rest).toHaveLength(5);
+      expect(rest).toHaveLength(8);
 
       expect(countries.state).toBeUndefined();
       expect(countries.lensModel).toBe('RF24-105mm F4 L IS USM');

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -639,6 +639,7 @@ export class SearchRepository {
       const ratings = await this.getSmartFacetRatings(trx, options);
       const mediaTypes = await this.getSmartFacetMediaTypes(trx, options);
       const hasFavorites = await this.getSmartFacetHasFavorites(trx, options);
+      const albumMembership = await this.getSmartFacetAlbumMembership(trx, options);
 
       return {
         total,
@@ -653,8 +654,7 @@ export class SearchRepository {
         mediaTypes,
         hasUnnamedPeople: peopleResult.hasUnnamedPeople,
         hasFavorites,
-        hasAssetsInAlbum: false,
-        hasAssetsNotInAlbum: false,
+        ...albumMembership,
       };
     });
   }
@@ -672,6 +672,8 @@ export class SearchRepository {
         'rating',
         'type',
         'isFavorite',
+        'isInAlbum',
+        'isNotInAlbum',
         'takenAfter',
         'takenBefore',
         'personIds',
@@ -733,6 +735,14 @@ export class SearchRepository {
       .$if(exclude !== 'media' && !!options.type, (qb) => qb.where('asset.type', '=', options.type!))
       .$if(exclude !== 'favorites' && options.isFavorite !== undefined, (qb) =>
         qb.where('asset.isFavorite', '=', options.isFavorite!),
+      )
+      .$if(exclude !== 'albums' && !!options.isNotInAlbum, (qb) =>
+        qb.where((eb) =>
+          eb.not(eb.exists(eb.selectFrom('album_asset').whereRef('album_asset.assetId', '=', 'asset.id'))),
+        ),
+      )
+      .$if(exclude !== 'albums' && !!options.isInAlbum, (qb) =>
+        qb.where((eb) => eb.exists(eb.selectFrom('album_asset').whereRef('album_asset.assetId', '=', 'asset.id'))),
       )
       .$if(needsExifJoin, (qb) =>
         qb
@@ -991,6 +1001,26 @@ export class SearchRepository {
       .limit(1)
       .executeTakeFirst();
     return !!row;
+  }
+
+  private async getSmartFacetAlbumMembership(
+    trx: Kysely<DB>,
+    options: SmartSearchFacetsOptions,
+  ): Promise<{ hasAssetsInAlbum: boolean; hasAssetsNotInAlbum: boolean }> {
+    const probe = (filed: boolean) =>
+      trx
+        .selectFrom('asset')
+        .select('asset.id')
+        .where('asset.id', 'in', this.buildSmartFacetFilteredAssetIds(trx, options, 'albums'))
+        .where((eb) => {
+          const inAlbum = eb.exists(eb.selectFrom('album_asset').whereRef('album_asset.assetId', '=', 'asset.id'));
+          return filed ? inAlbum : eb.not(inAlbum);
+        })
+        .limit(1)
+        .executeTakeFirst();
+
+    const [filed, unfiled] = await Promise.all([probe(true), probe(false)]);
+    return { hasAssetsInAlbum: !!filed, hasAssetsNotInAlbum: !!unfiled };
   }
 
   @GenerateSql(

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -219,7 +219,17 @@ export type SmartSearchOptions = SearchDateOptions &
 export type SmartSearchFacetsOptions = Omit<SmartSearchOptions, 'orderDirection'>;
 
 type SmartFacetExclude =
-  'time' | 'people' | 'location' | 'city' | 'camera' | 'cameraModel' | 'tags' | 'rating' | 'media';
+  | 'time'
+  | 'people'
+  | 'location'
+  | 'city'
+  | 'camera'
+  | 'cameraModel'
+  | 'tags'
+  | 'rating'
+  | 'media'
+  | 'favorites'
+  | 'albums';
 
 export interface SmartSearchFacetsResult {
   total: number;
@@ -233,6 +243,9 @@ export interface SmartSearchFacetsResult {
   ratings: number[];
   mediaTypes: AssetType[];
   hasUnnamedPeople: boolean;
+  hasFavorites: boolean;
+  hasAssetsInAlbum: boolean;
+  hasAssetsNotInAlbum: boolean;
 }
 
 export type OcrSearchOptions = SearchDateOptions & SearchOcrOptions;
@@ -625,6 +638,7 @@ export class SearchRepository {
       const peopleResult = await this.getSmartFacetPeople(trx, options);
       const ratings = await this.getSmartFacetRatings(trx, options);
       const mediaTypes = await this.getSmartFacetMediaTypes(trx, options);
+      const hasFavorites = await this.getSmartFacetHasFavorites(trx, options);
 
       return {
         total,
@@ -638,6 +652,9 @@ export class SearchRepository {
         ratings,
         mediaTypes,
         hasUnnamedPeople: peopleResult.hasUnnamedPeople,
+        hasFavorites,
+        hasAssetsInAlbum: false,
+        hasAssetsNotInAlbum: false,
       };
     });
   }
@@ -714,7 +731,9 @@ export class SearchRepository {
         qb.where('asset.fileCreatedAt', '<=', options.takenBefore!),
       )
       .$if(exclude !== 'media' && !!options.type, (qb) => qb.where('asset.type', '=', options.type!))
-      .$if(options.isFavorite !== undefined, (qb) => qb.where('asset.isFavorite', '=', options.isFavorite!))
+      .$if(exclude !== 'favorites' && options.isFavorite !== undefined, (qb) =>
+        qb.where('asset.isFavorite', '=', options.isFavorite!),
+      )
       .$if(needsExifJoin, (qb) =>
         qb
           .innerJoin('asset_exif', 'asset_exif.assetId', 'asset.id')
@@ -961,6 +980,17 @@ export class SearchRepository {
       .orderBy('type')
       .execute();
     return rows.map((row) => row.type);
+  }
+
+  private async getSmartFacetHasFavorites(trx: Kysely<DB>, options: SmartSearchFacetsOptions): Promise<boolean> {
+    const row = await trx
+      .selectFrom('asset')
+      .select('asset.id')
+      .where('asset.id', 'in', this.buildSmartFacetFilteredAssetIds(trx, options, 'favorites'))
+      .where('asset.isFavorite', '=', true)
+      .limit(1)
+      .executeTakeFirst();
+    return !!row;
   }
 
   @GenerateSql(

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -350,6 +350,9 @@ export interface FilterSuggestionsResult {
   ratings: number[];
   mediaTypes: string[];
   hasUnnamedPeople: boolean;
+  hasFavorites: boolean;
+  hasAssetsInAlbum: boolean;
+  hasAssetsNotInAlbum: boolean;
 }
 
 /** Skip threshold when disabled (0), undefined, or at max cosine distance (>= 2) since it would filter nothing */
@@ -1399,7 +1402,7 @@ export class SearchRepository {
     ],
   })
   async getFilterSuggestions(userIds: string[], options: FilterSuggestionsOptions): Promise<FilterSuggestionsResult> {
-    const [countries, cameraMakes, tags, peopleResult, ratings, mediaTypes] = await Promise.all([
+    const [countries, cameraMakes, tags, peopleResult, ratings, mediaTypes, hasFavorites] = await Promise.all([
       // `state` joins `country` / `city` in the location group's self-exclusion: it implies its
       // country, so leaving it applied would collapse the country selector to a single row —
       // exactly the reason `city` is excluded here. Every other list keeps `state` applied.
@@ -1411,6 +1414,7 @@ export class SearchRepository {
       this.getFilteredPeople(userIds, without(options, 'personIds', 'identityIds')),
       this.getFilteredRatings(userIds, without(options, 'rating')),
       this.getFilteredMediaTypes(userIds, without(options, 'mediaType')),
+      this.getFilteredHasFavorites(userIds, without(options, 'isFavorite')),
     ]);
 
     return {
@@ -1421,6 +1425,9 @@ export class SearchRepository {
       ratings,
       mediaTypes,
       hasUnnamedPeople: peopleResult.hasUnnamedPeople,
+      hasFavorites,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: false,
     };
   }
 
@@ -1907,5 +1914,20 @@ export class SearchRepository {
       .orderBy('type')
       .execute();
     return res.map((row) => row.type);
+  }
+
+  /**
+   * #910: presence probes for the Favourites / Albums sections. `limit 1` rather than an aggregate so
+   * Postgres stops at the first matching row — the answer is "does one exist", not "how many".
+   */
+  private async getFilteredHasFavorites(userIds: string[], options: FilterSuggestionsOptions): Promise<boolean> {
+    const row = await this.db
+      .selectFrom('asset')
+      .select('asset.id')
+      .where('asset.id', 'in', this.buildFilteredAssetIds(userIds, options))
+      .where('asset.isFavorite', '=', true)
+      .limit(1)
+      .executeTakeFirst();
+    return !!row;
   }
 }

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -736,12 +736,12 @@ export class SearchRepository {
       .$if(exclude !== 'favorites' && options.isFavorite !== undefined, (qb) =>
         qb.where('asset.isFavorite', '=', options.isFavorite!),
       )
-      .$if(exclude !== 'albums' && !!options.isNotInAlbum, (qb) =>
+      .$if(exclude !== 'albums' && !!options.isNotInAlbum && !options.albumIds?.length, (qb) =>
         qb.where((eb) =>
           eb.not(eb.exists(eb.selectFrom('album_asset').whereRef('album_asset.assetId', '=', 'asset.id'))),
         ),
       )
-      .$if(exclude !== 'albums' && !!options.isInAlbum, (qb) =>
+      .$if(exclude !== 'albums' && !!options.isInAlbum && !options.albumIds?.length, (qb) =>
         qb.where((eb) => eb.exists(eb.selectFrom('album_asset').whereRef('album_asset.assetId', '=', 'asset.id'))),
       )
       .$if(needsExifJoin, (qb) =>

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -1459,6 +1459,9 @@ export class SearchRepository {
       'WITH\n  filtered_assets',
       'select distinct\n  "rating"',
       'select distinct\n  "type"',
+      'and "asset"."isFavorite" = $',
+      '  and exists (\n    select\n    from\n      "album_asset"',
+      '  and not exists (\n    select\n    from\n      "album_asset"',
     ],
   })
   async getFilterSuggestions(userIds: string[], options: FilterSuggestionsOptions): Promise<FilterSuggestionsResult> {

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -1402,20 +1402,22 @@ export class SearchRepository {
     ],
   })
   async getFilterSuggestions(userIds: string[], options: FilterSuggestionsOptions): Promise<FilterSuggestionsResult> {
-    const [countries, cameraMakes, tags, peopleResult, ratings, mediaTypes, hasFavorites] = await Promise.all([
-      // `state` joins `country` / `city` in the location group's self-exclusion: it implies its
-      // country, so leaving it applied would collapse the country selector to a single row —
-      // exactly the reason `city` is excluded here. Every other list keeps `state` applied.
-      this.getFilteredCountries(userIds, without(options, 'country', 'state', 'city')),
-      // `lensModel` deliberately stays applied, matching the standalone getCameraMakes endpoint:
-      // clicking a make does not clear the lens chip, so the make list may honestly narrow by it.
-      this.getFilteredCameraMakes(userIds, without(options, 'make', 'model')),
-      this.getFilteredTags(userIds, without(options, 'tagIds')),
-      this.getFilteredPeople(userIds, without(options, 'personIds', 'identityIds')),
-      this.getFilteredRatings(userIds, without(options, 'rating')),
-      this.getFilteredMediaTypes(userIds, without(options, 'mediaType')),
-      this.getFilteredHasFavorites(userIds, without(options, 'isFavorite')),
-    ]);
+    const [countries, cameraMakes, tags, peopleResult, ratings, mediaTypes, hasFavorites, albumMembership] =
+      await Promise.all([
+        // `state` joins `country` / `city` in the location group's self-exclusion: it implies its
+        // country, so leaving it applied would collapse the country selector to a single row —
+        // exactly the reason `city` is excluded here. Every other list keeps `state` applied.
+        this.getFilteredCountries(userIds, without(options, 'country', 'state', 'city')),
+        // `lensModel` deliberately stays applied, matching the standalone getCameraMakes endpoint:
+        // clicking a make does not clear the lens chip, so the make list may honestly narrow by it.
+        this.getFilteredCameraMakes(userIds, without(options, 'make', 'model')),
+        this.getFilteredTags(userIds, without(options, 'tagIds')),
+        this.getFilteredPeople(userIds, without(options, 'personIds', 'identityIds')),
+        this.getFilteredRatings(userIds, without(options, 'rating')),
+        this.getFilteredMediaTypes(userIds, without(options, 'mediaType')),
+        this.getFilteredHasFavorites(userIds, without(options, 'isFavorite')),
+        this.getFilteredAlbumMembership(userIds, without(options, 'isInAlbum', 'isNotInAlbum')),
+      ]);
 
     return {
       countries,
@@ -1426,8 +1428,7 @@ export class SearchRepository {
       mediaTypes,
       hasUnnamedPeople: peopleResult.hasUnnamedPeople,
       hasFavorites,
-      hasAssetsInAlbum: false,
-      hasAssetsNotInAlbum: false,
+      ...albumMembership,
     };
   }
 
@@ -1929,5 +1930,25 @@ export class SearchRepository {
       .limit(1)
       .executeTakeFirst();
     return !!row;
+  }
+
+  private async getFilteredAlbumMembership(
+    userIds: string[],
+    options: FilterSuggestionsOptions,
+  ): Promise<{ hasAssetsInAlbum: boolean; hasAssetsNotInAlbum: boolean }> {
+    const probe = (filed: boolean) =>
+      this.db
+        .selectFrom('asset')
+        .select('asset.id')
+        .where('asset.id', 'in', this.buildFilteredAssetIds(userIds, options))
+        .where((eb) => {
+          const inAlbum = eb.exists(eb.selectFrom('album_asset').whereRef('album_asset.assetId', '=', 'asset.id'));
+          return filed ? inAlbum : eb.not(inAlbum);
+        })
+        .limit(1)
+        .executeTakeFirst();
+
+    const [filed, unfiled] = await Promise.all([probe(true), probe(false)]);
+    return { hasAssetsInAlbum: !!filed, hasAssetsNotInAlbum: !!unfiled };
   }
 }

--- a/server/src/services/search.service.spec.ts
+++ b/server/src/services/search.service.spec.ts
@@ -1269,6 +1269,9 @@ describe(SearchService.name, () => {
       ratings: [4, 5],
       mediaTypes: [AssetType.Image],
       hasUnnamedPeople: false,
+      hasFavorites: false,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: false,
     };
 
     beforeEach(() => {

--- a/server/src/services/search.service.spec.ts
+++ b/server/src/services/search.service.spec.ts
@@ -1946,6 +1946,9 @@ describe(SearchService.name, () => {
       ratings: [],
       mediaTypes: [],
       hasUnnamedPeople: false,
+      hasFavorites: false,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: false,
     };
 
     it('should return filter suggestions', async () => {
@@ -1960,6 +1963,9 @@ describe(SearchService.name, () => {
         ratings: [4, 5],
         mediaTypes: ['IMAGE', 'VIDEO'],
         hasUnnamedPeople: false,
+        hasFavorites: false,
+        hasAssetsInAlbum: false,
+        hasAssetsNotInAlbum: false,
       });
       (mocks.faceIdentity as any).getAccessiblePersonFilterSuggestions.mockResolvedValue({
         people: [{ id: 'p1', name: 'Alice' }],
@@ -2046,6 +2052,9 @@ describe(SearchService.name, () => {
         ratings: [5],
         mediaTypes: ['IMAGE'],
         hasUnnamedPeople: false,
+        hasFavorites: false,
+        hasAssetsInAlbum: false,
+        hasAssetsNotInAlbum: false,
       });
 
       const result = await sut.getFilterSuggestions(auth, { albumId });

--- a/server/test/medium/specs/repositories/search.repository.spec.ts
+++ b/server/test/medium/specs/repositories/search.repository.spec.ts
@@ -334,6 +334,9 @@ describe(SearchRepository.name, () => {
         ratings: [],
         mediaTypes: [],
         hasUnnamedPeople: false,
+        hasFavorites: false,
+        hasAssetsInAlbum: false,
+        hasAssetsNotInAlbum: false,
       });
     });
 
@@ -469,6 +472,23 @@ describe(SearchRepository.name, () => {
         },
       ]);
       expect(result.hasUnnamedPeople).toBe(false);
+    });
+
+    it('computes hasFavorites ignoring its own isFavorite filter (#910)', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset: favourite } = await ctx.newAsset({ ownerId: user.id, isFavorite: true });
+      await addEmbedding(defaultDatabase, favourite.id);
+      const { asset: plain } = await ctx.newAsset({ ownerId: user.id });
+      await addEmbedding(defaultDatabase, plain.id);
+
+      const result = await sut.getSmartSearchFacets({
+        userIds: [user.id],
+        embedding: matchingEmbedding,
+        isFavorite: false,
+      });
+
+      expect(result.hasFavorites).toBe(true);
     });
   });
 

--- a/server/test/medium/specs/repositories/search.repository.spec.ts
+++ b/server/test/medium/specs/repositories/search.repository.spec.ts
@@ -601,6 +601,91 @@ describe(SearchRepository.name, () => {
         expect(result.hasFavorites).toBe(false);
       });
     });
+
+    describe('album membership (#910)', () => {
+      it('reports not-in-album only when the scope has no albums', async () => {
+        const { ctx, sut } = setup();
+        const { user } = await ctx.newUser();
+        await ctx.newAsset({ ownerId: user.id });
+
+        const result = await sut.getFilterSuggestions([user.id], {});
+
+        expect(result.hasAssetsInAlbum).toBe(false);
+        expect(result.hasAssetsNotInAlbum).toBe(true);
+      });
+
+      it('reports in-album only when every asset is filed', async () => {
+        const { ctx, sut } = setup();
+        const { user } = await ctx.newUser();
+        const { asset } = await ctx.newAsset({ ownerId: user.id });
+        const { album } = await ctx.newAlbum({ ownerId: user.id });
+        await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+
+        const result = await sut.getFilterSuggestions([user.id], {});
+
+        expect(result.hasAssetsInAlbum).toBe(true);
+        expect(result.hasAssetsNotInAlbum).toBe(false);
+      });
+
+      it('reports both when the scope is mixed', async () => {
+        const { ctx, sut } = setup();
+        const { user } = await ctx.newUser();
+        const { asset: filed } = await ctx.newAsset({ ownerId: user.id });
+        await ctx.newAsset({ ownerId: user.id });
+        const { album } = await ctx.newAlbum({ ownerId: user.id });
+        await ctx.newAlbumAsset({ albumId: album.id, assetId: filed.id });
+
+        const result = await sut.getFilterSuggestions([user.id], {});
+
+        expect(result.hasAssetsInAlbum).toBe(true);
+        expect(result.hasAssetsNotInAlbum).toBe(true);
+      });
+
+      it('ignores its own isNotInAlbum filter', async () => {
+        const { ctx, sut } = setup();
+        const { user } = await ctx.newUser();
+        const { asset: filed } = await ctx.newAsset({ ownerId: user.id });
+        await ctx.newAsset({ ownerId: user.id });
+        const { album } = await ctx.newAlbum({ ownerId: user.id });
+        await ctx.newAlbumAsset({ albumId: album.id, assetId: filed.id });
+
+        // Filtering to un-filed assets must not erase the evidence that filed ones exist.
+        const result = await sut.getFilterSuggestions([user.id], { isNotInAlbum: true });
+
+        expect(result.hasAssetsInAlbum).toBe(true);
+        expect(result.hasAssetsNotInAlbum).toBe(true);
+      });
+
+      it('reports every asset filed when scoped to one album', async () => {
+        const { ctx, sut } = setup();
+        const { user } = await ctx.newUser();
+        const { asset } = await ctx.newAsset({ ownerId: user.id });
+        await ctx.newAsset({ ownerId: user.id });
+        const { album } = await ctx.newAlbum({ ownerId: user.id });
+        await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+
+        const result = await sut.getFilterSuggestions([user.id], { albumId: album.id });
+
+        expect(result.hasAssetsInAlbum).toBe(true);
+        expect(result.hasAssetsNotInAlbum).toBe(false);
+      });
+
+      it('honours the other active dimensions', async () => {
+        const { ctx, sut } = setup();
+        const { user } = await ctx.newUser();
+        const { asset: filed } = await ctx.newAsset({ ownerId: user.id });
+        await ctx.newExif({ assetId: filed.id, make: 'Canon' });
+        const { asset: unfiled } = await ctx.newAsset({ ownerId: user.id });
+        await ctx.newExif({ assetId: unfiled.id, make: 'Nikon' });
+        const { album } = await ctx.newAlbum({ ownerId: user.id });
+        await ctx.newAlbumAsset({ albumId: album.id, assetId: filed.id });
+
+        const result = await sut.getFilterSuggestions([user.id], { make: 'Nikon' });
+
+        expect(result.hasAssetsInAlbum).toBe(false);
+        expect(result.hasAssetsNotInAlbum).toBe(true);
+      });
+    });
   });
 
   describe('getCameraMakes (LOW #7)', () => {

--- a/server/test/medium/specs/repositories/search.repository.spec.ts
+++ b/server/test/medium/specs/repositories/search.repository.spec.ts
@@ -554,6 +554,66 @@ describe(SearchRepository.name, () => {
       // Only the filed Canon survives the filter, so Nikon must be gone from the makes facet.
       expect(result.cameraMakes).toEqual(['Canon']);
     });
+
+    it('reports no favourites and mixed album membership on the smart path (#910)', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset: filed } = await ctx.newAsset({ ownerId: user.id });
+      await addEmbedding(defaultDatabase, filed.id);
+      const { asset: unfiled } = await ctx.newAsset({ ownerId: user.id });
+      await addEmbedding(defaultDatabase, unfiled.id);
+      const { album } = await ctx.newAlbum({ ownerId: user.id });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: filed.id });
+
+      const result = await sut.getSmartSearchFacets({ userIds: [user.id], embedding: matchingEmbedding });
+
+      expect(result.total).toBe(2);
+      expect(result.hasFavorites).toBe(false);
+      expect(result.hasAssetsInAlbum).toBe(true);
+      expect(result.hasAssetsNotInAlbum).toBe(true);
+    });
+
+    it('reports hasAssetsNotInAlbum false on the smart path when everything is filed (#910)', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await addEmbedding(defaultDatabase, asset.id);
+      const { album } = await ctx.newAlbum({ ownerId: user.id });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+
+      const result = await sut.getSmartSearchFacets({ userIds: [user.id], embedding: matchingEmbedding });
+
+      expect(result.total).toBe(1);
+      expect(result.hasAssetsInAlbum).toBe(true);
+      expect(result.hasAssetsNotInAlbum).toBe(false);
+    });
+
+    it('reports hasAssetsInAlbum false on the smart path when nothing is filed (#910)', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: user.id });
+      await addEmbedding(defaultDatabase, asset.id);
+
+      const result = await sut.getSmartSearchFacets({ userIds: [user.id], embedding: matchingEmbedding });
+
+      expect(result.total).toBe(1);
+      expect(result.hasAssetsInAlbum).toBe(false);
+      expect(result.hasAssetsNotInAlbum).toBe(true);
+    });
+
+    it('reports hasFavorites true on the smart path when a favourite is present (#910)', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset: favourite } = await ctx.newAsset({ ownerId: user.id, isFavorite: true });
+      await addEmbedding(defaultDatabase, favourite.id);
+      const { asset: plain } = await ctx.newAsset({ ownerId: user.id });
+      await addEmbedding(defaultDatabase, plain.id);
+
+      const result = await sut.getSmartSearchFacets({ userIds: [user.id], embedding: matchingEmbedding });
+
+      expect(result.total).toBe(2);
+      expect(result.hasFavorites).toBe(true);
+    });
   });
 
   describe('getFilterSuggestions', () => {
@@ -638,6 +698,18 @@ describe(SearchRepository.name, () => {
       });
     });
 
+    it('reports every #910 facet false under forceEmptyResult', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      await ctx.newAsset({ ownerId: user.id, isFavorite: true });
+
+      const result = await sut.getFilterSuggestions([user.id], { forceEmptyResult: true });
+
+      expect(result.hasFavorites).toBe(false);
+      expect(result.hasAssetsInAlbum).toBe(false);
+      expect(result.hasAssetsNotInAlbum).toBe(false);
+    });
+
     describe('hasFavorites (#910)', () => {
       it('is false when the scope has no favourite', async () => {
         const { ctx, sut } = setup();
@@ -683,6 +755,28 @@ describe(SearchRepository.name, () => {
         const result = await sut.getFilterSuggestions([user.id], { make: 'Nikon' });
 
         expect(result.hasFavorites).toBe(false);
+      });
+
+      it('sees a shared-space favourite only with timelineSpaceIds (#910)', async () => {
+        const { ctx, sut } = setup();
+        const { user: owner } = await ctx.newUser();
+        const { user: member } = await ctx.newUser();
+        const { asset } = await ctx.newAsset({ ownerId: owner.id, isFavorite: true });
+
+        const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+        await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+        await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: 'viewer' });
+        await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id, addedById: owner.id });
+
+        // The member owns nothing. Without the space in scope the favourite is invisible to them...
+        const ownScope = await sut.getFilterSuggestions([member.id], {});
+        expect(ownScope.hasFavorites).toBe(false);
+
+        // ...and with it, it is. The two scopes disagree, which is exactly what §4.6 documents:
+        // the photos page drops withSharedSpaces when isFavorite is set, so `current` is narrower
+        // than `baseline`. Subset, so it can only grey — never wrongly hide.
+        const spaceScope = await sut.getFilterSuggestions([member.id], { timelineSpaceIds: [space.id] });
+        expect(spaceScope.hasFavorites).toBe(true);
       });
     });
 

--- a/server/test/medium/specs/repositories/search.repository.spec.ts
+++ b/server/test/medium/specs/repositories/search.repository.spec.ts
@@ -548,6 +548,57 @@ describe(SearchRepository.name, () => {
         ratings: [],
         mediaTypes: [],
         hasUnnamedPeople: false,
+        hasFavorites: false,
+        hasAssetsInAlbum: false,
+        hasAssetsNotInAlbum: false,
+      });
+    });
+
+    describe('hasFavorites (#910)', () => {
+      it('is false when the scope has no favourite', async () => {
+        const { ctx, sut } = setup();
+        const { user } = await ctx.newUser();
+        await ctx.newAsset({ ownerId: user.id });
+
+        const result = await sut.getFilterSuggestions([user.id], {});
+
+        expect(result.hasFavorites).toBe(false);
+      });
+
+      it('is true when the scope has a favourite', async () => {
+        const { ctx, sut } = setup();
+        const { user } = await ctx.newUser();
+        await ctx.newAsset({ ownerId: user.id, isFavorite: true });
+
+        const result = await sut.getFilterSuggestions([user.id], {});
+
+        expect(result.hasFavorites).toBe(true);
+      });
+
+      it('ignores its own isFavorite filter', async () => {
+        const { ctx, sut } = setup();
+        const { user } = await ctx.newUser();
+        await ctx.newAsset({ ownerId: user.id, isFavorite: true });
+        await ctx.newAsset({ ownerId: user.id });
+
+        // Filtering to non-favourites must not make the facet claim there are none.
+        const result = await sut.getFilterSuggestions([user.id], { isFavorite: false });
+
+        expect(result.hasFavorites).toBe(true);
+      });
+
+      it('honours the other active dimensions', async () => {
+        const { ctx, sut } = setup();
+        const { user } = await ctx.newUser();
+        const { asset: favourite } = await ctx.newAsset({ ownerId: user.id, isFavorite: true });
+        await ctx.newExif({ assetId: favourite.id, make: 'Canon' });
+        const { asset: plain } = await ctx.newAsset({ ownerId: user.id });
+        await ctx.newExif({ assetId: plain.id, make: 'Nikon' });
+
+        // The only favourite is a Canon, so a Nikon filter must report no favourites.
+        const result = await sut.getFilterSuggestions([user.id], { make: 'Nikon' });
+
+        expect(result.hasFavorites).toBe(false);
       });
     });
   });

--- a/server/test/medium/specs/repositories/search.repository.spec.ts
+++ b/server/test/medium/specs/repositories/search.repository.spec.ts
@@ -490,6 +490,48 @@ describe(SearchRepository.name, () => {
 
       expect(result.hasFavorites).toBe(true);
     });
+
+    it('computes album membership ignoring its own isNotInAlbum filter (#910)', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset: filed } = await ctx.newAsset({ ownerId: user.id });
+      await addEmbedding(defaultDatabase, filed.id);
+      const { asset: unfiled } = await ctx.newAsset({ ownerId: user.id });
+      await addEmbedding(defaultDatabase, unfiled.id);
+      const { album } = await ctx.newAlbum({ ownerId: user.id });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: filed.id });
+
+      const result = await sut.getSmartSearchFacets({
+        userIds: [user.id],
+        embedding: matchingEmbedding,
+        isNotInAlbum: true,
+      });
+
+      expect(result.hasAssetsInAlbum).toBe(true);
+      expect(result.hasAssetsNotInAlbum).toBe(true);
+    });
+
+    it('still applies isNotInAlbum to the non-album facets (#910)', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset: filed } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newExif({ assetId: filed.id, make: 'Canon' });
+      await addEmbedding(defaultDatabase, filed.id);
+      const { asset: unfiled } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newExif({ assetId: unfiled.id, make: 'Nikon' });
+      await addEmbedding(defaultDatabase, unfiled.id);
+      const { album } = await ctx.newAlbum({ ownerId: user.id });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: filed.id });
+
+      const result = await sut.getSmartSearchFacets({
+        userIds: [user.id],
+        embedding: matchingEmbedding,
+        isNotInAlbum: true,
+      });
+
+      // Only the un-filed Nikon survives the filter, so Canon must be gone from the makes facet.
+      expect(result.cameraMakes).toEqual(['Nikon']);
+    });
   });
 
   describe('getFilterSuggestions', () => {

--- a/server/test/medium/specs/repositories/search.repository.spec.ts
+++ b/server/test/medium/specs/repositories/search.repository.spec.ts
@@ -489,6 +489,32 @@ describe(SearchRepository.name, () => {
       });
 
       expect(result.hasFavorites).toBe(true);
+      // The isFavorite: false filter still applies to `total` itself — only hasFavorites ignores it.
+      // If a future change over-corrected and dropped the predicate everywhere, hasFavorites would
+      // still read true here but total would silently go from 1 to 2.
+      expect(result.total).toBe(1);
+    });
+
+    it('honours the other active dimensions on the smart-search path (tag) (#910)', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset: favourite } = await ctx.newAsset({ ownerId: user.id, isFavorite: true });
+      await addEmbedding(defaultDatabase, favourite.id);
+      const { asset: plain } = await ctx.newAsset({ ownerId: user.id });
+      await addEmbedding(defaultDatabase, plain.id);
+      const [tagA, tagB] = await upsertTags(ctx.get(TagRepository), { userId: user.id, tags: ['TagA', 'TagB'] });
+      await ctx.newTagAsset({ tagIds: [tagA.id], assetIds: [favourite.id] });
+      await ctx.newTagAsset({ tagIds: [tagB.id], assetIds: [plain.id] });
+
+      // The only favourite carries tag A, so filtering to tag B must report no favourites — the
+      // smart-search mirror of the browse-path tag case above.
+      const result = await sut.getSmartSearchFacets({
+        userIds: [user.id],
+        embedding: matchingEmbedding,
+        tagIds: [tagB.id],
+      });
+
+      expect(result.hasFavorites).toBe(false);
     });
 
     it('computes album membership ignoring its own isNotInAlbum filter (#910)', async () => {
@@ -763,6 +789,23 @@ describe(SearchRepository.name, () => {
         expect(result.hasFavorites).toBe(false);
       });
 
+      it('honours the other active dimensions (tag)', async () => {
+        const { ctx, sut } = setup();
+        const { user } = await ctx.newUser();
+        const { asset: favourite } = await ctx.newAsset({ ownerId: user.id, isFavorite: true });
+        const { asset: plain } = await ctx.newAsset({ ownerId: user.id });
+        const [tagA, tagB] = await upsertTags(ctx.get(TagRepository), { userId: user.id, tags: ['TagA', 'TagB'] });
+        await ctx.newTagAsset({ tagIds: [tagA.id], assetIds: [favourite.id] });
+        await ctx.newTagAsset({ tagIds: [tagB.id], assetIds: [plain.id] });
+
+        // The only favourite carries tag A, so filtering to tag B must report no favourites. Tags go
+        // through a `tag_asset` EXISTS subquery rather than the `asset_exif` join the make case above
+        // exercises, so this covers a different code path.
+        const result = await sut.getFilterSuggestions([user.id], { tagIds: [tagB.id] });
+
+        expect(result.hasFavorites).toBe(false);
+      });
+
       it('sees a shared-space favourite only with timelineSpaceIds (#910)', async () => {
         const { ctx, sut } = setup();
         const { user: owner } = await ctx.newUser();
@@ -770,7 +813,7 @@ describe(SearchRepository.name, () => {
         const { asset } = await ctx.newAsset({ ownerId: owner.id, isFavorite: true });
         // A distinctive make so the second assertion can identify THIS asset specifically —
         // a `toBe(true)` non-emptiness check alone would also pass for an over-broad scope
-        // that leaked in unrelated assets (see the mutation check in the task report).
+        // that leaked in unrelated assets.
         await ctx.newExif({ assetId: asset.id, make: 'SpaceMake' });
 
         const { space } = await ctx.newSharedSpace({ createdById: owner.id });

--- a/server/test/medium/specs/repositories/search.repository.spec.ts
+++ b/server/test/medium/specs/repositories/search.repository.spec.ts
@@ -701,7 +701,13 @@ describe(SearchRepository.name, () => {
     it('reports every #910 facet false under forceEmptyResult', async () => {
       const { ctx, sut } = setup();
       const { user } = await ctx.newUser();
-      await ctx.newAsset({ ownerId: user.id, isFavorite: true });
+      // The favourite is filed (makes hasAssetsInAlbum load-bearing) and a separate plain asset
+      // is left unfiled (makes hasAssetsNotInAlbum load-bearing too) — without forceEmptyResult
+      // all three facets would flip to true/true/true, not vacuously stay false.
+      const { asset: favourite } = await ctx.newAsset({ ownerId: user.id, isFavorite: true });
+      const { album } = await ctx.newAlbum({ ownerId: user.id });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: favourite.id });
+      await ctx.newAsset({ ownerId: user.id });
 
       const result = await sut.getFilterSuggestions([user.id], { forceEmptyResult: true });
 
@@ -762,6 +768,10 @@ describe(SearchRepository.name, () => {
         const { user: owner } = await ctx.newUser();
         const { user: member } = await ctx.newUser();
         const { asset } = await ctx.newAsset({ ownerId: owner.id, isFavorite: true });
+        // A distinctive make so the second assertion can identify THIS asset specifically —
+        // a `toBe(true)` non-emptiness check alone would also pass for an over-broad scope
+        // that leaked in unrelated assets (see the mutation check in the task report).
+        await ctx.newExif({ assetId: asset.id, make: 'SpaceMake' });
 
         const { space } = await ctx.newSharedSpace({ createdById: owner.id });
         await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
@@ -777,6 +787,10 @@ describe(SearchRepository.name, () => {
         // than `baseline`. Subset, so it can only grey — never wrongly hide.
         const spaceScope = await sut.getFilterSuggestions([member.id], { timelineSpaceIds: [space.id] });
         expect(spaceScope.hasFavorites).toBe(true);
+        // Pins the space asset specifically, not merely "scope became non-empty": an over-broad
+        // scope (e.g. the timelineSpaceIds arm silently falling through to unfiltered) would leak
+        // other tests' makes into this array and fail the toEqual.
+        expect(spaceScope.cameraMakes).toEqual(['SpaceMake']);
       });
     });
 

--- a/server/test/medium/specs/repositories/search.repository.spec.ts
+++ b/server/test/medium/specs/repositories/search.repository.spec.ts
@@ -532,6 +532,28 @@ describe(SearchRepository.name, () => {
       // Only the un-filed Nikon survives the filter, so Canon must be gone from the makes facet.
       expect(result.cameraMakes).toEqual(['Nikon']);
     });
+
+    it('still applies isInAlbum to the non-album facets (#910)', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { asset: filed } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newExif({ assetId: filed.id, make: 'Canon' });
+      await addEmbedding(defaultDatabase, filed.id);
+      const { asset: unfiled } = await ctx.newAsset({ ownerId: user.id });
+      await ctx.newExif({ assetId: unfiled.id, make: 'Nikon' });
+      await addEmbedding(defaultDatabase, unfiled.id);
+      const { album } = await ctx.newAlbum({ ownerId: user.id });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: filed.id });
+
+      const result = await sut.getSmartSearchFacets({
+        userIds: [user.id],
+        embedding: matchingEmbedding,
+        isInAlbum: true,
+      });
+
+      // Only the filed Canon survives the filter, so Nikon must be gone from the makes facet.
+      expect(result.cameraMakes).toEqual(['Canon']);
+    });
   });
 
   describe('getFilterSuggestions', () => {

--- a/web/src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/contextual-refetch.spec.ts
@@ -48,6 +48,9 @@ const defaultSuggestions: FilterSuggestionsResponse = {
   ratings: [3, 4, 5],
   mediaTypes: ['IMAGE', 'VIDEO'],
   hasUnnamedPeople: false,
+  hasFavorites: true,
+  hasAssetsInAlbum: true,
+  hasAssetsNotInAlbum: true,
 };
 
 describe('Contextual re-fetch on temporal change', () => {

--- a/web/src/lib/components/filter-panel/__tests__/contextual-selection.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/contextual-selection.spec.ts
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { init, register, waitLocale } from 'svelte-i18n';
 import { buildPersonFilterPatch } from '$lib/utils/filter-target';
 import { getPhotosPersonFilterId } from '$lib/utils/photos-filter-options';
@@ -31,6 +31,9 @@ const suggestions = (overrides: Partial<FilterSuggestionsResponse> = {}): Filter
   ratings: [],
   mediaTypes: [],
   hasUnnamedPeople: false,
+  hasFavorites: false,
+  hasAssetsInAlbum: false,
+  hasAssetsNotInAlbum: false,
   ...overrides,
 });
 
@@ -70,7 +73,8 @@ describe('the panel reflects a contextual PERSON filter', () => {
       { personIds: patch.personIds },
     );
 
-    const row = await screen.findByTestId(`people-item-${optionId}`);
+    await waitFor(() => expect(screen.getByTestId(`people-item-${optionId}`)).toHaveTextContent('Bob'));
+    const row = screen.getByTestId(`people-item-${optionId}`);
     expect(row).toHaveTextContent('Bob');
     expect(row.className).toContain('font-medium');
     expect(screen.queryByTestId(`people-item-${PERSON_UUID}`)).toBeNull();
@@ -326,6 +330,7 @@ describe('the panel keeps a selected entry visible in a long list', () => {
       { tagIds: ['tag-30'] },
     );
 
+    await waitFor(() => expect(screen.getAllByTestId(/^tags-item-/)).toHaveLength(10));
     const row = await screen.findByTestId('tags-item-tag-30');
     expect(row).toHaveAttribute('aria-pressed', 'true');
     expect(row.querySelector('.bg-immich-primary')).not.toBeNull();
@@ -347,7 +352,8 @@ describe('the panel keeps a selected entry visible in a long list', () => {
       { tagIds: ['tag-30', 'tag-35'] },
     );
 
-    await screen.findByTestId('tags-item-tag-30');
+    await waitFor(() => expect(screen.getByTestId('tags-show-more')).toBeInTheDocument());
+    expect(screen.getByTestId('tags-item-tag-30')).toBeInTheDocument();
     expect(screen.getByTestId('tags-item-tag-35')).toBeInTheDocument();
     expect(screen.getByTestId('tags-show-more')).toHaveTextContent('30');
   });
@@ -362,6 +368,7 @@ describe('the panel keeps a selected entry visible in a long list', () => {
       { personIds: ['person-30'] },
     );
 
+    await waitFor(() => expect(screen.getAllByTestId(/^people-item-/)).toHaveLength(5));
     const row = await screen.findByTestId('people-item-person-30');
     expect(row.querySelector('.bg-immich-primary')).not.toBeNull();
 

--- a/web/src/lib/components/filter-panel/__tests__/filter-availability.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-availability.spec.ts
@@ -121,6 +121,18 @@ describe('getSectionAvailability', () => {
     it.each(GATED)('never hides %s while the baseline is unknown', (section) => {
       expect(getSectionAvailability(section, input({ current: barren(), baseline: undefined }))).toBe('empty');
     });
+
+    // Slice 3 review gap: every existing baseline-undefined case above pairs it with a BARREN
+    // current, so the current-emptiness check and the baseline-undefined check are never both live at
+    // once — swapping their order would leave every test above green. A populated current with an
+    // unknown baseline is the case that actually exercises the order: it must resolve on the
+    // current-emptiness check alone and never even look at `baseline`.
+    it.each(GATED)(
+      'reports %s available when the current facet is populated but the baseline is unknown',
+      (section) => {
+        expect(getSectionAvailability(section, input({ baseline: undefined }))).toBe('available');
+      },
+    );
   });
 
   describe('exempt sections', () => {

--- a/web/src/lib/components/filter-panel/__tests__/filter-availability.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-availability.spec.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import { getSectionAvailability, type AvailabilityInput } from '../filter-availability';
+import type { FilterSection, FilterSuggestionsResponse } from '../filter-panel';
+
+/** A scope in which every section is usable. Individual tests knock out one dimension at a time. */
+const full = (): FilterSuggestionsResponse => ({
+  countries: ['Germany'],
+  cameraMakes: ['Canon'],
+  tags: [{ id: 'tag-1', name: 'Vacation' }],
+  people: [{ id: 'person-1', name: 'Alice' }],
+  ratings: [5],
+  mediaTypes: ['IMAGE', 'VIDEO'],
+  hasUnnamedPeople: false,
+  hasFavorites: true,
+  hasAssetsInAlbum: true,
+  hasAssetsNotInAlbum: true,
+});
+
+/** A scope in which no section can filter anything. */
+const barren = (): FilterSuggestionsResponse => ({
+  countries: [],
+  cameraMakes: [],
+  tags: [],
+  people: [],
+  ratings: [],
+  mediaTypes: ['IMAGE'],
+  hasUnnamedPeople: false,
+  hasFavorites: false,
+  hasAssetsInAlbum: false,
+  hasAssetsNotInAlbum: true,
+});
+
+const input = (overrides: Partial<AvailabilityInput> = {}): AvailabilityInput => ({
+  current: full(),
+  baseline: full(),
+  hasActiveFilter: false,
+  timeBucketCount: 3,
+  ...overrides,
+});
+
+const GATED: FilterSection[] = ['people', 'location', 'camera', 'tags', 'rating', 'media', 'favorites', 'albums'];
+
+describe('getSectionAvailability', () => {
+  describe('the three verdicts', () => {
+    it.each(GATED)('reports %s available when its facet is populated', (section) => {
+      expect(getSectionAvailability(section, input())).toBe('available');
+    });
+
+    it.each(GATED)('reports %s empty when only the current facet is bare', (section) => {
+      expect(getSectionAvailability(section, input({ current: barren() }))).toBe('empty');
+    });
+
+    it.each(GATED)('reports %s unavailable when both facets are bare', (section) => {
+      expect(getSectionAvailability(section, input({ current: barren(), baseline: barren() }))).toBe('unavailable');
+    });
+  });
+
+  describe('per-section emptiness rules', () => {
+    it('treats a single media type as unusable', () => {
+      const single = { ...full(), mediaTypes: ['IMAGE'] };
+      expect(getSectionAvailability('media', input({ current: single, baseline: single }))).toBe('unavailable');
+    });
+
+    it('treats photos plus videos as usable', () => {
+      expect(getSectionAvailability('media', input())).toBe('available');
+    });
+
+    // `getFilteredMediaTypes` returns raw `distinct asset.type`, and AssetType is
+    // IMAGE | VIDEO | AUDIO | OTHER. A length>=2 rule would call this section usable while the
+    // Videos button is still dead — the exact thing #910 exists to stop.
+    it.each([['OTHER'], ['AUDIO']])('does not count %s towards a usable media section', (other) => {
+      const noVideo = { ...full(), mediaTypes: ['IMAGE', other] };
+      expect(getSectionAvailability('media', input({ current: noVideo, baseline: noVideo }))).toBe('unavailable');
+    });
+
+    it('keeps media usable when an extra type accompanies both photos and videos', () => {
+      const extra = { ...full(), mediaTypes: ['IMAGE', 'OTHER', 'VIDEO'] };
+      expect(getSectionAvailability('media', input({ current: extra, baseline: extra }))).toBe('available');
+    });
+
+    it('treats videos-only as unusable, mirroring photos-only', () => {
+      const single = { ...full(), mediaTypes: ['VIDEO'] };
+      expect(getSectionAvailability('media', input({ current: single, baseline: single }))).toBe('unavailable');
+    });
+
+    it('keeps people available when unnamed faces exist', () => {
+      const unnamed = { ...barren(), hasUnnamedPeople: true };
+      expect(getSectionAvailability('people', input({ current: unnamed, baseline: unnamed }))).toBe('available');
+    });
+
+    it('hides people when there are none at all', () => {
+      expect(getSectionAvailability('people', input({ current: barren(), baseline: barren() }))).toBe('unavailable');
+    });
+
+    it('hides albums when nothing is filed', () => {
+      const none = { ...full(), hasAssetsInAlbum: false };
+      expect(getSectionAvailability('albums', input({ current: none, baseline: none }))).toBe('unavailable');
+    });
+
+    it('hides albums when everything is filed', () => {
+      const all = { ...full(), hasAssetsNotInAlbum: false };
+      expect(getSectionAvailability('albums', input({ current: all, baseline: all }))).toBe('unavailable');
+    });
+
+    it('keeps albums available only when both sides exist', () => {
+      expect(getSectionAvailability('albums', input())).toBe('available');
+    });
+
+    it('hides favorites when nothing is favourited', () => {
+      const none = { ...full(), hasFavorites: false };
+      expect(getSectionAvailability('favorites', input({ current: none, baseline: none }))).toBe('unavailable');
+    });
+  });
+
+  describe('overriding rules', () => {
+    it.each(GATED)('never hides or greys %s while it has an active filter', (section) => {
+      const state = input({ current: barren(), baseline: barren(), hasActiveFilter: true });
+      expect(getSectionAvailability(section, state)).toBe('available');
+    });
+
+    it.each(GATED)('never hides %s while the baseline is unknown', (section) => {
+      expect(getSectionAvailability(section, input({ current: barren(), baseline: undefined }))).toBe('empty');
+    });
+  });
+
+  describe('exempt sections', () => {
+    it('greys timeline on an empty bucket list but never hides it', () => {
+      const state = input({ current: barren(), baseline: barren(), timeBucketCount: 0 });
+      expect(getSectionAvailability('timeline', state)).toBe('empty');
+    });
+
+    it('keeps timeline available while it has buckets', () => {
+      expect(getSectionAvailability('timeline', input())).toBe('available');
+    });
+
+    it('keeps timeline available while a date filter is active', () => {
+      const state = input({ timeBucketCount: 0, hasActiveFilter: true });
+      expect(getSectionAvailability('timeline', state)).toBe('available');
+    });
+
+    it('always reports text available', () => {
+      const state = input({ current: barren(), baseline: barren(), timeBucketCount: 0 });
+      expect(getSectionAvailability('text', state)).toBe('available');
+    });
+
+    // The `default:` branch of isSectionEmpty. A section added to FilterSection in future must
+    // default to visible, not silently vanish because nobody wrote it a rule.
+    it('reports an unrecognised section available rather than hiding it', () => {
+      const state = input({ current: barren(), baseline: barren() });
+      expect(getSectionAvailability('newcomer' as FilterSection, state)).toBe('available');
+    });
+  });
+});

--- a/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
@@ -1343,6 +1343,9 @@ describe('section availability (#910)', () => {
     // The sibling assertion matters: without it a panel that rendered nothing would pass.
     await waitFor(() => expect(screen.getByTestId('filter-section-media')).toBeInTheDocument());
     expect(screen.queryByTestId('filter-section-rating')).not.toBeInTheDocument();
+
+    // The section toggles live inside the cog's popover, so it has to be opened to see them.
+    await fireEvent.click(screen.getByTestId('section-menu-btn'));
     expect(screen.queryByTestId('section-toggle-rating')).not.toBeInTheDocument();
     expect(screen.getByTestId('section-toggle-media')).toBeInTheDocument();
   });

--- a/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-panel.spec.ts
@@ -1300,3 +1300,279 @@ describe('Section Accordion Persistence', () => {
     });
   });
 });
+
+const availableEverything = {
+  countries: ['Germany'],
+  cameraMakes: ['Canon'],
+  tags: [{ id: 't', name: 'Tag' }],
+  people: [{ id: 'p', name: 'Alice' }],
+  ratings: [5],
+  mediaTypes: ['IMAGE', 'VIDEO'],
+  hasUnnamedPeople: false,
+  hasFavorites: true,
+  hasAssetsInAlbum: true,
+  hasAssetsNotInAlbum: true,
+};
+
+describe('section availability (#910)', () => {
+  // Real timers race the unified effect's setTimeout debounce against `render`/`rerender`'s
+  // microtask-only flush (`Svelte.tick()`): a rerender can synchronously cancel-and-reschedule a
+  // pending 0ms fetch before it ever gets a macrotask turn to fire, silently dropping it. Fake timers
+  // plus an explicit `advanceTimersByTimeAsync` after every render/rerender make each fetch
+  // deterministic, matching every sibling test in unified-suggestions.spec.ts. Note `waitFor` does NOT
+  // self-advance Vitest's fake clock, so the state must already be correct before a `waitFor` runs —
+  // it is kept below only as a defensive assertion wrapper, not as the thing doing the waiting.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('hides a structurally unavailable section and its toggle', async () => {
+    const config = {
+      sections: ['rating', 'media'] as FilterSection[],
+      suggestionsProvider: vi.fn().mockResolvedValue({ ...availableEverything, ratings: [] }),
+    };
+
+    render(FilterPanel, { props: { config, timeBuckets: [] } });
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The sibling assertion matters: without it a panel that rendered nothing would pass.
+    await waitFor(() => expect(screen.getByTestId('filter-section-media')).toBeInTheDocument());
+    expect(screen.queryByTestId('filter-section-rating')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('section-toggle-rating')).not.toBeInTheDocument();
+    expect(screen.getByTestId('section-toggle-media')).toBeInTheDocument();
+  });
+
+  it('greys a section the current filters emptied, rather than hiding it', async () => {
+    // `favorites` (not `tags`, despite the brief's literal example — see task-2-report.md): `tags`
+    // already has a *pre-#910* legacy count formula (`filterContext ? ... tags.length ...` a few
+    // lines down) that reads the same `tags` state this fetch also updates, and `filterContext`
+    // includes `personIds`. So rerendering with a person filter would grey the tags section via that
+    // OLD #858 code path too, passing this test even against pre-#910 code and defeating it as a
+    // regression guard. `favorites` has no such legacy formula, so greying it can only come from the
+    // new `availability`-driven `count` branch.
+    const suggestionsProvider = vi
+      .fn()
+      .mockResolvedValueOnce(availableEverything)
+      .mockResolvedValue({ ...availableEverything, hasFavorites: false });
+    const config = { sections: ['favorites', 'media'] as FilterSection[], suggestionsProvider };
+    const filters = { ...createFilterState() };
+
+    const { rerender } = render(FilterPanel, { props: { config, timeBuckets: [], filters } });
+    await vi.advanceTimersByTimeAsync(0);
+    await waitFor(() => expect(suggestionsProvider).toHaveBeenCalledTimes(1));
+
+    await rerender({ config, timeBuckets: [], filters: { ...filters, personIds: ['p'] } });
+    // Discrete (non-temporal) filter changes debounce at 50ms.
+    await vi.advanceTimersByTimeAsync(50);
+
+    await waitFor(() => {
+      // getAllByRole, not getByRole: the section was open before this fetch, so its collapse plays
+      // an outro transition — the now-stale content (with its own buttons) can still be in the DOM,
+      // marked inert, at the instant this assertion runs. The header button is always rendered first.
+      const [button] = within(screen.getByTestId('filter-section-favorites')).getAllByRole('button');
+      expect(button).toBeDisabled();
+      expect(button.textContent).toContain('(0)');
+    });
+  });
+
+  it('never writes availability into the stored ledger', async () => {
+    const config = {
+      sections: ['rating', 'media'] as FilterSection[],
+      suggestionsProvider: vi.fn().mockResolvedValue({ ...availableEverything, ratings: [] }),
+    };
+
+    render(FilterPanel, { props: { config, timeBuckets: [], storageKey: 'test-key' } });
+    await vi.advanceTimersByTimeAsync(0);
+    await waitFor(() => expect(screen.getByTestId('filter-section-media')).toBeInTheDocument());
+
+    const stored = JSON.parse(localStorage.getItem('test-key')!);
+    // Both halves matter: `selected` keeps it un-hidden, `known` keeps PR #926 from re-introducing it
+    // as a brand-new section on the next load.
+    expect(stored.selected).toContain('rating');
+    expect(stored.known).toContain('rating');
+  });
+
+  it('shows a section again once its facet comes back', async () => {
+    const suggestionsProvider = vi
+      .fn()
+      .mockResolvedValueOnce({ ...availableEverything, ratings: [] })
+      .mockResolvedValue(availableEverything);
+    const config = { sections: ['rating', 'media'] as FilterSection[], suggestionsProvider };
+    const filters = { ...createFilterState() };
+
+    const { rerender } = render(FilterPanel, { props: { config, timeBuckets: [], filters } });
+    await vi.advanceTimersByTimeAsync(0);
+    await waitFor(() => expect(screen.queryByTestId('filter-section-rating')).not.toBeInTheDocument());
+
+    await rerender({ config, timeBuckets: [], filters: { ...filters, personIds: ['p'] } });
+    await vi.advanceTimersByTimeAsync(50);
+
+    await waitFor(() => expect(screen.getByTestId('filter-section-rating')).toBeInTheDocument());
+  });
+
+  it('calls baselineProvider once when it mounts with filters applied', async () => {
+    const suggestionsProvider = vi.fn().mockResolvedValue(availableEverything);
+    const baselineProvider = vi.fn().mockResolvedValue(availableEverything);
+    const config = { sections: ['rating'] as FilterSection[], suggestionsProvider, baselineProvider };
+
+    render(FilterPanel, { props: { config, timeBuckets: [], filters: { ...createFilterState(), rating: 5 } } });
+    await vi.advanceTimersByTimeAsync(0);
+
+    await waitFor(() => expect(baselineProvider).toHaveBeenCalledTimes(1));
+    // The baseline is a SEPARATE hook, never a second suggestionsProvider call: spec §4.5 explains
+    // why reusing the provider corrupts the query-mode pages.
+    expect(suggestionsProvider).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls no baseline provider when it mounts clean', async () => {
+    const suggestionsProvider = vi.fn().mockResolvedValue(availableEverything);
+    const baselineProvider = vi.fn().mockResolvedValue(availableEverything);
+    const config = { sections: ['rating'] as FilterSection[], suggestionsProvider, baselineProvider };
+
+    render(FilterPanel, { props: { config, timeBuckets: [] } });
+    await vi.advanceTimersByTimeAsync(0);
+
+    await waitFor(() => expect(suggestionsProvider).toHaveBeenCalledTimes(1));
+    // Give any stray request time to land before asserting it did not. The clean-mount response IS
+    // the baseline, so a second call would be pure waste.
+    await vi.advanceTimersByTimeAsync(100);
+    expect(baselineProvider).not.toHaveBeenCalled();
+  });
+
+  // The filter is on `people`, NOT on `rating`. That distinction is the whole test: with the filter
+  // on the section under assertion, hasActiveFilter short-circuits to 'available' before the code
+  // ever reads `baseline`, and the test passes whether or not the failure path works at all.
+  it.each([
+    ['rejects', () => Promise.reject(new Error('baseline failed'))],
+    ['resolves undefined', () => Promise.resolve(undefined)],
+  ])('hides nothing when the baseline provider %s', async (_label, baseline) => {
+    const config = {
+      sections: ['rating', 'media'] as FilterSection[],
+      suggestionsProvider: vi.fn().mockResolvedValue({ ...availableEverything, ratings: [] }),
+      baselineProvider: vi.fn().mockImplementation(baseline),
+    };
+
+    render(FilterPanel, {
+      props: { config, timeBuckets: [], filters: { ...createFilterState(), personIds: ['p'] } },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    await waitFor(() => expect(screen.getByTestId('filter-section-media')).toBeInTheDocument());
+    expect(screen.getByTestId('filter-section-rating')).toBeInTheDocument();
+  });
+
+  it('hides nothing when no baselineProvider is configured at all', async () => {
+    const config = {
+      sections: ['rating', 'media'] as FilterSection[],
+      suggestionsProvider: vi.fn().mockResolvedValue({ ...availableEverything, ratings: [] }),
+    };
+
+    render(FilterPanel, {
+      props: { config, timeBuckets: [], filters: { ...createFilterState(), personIds: ['p'] } },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    await waitFor(() => expect(screen.getByTestId('filter-section-media')).toBeInTheDocument());
+    expect(screen.getByTestId('filter-section-rating')).toBeInTheDocument();
+  });
+
+  it('keeps the previous facets when a later refetch rejects', async () => {
+    const suggestionsProvider = vi
+      .fn()
+      .mockResolvedValueOnce(availableEverything)
+      .mockRejectedValue(new Error('network blip'));
+    const config = { sections: ['rating', 'media'] as FilterSection[], suggestionsProvider };
+    const filters = { ...createFilterState() };
+
+    const { rerender } = render(FilterPanel, { props: { config, timeBuckets: [], filters } });
+    await vi.advanceTimersByTimeAsync(0);
+    await waitFor(() => expect(screen.getByTestId('filter-section-rating')).toBeInTheDocument());
+
+    await rerender({ config, timeBuckets: [], filters: { ...filters, personIds: ['p'] } });
+    await vi.advanceTimersByTimeAsync(50);
+    await waitFor(() => expect(suggestionsProvider).toHaveBeenCalledTimes(2));
+
+    // §4.6 at panel level: a rejection must leave `current` and `baseline` untouched, not blank the
+    // panel. Slice 4 made the surfaces reject instead of resolving empty precisely so this holds.
+    expect(screen.getByTestId('filter-section-rating')).toBeInTheDocument();
+    expect(screen.getByTestId('filter-section-media')).toBeInTheDocument();
+  });
+
+  it('greys the timeline while it has no buckets, and restores it when they arrive', async () => {
+    const config = {
+      sections: ['timeline', 'media'] as FilterSection[],
+      suggestionsProvider: vi.fn().mockResolvedValue(availableEverything),
+    };
+
+    // Every query-mode surface passes through timeBuckets: [] before its first facet response.
+    const { rerender } = render(FilterPanel, { props: { config, timeBuckets: [] } });
+    await vi.advanceTimersByTimeAsync(0);
+
+    await waitFor(() => {
+      // getAllByRole, not getByRole: while disabled the section is collapsed (one button, the
+      // header), but once it re-enables below its content expands and the year-grid buttons join
+      // it, so a single-match query would throw. The header is always rendered first.
+      const [button] = within(screen.getByTestId('filter-section-timeline')).getAllByRole('button');
+      expect(button).toBeDisabled();
+      expect(button.textContent).toContain('(0)');
+    });
+
+    await rerender({ config, timeBuckets: [{ timeBucket: '2024-01-01', count: 3 }] });
+
+    // `isOpen` is derived, not stored, so it must recover on its own. No provider round-trip is
+    // involved here — availability recomputes synchronously off the new `timeBuckets` prop — so no
+    // further timer advance is needed.
+    await waitFor(() => {
+      const [button] = within(screen.getByTestId('filter-section-timeline')).getAllByRole('button');
+      expect(button).toBeEnabled();
+    });
+  });
+
+  it('keeps a section with an active filter visible even when its facet is empty', async () => {
+    const config = {
+      sections: ['rating'] as FilterSection[],
+      suggestionsProvider: vi.fn().mockResolvedValue({ ...availableEverything, ratings: [] }),
+    };
+
+    render(FilterPanel, { props: { config, timeBuckets: [], filters: { ...createFilterState(), rating: 5 } } });
+    await vi.advanceTimersByTimeAsync(0);
+
+    await waitFor(() => expect(screen.getByTestId('filter-section-rating')).toBeInTheDocument());
+  });
+
+  it('offers the show-all hint when every AVAILABLE section is user-hidden', async () => {
+    // The user hid `media`; `rating` is unavailable. Nothing renders, so the hint must appear —
+    // but `visibleSections` still contains `rating`, so a `.size === 0` check would miss it.
+    localStorage.setItem('test-key', JSON.stringify({ selected: ['rating'], known: ['rating', 'media'] }));
+    const config = {
+      sections: ['rating', 'media'] as FilterSection[],
+      suggestionsProvider: vi.fn().mockResolvedValue({ ...availableEverything, ratings: [] }),
+    };
+
+    render(FilterPanel, { props: { config, timeBuckets: [], storageKey: 'test-key' } });
+    await vi.advanceTimersByTimeAsync(0);
+
+    // This file's top-level `beforeAll` loads the real en-US locale (unlike specs that skip that
+    // bootstrap and get raw i18n keys back from `$t()`), so the hint's actual text is "Show all" —
+    // asserting on the stable testid instead of either string keeps this immune to copy changes.
+    await waitFor(() => expect(screen.getByTestId('show-all-sections')).toBeInTheDocument());
+  });
+
+  it('leaves the legacy providers path ungated', async () => {
+    const config = {
+      sections: ['people', 'camera'] as FilterSection[],
+      providers: { people: vi.fn().mockResolvedValue([]), cameras: vi.fn().mockResolvedValue([]) },
+    };
+
+    render(FilterPanel, { props: { config, timeBuckets: [] } });
+    await vi.advanceTimersByTimeAsync(0);
+
+    await waitFor(() => expect(screen.getByTestId('filter-section-people')).toBeInTheDocument());
+    expect(screen.getByTestId('filter-section-camera')).toBeInTheDocument();
+  });
+});

--- a/web/src/lib/components/filter-panel/__tests__/unified-suggestions.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/unified-suggestions.spec.ts
@@ -16,6 +16,9 @@ const defaultResponse: FilterSuggestionsResponse = {
   ratings: [3, 4, 5],
   mediaTypes: ['IMAGE', 'VIDEO'],
   hasUnnamedPeople: false,
+  hasFavorites: true,
+  hasAssetsInAlbum: true,
+  hasAssetsNotInAlbum: true,
 };
 
 const timeBuckets = [

--- a/web/src/lib/components/filter-panel/__tests__/unified-suggestions.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/unified-suggestions.spec.ts
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
-import type { FilterPanelConfig, FilterSuggestionsResponse } from '../filter-panel';
+import type { FilterPanelConfig, FilterSection, FilterSuggestionsResponse } from '../filter-panel';
 import FilterPanel from '../filter-panel.svelte';
 
 const defaultResponse: FilterSuggestionsResponse = {
@@ -174,6 +174,35 @@ describe('Unified suggestionsProvider', () => {
     await waitFor(() => {
       expect(screen.getByText('Germany')).toBeTruthy();
     });
+  });
+
+  it('consumes the facets without dimming the controls (#910, feedback_no_dynamic_rating_media_hiding)', async () => {
+    const suggestionsProvider = vi.fn().mockResolvedValue({
+      ...defaultResponse,
+      ratings: [2],
+      mediaTypes: ['IMAGE', 'VIDEO'],
+    });
+    const config = { sections: ['rating', 'media'] as FilterSection[], suggestionsProvider };
+
+    render(FilterPanel, { props: { config, timeBuckets: [] } });
+
+    // Every other test in this file advances fake timers before waitFor for the same reason:
+    // @testing-library's waitFor only self-advances Jest fake timers (it probes a global `jest`),
+    // not Vitest's, so the initial-mount debounce (0ms) needs a manual nudge or these hang for
+    // real until the test's own 5s timeout.
+    await vi.advanceTimersByTimeAsync(0);
+
+    await waitFor(() => expect(suggestionsProvider).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByTestId('rating-star-5')).toBeInTheDocument());
+
+    // Re-introducing `availableRatings` would dim stars 1, 3, 4 and 5 here. Re-introducing
+    // `availableMediaTypes` would drop a media button. Neither may happen.
+    for (const star of [1, 2, 3, 4, 5]) {
+      expect(screen.getByTestId(`rating-star-${star}`).className).not.toContain('opacity-50');
+    }
+    for (const type of ['all', 'image', 'video']) {
+      expect(screen.getByTestId(`media-type-${type}`)).toBeInTheDocument();
+    }
   });
 
   it('should pass active filters when fetching dependent cities', async () => {

--- a/web/src/lib/components/filter-panel/filter-availability.ts
+++ b/web/src/lib/components/filter-panel/filter-availability.ts
@@ -1,0 +1,97 @@
+import type { FilterSection, FilterSuggestionsResponse } from './filter-panel';
+
+/**
+ * Whether a filter section can do anything for the user right now (#910).
+ *
+ * - `available`   — render normally.
+ * - `empty`       — the current filters narrowed it to nothing; grey it out with `(0)`.
+ * - `unavailable` — nothing in this scope could ever populate it; do not render it at all.
+ */
+export type SectionAvailability = 'available' | 'empty' | 'unavailable';
+
+export interface AvailabilityInput {
+  /** Facets for the filters the user has applied right now. */
+  current: FilterSuggestionsResponse;
+  /** Facets for the same scope with no filters applied. `undefined` while it is still in flight. */
+  baseline: FilterSuggestionsResponse | undefined;
+  /** Whether this section itself currently holds a filter value. */
+  hasActiveFilter: boolean;
+  /** Timeline is fed by the page's own buckets rather than a server facet. */
+  timeBucketCount: number;
+}
+
+/**
+ * Whether this section's facet offers the user a choice. Not simply "is the list empty": a control that
+ * can only select everything, or only select nothing, is equally useless.
+ */
+function isSectionEmpty(section: FilterSection, facets: FilterSuggestionsResponse): boolean {
+  switch (section) {
+    case 'people': {
+      // Zero named people is still useful while unnamed faces exist — the empty state is the only
+      // prompt to name one.
+      return facets.people.length === 0 && !facets.hasUnnamedPeople;
+    }
+    case 'location': {
+      return facets.countries.length === 0;
+    }
+    case 'camera': {
+      return facets.cameraMakes.length === 0;
+    }
+    case 'tags': {
+      return facets.tags.length === 0;
+    }
+    case 'rating': {
+      return facets.ratings.length === 0;
+    }
+    case 'media': {
+      // The control offers All / Photos / Videos, so it needs both of those types to discriminate:
+      // with only images, "Photos" is a synonym for "All" and "Videos" is empty.
+      //
+      // NOT `mediaTypes.length < 2`. getFilteredMediaTypes returns raw `distinct asset.type` and
+      // AssetType is IMAGE | VIDEO | AUDIO | OTHER (enum.ts:38), so a photo library holding one
+      // OTHER asset would pass a length test with a dead Videos button.
+      return !(facets.mediaTypes.includes('IMAGE') && facets.mediaTypes.includes('VIDEO'));
+    }
+    case 'favorites': {
+      return !facets.hasFavorites;
+    }
+    case 'albums': {
+      // Needs both sides: with nothing filed "Has album" is empty, with everything filed "Has no
+      // album" is, and either way the control cannot discriminate.
+      return !(facets.hasAssetsInAlbum && facets.hasAssetsNotInAlbum);
+    }
+    default: {
+      return false;
+    }
+  }
+}
+
+export function getSectionAvailability(section: FilterSection, input: AvailabilityInput): SectionAvailability {
+  // Free text has no enumerable domain to be empty of.
+  if (section === 'text') {
+    return 'available';
+  }
+
+  // Never strand a filter the user cannot then reach to clear. Cross-section narrowing can empty a
+  // facet whose own filter is set — person X plus rating 5, where X has no rated photos.
+  if (input.hasActiveFilter) {
+    return 'available';
+  }
+
+  // Timeline's emptiness means "this page has no assets", which the surfaces handle with the panel's
+  // `hidden` prop, so it greys but never hides.
+  if (section === 'timeline') {
+    return input.timeBucketCount === 0 ? 'empty' : 'available';
+  }
+
+  if (!isSectionEmpty(section, input.current)) {
+    return 'available';
+  }
+
+  // A section is never hidden on missing information.
+  if (input.baseline === undefined) {
+    return 'empty';
+  }
+
+  return isSectionEmpty(section, input.baseline) ? 'unavailable' : 'empty';
+}

--- a/web/src/lib/components/filter-panel/filter-panel.svelte
+++ b/web/src/lib/components/filter-panel/filter-panel.svelte
@@ -9,6 +9,7 @@
     FilterPanelConfig,
     FilterSection as FilterSectionType,
     FilterState,
+    FilterSuggestionsResponse,
     PersonOption,
     TagOption,
   } from './filter-panel';
@@ -80,6 +81,18 @@
   let tags = $state<TagOption[]>([]);
   let availableRatings = $state<number[] | undefined>();
   let availableMediaTypes = $state<string[] | undefined>();
+
+  // #910: the facets for the filters in force right now, and for the same scope with none applied.
+  // The baseline answers "could this section EVER do anything here", which is what separates hiding a
+  // section from merely greying it. Captured here; wired into getSectionAvailability in the next
+  // commit, so each is genuinely unread until then — disable no-unused-vars per line rather than
+  // delay the declarations to that commit.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let currentSuggestions = $state<FilterSuggestionsResponse | undefined>();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let baseline = $state<FilterSuggestionsResponse | undefined>();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let baselineRequested = false;
 
   // The count gate answers "has a *cross-section* filter narrowed the panel?". It drives the
   // empty-section disable in filter-section.svelte, not a request, so the location/camera/media
@@ -168,11 +181,12 @@
           cameraMakes = result.cameraMakes;
           tags = result.tags;
           // Note: availableRatings and availableMediaTypes are intentionally NOT set from
-          // suggestionsProvider. Hiding rating stars and media type buttons based on the
-          // current result set is too aggressive — it breaks existing E2E tests and confuses
-          // users who expect these fixed options to always be visible. The core value of
-          // interdependent filtering is in people/countries/cameras/tags narrowing.
+          // suggestionsProvider. Hiding or dimming rating stars and media type buttons based on the
+          // current result set breaks their positional meaning (PR #261) and the E2E suites that click
+          // them. #910 gates the *sections* instead — the facets reach getSectionAvailability through
+          // `currentSuggestions` below, never the controls. See spec §2.4.
           hasUnnamedPeople = result.hasUnnamedPeople;
+          currentSuggestions = result;
         })
         .catch((error: unknown) => {
           if (!controller.signal.aborted) {

--- a/web/src/lib/components/filter-panel/filter-panel.svelte
+++ b/web/src/lib/components/filter-panel/filter-panel.svelte
@@ -798,6 +798,14 @@
         <div class="pt-4">
           {#each renderableSections as section (section)}
             {#if visibleSections.has(section)}
+              <!-- The "(0)" / disable gate answers "has a CROSS-SECTION filter narrowed the panel?",
+                   so the #910 availability verdict is gated on filterContext exactly as the legacy
+                   formula below is: #858 §3.3 decision 3 keeps `state` / `lensModel` / `ownerId`
+                   (and the location/camera/media dimensions) out of it, because those arrive from a
+                   contextual filter or a link rather than the panel's own controls. 'timeline' is
+                   the one exception — its `empty` means "this page has no assets at all", which no
+                   filter is responsible for. Hiding an `unavailable` section is separate and stays
+                   ungated (renderableSections, above). -->
               <FilterSection
                 title={sectionTitles[section]}
                 testId={section}
@@ -805,7 +813,7 @@
                 expanded={expandedSections.has(section)}
                 onToggleExpanded={() => toggleSectionExpanded(section)}
                 count={config.suggestionsProvider
-                  ? availability.get(section) === 'empty'
+                  ? (section === 'timeline' || filterContext) && availability.get(section) === 'empty'
                     ? 0
                     : undefined
                   : filterContext

--- a/web/src/lib/components/filter-panel/filter-panel.svelte
+++ b/web/src/lib/components/filter-panel/filter-panel.svelte
@@ -17,10 +17,12 @@
     ALL_FILTER_SECTIONS,
     buildFilterContext,
     createFilterState,
+    getActiveFilterCount,
     loadFilterCollapsed,
     PRE_LEDGER_FILTER_SECTIONS,
     saveFilterCollapsed,
   } from './filter-panel';
+  import { getSectionAvailability, type SectionAvailability } from './filter-availability';
   import FilterSection from './filter-section.svelte';
   import FilterSectionMenu from './filter-section-menu.svelte';
   import TemporalPicker from './temporal-picker.svelte';
@@ -84,14 +86,9 @@
 
   // #910: the facets for the filters in force right now, and for the same scope with none applied.
   // The baseline answers "could this section EVER do anything here", which is what separates hiding a
-  // section from merely greying it. Captured here; wired into getSectionAvailability in the next
-  // commit, so each is genuinely unread until then — disable no-unused-vars per line rather than
-  // delay the declarations to that commit.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  // section from merely greying it.
   let currentSuggestions = $state<FilterSuggestionsResponse | undefined>();
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let baseline = $state<FilterSuggestionsResponse | undefined>();
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let baselineRequested = false;
 
   // The count gate answers "has a *cross-section* filter narrowed the panel?". It drives the
@@ -187,6 +184,10 @@
           // `currentSuggestions` below, never the controls. See spec §2.4.
           hasUnnamedPeople = result.hasUnnamedPeople;
           currentSuggestions = result;
+          if (getActiveFilterCount(currentFilters) === 0) {
+            // Mounted clean, so this response is already the no-filters baseline — no second request.
+            baseline = result;
+          }
         })
         .catch((error: unknown) => {
           if (!controller.signal.aborted) {
@@ -205,6 +206,31 @@
     return () => {
       clearTimeout(timeout);
     };
+  });
+
+  // Only fires when the panel mounts with filters already applied (a deep link, or restored state) —
+  // otherwise the effect above captures the baseline for free. Scope changes remount the panel, so this
+  // needs no invalidation: see spec §4.5 for the `{#key}` blocks that guarantee it.
+  $effect(() => {
+    const provider = config.baselineProvider;
+    if (!config.suggestionsProvider || !provider || baselineRequested) {
+      return;
+    }
+    baselineRequested = true;
+
+    if (untrack(() => getActiveFilterCount(filters)) === 0) {
+      return;
+    }
+
+    void provider()
+      // A surface with no cheap baseline resolves `undefined` (every query-mode branch does). Assigning
+      // it is a no-op that keeps the "never hidden on missing information" rule intact.
+      .then((result) => {
+        baseline = result;
+      })
+      .catch(() => {
+        // Leave it undefined. A section is never hidden on missing information.
+      });
   });
 
   let prevTakenAfter: string | undefined = $state();
@@ -675,6 +701,27 @@
 
   // Whether any section has an active filter — surfaced as a single dot on the collapsed filter button.
   let anyActiveFilter = $derived(config.sections.some((section) => hasActiveFilter(section)));
+
+  // Availability is derived, never persisted — the storage effect keeps writing `config.sections`.
+  // Conflating the two would record a section as user-hidden the moment it went unavailable, and it
+  // would never come back.
+  let availability = $derived<Map<FilterSectionType, SectionAvailability>>(
+    new Map(
+      config.sections.map((section) => [
+        section,
+        config.suggestionsProvider && currentSuggestions
+          ? getSectionAvailability(section, {
+              current: currentSuggestions,
+              baseline,
+              hasActiveFilter: hasActiveFilter(section),
+              timeBucketCount: timeBuckets.length,
+            })
+          : 'available',
+      ]),
+    ),
+  );
+
+  let renderableSections = $derived(config.sections.filter((section) => availability.get(section) !== 'unavailable'));
 </script>
 
 {#if hidden}
@@ -724,10 +771,10 @@
         >
           <div class="flex items-center gap-1">
             <span class="text-sm font-medium">{$t('filters')}</span>
-            {#if config.sections.length > 0}
+            {#if renderableSections.length > 0}
               <FilterSectionMenu
                 bind:open={sectionMenuOpen}
-                sections={config.sections}
+                sections={renderableSections}
                 visible={visibleSections}
                 titles={sectionTitles}
                 toggleLabels={sectionToggleLabels}
@@ -749,7 +796,7 @@
         </div>
 
         <div class="pt-4">
-          {#each config.sections as section (section)}
+          {#each renderableSections as section (section)}
             {#if visibleSections.has(section)}
               <FilterSection
                 title={sectionTitles[section]}
@@ -757,17 +804,21 @@
                 refetching={isRefetching && section !== 'timeline'}
                 expanded={expandedSections.has(section)}
                 onToggleExpanded={() => toggleSectionExpanded(section)}
-                count={filterContext
-                  ? section === 'people'
-                    ? people.length
-                    : section === 'location'
-                      ? countries.length
-                      : section === 'camera'
-                        ? cameraMakes.length
-                        : section === 'tags'
-                          ? tags.length
-                          : undefined
-                  : undefined}
+                count={config.suggestionsProvider
+                  ? availability.get(section) === 'empty'
+                    ? 0
+                    : undefined
+                  : filterContext
+                    ? section === 'people'
+                      ? people.length
+                      : section === 'location'
+                        ? countries.length
+                        : section === 'camera'
+                          ? cameraMakes.length
+                          : section === 'tags'
+                            ? tags.length
+                            : undefined
+                    : undefined}
               >
                 {#if section === 'timeline'}
                   <TemporalPicker
@@ -874,8 +925,10 @@
           {/each}
 
           <!-- Emptiness is per surface, not per ledger: the set can still hold a section another
-               surface tracks under the same storage key (#797). -->
-          {#if config.sections.every((section) => !visibleSections.has(section))}
+               surface tracks under the same storage key (#797). Gated on renderableSections, not
+               config.sections: an unavailable section still counts as "visible" in the persisted
+               ledger, so a panel rendering nothing could otherwise have no hint (#910). -->
+          {#if renderableSections.every((section) => !visibleSections.has(section))}
             <div class="flex flex-col items-center gap-2 px-4 py-8 text-center">
               <p class="text-xs text-gray-500 dark:text-gray-400">{$t('filter_show_sections_hint')}</p>
               <button

--- a/web/src/lib/components/filter-panel/filter-panel.ts
+++ b/web/src/lib/components/filter-panel/filter-panel.ts
@@ -108,11 +108,25 @@ export interface FilterSuggestionsResponse {
   ratings: number[];
   mediaTypes: string[];
   hasUnnamedPeople: boolean;
+  hasFavorites: boolean;
+  hasAssetsInAlbum: boolean;
+  hasAssetsNotInAlbum: boolean;
 }
 
 export interface FilterPanelConfig {
   sections: FilterSection[];
   suggestionsProvider?: (filters: FilterState) => Promise<FilterSuggestionsResponse>;
+  /**
+   * Facets for this surface's scope with no filters applied (#910). The panel only calls this when it
+   * mounts with filters already active — otherwise the ordinary response is already the baseline.
+   *
+   * Resolving `undefined` means "no cheap baseline here", and the panel then never hides a section.
+   * The three query-mode surfaces return `undefined` deliberately: their `smartFacetInFlight` slot is
+   * single-entry and their `smartFacets` state feeds the timeline and the result count, so a second
+   * concurrent facet request would abort the first and then overwrite the page's own data. See spec
+   * §4.5 — this hook exists because `suggestionsProvider(createFilterState())` cannot be used.
+   */
+  baselineProvider?: () => Promise<FilterSuggestionsResponse | undefined>;
   providers?: {
     people?: (context?: FilterContext) => Promise<PersonOption[]>;
     allPeople?: () => Promise<PersonOption[]>;

--- a/web/src/lib/utils/__tests__/album-filter-config.spec.ts
+++ b/web/src/lib/utils/__tests__/album-filter-config.spec.ts
@@ -15,6 +15,9 @@ vi.mock('@immich/sdk', async (importOriginal) => {
       ratings: [5],
       mediaTypes: ['IMAGE'],
       hasUnnamedPeople: false,
+      hasFavorites: true,
+      hasAssetsInAlbum: true,
+      hasAssetsNotInAlbum: false,
     }),
     getSearchSuggestions: vi.fn().mockResolvedValue(['Berlin']),
   };
@@ -174,6 +177,14 @@ describe('buildAlbumDetailFilterConfig', () => {
     expect(getFilterSuggestions).toHaveBeenCalledWith(
       expect.objectContaining({ albumId: 'album-1', isFavorite: true }),
     );
+  });
+
+  it('forwards the #910 availability facets', async () => {
+    const result = await buildAlbumDetailFilterConfig('album-1').suggestionsProvider!(createFilterState());
+
+    expect(result.hasFavorites).toBe(true);
+    expect(result.hasAssetsInAlbum).toBe(true);
+    expect(result.hasAssetsNotInAlbum).toBe(false);
   });
 });
 

--- a/web/src/lib/utils/__tests__/album-filter-config.spec.ts
+++ b/web/src/lib/utils/__tests__/album-filter-config.spec.ts
@@ -284,6 +284,27 @@ describe('buildAlbumAssetPickerFilterConfig', () => {
     expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ albumId: 'album-1' }));
   });
 
+  it('forwards isInAlbum and isNotInAlbum to filter suggestions (#910)', async () => {
+    const config = buildAlbumAssetPickerFilterConfig();
+
+    await config.suggestionsProvider!({ ...createFilterState(), isInAlbum: true });
+    const isInAlbumRequest = vi.mocked(getFilterSuggestions).mock.calls.at(-1)?.[0];
+    expect(isInAlbumRequest?.isInAlbum).toBe(true);
+    expect(isInAlbumRequest?.isNotInAlbum).toBeUndefined();
+
+    await config.suggestionsProvider!({ ...createFilterState(), isNotInAlbum: true });
+    const isNotInAlbumRequest = vi.mocked(getFilterSuggestions).mock.calls.at(-1)?.[0];
+    expect(isNotInAlbumRequest?.isNotInAlbum).toBe(true);
+    expect(isNotInAlbumRequest?.isInAlbum).toBeUndefined();
+
+    // An explicit `false` means "only assets that ARE/aren't in an album", not "don't filter" —
+    // it must not be forwarded as `false`, only `true` or omitted.
+    await config.suggestionsProvider!({ ...createFilterState(), isInAlbum: false, isNotInAlbum: false });
+    const bothFalseRequest = vi.mocked(getFilterSuggestions).mock.calls.at(-1)?.[0];
+    expect(bothFalseRequest?.isInAlbum).toBeUndefined();
+    expect(bothFalseRequest?.isNotInAlbum).toBeUndefined();
+  });
+
   it('offers a browse-mode baseline computed with no filters, unscoped (#910)', async () => {
     const config = buildAlbumAssetPickerFilterConfig();
     vi.mocked(getFilterSuggestions).mockClear();

--- a/web/src/lib/utils/__tests__/album-filter-config.spec.ts
+++ b/web/src/lib/utils/__tests__/album-filter-config.spec.ts
@@ -186,6 +186,17 @@ describe('buildAlbumDetailFilterConfig', () => {
     expect(result.hasAssetsInAlbum).toBe(true);
     expect(result.hasAssetsNotInAlbum).toBe(false);
   });
+
+  it('offers a browse-mode baseline computed with no filters, scoped to the album (#910)', async () => {
+    const config = buildAlbumDetailFilterConfig('album-1');
+    vi.mocked(getFilterSuggestions).mockClear();
+
+    const baseline = await config.baselineProvider!();
+
+    expect(baseline).toBeDefined();
+    expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ albumId: 'album-1' }));
+    expect(getFilterSuggestions).not.toHaveBeenCalledWith(expect.objectContaining({ rating: expect.anything() }));
+  });
 });
 
 describe('buildAlbumAssetPickerFilterConfig', () => {
@@ -271,5 +282,18 @@ describe('buildAlbumAssetPickerFilterConfig', () => {
     });
 
     expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ albumId: 'album-1' }));
+  });
+
+  it('offers a browse-mode baseline computed with no filters, unscoped (#910)', async () => {
+    const config = buildAlbumAssetPickerFilterConfig();
+    vi.mocked(getFilterSuggestions).mockClear();
+
+    const baseline = await config.baselineProvider!();
+
+    expect(baseline).toBeDefined();
+    const call = vi.mocked(getFilterSuggestions).mock.calls.at(-1)?.[0];
+    expect(call).not.toHaveProperty('albumId');
+    expect(call).not.toHaveProperty('withSharedSpaces');
+    expect(call).not.toHaveProperty('rating');
   });
 });

--- a/web/src/lib/utils/__tests__/filter-section-parity.spec.ts
+++ b/web/src/lib/utils/__tests__/filter-section-parity.spec.ts
@@ -16,6 +16,9 @@ vi.mock('@immich/sdk', async (importOriginal) => {
       ratings: [],
       mediaTypes: [],
       hasUnnamedPeople: false,
+      hasFavorites: false,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: false,
     }),
     getSearchSuggestions: vi.fn().mockResolvedValue([]),
   };

--- a/web/src/lib/utils/__tests__/map-filter-config.spec.ts
+++ b/web/src/lib/utils/__tests__/map-filter-config.spec.ts
@@ -299,6 +299,28 @@ describe('buildMapFilterConfig', () => {
     expect(getSearchSuggestions).toHaveBeenCalledWith(expect.objectContaining({ spaceId: 'space-123', make: 'Nikon' }));
   });
 
+  describe('baselineProvider', () => {
+    it('offers a browse-mode baseline computed with no filters (#910)', async () => {
+      const config = buildMapFilterConfig();
+      vi.mocked(getFilterSuggestions).mockClear();
+
+      const baseline = await config.baselineProvider!();
+
+      expect(baseline).toBeDefined();
+      expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ withSharedSpaces: true }));
+      expect(getFilterSuggestions).not.toHaveBeenCalledWith(expect.objectContaining({ rating: expect.anything() }));
+    });
+
+    it('scopes the baseline by spaceId when provided', async () => {
+      const config = buildMapFilterConfig('space-123');
+      vi.mocked(getFilterSuggestions).mockClear();
+
+      await config.baselineProvider!();
+
+      expect(getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ spaceId: 'space-123' }));
+    });
+  });
+
   it('should pass withSharedSpaces to cities provider when no spaceId', async () => {
     vi.mocked(getSearchSuggestions).mockResolvedValue(['Paris'] as never);
 

--- a/web/src/lib/utils/__tests__/map-filter-config.spec.ts
+++ b/web/src/lib/utils/__tests__/map-filter-config.spec.ts
@@ -14,6 +14,9 @@ vi.mock('@immich/sdk', async (importOriginal) => {
       ratings: [],
       mediaTypes: [],
       hasUnnamedPeople: false,
+      hasFavorites: false,
+      hasAssetsInAlbum: true,
+      hasAssetsNotInAlbum: true,
     }),
     getSearchSuggestions: vi.fn().mockResolvedValue([]),
   };
@@ -264,6 +267,15 @@ describe('buildMapFilterConfig', () => {
 
       expect(result.tags).toHaveLength(1);
       expect(result.tags[0]).toEqual({ id: 'tag-1', name: 'Nature' });
+    });
+
+    it('forwards the #910 availability facets', async () => {
+      const config = buildMapFilterConfig();
+      const result = await config.suggestionsProvider!(emptyFilters);
+
+      expect(result.hasFavorites).toBe(false);
+      expect(result.hasAssetsInAlbum).toBe(true);
+      expect(result.hasAssetsNotInAlbum).toBe(true);
     });
   });
 

--- a/web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts
+++ b/web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts
@@ -185,6 +185,21 @@ describe('buildRecentlyAddedFilterConfig', () => {
     expect(result.hasAssetsNotInAlbum).toBe(false);
   });
 
+  it('offers a browse-mode baseline computed with no filters (#910)', async () => {
+    const config = buildRecentlyAddedFilterConfig();
+    vi.mocked(getFilterSuggestions).mockClear();
+
+    const baseline = await config.baselineProvider!();
+
+    expect(baseline).toBeDefined();
+    const call = vi.mocked(getFilterSuggestions).mock.calls.at(-1)?.[0];
+    expect(call).not.toHaveProperty('personIds');
+    expect(call).not.toHaveProperty('rating');
+    expect(call).not.toHaveProperty('withSharedSpaces');
+    expect(call).not.toHaveProperty('albumId');
+    expect(call).not.toHaveProperty('spaceId');
+  });
+
   it('passes the dependent-provider arguments and context through', async () => {
     const config = buildRecentlyAddedFilterConfig();
 
@@ -275,6 +290,17 @@ describe('buildRecentlyAddedFilterConfig in query mode', () => {
     expect(vi.mocked(searchSmartFacets).mock.calls[1][0].smartSearchFacetsDto).toEqual(
       expect.objectContaining({ query: 'sunset' }),
     );
+  });
+
+  it('offers no baseline in query mode (#910)', async () => {
+    // Regression guard for spec §4.5: this config is spread as-is into the Recently Added page's
+    // FilterPanelConfig (no page-level override), so the query-mode guard has to live here.
+    const config = buildRecentlyAddedFilterConfig(searchContext);
+    vi.mocked(getFilterSuggestions).mockClear();
+
+    await expect(config.baselineProvider!()).resolves.toBeUndefined();
+
+    expect(getFilterSuggestions).not.toHaveBeenCalled();
   });
 
   it('falls back to the browse path when the query is blank', async () => {

--- a/web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts
+++ b/web/src/lib/utils/__tests__/recently-added-filter-config.spec.ts
@@ -15,6 +15,9 @@ vi.mock('@immich/sdk', async (importOriginal) => {
       ratings: [5],
       mediaTypes: ['IMAGE'],
       hasUnnamedPeople: false,
+      hasFavorites: true,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: false,
     }),
     getSearchSuggestions: vi.fn().mockResolvedValue(['Berlin']),
     searchSmartFacets: vi.fn().mockResolvedValue({
@@ -172,6 +175,14 @@ describe('buildRecentlyAddedFilterConfig', () => {
         takenBefore: '2025-01-01T00:00:00.000Z',
       }),
     );
+  });
+
+  it('forwards the #910 availability facets', async () => {
+    const result = await buildRecentlyAddedFilterConfig().suggestionsProvider!(createFilterState());
+
+    expect(result.hasFavorites).toBe(true);
+    expect(result.hasAssetsInAlbum).toBe(false);
+    expect(result.hasAssetsNotInAlbum).toBe(false);
   });
 
   it('passes the dependent-provider arguments and context through', async () => {

--- a/web/src/lib/utils/__tests__/space-search.spec.ts
+++ b/web/src/lib/utils/__tests__/space-search.spec.ts
@@ -453,6 +453,9 @@ describe('mapSmartSearchFacetsToFilterSuggestions', () => {
         ratings: [4],
         mediaTypes: [AssetTypeEnum.Image],
         hasUnnamedPeople: true,
+        hasFavorites: true,
+        hasAssetsInAlbum: true,
+        hasAssetsNotInAlbum: true,
       },
       { spaceId: 'space-1' },
     );
@@ -473,6 +476,9 @@ describe('mapSmartSearchFacetsToFilterSuggestions', () => {
       ratings: [4],
       mediaTypes: [AssetTypeEnum.Image],
       hasUnnamedPeople: true,
+      hasFavorites: true,
+      hasAssetsInAlbum: true,
+      hasAssetsNotInAlbum: true,
     });
   });
 
@@ -495,6 +501,9 @@ describe('mapSmartSearchFacetsToFilterSuggestions', () => {
       ratings: [],
       mediaTypes: [],
       hasUnnamedPeople: false,
+      hasFavorites: false,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: false,
     });
 
     expect(result.people).toEqual([
@@ -526,6 +535,9 @@ describe('mapSmartSearchFacetsToFilterSuggestions', () => {
       ratings: [],
       mediaTypes: [],
       hasUnnamedPeople: false,
+      hasFavorites: false,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: false,
     });
 
     expect(result.people[0]).toEqual(

--- a/web/src/lib/utils/__tests__/space-search.spec.ts
+++ b/web/src/lib/utils/__tests__/space-search.spec.ts
@@ -535,6 +535,29 @@ describe('mapSmartSearchFacetsToFilterSuggestions', () => {
       }),
     );
   });
+
+  it('forwards the #910 availability facets', () => {
+    const result = mapSmartSearchFacetsToFilterSuggestions({
+      total: 0,
+      timeBuckets: [],
+      countries: [],
+      cities: [],
+      cameraMakes: [],
+      cameraModels: [],
+      tags: [],
+      people: [],
+      ratings: [],
+      mediaTypes: [],
+      hasUnnamedPeople: false,
+      hasFavorites: false,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: true,
+    });
+
+    expect(result.hasFavorites).toBe(false);
+    expect(result.hasAssetsInAlbum).toBe(false);
+    expect(result.hasAssetsNotInAlbum).toBe(true);
+  });
 });
 
 describe('SEARCH_FILTER_DEBOUNCE_MS', () => {

--- a/web/src/lib/utils/album-filter-config.ts
+++ b/web/src/lib/utils/album-filter-config.ts
@@ -35,6 +35,9 @@ function mapSuggestions(response: Awaited<ReturnType<typeof getFilterSuggestions
     ratings: response.ratings,
     mediaTypes: response.mediaTypes,
     hasUnnamedPeople: response.hasUnnamedPeople,
+    hasFavorites: response.hasFavorites,
+    hasAssetsInAlbum: response.hasAssetsInAlbum,
+    hasAssetsNotInAlbum: response.hasAssetsNotInAlbum,
   };
 }
 

--- a/web/src/lib/utils/album-filter-config.ts
+++ b/web/src/lib/utils/album-filter-config.ts
@@ -71,6 +71,9 @@ export function buildAlbumDetailFilterConfig(albumId: string): FilterPanelConfig
     sections: [...albumDetailSections],
     suggestionsProvider: async (filters) =>
       mapSuggestions(await getFilterSuggestions({ albumId, ...toSuggestionRequest(filters) })),
+    // #910: the baseline is the same call with the filter arguments dropped, keeping only the
+    // album scope.
+    baselineProvider: async () => mapSuggestions(await getFilterSuggestions({ albumId })),
     providers: {
       cities: (country, context) =>
         getSearchSuggestions({ $type: SearchSuggestionType.City, albumId, country, ...context }),
@@ -84,6 +87,8 @@ export function buildAlbumAssetPickerFilterConfig(): FilterPanelConfig {
   return {
     sections: [...albumPickerSections],
     suggestionsProvider: async (filters) => mapSuggestions(await getFilterSuggestions(toSuggestionRequest(filters))),
+    // #910: the picker is not scoped to anything, so the baseline is a plain, filter-free call.
+    baselineProvider: async () => mapSuggestions(await getFilterSuggestions({})),
     providers: {
       cities: (country, context) => getSearchSuggestions({ $type: SearchSuggestionType.City, country, ...context }),
       cameraModels: (make, context) =>

--- a/web/src/lib/utils/album-filter-config.ts
+++ b/web/src/lib/utils/album-filter-config.ts
@@ -61,6 +61,8 @@ function toSuggestionRequest(filters: FilterState) {
         : filters.mediaType === 'image'
           ? AssetTypeEnum.Image
           : AssetTypeEnum.Video,
+    isNotInAlbum: filters.isNotInAlbum === true ? true : undefined,
+    isInAlbum: filters.isInAlbum === true ? true : undefined,
     takenAfter: context?.takenAfter,
     takenBefore: context?.takenBefore,
   };

--- a/web/src/lib/utils/filter-name-capture.spec.ts
+++ b/web/src/lib/utils/filter-name-capture.spec.ts
@@ -14,6 +14,9 @@ const EMPTY_SUGGESTIONS: FilterSuggestionsResponse = {
   ratings: [],
   mediaTypes: [],
   hasUnnamedPeople: false,
+  hasFavorites: false,
+  hasAssetsInAlbum: false,
+  hasAssetsNotInAlbum: false,
 };
 
 function makeConfig(suggestions: FilterSuggestionsResponse, hasProvider = true): FilterPanelConfig {

--- a/web/src/lib/utils/map-filter-config.ts
+++ b/web/src/lib/utils/map-filter-config.ts
@@ -55,6 +55,9 @@ export function buildMapFilterConfig(spaceId?: string): FilterPanelConfig {
       ratings: response.ratings,
       mediaTypes: response.mediaTypes,
       hasUnnamedPeople: response.hasUnnamedPeople,
+      hasFavorites: response.hasFavorites,
+      hasAssetsInAlbum: response.hasAssetsInAlbum,
+      hasAssetsNotInAlbum: response.hasAssetsNotInAlbum,
     };
   };
 

--- a/web/src/lib/utils/map-filter-config.ts
+++ b/web/src/lib/utils/map-filter-config.ts
@@ -14,6 +14,27 @@ import {
 import { createUrl } from '$lib/utils';
 import { getPhotosPersonFilterId, getPhotosPersonFilterThumbnailUrl } from '$lib/utils/photos-filter-options';
 
+function mapSuggestions(response: Awaited<ReturnType<typeof getFilterSuggestions>>, spaceId?: string) {
+  return {
+    countries: response.countries,
+    cameraMakes: response.cameraMakes,
+    tags: response.tags.map((t: { id: string; value: string }) => ({ id: t.id, name: t.value })),
+    people: response.people.map((p: FilterSuggestionsPersonDto) => ({
+      id: spaceId ? p.id : getPhotosPersonFilterId(p),
+      name: p.name,
+      thumbnailUrl: spaceId
+        ? createUrl(`/shared-spaces/${spaceId}/people/${p.primaryProfile?.id ?? p.id}/thumbnail`)
+        : getPhotosPersonFilterThumbnailUrl(p),
+    })),
+    ratings: response.ratings,
+    mediaTypes: response.mediaTypes,
+    hasUnnamedPeople: response.hasUnnamedPeople,
+    hasFavorites: response.hasFavorites,
+    hasAssetsInAlbum: response.hasAssetsInAlbum,
+    hasAssetsNotInAlbum: response.hasAssetsNotInAlbum,
+  };
+}
+
 export function buildMapFilterConfig(spaceId?: string): FilterPanelConfig {
   const suggestionsProvider = async (filters: FilterState) => {
     const context = buildFilterContext(filters);
@@ -41,29 +62,15 @@ export function buildMapFilterConfig(spaceId?: string): FilterPanelConfig {
       takenBefore: context?.takenBefore,
       ...(spaceId ? { spaceId } : { withSharedSpaces: true }),
     });
-    return {
-      countries: response.countries,
-      cameraMakes: response.cameraMakes,
-      tags: response.tags.map((t: { id: string; value: string }) => ({ id: t.id, name: t.value })),
-      people: response.people.map((p: FilterSuggestionsPersonDto) => ({
-        id: spaceId ? p.id : getPhotosPersonFilterId(p),
-        name: p.name,
-        thumbnailUrl: spaceId
-          ? createUrl(`/shared-spaces/${spaceId}/people/${p.primaryProfile?.id ?? p.id}/thumbnail`)
-          : getPhotosPersonFilterThumbnailUrl(p),
-      })),
-      ratings: response.ratings,
-      mediaTypes: response.mediaTypes,
-      hasUnnamedPeople: response.hasUnnamedPeople,
-      hasFavorites: response.hasFavorites,
-      hasAssetsInAlbum: response.hasAssetsInAlbum,
-      hasAssetsNotInAlbum: response.hasAssetsNotInAlbum,
-    };
+    return mapSuggestions(response, spaceId);
   };
 
   return {
     sections: [...ALL_FILTER_SECTIONS],
     suggestionsProvider,
+    // #910: the baseline is the same call with the filter arguments dropped, keeping only scope.
+    baselineProvider: async () =>
+      mapSuggestions(await getFilterSuggestions({ ...(spaceId ? { spaceId } : { withSharedSpaces: true }) }), spaceId),
     providers: {
       cities: (country: string, context) =>
         getSearchSuggestions({

--- a/web/src/lib/utils/recently-added-filter-config.ts
+++ b/web/src/lib/utils/recently-added-filter-config.ts
@@ -24,6 +24,9 @@ function mapSuggestions(response: Awaited<ReturnType<typeof getFilterSuggestions
     ratings: response.ratings,
     mediaTypes: response.mediaTypes,
     hasUnnamedPeople: response.hasUnnamedPeople,
+    hasFavorites: response.hasFavorites,
+    hasAssetsInAlbum: response.hasAssetsInAlbum,
+    hasAssetsNotInAlbum: response.hasAssetsNotInAlbum,
   };
 }
 

--- a/web/src/lib/utils/recently-added-filter-config.ts
+++ b/web/src/lib/utils/recently-added-filter-config.ts
@@ -81,6 +81,16 @@ export function buildRecentlyAddedFilterConfig(
       }
       return mapSmartSearchFacetsToFilterSuggestions(await fetchFacets(context, filters));
     },
+    // #910: unlike Photos and Spaces, this config is spread as-is into the page's FilterPanelConfig
+    // with no page-level override (see the +page.svelte's `baseFilterConfig` spread) — so the
+    // query-mode guard has to live here. Own + partner scope only, so the browse-mode call carries
+    // no scope arguments either.
+    baselineProvider: async () => {
+      if (activeSearch()) {
+        return undefined;
+      }
+      return mapSuggestions(await getFilterSuggestions({}));
+    },
     providers: {
       cities: async (country, filterContext) => {
         const context = activeSearch();

--- a/web/src/lib/utils/space-search.ts
+++ b/web/src/lib/utils/space-search.ts
@@ -196,5 +196,8 @@ export function mapSmartSearchFacetsToFilterSuggestions(
     ratings: facets.ratings,
     mediaTypes: facets.mediaTypes,
     hasUnnamedPeople: facets.hasUnnamedPeople,
+    hasFavorites: facets.hasFavorites,
+    hasAssetsInAlbum: facets.hasAssetsInAlbum,
+    hasAssetsNotInAlbum: facets.hasAssetsNotInAlbum,
   };
 }

--- a/web/src/lib/utils/typed-search/typed-search-resolver.spec.ts
+++ b/web/src/lib/utils/typed-search/typed-search-resolver.spec.ts
@@ -27,6 +27,9 @@ describe('resolveTypedSearchFilters', () => {
       ratings: [],
       mediaTypes: [AssetTypeEnum.Image, AssetTypeEnum.Video],
       hasUnnamedPeople: false,
+      hasFavorites: false,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: false,
     });
     vi.mocked(getSearchSuggestions).mockResolvedValue([]);
   });
@@ -41,6 +44,9 @@ describe('resolveTypedSearchFilters', () => {
       ratings: [4],
       mediaTypes: [AssetTypeEnum.Image],
       hasUnnamedPeople: false,
+      hasFavorites: false,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: false,
     });
 
     const result = await resolveTypedSearchFilters(parseTypedSearch('beach person:anna tag:travel camera:nikon'), {});
@@ -119,6 +125,9 @@ describe('resolveTypedSearchFilters', () => {
       ratings: [],
       mediaTypes: [AssetTypeEnum.Image],
       hasUnnamedPeople: false,
+      hasFavorites: false,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: false,
     });
     vi.mocked(getSearchSuggestions).mockResolvedValue(['Munich']);
 
@@ -230,6 +239,9 @@ describe('resolveTypedSearchFilters', () => {
       ratings: [],
       mediaTypes: [],
       hasUnnamedPeople: false,
+      hasFavorites: false,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: false,
     });
 
     const result = await resolveTypedSearchFilters(
@@ -265,6 +277,9 @@ describe('resolveTypedSearchFilters', () => {
       ratings: [],
       mediaTypes: [],
       hasUnnamedPeople: false,
+      hasFavorites: false,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: false,
     });
 
     const result = await resolveTypedSearchFilters(parseTypedSearch('tag:trav'), {});
@@ -296,6 +311,9 @@ describe('resolveTypedSearchFilters', () => {
       ratings: [],
       mediaTypes: [],
       hasUnnamedPeople: false,
+      hasFavorites: false,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: false,
     });
 
     const result = await resolveTypedSearchFilters(parseTypedSearch('person:anna'), { spaceId: 'space-1' });
@@ -317,6 +335,9 @@ describe('resolveTypedSearchFilters', () => {
       ratings: [],
       mediaTypes: [],
       hasUnnamedPeople: false,
+      hasFavorites: false,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: false,
     });
     vi.mocked(getSearchSuggestions).mockResolvedValue(['Nikon']);
 

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts
@@ -94,6 +94,9 @@ function renderPage(album = albumFactory.build({ assetCount: 2 })) {
         ratings: [5],
         mediaTypes: ['IMAGE'],
         hasUnnamedPeople: false,
+        hasFavorites: true,
+        hasAssetsInAlbum: true,
+        hasAssetsNotInAlbum: true,
       });
     }
 
@@ -108,6 +111,9 @@ function renderPage(album = albumFactory.build({ assetCount: 2 })) {
       ratings: [5],
       mediaTypes: ['IMAGE'],
       hasUnnamedPeople: false,
+      hasFavorites: true,
+      hasAssetsInAlbum: true,
+      hasAssetsNotInAlbum: true,
     });
   });
 

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -168,18 +168,6 @@
   const smartFacetBuckets = $derived(showSearchResults ? (smartFacets?.timeBuckets ?? []) : timelineBuckets);
   const smartFacetTotal = $derived(showSearchResults ? smartFacets?.total : undefined);
 
-  const emptyFilterSuggestions = () => ({
-    countries: [],
-    cities: [],
-    cameraMakes: [],
-    cameraModels: [],
-    tags: [],
-    people: [],
-    ratings: [],
-    mediaTypes: [],
-    hasUnnamedPeople: false,
-  });
-
   const loadPhotoFilterSuggestions = async (nextFilters: FilterState) => {
     const context = buildFilterContext(nextFilters);
     const response = await getFilterSuggestions({
@@ -306,7 +294,10 @@
 
       const facets = await loadPhotoSmartFacets(nextFilters);
       if (!facets) {
-        return emptyFilterSuggestions();
+        // #910: never resolve with a fabricated empty response — the panel cannot tell it apart from a
+        // genuinely empty library and would hide every section. Rejecting lets the panel keep the last
+        // good facets.
+        throw new Error('smart-search facets unavailable');
       }
 
       for (const p of facets.people) {

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -213,6 +213,9 @@
       ratings: response.ratings,
       mediaTypes: response.mediaTypes,
       hasUnnamedPeople: response.hasUnnamedPeople,
+      hasFavorites: response.hasFavorites,
+      hasAssetsInAlbum: response.hasAssetsInAlbum,
+      hasAssetsNotInAlbum: response.hasAssetsNotInAlbum,
     };
   };
 

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -317,6 +317,10 @@
       }
       return mapSmartSearchFacetsToFilterSuggestions(facets);
     },
+    // #910: no baseline in query mode. A second concurrent facet request would abort the in-flight
+    // one (single `smartFacetInFlight` slot) and then clobber `smartFacets`, which feeds the
+    // timeline and the result count. `undefined` means "don't hide anything here" — see spec §4.5.
+    baselineProvider: async () => (showSearchResults ? undefined : loadPhotoFilterSuggestions(createFilterState())),
     providers: {
       ...normalProviders,
       cities: async (country, context) => {

--- a/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
@@ -651,6 +651,44 @@ describe('Photos page search URL state', () => {
     await vi.waitFor(() => expect(sdkMock.getFilterSuggestions).toHaveBeenCalled());
   });
 
+  it('offers a browse-mode baseline computed with no filters (#910)', async () => {
+    mockPage.url = new URL('https://gallery.test/photos');
+
+    renderPage();
+    await waitFor(() => expect(sdkMock.getFilterSuggestions).toHaveBeenCalled());
+
+    // The whole point: the baseline ignores whatever filters are active.
+    await fireEvent.click(screen.getByTestId('select-favorites-filter'));
+    await waitFor(() =>
+      expect(sdkMock.getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ isFavorite: true })),
+    );
+    sdkMock.getFilterSuggestions.mockClear();
+
+    await fireEvent.click(screen.getByTestId('load-baseline'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('filter-panel-stub')).not.toHaveAttribute('data-baseline', 'undefined');
+    });
+    expect(sdkMock.getFilterSuggestions).toHaveBeenCalledWith(
+      expect.objectContaining({ rating: undefined, personIds: undefined, isFavorite: undefined }),
+    );
+  });
+
+  it('offers no baseline in query mode, and leaves the page facets alone (#910)', async () => {
+    renderPage();
+    await vi.waitFor(() => expect(sdkMock.searchSmartFacets).toHaveBeenCalledTimes(1));
+    sdkMock.searchSmartFacets.mockClear();
+
+    await fireEvent.click(screen.getByTestId('load-baseline'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute('data-baseline', 'undefined');
+    });
+    // Regression guard for spec §4.5: a baseline request here would abort the in-flight facet
+    // fetch and then overwrite smartFacets, corrupting the timeline and the result count.
+    expect(sdkMock.searchSmartFacets).not.toHaveBeenCalled();
+  });
+
   it('does not include sort order in the smart facet payload', async () => {
     mockPage.url = new URL('https://gallery.test/photos?q=nature&sort=asc');
 

--- a/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
@@ -264,6 +264,9 @@ describe('Photos page search URL state', () => {
       ratings: [],
       mediaTypes: [],
       hasUnnamedPeople: false,
+      hasFavorites: false,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: false,
     });
     sdkMock.searchSmartFacets.mockResolvedValue({
       total: 12,
@@ -277,6 +280,9 @@ describe('Photos page search URL state', () => {
       ratings: [4],
       mediaTypes: [AssetTypeEnum.Image],
       hasUnnamedPeople: false,
+      hasFavorites: true,
+      hasAssetsInAlbum: true,
+      hasAssetsNotInAlbum: true,
     });
     sdkMock.getSearchSuggestions.mockResolvedValue([]);
   });

--- a/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
@@ -2,6 +2,7 @@ import { AssetTypeEnum } from '@immich/sdk';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { tick, type Component } from 'svelte';
+import { SvelteURL } from 'svelte/reactivity';
 import { goto } from '$app/navigation';
 import { sdkMock } from '$lib/__mocks__/sdk.mock';
 import TestWrapper from '$lib/components/TestWrapper.svelte';
@@ -693,6 +694,26 @@ describe('Photos page search URL state', () => {
     // Regression guard for spec §4.5: a baseline request here would abort the in-flight facet
     // fetch and then overwrite smartFacets, corrupting the timeline and the result count.
     expect(sdkMock.searchSmartFacets).not.toHaveBeenCalled();
+  });
+
+  it('remounts the filter panel on the browse-to-query transition, dropping the stale baseline (#910)', async () => {
+    mockPage.url = new SvelteURL('https://gallery.test/photos');
+
+    renderPage();
+    await waitFor(() => expect(sdkMock.getFilterSuggestions).toHaveBeenCalled());
+    await fireEvent.click(screen.getByTestId('load-baseline'));
+    await waitFor(() => {
+      expect(screen.getByTestId('filter-panel-stub')).not.toHaveAttribute('data-baseline', 'not-loaded');
+    });
+
+    // Commit a query without unmounting the page: the panel's {#key} must remount it so the
+    // browse-mode baseline (cached on the stub for the component's lifetime) doesn't survive into
+    // query mode, where §4.5 says the baseline provider must return undefined.
+    mockPage.url.search = '?q=beach';
+
+    await waitFor(() => {
+      expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute('data-baseline', 'not-loaded');
+    });
   });
 
   it('does not include sort order in the smart facet payload', async () => {

--- a/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
@@ -717,6 +717,21 @@ describe('Photos page search URL state', () => {
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'nature');
   });
 
+  it('rejects rather than reporting an empty library when the facet fetch fails (#910)', async () => {
+    sdkMock.searchSmartFacets.mockRejectedValue(new Error('boom'));
+
+    renderPage();
+
+    await vi.waitFor(() => expect(sdkMock.searchSmartFacets).toHaveBeenCalled());
+    // The stub's suggestionsProvider effect sets data-suggestions to 'error' on rejection, and to a
+    // JSON dump of the resolved value otherwise — an empty-sentinel resolution would show up here as
+    // JSON, not 'error'. #910: on a first-ever failure (no previous smartFacets to fall back to),
+    // the provider must reject rather than resolve with a fabricated empty response.
+    await waitFor(() => {
+      expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute('data-suggestions', 'error');
+    });
+  });
+
   it('preserves previous facet total and buckets when a later facet fetch fails', async () => {
     renderPage();
     await vi.waitFor(() => expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-total', '12'));

--- a/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -179,18 +179,6 @@
   const smartFacetBuckets = $derived(showSearchResults ? (smartFacets?.timeBuckets ?? []) : pickerBuckets);
   const smartFacetTotal = $derived(showSearchResults ? smartFacets?.total : undefined);
 
-  const emptyFilterSuggestions = () => ({
-    countries: [],
-    cities: [],
-    cameraMakes: [],
-    cameraModels: [],
-    tags: [],
-    people: [],
-    ratings: [],
-    mediaTypes: [],
-    hasUnnamedPeople: false,
-  });
-
   // Own + partner scope only — `withSharedSpaces` is hardcoded `false` here (never derived from
   // `filters`, unlike Photos), matching every other search-path call in this view.
   async function loadRecentlyAddedSmartFacets(
@@ -263,7 +251,10 @@
 
         const facets = await loadRecentlyAddedSmartFacets(nextFilters);
         if (!facets) {
-          return emptyFilterSuggestions();
+          // #910: never resolve with a fabricated empty response — the panel cannot tell it apart from
+          // a genuinely empty library and would hide every section. Rejecting lets the panel keep the
+          // last good facets.
+          throw new Error('smart-search facets unavailable');
         }
         return mapSmartSearchFacetsToFilterSuggestions(facets);
       },

--- a/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts
+++ b/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts
@@ -403,6 +403,21 @@ describe('Recently Added page query mode', () => {
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-total', '12');
   });
 
+  it('rejects rather than reporting an empty library when the facet fetch fails (#910)', async () => {
+    sdkMock.searchSmartFacets.mockRejectedValue(new Error('boom'));
+
+    renderPage();
+
+    await waitFor(() => expect(sdkMock.searchSmartFacets).toHaveBeenCalled());
+    // The stub's suggestionsProvider effect sets data-suggestions to 'error' on rejection, and to a
+    // JSON dump of the resolved value otherwise — an empty-sentinel resolution would show up here as
+    // JSON, not 'error'. #910: on a first-ever failure (no previous smartFacets to fall back to), the
+    // provider must reject rather than resolve with a fabricated empty response.
+    await waitFor(() => {
+      expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute('data-suggestions', 'error');
+    });
+  });
+
   it('re-rendering with an unchanged query+filters does not refetch facets (key cache)', async () => {
     renderPage();
     await waitFor(() => expect(sdkMock.searchSmartFacets).toHaveBeenCalledTimes(1));

--- a/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts
+++ b/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts
@@ -207,6 +207,9 @@ describe('Recently Added page filters', () => {
       ratings: [],
       mediaTypes: [],
       hasUnnamedPeople: false,
+      hasFavorites: false,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: false,
     });
     sdkMock.getSearchSuggestions.mockResolvedValue([]);
     sdkMock.getTimeBuckets.mockResolvedValue([]);
@@ -332,6 +335,9 @@ describe('Recently Added page query mode', () => {
       ratings: [],
       mediaTypes: [],
       hasUnnamedPeople: false,
+      hasFavorites: false,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: false,
     });
     sdkMock.getSearchSuggestions.mockResolvedValue([]);
     sdkMock.getTimeBuckets.mockResolvedValue([]);
@@ -347,6 +353,9 @@ describe('Recently Added page query mode', () => {
       ratings: [4],
       mediaTypes: [AssetTypeEnum.Image],
       hasUnnamedPeople: false,
+      hasFavorites: true,
+      hasAssetsInAlbum: true,
+      hasAssetsNotInAlbum: true,
     });
   });
 

--- a/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts
+++ b/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import type { Component } from 'svelte';
 import { init, register, waitLocale } from 'svelte-i18n';
+import { SvelteURL } from 'svelte/reactivity';
 import { goto } from '$app/navigation';
 import { sdkMock } from '$lib/__mocks__/sdk.mock';
 import TestWrapper from '$lib/components/TestWrapper.svelte';
@@ -435,5 +436,25 @@ describe('Recently Added page query mode', () => {
 
     await waitFor(() => expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-sort-order', 'asc'));
     expect(sdkMock.searchSmartFacets).toHaveBeenCalledTimes(1);
+  });
+
+  it('remounts the filter panel on the browse-to-query transition, dropping the stale baseline (#910)', async () => {
+    mockPage.url = new SvelteURL('https://gallery.test/recently-added');
+
+    renderPage();
+    await waitFor(() => expect(sdkMock.getFilterSuggestions).toHaveBeenCalled());
+    await fireEvent.click(screen.getByTestId('load-baseline'));
+    await waitFor(() => {
+      expect(screen.getByTestId('filter-panel-stub')).not.toHaveAttribute('data-baseline', 'not-loaded');
+    });
+
+    // Commit a query without unmounting the page: the panel's {#key} must remount it so the
+    // browse-mode baseline (cached on the stub for the component's lifetime) doesn't survive into
+    // query mode, where §4.5 says the baseline provider must return undefined.
+    mockPage.url.search = '?q=beach';
+
+    await waitFor(() => {
+      expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute('data-baseline', 'not-loaded');
+    });
   });
 });

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -181,18 +181,6 @@
       }
     | undefined;
 
-  const emptyFilterSuggestions = () => ({
-    countries: [],
-    cities: [],
-    cameraMakes: [],
-    cameraModels: [],
-    tags: [],
-    people: [],
-    ratings: [],
-    mediaTypes: [],
-    hasUnnamedPeople: false,
-  });
-
   const loadSpaceFilterSuggestions = async (nextFilters: FilterState) => {
     const context = buildFilterContext(nextFilters);
     const response = await getFilterSuggestions({
@@ -318,7 +306,10 @@
 
       const facets = await loadSpaceSmartFacets(nextFilters);
       if (!facets) {
-        return emptyFilterSuggestions();
+        // #910: never resolve with a fabricated empty response — the panel cannot tell it apart from a
+        // genuinely empty library and would hide every section. Rejecting lets the panel keep the last
+        // good facets.
+        throw new Error('smart-search facets unavailable');
       }
 
       for (const p of facets.people) {

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -226,6 +226,9 @@
       ratings: response.ratings,
       mediaTypes: response.mediaTypes,
       hasUnnamedPeople: response.hasUnnamedPeople,
+      hasFavorites: response.hasFavorites,
+      hasAssetsInAlbum: response.hasAssetsInAlbum,
+      hasAssetsNotInAlbum: response.hasAssetsNotInAlbum,
     };
   };
 

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -329,6 +329,10 @@
       }
       return mapSmartSearchFacetsToFilterSuggestions(facets, { spaceId: space.id });
     },
+    // #910: no baseline in query mode. A second concurrent facet request would abort the in-flight
+    // one (single `smartFacetInFlight` slot) and then clobber `smartFacets`, which feeds the
+    // timeline and the result count. `undefined` means "don't hide anything here" — see spec §4.5.
+    baselineProvider: async () => (showSearchResults ? undefined : loadSpaceFilterSuggestions(createFilterState())),
     providers: {
       ...normalProviders,
       cities: async (country, context) => {

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -262,6 +262,9 @@ describe('Spaces page search URL state', () => {
       ratings: [],
       mediaTypes: [],
       hasUnnamedPeople: false,
+      hasFavorites: false,
+      hasAssetsInAlbum: false,
+      hasAssetsNotInAlbum: false,
     });
     sdkMock.searchSmartFacets.mockResolvedValue({
       total: 7,
@@ -275,6 +278,9 @@ describe('Spaces page search URL state', () => {
       ratings: [5],
       mediaTypes: [AssetTypeEnum.Image],
       hasUnnamedPeople: false,
+      hasFavorites: true,
+      hasAssetsInAlbum: true,
+      hasAssetsNotInAlbum: true,
     });
     sdkMock.getSearchSuggestions.mockResolvedValue([]);
   });

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -586,6 +586,22 @@ describe('Spaces page search URL state', () => {
     });
   });
 
+  it('rejects rather than reporting an empty library when the facet fetch fails (#910)', async () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach');
+    sdkMock.searchSmartFacets.mockRejectedValue(new Error('boom'));
+
+    renderPage();
+
+    await vi.waitFor(() => expect(sdkMock.searchSmartFacets).toHaveBeenCalled());
+    // The stub's suggestionsProvider effect sets data-suggestions to 'error' on rejection, and to a
+    // JSON dump of the resolved value otherwise — an empty-sentinel resolution would show up here as
+    // JSON, not 'error'. #910: on a first-ever failure (no previous smartFacets to fall back to),
+    // the provider must reject rather than resolve with a fabricated empty response.
+    await waitFor(() => {
+      expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute('data-suggestions', 'error');
+    });
+  });
+
   it('preserves previous space facet total and buckets when a later facet fetch fails', async () => {
     mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach');
     renderPage();

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -3,6 +3,7 @@ import { AssetTypeEnum, AssetVisibility, SharedSpaceRole } from '@immich/sdk';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import { tick, type Component } from 'svelte';
+import { SvelteURL } from 'svelte/reactivity';
 import { sdkMock } from '$lib/__mocks__/sdk.mock';
 import TestWrapper from '$lib/components/TestWrapper.svelte';
 import type { FilterState } from '$lib/components/filter-panel/filter-panel';
@@ -523,6 +524,26 @@ describe('Spaces page search URL state', () => {
     // Regression guard for spec §4.5: a baseline request here would abort the in-flight facet
     // fetch and then overwrite smartFacets, corrupting the timeline and the result count.
     expect(sdkMock.searchSmartFacets).not.toHaveBeenCalled();
+  });
+
+  it('remounts the filter panel on the browse-to-query transition, dropping the stale baseline (#910)', async () => {
+    mockPage.url = new SvelteURL('https://gallery.test/spaces/space-1/photos');
+
+    renderPage();
+    await waitFor(() => expect(sdkMock.getFilterSuggestions).toHaveBeenCalled());
+    await fireEvent.click(screen.getByTestId('load-baseline'));
+    await waitFor(() => {
+      expect(screen.getByTestId('filter-panel-stub')).not.toHaveAttribute('data-baseline', 'not-loaded');
+    });
+
+    // Commit a query without unmounting the page: the panel's {#key} must remount it so the
+    // browse-mode baseline (cached on the stub for the component's lifetime) doesn't survive into
+    // query mode, where §4.5 says the baseline provider must return undefined.
+    mockPage.url.search = '?q=beach';
+
+    await waitFor(() => {
+      expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute('data-baseline', 'not-loaded');
+    });
   });
 
   it('fetches smart facets with spaceId for committed space search', async () => {

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -481,6 +481,44 @@ describe('Spaces page search URL state', () => {
     );
   });
 
+  it('offers a browse-mode baseline computed with no filters, scoped to the space (#910)', async () => {
+    renderPage();
+    await waitFor(() => expect(sdkMock.getFilterSuggestions).toHaveBeenCalled());
+
+    // The whole point: the baseline ignores whatever filters are active.
+    await fireEvent.click(screen.getByTestId('select-favorites-filter'));
+    await waitFor(() =>
+      expect(sdkMock.getFilterSuggestions).toHaveBeenCalledWith(expect.objectContaining({ isFavorite: true })),
+    );
+    sdkMock.getFilterSuggestions.mockClear();
+
+    await fireEvent.click(screen.getByTestId('load-baseline'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('filter-panel-stub')).not.toHaveAttribute('data-baseline', 'undefined');
+    });
+    expect(sdkMock.getFilterSuggestions).toHaveBeenCalledWith(
+      expect.objectContaining({ spaceId: 'space-1', rating: undefined, isFavorite: undefined }),
+    );
+  });
+
+  it('offers no baseline in query mode, and leaves the space facets alone (#910)', async () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach');
+
+    renderPage();
+    await vi.waitFor(() => expect(sdkMock.searchSmartFacets).toHaveBeenCalledTimes(1));
+    sdkMock.searchSmartFacets.mockClear();
+
+    await fireEvent.click(screen.getByTestId('load-baseline'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute('data-baseline', 'undefined');
+    });
+    // Regression guard for spec §4.5: a baseline request here would abort the in-flight facet
+    // fetch and then overwrite smartFacets, corrupting the timeline and the result count.
+    expect(sdkMock.searchSmartFacets).not.toHaveBeenCalled();
+  });
+
   it('fetches smart facets with spaceId for committed space search', async () => {
     mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach');
 

--- a/web/src/test-data/mocks/bindable-filter-panel.stub.svelte
+++ b/web/src/test-data/mocks/bindable-filter-panel.stub.svelte
@@ -28,6 +28,14 @@
   }: Props = $props();
   let suggestions = $state('');
   let requestToken = 0;
+  // #910: 'not-loaded' vs the string 'undefined' lets tests tell "never clicked" apart from "the
+  // provider resolved undefined" without adding a second attribute.
+  let baseline = $state('not-loaded');
+
+  async function loadBaseline() {
+    const result = await config?.baselineProvider?.();
+    baseline = result === undefined ? 'undefined' : JSON.stringify(result);
+  }
 
   function updateFilters(nextFilters: FilterState) {
     filters = nextFilters;
@@ -102,6 +110,7 @@
   data-date-before={filters?.dateBefore ?? ''}
   data-time-buckets={JSON.stringify(timeBuckets)}
   data-suggestions={suggestions}
+  data-baseline={baseline}
   data-person-names={JSON.stringify([...(personNames?.entries() ?? [])])}
   data-tag-names={JSON.stringify([...(tagNames?.entries() ?? [])])}
   data-collapsed={String(collapsed)}
@@ -130,6 +139,7 @@
   <button type="button" data-testid="load-camera-model-suggestions" onclick={loadCameraModelSuggestions}>
     Load camera models
   </button>
+  <button type="button" data-testid="load-baseline" onclick={loadBaseline}>Load baseline</button>
   <button
     type="button"
     data-testid="filter-panel-set-country"


### PR DESCRIPTION
Closes #910.

A filter section is no longer offered when using it cannot change what you see. A section that is empty **for the whole scope regardless of filters** is hidden; one that is empty **only because of the filters currently applied** keeps today's treatment — 50% opacity, a `(0)` suffix, collapsed and disabled.

All eight enumerable sections take the rule (People, Location, Camera, Tags, Rating, Media, Favorites, Albums), on **web and mobile**. Timeline and Text are exempt.

## Heads-up for reviewers

**A fresh library will show fewer sections than before.** With no faces named, no GPS, no tags, no albums and no favourites, the panel shows Timeline, People (the unnamed-faces hint), Media and Text only. That is the intended behaviour — the hidden sections genuinely cannot filter anything — but it is a visible change and worth knowing before you open the panel on a clean install.

**Base branch.** This targets `fix/797-filter-section-ledger` (#926), not `main`. #926 rewrites the `{ selected, known }` section ledger in the same files slice 5 edits heavily, so developing both against `main` would have meant a 162-line conflict. Retarget to `main` once #926 merges.

## What changed

**Server** — three new facets on both filter-suggestion paths, each computed with its own filter excluded: `hasFavorites`, `hasAssetsInAlbum`, `hasAssetsNotInAlbum`. Two pre-existing defects fixed along the way: `isFavorite` was applied unconditionally in the smart-facet builder while every other dimension was guarded, and the album predicates were baked into the smart-search candidate temp table so no facet could exclude them.

**Web** — a pure rule module (`filter-availability.ts`) turns facet data into one of three verdicts, and the panel gates both the section body and its toggle icon. Availability is derived and never written to the persisted section ledger, so a section going unavailable is not recorded as user-hidden and returns on its own when the library gains its first video.

**Mobile** — the same model, minus the greyed state (mobile has no `(0)` treatment, so it hides or shows).

**Two failure sentinels removed.** Both clients fabricated an all-empty facet response when the request failed. Harmless before; under this feature it is indistinguishable from an empty library and would hide every section at once. Both now reject, so the panel keeps its last good facets.

## Notes on two decisions

**Rating stars and media buttons are untouched.** Their facets are read to decide whether the *section* is offered, and never reach the controls. All five stars and all three buttons always render. Filtering them made the stars positional liars — with `[1,2,3,5]` available, clicking the fourth visible star selected rating 5 (#261).

**The baseline is a separate `baselineProvider` hook, not a second `suggestionsProvider` call.** The three query-mode pages keep a single in-flight facet slot and abort on key mismatch, and their resolve handler writes the state that drives the timeline and the result count — so a concurrent unfiltered request would both kill the real one and render unfiltered data under active filters. Query mode returns no baseline, which means it greys rather than hides; that is the safe direction.

## Incidental fix

`asset_face.sourceType` defaults to `machine-learning`, so on any stack with facial recognition enabled `handleDetectFaces` treated a manually-seeded face as a prior detection, re-ran detection, found nothing in a synthetic fixture, and deleted it. Faces seeded by `utils.createFace` / `utils.createSpacePerson` vanished seconds after creation. Both helpers now insert `sourceType: 'manual'`, matching what the app's own manual-face endpoint writes. This affects 22 call sites across the e2e suites.

## Verification

| | |
|---|---|
| Server | 5252 unit / 154 files · medium 77/77 · tsc, eslint, prettier |
| Web | 4255 tests / 300 files · tsc · svelte-check 575 files · eslint, prettier |
| Mobile | 3024 tests · `dart analyze --fatal-infos` 0 · dart format |
| E2E | 111 across photos/spaces/recently-added/album · rebase-smoke 10 |

E2E ran against `:3000` rather than `make e2e-web-dev`'s hardcoded `:2283`, which serves zero-length bodies for non-API routes on a dev stack. Same application source; CI serves a production bundle, so treat that as "seeds and assertions are correct" rather than "CI is green".

## Known follow-ups (not blocking)

- The web album **picker** does not forward `isInAlbum`/`isNotInAlbum` to its facets request. The other five web surfaces do.
- Mobile fires a duplicate baseline request when the filter sheet's search bar holds text: `SearchFilter.isEmpty` counts `context`, but the facets request never forwards it.
- Mobile sends `withSharedSpaces: true` unconditionally, so the per-user-favourites scope reasoning in the design does not transfer there.

Design: `docs/superpowers/specs/2026-08-04-interdependent-filter-sections-910-design.md`
