### PR TITLE
feat(portainer): add app-template stackfile

### DIFF
--- a/Template/Stack/noodle-gallery.yml
+++ b/Template/Stack/noodle-gallery.yml
@@ -1,0 +1,82 @@
+# Noodle Gallery — Portainer app template stackfile.
+#
+# This is NOT the file to use for a normal Docker Compose install. For that, see
+# https://docs.opennoodle.de/install/docker-compose and use
+# https://github.com/open-noodle/gallery/releases/latest/download/docker-compose.yml
+#
+# It exists because Portainer deploys stacks differently from `docker compose`:
+#
+#   1. Portainer injects environment variables directly and never creates a
+#      .env file, so the canonical compose's `env_file: - .env` cannot be used.
+#      Variables are declared explicitly below instead.
+#
+#   2. Portainer resolves relative host paths against its OWN container's working
+#      directory (/data/compose/<id>/), not against the host. UPLOAD_LOCATION and
+#      DB_DATA_LOCATION must therefore be ABSOLUTE paths. The app template
+#      defaults them to /opt/noodle-gallery/*; do not change those to relative
+#      paths — on Linux the stack will still start, but the photo library and
+#      database end up inside Portainer's own data volume and are lost when
+#      Portainer is reinstalled.
+#
+# Keep the image pins here in sync with docker/docker-compose.yml on each release.
+
+name: immich
+
+services:
+  immich-server:
+    container_name: immich_server
+    image: ghcr.io/open-noodle/gallery-server:${IMMICH_VERSION:-release}
+    volumes:
+      - ${UPLOAD_LOCATION}:/data
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      DB_HOSTNAME: database
+      DB_USERNAME: postgres
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_DATABASE_NAME: immich
+      REDIS_HOSTNAME: redis
+      TZ: ${TZ:-Etc/UTC}
+    ports:
+      - '2283:2283'
+    depends_on:
+      - redis
+      - database
+    restart: always
+    healthcheck:
+      disable: false
+
+  immich-machine-learning:
+    container_name: immich_machine_learning
+    # For hardware acceleration, add one of -[armnn, cuda, rocm, openvino, rknn]
+    # to the image tag. See https://docs.opennoodle.de/features/ml-hardware-acceleration
+    image: ghcr.io/open-noodle/gallery-ml:${IMMICH_VERSION:-release}
+    volumes:
+      - model-cache:/cache
+    restart: always
+    healthcheck:
+      disable: false
+
+  redis:
+    container_name: immich_redis
+    image: docker.io/valkey/valkey:9@sha256:8e8d64b405ce18f41b8e5ee20aa4687a8ed0022d1298f2ce31cdcf3a76e09411
+    healthcheck:
+      test: redis-cli ping || exit 1
+    restart: always
+
+  database:
+    container_name: immich_postgres
+    image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:bcf63357191b76a916ae5eb93464d65c07511da41e3bf7a8416db519b40b1c23
+    environment:
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_USER: postgres
+      POSTGRES_DB: immich
+      POSTGRES_INITDB_ARGS: '--data-checksums'
+    volumes:
+      - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
+    shm_size: 128mb
+    restart: always
+    healthcheck:
+      disable: false
+
+volumes:
+  model-cache:


### PR DESCRIPTION
Portainer app templates fetch their stackfile from a repo path. This adds that file at `Template/Stack/noodle-gallery.yml`, which is what the template entry we're submitting to the community template lists points at. Without it the template is broken.

## Why it isn't just the canonical compose

It differs from `docker/docker-compose.yml` in exactly two ways, both forced by how Portainer deploys stacks. Both were found by actually deploying it, not by reading docs.

**1. `env_file` doesn't exist in a Portainer deploy.** Portainer injects environment variables directly and never writes a `.env`, so `env_file: - .env` cannot be used. Variables are declared explicitly, and `DB_USERNAME`/`DB_DATABASE_NAME` are inlined since the template doesn't prompt for them.

**2. Relative host paths resolve inside Portainer, not on the host.** Deploying with the canonical `./library` / `./postgres` defaults failed:

```
HTTP 500 — mounts denied:
The path /data/compose/1/postgres is not shared from the host
```

Portainer resolved `./postgres` against its *own* container's working directory. On Docker Desktop that fails loudly. On a typical Linux Portainer host it would fail **silently and worse** — the stack comes up with the user's photo library and database written inside Portainer's data volume, lost whenever Portainer is reinstalled. The template defaults both to absolute paths, and the file header documents why.

## Compatibility

Images, container names, and the `immich` project name are **byte-identical** to the canonical compose (verified by diff), so the documented drop-in migration to and from upstream is unaffected.

## Verification

`docker compose config -q` passes, and this exact file was deployed through the Portainer API against a real Portainer CE instance:

| Check | Result |
|---|---|
| Stack create via API | `HTTP 200` |
| All four containers healthy | server, postgres, redis, machine-learning |
| App reachable | `GET :2283` → `200` |
| Admin account creates | `POST /api/auth/admin-sign-up` → `201` |
| Data on the host path | 315 MB Postgres written to the configured absolute path |

An earlier round on the same setup also confirmed photo upload (`201`) with thumbnail generation, proving the server↔Redis↔Postgres job pipeline, and survival across a full stack restart.

Submission copy and the template JSON live in `platform` PR #288.