### PR TITLE
docs(portainer): match documented default paths to the submitted template

### DIFF
--- a/Template/Stack/noodle-gallery.yml
+++ b/Template/Stack/noodle-gallery.yml
@@ -12,11 +12,11 @@
 #
 #   2. Portainer resolves relative host paths against its OWN container's working
 #      directory (/data/compose/<id>/), not against the host. UPLOAD_LOCATION and
-#      DB_DATA_LOCATION must therefore be ABSOLUTE paths. The app template
-#      defaults them to /opt/noodle-gallery/*; do not change those to relative
-#      paths — on Linux the stack will still start, but the photo library and
-#      database end up inside Portainer's own data volume and are lost when
-#      Portainer is reinstalled.
+#      DB_DATA_LOCATION must therefore be ABSOLUTE paths. The template defaults
+#      them under /portainer/Files/AppData/Config/noodle-gallery/; do not change
+#      those to relative paths — on Linux the stack will still start, but the
+#      photo library and database end up inside Portainer's own data volume and
+#      are lost when Portainer is reinstalled.
 #
 # Keep the image pins here in sync with docker/docker-compose.yml on each release.
 


### PR DESCRIPTION
The stackfile header claimed the template defaults `UPLOAD_LOCATION`/`DB_DATA_LOCATION` to `/opt/noodle-gallery/*`, but the entry actually submitted to `xneo1/portainer_templates` uses that repo's house convention, `/portainer/Files/AppData/Config/noodle-gallery/`.

The absolute-path requirement — and the reason for it — is unchanged; only the documented default was out of step with what shipped.

Submission: https://github.com/xneo1/portainer_templates/pull/13 (draft)

Verified with `docker compose config -q`.