### PR TITLE
fix(docker): point the release compose at Gallery's own docs and releases

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,9 +1,9 @@
 #
-# WARNING: To install Immich, follow our guide: https://docs.immich.app/install/docker-compose
+# WARNING: To install Noodle Gallery, follow our guide: https://docs.opennoodle.de/install/docker-compose
 #
 # Make sure to use the docker-compose.yml of the current release:
 #
-# https://github.com/immich-app/immich/releases/latest/download/docker-compose.yml
+# https://github.com/open-noodle/gallery/releases/latest/download/docker-compose.yml
 #
 # The compose file on main may not be compatible with the latest release.
 
@@ -36,7 +36,7 @@ services:
     # For hardware acceleration, add one of -[armnn, cuda, rocm, openvino, rknn] to the image tag.
     # Example tag: ${IMMICH_VERSION:-release}-cuda
     image: ghcr.io/open-noodle/gallery-ml:${IMMICH_VERSION:-release}
-    # extends: # uncomment this section for hardware acceleration - see https://docs.immich.app/features/ml-hardware-acceleration
+    # extends: # uncomment this section for hardware acceleration - see https://docs.opennoodle.de/features/ml-hardware-acceleration
     #   file: hwaccel.ml.yml
     #   service: cpu # set to one of [armnn, cuda, rocm, openvino, openvino-wsl, rknn] for accelerated inference - use the `-wsl` version for WSL2 where applicable
     volumes:


### PR DESCRIPTION
`docker/docker-compose.yml` is the file self-hosters actually download to install Gallery. Its header was still sending them to upstream:

| Line | Was | Now |
|---|---|---|
| 2 | `To install Immich … docs.immich.app/install/docker-compose` | `To install Noodle Gallery … docs.opennoodle.de/install/docker-compose` |
| 6 | `github.com/immich-app/immich/releases/latest/download/docker-compose.yml` | `github.com/open-noodle/gallery/releases/latest/download/docker-compose.yml` |
| 39 | `docs.immich.app/features/ml-hardware-acceleration` | `docs.opennoodle.de/features/ml-hardware-acceleration` |

All three new targets verified `200`, and Gallery does publish its own `docker-compose.yml` release asset (latest `v5.3.0`, alongside `example.env` and the APK).

## Deliberately unchanged

`name: immich`, `container_name: immich_*`, and `IMMICH_VERSION` all stay. The compose project name namespaces volumes and networks, so renaming it would orphan an existing Immich user's data on switch — these are exactly what make the documented drop-in migration ("three-line config change") work.

Verified with `docker compose config -q` against `example.env`.