### PR TITLE
docs(hosted-service): customer docs for the hosted Gallery service

### DIFF
--- a/docs/docs/hosted-service/_category_.json
+++ b/docs/docs/hosted-service/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Hosted Service",
+  "position": 1.5
+}

--- a/docs/docs/hosted-service/billing-and-your-plan.md
+++ b/docs/docs/hosted-service/billing-and-your-plan.md
@@ -1,0 +1,87 @@
+---
+sidebar_position: 2
+---
+
+# Billing and your plan
+
+This page covers hosted Gallery billing: how checkout works, changing plans,
+cancelling, and — most importantly — exactly how much time you have to get your photos
+out before an account is erased. Read the grace-period sections carefully; the numbers
+below are exact, not approximate.
+
+## How checkout and billing work
+
+Checkout and billing are handled by [Polar](https://polar.sh), our payment processor —
+see [Signing up for hosted Gallery](./signing-up.md) for how checkout itself works.
+Afterwards, from your **Account** page in the dashboard, **Manage billing** opens Polar's
+secure billing portal, where you can update your card and view invoices at any time.
+
+## Changing your plan
+
+Go to the [Plans page](https://app.noodlegallery.de/plans) while signed in and pick a
+new tier or billing interval.
+
+- **Upgrading** to a bigger plan applies immediately — you're charged a prorated amount
+  for the rest of the current period and get the extra storage right away.
+- **Downgrading** to a smaller plan takes effect at the end of your current billing
+  period, not immediately. If you're using more storage than the smaller plan allows,
+  you'll need to free some up first before the downgrade is allowed.
+
+## Cancelling your plan
+
+From your **Account** page, under **Manage subscription**, choose **Cancel
+subscription**. Cancelling does **not** delete anything right away: you keep your plan
+and all your photos exactly as they are until the end of the period you already paid
+for. On that date it simply won't renew — no further charges. You can resume with one
+click any time before then.
+
+## Two ways an account gets erased — read both
+
+There are two separate paths that end with your Gallery and photos being permanently
+deleted, with **different** waiting periods. Don't confuse them.
+
+### 1. Letting a cancelled plan lapse — 60-day grace period
+
+If you cancel and don't resubscribe, your subscription eventually ends for real (the
+last paid period runs out). From **that** date — not the day you clicked cancel — your
+Gallery and all your photos stay exactly where they are for **60 days**. Around 30 days
+in, we'll email you a reminder that erasure is coming. If you haven't resubscribed or
+exported your data by the end of the 60 days, your Gallery, its photos and videos, and
+your account are permanently deleted. This cannot be undone.
+
+Your Gallery keeps working normally throughout this 60-day window — you can still log in
+on the web or the mobile app and export your photos right up until it ends.
+
+### 2. Deleting your account yourself — 7-day grace period
+
+If you'd rather not wait, your **Account** page has a "Delete account" option that
+schedules deletion much sooner. Deleting this way permanently removes your account, your
+Gallery, and all your photos and videos after a **7-day** grace period, and you'll need
+to type your account email to confirm. This also cancels your subscription. Like the
+60-day path, this can be undone — but only during those 7 days, with a "Cancel deletion"
+button on the same page. After the 7 days are up, it's permanent.
+
+### Changed your mind within 14 days? Withdraw instead
+
+If you're within the first 14 days of signing up, there's a third, separate option:
+**Withdraw and get a full refund (Widerruf)**, also on your Account page. This refunds
+you in full and closes the account immediately — it isn't a grace period at all, and
+once submitted it can't be undone.
+
+## Export your photos before erasure
+
+Do this well before whichever grace period above applies to you — once an account is
+erased, nothing can be recovered.
+
+On your **Account** page, under **Your data**:
+
+- **Download my data (JSON)** gives you the account information we hold about you.
+- **Prepare full download** packages all of your original photos and videos into one or
+  more downloadable parts. For large libraries this can take a few minutes — refresh the
+  page to check on progress. Once it's ready, the download link stays available for
+  **7 days**; if you need it again later, use **Prepare again** to generate a fresh one.
+
+## Is something down?
+
+Check [status.opennoodle.de](https://status.opennoodle.de) before assuming a billing or
+login problem is on your end.

--- a/docs/docs/hosted-service/mobile-app-login.md
+++ b/docs/docs/hosted-service/mobile-app-login.md
@@ -1,0 +1,49 @@
+---
+sidebar_position: 3
+---
+
+# Logging in on the mobile app
+
+Hosted Gallery uses the same Noodle-branded mobile app documented in
+[Mobile App](/features/mobile-app.mdx) — you just point it at the server we host for
+you instead of a self-hosted one. This page covers the one part that's different: how a
+hosted-Gallery customer signs in.
+
+## Download the app
+
+- [App Store](https://apps.apple.com/il/app/noodle-gallery/id6761776289)
+- [Google Play Store](https://play.google.com/store/apps/details?id=de.opennoodle.gallery)
+
+## Add your server
+
+When the app asks for a server, enter your Gallery's address:
+
+```
+https://<your-subdomain>.noodlegallery.de
+```
+
+You'll find your exact address in the "Your gallery is open" email we sent you, and on
+your **Account** page in the dashboard.
+
+## Sign in
+
+Hosted Gallery accounts don't have a separate Gallery username or password — signing in
+goes through your Noodle account instead, the same one you use at
+[app.noodlegallery.de](https://app.noodlegallery.de). After you enter your server
+address, the app takes you to our sign-in page at `auth.noodlegallery.de`. Log in there
+with your account email and password, and you're taken back into the app, signed in.
+
+## Back up your photos
+
+Once you're signed in, backup, album sync, and everything else in the app works exactly
+as described in [Mobile App](/features/mobile-app.mdx) — that page covers turning on
+backup, syncing only selected photos, and freeing up space on your device.
+
+## Trouble logging in?
+
+- Double-check the server address — it must be your own `<uid>.noodlegallery.de`
+  address, not `noodlegallery.de` or `app.noodlegallery.de`.
+- Make sure the mobile app is up to date; an old app version can fail to sign in against
+  a newer server.
+- Check [status.opennoodle.de](https://status.opennoodle.de) to see whether sign-in is
+  having a known issue before troubleshooting further.

--- a/docs/docs/hosted-service/signing-up.md
+++ b/docs/docs/hosted-service/signing-up.md
@@ -1,0 +1,60 @@
+---
+sidebar_position: 1
+---
+
+# Signing up for hosted Gallery
+
+Everything else in these docs is about running Gallery yourself. This page — and the
+rest of this section — is for the other option: **Noodle Gallery, hosted for you**. You
+sign up, we run the server, you get a private, ready-to-use Gallery.
+
+## What you get
+
+- Your own private Gallery instance — nobody else's photos share your database or your
+  storage.
+- A storage plan sized to your library. Pick a tier when you check out; see current
+  plans and pricing on the [Plans page](https://app.noodlegallery.de/plans) once you're
+  signed in.
+- Your data stays in the EU. Both the servers and the storage behind hosted Gallery run
+  entirely on European infrastructure.
+- The same mobile app and web interface documented throughout this site — hosted Gallery
+  just points them at a server we run for you instead of one you run yourself.
+
+## Create your account
+
+Go to [app.noodlegallery.de](https://app.noodlegallery.de) and register with an email
+and password. This is the account you'll use to sign in everywhere — the dashboard, your
+Gallery on the web, and the mobile app. There's no separate Gallery-specific password to
+remember.
+
+## Choose a plan and check out
+
+From the [Plans page](https://app.noodlegallery.de/plans), pick a storage tier and
+billing interval, then continue to checkout. Checkout happens on a secure page hosted by
+our payment processor, [Polar](https://polar.sh) — your card details go directly to
+them, not to us. Polar also handles EU VAT automatically, so the price you see is the
+price you pay.
+
+## What happens after payment
+
+Once checkout completes, you'll land on a page that sets up your Gallery in real time:
+your storage is reserved, a private instance is built just for you, and it's switched
+on — all without you doing anything. This usually takes about two minutes. If it takes a
+little longer, that's normal too: you can safely close the tab and we'll email you the
+moment it's ready.
+
+## Your first login
+
+When your Gallery is ready, you'll see an "Open your Gallery" link right there on the
+page (and we'll also email it to you, along with a QR code for the mobile app). Follow
+it and you'll be asked to sign in — using the same email and password you created at
+signup, not a separate Gallery account. Once you sign in, you're straight in: no admin
+setup, no configuration, just your empty Gallery ready for photos.
+
+To log in from your phone instead, see
+[Logging in on the mobile app](./mobile-app-login.md).
+
+## Something not working?
+
+Check [status.opennoodle.de](https://status.opennoodle.de) to see whether there's a
+known issue before troubleshooting on your end.


### PR DESCRIPTION
## Summary

`docs.opennoodle.de` covered self-hosting only — a customer who paid for the hosted
service and couldn't log in on their phone had nothing to read. Adds a new **Hosted
Service** sidebar section (position 1.5, right after Overview) with three pages:

- **Signing up for hosted Gallery** — what you get, EU data residency, checkout via
  Polar, the ~2-minute provisioning wait (sourced from the actual welcome-flow copy),
  and first login.
- **Billing and your plan** — how checkout/billing works, changing plans (upgrade =
  immediate/prorated, downgrade = end of period + storage gate), cancelling, and the
  **two distinct erasure paths with their exact grace periods**:
  - 60 days after a cancelled subscription actually lapses (not the day you click
    cancel) — `DELETION_GRACE_DAYS = 60` / `WARNING_DAY = 30` in
    `deprovision.server.ts`.
  - 7 days for the separate self-service "Delete account" option —
    `DELETION_GRACE_DAYS = 7` in `deletion.server.ts`.
  - Plus the 14-day Widerruf withdrawal path (immediate, no grace period).
  - Plus how to export photos first (7-day download-link availability from
    `export/constants.ts`'s `EXPORT_TTL_DAYS`).
- **Logging in on the mobile app** — the Noodle-branded app (App Store / Play Store
  links verified live), that sign-in goes through `auth.noodlegallery.de`, and the
  per-tenant server URL (`https://<uid>.noodlegallery.de`) to enter.

Links `https://status.opennoodle.de` wherever a customer would look for "is it down".

Every factual claim was verified against the platform repo (`deletion.server.ts`,
`deprovision.server.ts`, `cancel.server.ts`, `switch.server.ts`, `account.tsx`,
`plans.tsx`, `teardown-export.server.ts`, `gallery-admin.server.ts`, `welcome/*`) rather
than assumed — see the task report for the full verification trail. Nothing was invented
about UI copy I couldn't confirm (e.g. the mobile app's exact sign-in button wording is
described functionally, not quoted).

**i18n:** `docusaurus.config.js` has `i18n.locales: ['en']` — this docs site is
English-only (unlike the marketing site's 7 locales), so no translation parity check is
affected by adding English-only pages.

## Test plan

- [x] `pnpm install --filter documentation --frozen-lockfile` + `pnpm run build` —
      succeeds, no `onBrokenLinks` failures (config has `onBrokenLinks: 'throw'`).
- [x] Confirmed all three pages exist in `build/hosted-service/*` and are linked from the
      rendered sidebar (`href="/hosted-service/..."` present in the built HTML).
- [x] `npx prettier --check docs/hosted-service/` — passes.
- [ ] CI — GitHub-hosted runners for this repo have historically queued for a long time
      when minutes run out; see PR checks for whether it actually ran.
