### PR TITLE
fix(branding): sign the release announcement with the fork's author

### DIFF
--- a/branding/config.json
+++ b/branding/config.json
@@ -18,12 +18,36 @@
     "server_id": "1480633426376921239"
   },
 
+  "author": {
+    "_comment": "Signs the in-app release announcement (i18n version_announcement_closing). A person, not the product — upstream signs it 'Your friend, Alex', so the fork signs it with its own author.",
+    "name": "Pierre",
+    "signoff_key": "version_announcement_closing"
+  },
+
   "upstream": {
     "name": "Immich",
     "version": "3.1.0",
     "url": "https://github.com/immich-app/immich",
     "docs_url": "https://docs.immich.app",
-    "discord_url": "https://discord.immich.app"
+    "discord_url": "https://discord.immich.app",
+    "_comment_author_names": "Every spelling Weblate translators gave upstream's author, transliterated per script. patch_i18n swaps these for author.name in the sign-off key. ORDER MATTERS: no entry may be a substring of a later entry, or the shorter one consumes part of the longer ('Alex' would leave 'Pierre가'). test-i18n-branding.sh asserts that invariant.",
+    "author_names": [
+      "Alex가",
+      "Alekss",
+      "Aleks",
+      "Alex",
+      "Ալեքսը",
+      "अ‍ॅलेक्स",
+      "एलेक्स",
+      "ಅಲೆಕ್ಸ್",
+      "അലക്സ്",
+      "அலெக்ச்",
+      "อเล็กซ์",
+      "أليكس",
+      "ایلکس",
+      "אלכס",
+      "Алекс"
+    ]
   },
 
   "mobile": {

--- a/branding/i18n/overrides-af.json
+++ b/branding/i18n/overrides-af.json
@@ -1,0 +1,3 @@
+{
+  "version_announcement_closing": "Jou vriend, Pierre"
+}

--- a/branding/scripts/apply-branding.sh
+++ b/branding/scripts/apply-branding.sh
@@ -41,6 +41,25 @@ UPSTREAM_IDENTIFIERS_JSON='[
   "app.immich"
 ]'
 
+# The in-app release announcement is signed by a person, not the product, so the
+# brand swap above cannot fix it: upstream signs it "Your friend, Alex" and a
+# rename only ever produces "Your friend, Alex" again. 55 of the 89 locales define
+# the key, and Weblate translators transliterated the name into their own script
+# ("Твой друг Алекс", "صديقك، أليكس", "당신의 친구, Alex가"), so there is no single
+# token to match — hence the explicit spelling list in config.json, ordered so no
+# entry is a substring of a later one.
+#
+# The fork keeps the name in Latin in every script, matching how it already leaves
+# "Noodle Gallery" in Latin inside Japanese and Arabic strings, and matching the
+# hand-written overrides shipped for de/es/fr/it/nl/pl. Transliterating instead
+# would mean 15 spellings of a real person's name that nobody here can proofread.
+#
+# The 34 locales that never define the key are already correct: svelte-i18n
+# resolves them against the branded en.json.
+AUTHOR_NAME=$(jq -r '.author.name' "$CONFIG")
+AUTHOR_SIGNOFF_KEY=$(jq -r '.author.signoff_key' "$CONFIG")
+UPSTREAM_AUTHOR_NAMES_JSON=$(jq -c '.upstream.author_names' "$CONFIG")
+
 # Mobile
 BUNDLE_ID=$(jq -r '.mobile.bundle_id' "$CONFIG")
 # bundle_id_debug / bundle_id_profile are no longer branded directly — #29077 derives
@@ -90,6 +109,25 @@ fi
 #
 # --- i18n ---
 #
+# Rewrite the release sign-off in one locale file so it names the fork's author.
+#
+# Scoped to the single sign-off key rather than a `walk` over every string: the
+# name appears in no other key in any of the 89 locales, so the narrow scope costs
+# nothing and makes it impossible for a short token like "Alex" to corrupt an
+# unrelated translation. split/join is a LITERAL replace — unlike gsub it cannot
+# reinterpret a name as a regex.
+swap_author_name() { # <locale-file>
+  local tmp
+  tmp=$(mktemp)
+  jq --arg key "$AUTHOR_SIGNOFF_KEY" --arg name "$AUTHOR_NAME" \
+     --argjson upstream "$UPSTREAM_AUTHOR_NAMES_JSON" '
+    def swap: reduce range(0; $upstream | length) as $i (.; split($upstream[$i]) | join($name));
+    if (.[$key] | type) == "string" then .[$key] |= swap else . end
+  ' "$1" > "$tmp"
+  chmod 644 "$tmp"
+  mv "$tmp" "$1"
+}
+
 patch_i18n() {
   echo "--- Patching i18n strings ---"
   local i18n_dir="$REPO_ROOT/i18n"
@@ -105,6 +143,16 @@ patch_i18n() {
     chmod 644 "$tmp"
     mv "$tmp" "$en_target"
     echo "  Merged $(jq '[paths(scalars)] | length' "$en_overrides") override keys into en.json"
+  fi
+
+  # overrides-en.json already carries the branded sign-off, so this is normally a
+  # no-op on en.json. Run it anyway: it keeps the invariant "every locale that
+  # defines the key names the fork's author" true of en too, so an upstream edit
+  # that outruns the override cannot slip through verify-branding.sh's check.
+  # Plain `if`, not `[[ ]] && cmd`: under `set -e` a false test makes the AND-list
+  # return 1 and aborts the whole branding run.
+  if [[ -f "$en_target" ]]; then
+    swap_author_name "$en_target"
   fi
 
   # The non-English locale files (i18n/de.json, fr.json, ...) are upstream
@@ -147,6 +195,12 @@ patch_i18n() {
       mv "$tmp" "$locale_file"
       echo "  Merged $(jq 'length' "$lang_overrides") override keys into ${lang}.json"
     fi
+
+    # 2b. Sign the release announcement with the fork's author. Runs AFTER the
+    #     override merge so a hand-written translation (de/es/fr/it/nl/pl, which
+    #     already say "Pierre") wins and this becomes a no-op there; it is the
+    #     only thing covering the other 47 locales that define the key.
+    swap_author_name "$locale_file"
 
     # 3. Rewrite every remaining upstream-name leak in this locale to the fork
     #    name. `walk` reaches leaves at any depth, so the nested admin.*

--- a/branding/scripts/test-i18n-branding.sh
+++ b/branding/scripts/test-i18n-branding.sh
@@ -42,6 +42,14 @@ fi
 source "$SCRIPT_DIR/apply-branding.sh"
 set +e # apply-branding.sh enables `set -e`; a failed grep/jq must not abort the run
 
+# apply-branding.sh keeps the author spellings as JSON (jq consumes them directly);
+# the assertions below need them as a shell array. Read loop, not `mapfile`, which is
+# bash 4+ and macOS still ships bash 3.2.
+UPSTREAM_AUTHOR_NAMES=()
+while IFS= read -r author_spelling; do
+  UPSTREAM_AUTHOR_NAMES+=("$author_spelling")
+done < <(jq -r '.upstream.author_names[]' "$CONFIG")
+
 # Mirror the whole i18n/ tree into a temp REPO_ROOT and patch the mirror.
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
@@ -196,6 +204,89 @@ fi
 echo "English-variant locales carry the fork's English wording (en_GB):"
 eq en_GB "$KEY" "Support Noodle Gallery" 'en_GB buy button is the branded English CTA, not "Buy"'
 eq en_GB version_announcement_closing "Your friend, Pierre" "en_GB release sign-off names the fork author, not upstream's"
+
+# The sign-off names a person, so the brand swap cannot reach it and every scan
+# above is blind to it — the string contains no upstream product name. 55 of the 89
+# locales define the key; hand-written overrides cover 8, and swap_author_name()
+# covers the other 47 by substituting the spellings in .upstream.author_names.
+echo "Release sign-off names the fork's author in every locale that defines it:"
+
+# The substitution list is order-sensitive: replacing a token that is a PREFIX of a
+# later one destroys the later match ("Alex" first would leave "Pierre가" for ko,
+# "Pierres" for lv). Assert the invariant instead of trusting the file's comment.
+order_violations=0
+for i in "${!UPSTREAM_AUTHOR_NAMES[@]}"; do
+  for j in "${!UPSTREAM_AUTHOR_NAMES[@]}"; do
+    [[ $j -le $i ]] && continue
+    if [[ "${UPSTREAM_AUTHOR_NAMES[$j]}" == *"${UPSTREAM_AUTHOR_NAMES[$i]}"* ]]; then
+      echo "  FAIL: config author_names['${UPSTREAM_AUTHOR_NAMES[$i]}'] precedes '${UPSTREAM_AUTHOR_NAMES[$j]}' but is a substring of it — move the longer one first"
+      order_violations=$((order_violations + 1))
+    fi
+  done
+done
+if [[ $order_violations -eq 0 ]]; then
+  echo "  ok:   ${#UPSTREAM_AUTHOR_NAMES[@]} author spellings ordered so none consumes a longer one"
+else
+  fails=$((fails + order_violations))
+fi
+
+# One per substitution class, so a failure says which kind broke.
+eq ru version_announcement_closing "Твой друг Pierre"      'ru sign-off: Cyrillic transliteration swapped, sentence intact'
+eq ko version_announcement_closing "당신의 친구, Pierre"     'ko sign-off: subject particle consumed with the name (Alex가)'
+eq lv version_announcement_closing "Tavs draugs, Pierre"   'lv sign-off: declined Latin form swapped (Alekss)'
+eq th version_announcement_closing "เพื่อนของคุณ Pierre"      'th sign-off: Thai transliteration swapped'
+eq ja version_announcement_closing "あなたの友人、Pierre"     'ja sign-off: bare Latin name in a CJK sentence'
+eq af version_announcement_closing "Jou vriend, Pierre"    'af sign-off: override fixes upstream half-English "Jou friend"'
+# A locale whose override already says Pierre must not be double-substituted.
+eq nl version_announcement_closing "Je vriend, Pierre"     'nl sign-off: hand-written override wins, swap is a no-op'
+
+# Whole-file guarantee, matching verify-branding.sh: assert the OUTCOME, so a future
+# locale arriving with an unlisted transliteration fails here too, not just in CI's
+# verify step. Locales that never define the key inherit branded en and are skipped.
+signoff_gaps=0
+signoff_seen=0
+for locale_file in "$TMP"/i18n/*.json; do
+  lang=$(basename "$locale_file" .json)
+  sign=$(val_at "$lang" version_announcement_closing)
+  [[ -z "$sign" ]] && continue
+  signoff_seen=$((signoff_seen + 1))
+  if ! printf '%s' "$sign" | grep -qF "$AUTHOR_NAME"; then
+    echo "  FAIL: ${lang} sign-off does not name '$AUTHOR_NAME': '$sign' — add its spelling to .upstream.author_names"
+    signoff_gaps=$((signoff_gaps + 1))
+  fi
+done
+if [[ $signoff_gaps -eq 0 ]]; then
+  echo "  ok:   $signoff_seen locales define the sign-off, all name '$AUTHOR_NAME'"
+else
+  fails=$((fails + signoff_gaps))
+fi
+
+# The swap is scoped to the sign-off key precisely so a short token like "Alex"
+# cannot damage an unrelated translation. No real locale exercises that today, so
+# prove it on a fixture: patch a second throwaway tree containing a decoy key.
+echo "The author swap touches only the sign-off key:"
+TMP_SCOPE="$(mktemp -d)"
+trap 'rm -rf "$TMP" "$TMP_SCOPE"' EXIT
+mkdir -p "$TMP_SCOPE/i18n"
+cp "$REPO/i18n/en.json" "$TMP_SCOPE/i18n/en.json"
+jq -n '{
+  "version_announcement_closing": "Din ven, Alex",
+  "album_name_example": "Alex in Paris",
+  "shared_by_user": "Aleks shared an album with you"
+}' > "$TMP_SCOPE/i18n/da.json"
+REPO_ROOT="$TMP_SCOPE" patch_i18n >/dev/null
+scope_got=$(jq -r '.version_announcement_closing' "$TMP_SCOPE/i18n/da.json")
+scope_decoy1=$(jq -r '.album_name_example' "$TMP_SCOPE/i18n/da.json")
+scope_decoy2=$(jq -r '.shared_by_user' "$TMP_SCOPE/i18n/da.json")
+if [[ "$scope_got" != "Din ven, Pierre" ]]; then
+  echo "  FAIL: fixture sign-off = '$scope_got' (expected 'Din ven, Pierre')"
+  fails=$((fails + 1))
+elif [[ "$scope_decoy1" != "Alex in Paris" || "$scope_decoy2" != "Aleks shared an album with you" ]]; then
+  echo "  FAIL: the swap escaped its key — album_name_example = '$scope_decoy1', shared_by_user = '$scope_decoy2'"
+  fails=$((fails + 1))
+else
+  echo "  ok:   sign-off swapped, 'Alex'/'Aleks' in other keys untouched"
+fi
 
 # Structural guard, not a spot check: for EVERY overridden key, branded en_GB must
 # equal branded en unless the difference is a deliberate UK variant listed below.

--- a/branding/scripts/verify-branding.sh
+++ b/branding/scripts/verify-branding.sh
@@ -8,6 +8,14 @@ CONFIG="$BRANDING_DIR/config.json"
 
 NAME=$(jq -r '.name' "$CONFIG")
 UPSTREAM_NAME=$(jq -r '.upstream_name' "$CONFIG")
+AUTHOR_NAME=$(jq -r '.author.name' "$CONFIG")
+AUTHOR_SIGNOFF_KEY=$(jq -r '.author.signoff_key' "$CONFIG")
+# read loop rather than `mapfile`, which is bash 4+ — macOS still ships bash 3.2 at
+# /bin/bash, and the rest of this repo's scripts stay runnable there.
+UPSTREAM_AUTHOR_NAMES=()
+while IFS= read -r author_spelling; do
+  UPSTREAM_AUTHOR_NAMES+=("$author_spelling")
+done < <(jq -r '.upstream.author_names[]' "$CONFIG")
 DEEP_LINK_SCHEME=$(jq -r '.mobile.deep_link_scheme' "$CONFIG")
 BUNDLE_ID=$(jq -r '.mobile.bundle_id' "$CONFIG")
 OAUTH_CALLBACK=$(jq -r '.mobile.oauth_callback' "$CONFIG")
@@ -111,6 +119,45 @@ if [[ -f "$overrides_file" && -f "$i18n_file" ]]; then
   done
   if [[ $locale_leaks -eq 0 ]]; then
     echo "  i18n: no '$UPSTREAM_NAME' leaks across rebranded keys in any locale"
+  fi
+
+  # The release sign-off names a PERSON, so none of the brand-name scans above can
+  # see it: "Your friend, Alex" contains no upstream product name and passes every
+  # one of them. patch_i18n's swap covers the spellings listed in config.json, but
+  # upstream gains locales continuously and Weblate translators keep transliterating
+  # the name into new scripts — a Georgian "ალექსი" landing in a future rebase would
+  # be a spelling the list has never seen.
+  #
+  # So assert the OUTCOME rather than the substitution: every locale that defines
+  # the key must name the fork's author. An unrecognised spelling survives the swap
+  # with no "$AUTHOR_NAME" in it and fails here, which turns a silent ship into a red
+  # build. Locales that never define the key are skipped — they inherit branded en.
+  signoff_leaks=0
+  signoff_checked=0
+  for locale_file in "$REPO_ROOT"/i18n/*.json; do
+    [[ -f "$locale_file" ]] || continue
+    lang=$(basename "$locale_file" .json)
+    signoff=$(jq -r --arg k "$AUTHOR_SIGNOFF_KEY" '.[$k] // empty' "$locale_file")
+    [[ -n "$signoff" ]] || continue
+    signoff_checked=$((signoff_checked + 1))
+    if ! printf '%s' "$signoff" | grep -qF "$AUTHOR_NAME"; then
+      echo "  WARN: i18n locale '$lang' sign-off does not name '$AUTHOR_NAME': '$signoff'"
+      echo "        add its spelling of the upstream author to .upstream.author_names in branding/config.json"
+      signoff_leaks=$((signoff_leaks + 1))
+      EXIT_CODE=1
+      continue
+    fi
+    for upstream_author in "${UPSTREAM_AUTHOR_NAMES[@]}"; do
+      if printf '%s' "$signoff" | grep -qF "$upstream_author"; then
+        echo "  WARN: i18n locale '$lang' sign-off still contains '$upstream_author': '$signoff'"
+        signoff_leaks=$((signoff_leaks + 1))
+        EXIT_CODE=1
+        break
+      fi
+    done
+  done
+  if [[ $signoff_leaks -eq 0 ]]; then
+    echo "  i18n: release sign-off names '$AUTHOR_NAME' in all $signoff_checked locales that define it"
   fi
 fi
 


### PR DESCRIPTION
Follow-up to #957. That PR translated the release sign-off for the seven locales the product ships in. The rest still said **"Your friend, Alex"** — upstream's author — in 47 more locales.

## Why the existing rebrand couldn't catch it

`patch_i18n` step 3 swaps the upstream *product* name. The sign-off names a *person*, so the string contains no product name at all: every leak scan in `verify-branding.sh` and `test-i18n-branding.sh` looked straight past it, and a rename only ever turns "Your friend, Alex" into "Your friend, Alex".

## Scope

| | |
|---|---|
| Locales total | 89 |
| Define `version_announcement_closing` | 55 |
| Already branded by #957 | 8 (`en`, `en_GB`, `de`, `es`, `fr`, `it`, `nl`, `pl`) |
| **Still naming upstream's author** | **47** |
| Don't define the key | 34 — already resolve to the branded `en.json`, untouched |

Weblate translators transliterated the name into their own scripts, so there was no single token to match: `Твой друг Алекс`, `صديقك، أليكس`, `당신의 친구, Alex가`, `เพื่อนของคุณ อเล็กซ์`, `Tavs draugs, Alekss`.

## Approach

Substituting at build time rather than hand-writing 47 more override entries, because upstream keeps gaining locales and each new one would otherwise ship unbranded until someone noticed.

- **`config.json`** — `author.name`, `author.signoff_key`, and `upstream.author_names` (15 spellings, ordered so no entry is a substring of a later one, or `Alex` would leave `Pierre가`).
- **`apply-branding.sh`** — `swap_author_name()` applies them with a literal `split`/`join`, **scoped to the sign-off key alone**. The name appears in no other key in any of the 89 locales, so the narrow scope costs nothing and stops a token as short as `Alex` reaching an unrelated translation. Runs *after* the override merge, so #957's seven hand-written translations still win and this is a no-op there.

The name stays Latin in every script. That matches how the fork already leaves "Noodle Gallery" in Latin inside Japanese and Arabic strings, matches the seven shipped overrides, and avoids shipping 15 unproofread spellings of a real person's name.

`af` gets an override instead of the swap — upstream's Afrikaans is half-untranslated (`"Jou friend, Alex"`), so a name swap alone would leave `"Jou friend, Pierre"`.

## The part that makes it stick

A substitution list only covers spellings it already knows. So `verify-branding.sh` asserts the **outcome**, not the substitution: every locale defining the key must name the fork's author. A future Weblate sync introducing an unlisted transliteration survives the swap without that name and **fails the build** instead of shipping.

Verified by simulating exactly that — a Georgian `შენი მეგობარი, ალექსი`:

```
FAIL: ka sign-off does not name 'Pierre': 'შენი მეგობარი, ალექსი'
      — add its spelling to .upstream.author_names
```

## Tests

`test-i18n-branding.sh` gains: the ordering invariant (asserted, not trusted to a comment), one case per substitution class (Cyrillic, Korean particle, Latvian declension, Thai, CJK, Afrikaans override, and a no-double-apply check), a whole-file outcome scan, and a fixture proving the swap cannot escape its key.

```
ok:   15 author spellings ordered so none consumes a longer one
ok:   55 locales define the sign-off, all name 'Pierre'
ok:   sign-off swapped, 'Alex'/'Aleks' in other keys untouched
```

Full gate green locally — `branding/scripts/gallery-branding-check.sh` (applies branding in a temp worktree, then verifies):

```
i18n: release sign-off names 'Pierre' in all 55 locales that define it
=== Gallery branding check passed ===
```

## Not covered

The sentence *around* the name is still upstream's Weblate translation in the 47 locales, unreviewed by a native speaker — same caveat as #957. Only the name is changed; the surrounding grammar is untouched, and a proper noun swap preserves it in every language here.