### PR TITLE
fix(web): make combobox dropdowns usable on iPad (#959)

### DIFF
--- a/web/src/lib/components/shared-components/Combobox.spec.ts
+++ b/web/src/lib/components/shared-components/Combobox.spec.ts
@@ -1,0 +1,159 @@
+import { fireEvent, screen } from '@testing-library/svelte';
+import { getIntersectionObserverMock } from '$lib/__mocks__/intersection-observer.mock';
+import { renderWithTooltips } from '$tests/helpers';
+import Combobox from './Combobox.svelte';
+
+// Geometry measured on an iPad Pro 13" simulator, on the "Sidebar" setting from Account
+// Settings > App Settings (issue #959).
+const LAYOUT_HEIGHT = 946;
+const INPUT_TOP = 586;
+const INPUT_BOTTOM = 626;
+const INPUT_LEFT = 502;
+
+// With the on-screen keyboard up, iPadOS shrinks the viewport to 448 and scrolls the
+// document 388px so the field clears the keyboard, landing it at 275..315.
+const KEYBOARD_VIEWPORT = 448;
+const KEYBOARD_SCROLL = 388;
+const KEYBOARD_INPUT_TOP = 275;
+const KEYBOARD_INPUT_BOTTOM = 315;
+
+const rect = (top: number, bottom: number, left = INPUT_LEFT) =>
+  ({
+    top,
+    bottom,
+    left,
+    right: left + 300,
+    width: 300,
+    height: bottom - top,
+    x: left,
+    y: top,
+    toJSON: () => '',
+  }) as DOMRect;
+
+const options = [
+  { label: 'Automatic', value: 'auto' },
+  { label: 'Always expanded', value: 'expanded' },
+  { label: 'Always compact', value: 'rail' },
+];
+
+/**
+ * `position: fixed` does not always resolve against the viewport - Bits UI dialogs and
+ * iPadOS-with-keyboard both shift the frame. `frameTop` is where a fixed `top: 0` actually
+ * lands, in client coordinates.
+ */
+const openDropdown = async ({
+  input,
+  visibleHeight = LAYOUT_HEIGHT,
+  scale = 1,
+  frameTop = 0,
+  frameBottom = LAYOUT_HEIGHT,
+}: {
+  input: DOMRect;
+  visibleHeight?: number;
+  scale?: number;
+  frameTop?: number;
+  frameBottom?: number;
+}) => {
+  vi.stubGlobal('innerHeight', visibleHeight);
+  vi.stubGlobal('visualViewport', {
+    height: visibleHeight,
+    width: 1376,
+    scale,
+    offsetLeft: 0,
+    offsetTop: 0,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+
+  renderWithTooltips(Combobox, { label: 'Sidebar', options, selectedOption: options[0] });
+
+  // happy-dom reports every rect as zero, so the geometry under test is stubbed onto the
+  // individual elements the component measures.
+  const inputElement = screen.getByRole('combobox');
+  inputElement.getBoundingClientRect = () => input;
+  const stubFrame = (side: string, top: number) => {
+    const probe = document.querySelector<HTMLElement>(`[data-fixed-frame="${CSS.escape(side)}"]`)!;
+    probe.getBoundingClientRect = () => rect(top, top, 0);
+  };
+  stubFrame('start', frameTop);
+  stubFrame('end', frameBottom);
+
+  await fireEvent.focus(inputElement);
+  return screen.getByRole('listbox');
+};
+
+/** The px budget the dropdown gets, parsed out of `min(<n>px, 18rem)`. */
+const maxHeightPx = (listbox: HTMLElement) => Number(/min\((?<px>[\d.]+)px/.exec(listbox.style.maxHeight)!.groups!.px);
+
+/** A single option row is roughly 36px tall; less than that shows nothing at all. */
+const ONE_OPTION = 36;
+
+describe('Combobox', () => {
+  beforeEach(() => {
+    vi.stubGlobal('IntersectionObserver', getIntersectionObserverMock());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('opens below the input when there is room below', async () => {
+    const listbox = await openDropdown({ input: rect(INPUT_TOP, INPUT_BOTTOM) });
+
+    expect(listbox.style.top).toBe(`${INPUT_BOTTOM}px`);
+    expect(listbox.style.bottom).toBe('');
+    expect(maxHeightPx(listbox)).toBeGreaterThanOrEqual(ONE_OPTION);
+  });
+
+  // Issue #959: on iPad the on-screen keyboard covers the space below the input, so sizing
+  // the dropdown against the shrunken viewport left it 0px tall - open, but invisible.
+  it('opens above the input when the on-screen keyboard leaves no room below', async () => {
+    const listbox = await openDropdown({
+      input: rect(KEYBOARD_INPUT_TOP, KEYBOARD_INPUT_BOTTOM),
+      visibleHeight: KEYBOARD_VIEWPORT,
+    });
+
+    expect(listbox.style.bottom).toBe(`${LAYOUT_HEIGHT - KEYBOARD_INPUT_TOP}px`);
+    expect(listbox.style.top).toBe('');
+    expect(maxHeightPx(listbox)).toBeGreaterThanOrEqual(ONE_OPTION);
+  });
+
+  // Issue #959, the part that actually put the list off-screen: iPadOS Safari resolves
+  // `position: fixed` against the document while the keyboard is up, so placing the
+  // dropdown at the input's client coordinates landed it `window.scrollY` too high.
+  it('offsets against the box fixed positioning really resolves against', async () => {
+    const listbox = await openDropdown({
+      input: rect(KEYBOARD_INPUT_TOP, KEYBOARD_INPUT_BOTTOM),
+      visibleHeight: LAYOUT_HEIGHT, // room below, so it opens downwards
+      frameTop: -KEYBOARD_SCROLL,
+      frameBottom: LAYOUT_HEIGHT - KEYBOARD_SCROLL,
+    });
+
+    // Placed at 315 - (-388): renders at client 703 - 388 = 315, flush under the input.
+    expect(listbox.style.top).toBe(`${KEYBOARD_INPUT_BOTTOM + KEYBOARD_SCROLL}px`);
+    expect(listbox.style.left).toBe(`${INPUT_LEFT}px`);
+  });
+
+  it('offsets upward placement against the same frame', async () => {
+    const listbox = await openDropdown({
+      input: rect(KEYBOARD_INPUT_TOP, KEYBOARD_INPUT_BOTTOM),
+      visibleHeight: KEYBOARD_VIEWPORT,
+      frameTop: -KEYBOARD_SCROLL,
+      frameBottom: LAYOUT_HEIGHT - KEYBOARD_SCROLL,
+    });
+
+    // Bottom edge lands at frameBottom - bottom = client 275, flush above the input.
+    expect(listbox.style.bottom).toBe(`${LAYOUT_HEIGHT - KEYBOARD_SCROLL - KEYBOARD_INPUT_TOP}px`);
+    expect(maxHeightPx(listbox)).toBeGreaterThanOrEqual(ONE_OPTION);
+  });
+
+  // Deliberate behaviour from upstream #12848: while pinch-zoomed the dropdown stays
+  // anchored directly below the input rather than flipping into unzoomed layout space.
+  it('stays below the input while the viewport is pinch-zoomed', async () => {
+    const listbox = await openDropdown({ input: rect(INPUT_TOP, INPUT_BOTTOM), visibleHeight: 473, scale: 2 });
+
+    expect(listbox.style.top).toBe(`${INPUT_BOTTOM}px`);
+    expect(listbox.style.bottom).toBe('');
+  });
+});

--- a/web/src/lib/components/shared-components/Combobox.svelte
+++ b/web/src/lib/components/shared-components/Combobox.svelte
@@ -78,6 +78,8 @@
   let selectedIndex: number | undefined = $state();
   let optionRefs: HTMLElement[] = $state([]);
   let input = $state<HTMLInputElement>();
+  let frameStart = $state<HTMLElement>();
+  let frameEnd = $state<HTMLElement>();
   let bounds: DOMRect | undefined = $state();
 
   const inputId = `combobox-${id}`;
@@ -181,45 +183,56 @@
   };
 
   // TODO: move this combobox component into @immich/ui
-  // Bits UI dialogs use `contain: layout` so fixed descendants are positioned in dialog space
-  const getModalBounds = () => {
-    const modalRoot = input?.closest('[data-dialog-content]');
-    if (!modalRoot || !getComputedStyle(modalRoot).contain.includes('layout')) {
-      return;
-    }
-
-    return modalRoot.getBoundingClientRect();
+  /**
+   * The dropdown is `position: fixed`, but "fixed" does not always mean "against the
+   * viewport", so the offsets it is placed at are measured rather than assumed:
+   *
+   * - Bits UI dialogs use `contain: layout`, which positions fixed descendants in dialog space.
+   * - iPadOS Safari resolves fixed positions against the *document* while the on-screen
+   *   keyboard is up, so a dropdown placed at the input's client coordinates lands
+   *   `window.scrollY` too high - off-screen once the keyboard scrolls the page (#959).
+   *
+   * `frameStart` and `frameEnd` are zero-sized probes pinned to the top and bottom of
+   * whatever box this dropdown's `fixed` positions actually resolve against. Wherever
+   * `fixed` behaves like the viewport they read 0 and `window.innerHeight`, leaving the
+   * arithmetic below unchanged.
+   */
+  const getFixedFrame = () => {
+    const start = frameStart?.getBoundingClientRect();
+    const end = frameEnd?.getBoundingClientRect();
+    return {
+      top: start?.top ?? 0,
+      left: start?.left ?? 0,
+      bottom: end?.top ?? window.innerHeight,
+    };
   };
 
-  const calculatePosition = (boundary: DOMRect | undefined) => {
-    const visualViewport = window.visualViewport;
+  /**
+   * The height the user can actually see. The on-screen keyboard shrinks the visual
+   * viewport, and on iPadOS it shrinks `window.innerHeight` along with it.
+   */
+  const getVisibleHeight = () => window.visualViewport?.height || window.innerHeight;
 
+  const calculatePosition = (boundary: DOMRect | undefined) => {
     if (!boundary) {
       return;
     }
 
-    const modalBounds = getModalBounds();
-    const offsetTop = modalBounds?.top || 0;
-    const offsetLeft = modalBounds?.left || 0;
-    const rootHeight = modalBounds?.height || window.innerHeight;
-
-    const top = boundary.top - offsetTop;
-    const bottom = boundary.bottom - offsetTop;
-    const left = boundary.left - offsetLeft;
+    const frame = getFixedFrame();
+    const left = boundary.left - frame.left;
 
     if (dropdownDirection === 'top') {
       return {
-        bottom: `${rootHeight - top}px`,
+        bottom: `${frame.bottom - boundary.top}px`,
         left: `${left}px`,
         width: `${boundary.width}px`,
         maxHeight: maxHeight(boundary.top - dropdownOffset),
       };
     }
 
-    const viewportHeight = visualViewport?.height || window.innerHeight;
-    const availableHeight = viewportHeight - boundary.bottom;
+    const availableHeight = getVisibleHeight() - boundary.bottom;
     return {
-      top: `${bottom}px`,
+      top: `${boundary.bottom - frame.top}px`,
       left: `${left}px`,
       width: `${boundary.width}px`,
       maxHeight: maxHeight(availableHeight - dropdownOffset),
@@ -243,13 +256,18 @@
       return 'bottom';
     }
 
-    const visualHeight = visualViewport?.height || 0;
-    const heightBelow = visualHeight - boundary.bottom;
+    const visibleHeight = getVisibleHeight();
+    const heightBelow = visibleHeight - boundary.bottom;
     const heightAbove = boundary.top;
 
-    const isViewportScaled = visualHeight && Math.floor(visualHeight) !== Math.floor(window.innerHeight);
+    // Pinch-zoom only. While zoomed in, a fixed dropdown flipped above the input lands in
+    // layout space the user is not looking at, so it stays anchored under the input. An
+    // on-screen keyboard also shrinks the visual viewport but leaves `scale` at 1, and it
+    // must still be able to flip - otherwise the dropdown is sized against the strip hidden
+    // behind the keyboard and opens 0px tall (#959).
+    const isViewportZoomed = (visualViewport?.scale || 1) > 1;
 
-    return heightBelow <= bottomBreakpoint && heightAbove > heightBelow && !isViewportScaled ? 'top' : 'bottom';
+    return heightBelow <= bottomBreakpoint && heightAbove > heightBelow && !isViewportZoomed ? 'top' : 'bottom';
   };
 
   const getInputPosition = () => input?.getBoundingClientRect();
@@ -267,7 +285,9 @@
   let dropdownDirection: 'bottom' | 'top' = $derived(getComboboxDirection(bounds, visualViewport));
 </script>
 
-<svelte:window onresize={onPositionChange} />
+<!-- iOS scrolls the document to lift a focused input above the on-screen keyboard, which
+     moves the input out from under an already-open dropdown. -->
+<svelte:window onresize={onPositionChange} onscroll={onPositionChange} />
 <Label class="mb-1 block {hideLabel ? 'sr-only' : ''} text-xs font-light text-neutral-500" for={inputId}>{label}</Label>
 <div
   class="relative w-full text-base text-gray-700 dark:text-gray-300"
@@ -376,6 +396,22 @@
       {/if}
     </div>
   </div>
+
+  <!-- Zero-sized probes that measure the box this dropdown's `fixed` offsets resolve
+       against. See getFixedFrame(). Inline styles because these are measurement aids
+       rather than UI, and must stay physically top/left anchored in RTL too. -->
+  <div
+    bind:this={frameStart}
+    data-fixed-frame="start"
+    aria-hidden="true"
+    style="position:fixed;top:0;left:0;width:0;height:0;visibility:hidden;pointer-events:none;"
+  ></div>
+  <div
+    bind:this={frameEnd}
+    data-fixed-frame="end"
+    aria-hidden="true"
+    style="position:fixed;bottom:0;left:0;width:0;height:0;visibility:hidden;pointer-events:none;"
+  ></div>
 
   <ul
     role="listbox"


### PR DESCRIPTION
Fixes the "Sidebar" setting dropdown not opening on iPad, reported in #959.

Tapping the combobox showed the search field but no option list. `aria-expanded`
was `true` the whole time — the list was open, just not where or how you could
see it. Two separate faults, both invisible on desktop because the on-screen
keyboard is what triggers them.

### 1. Sized to nothing

`max-height` came from `visualViewport.height - input.bottom`. The keyboard
shrinks the visual viewport, so once the field sat near the keyboard that went
negative and the list rendered `0px` tall.

The "not enough room below → open upward" fallback should have caught this, but
it was gated on `visualViewport.height !== window.innerHeight`. That check was
added for pinch-zoom (upstream #12848), and the keyboard trips the same
comparison — so the flip was suppressed exactly when it was needed. It now
detects zoom with `visualViewport.scale`, which the keyboard leaves at `1`.

### 2. Placed off-screen

The bigger one. iPadOS Safari resolves `position: fixed` against the **document**
while the keyboard is up, so placing the list at the input's client coordinates
landed it `window.scrollY` too high. Measured on device:

```
pos t=315px   scroll win=388   →   ul top=-73   (315 - 388)
```

The keyboard is also what makes iOS scroll the page to lift the field into view,
which is why the offset appears precisely when the dropdown is needed. It is also
why this looked orientation-dependent: landscape has less height, so iOS scrolls
further.

Rather than assume that coordinate space, two zero-sized probes measure the box
`fixed` actually resolves against. Where `fixed` behaves normally they read the
viewport and the arithmetic is unchanged. This **subsumes the hand-rolled
`getModalBounds()` Bits UI dialog special case**, which existed for the same
class of problem (`contain: layout`), and now also covers any future
transform/filter/contain ancestor.

### Scope

`Combobox.svelte` is shared, so this fixes every combobox on touch devices — the
Language selector on the same page is the same component and had the same bug
(it only looked fine because it sits higher up, so iOS scrolls less).

### Verification

- Reproduced and confirmed fixed on an iPad Pro 13" simulator, real keyboard, both orientations.
- 5 new `Combobox.spec.ts` tests using the geometry measured off the device. Confirmed they fail without the fix (3 fail if the frame compensation is stubbed out).
- Full web unit suite: 4341 passed. `tsc --noEmit`, `svelte-check` (585 files, 0 problems), eslint and prettier clean.

Note: this does **not** address the original #959 request (sidebar not auto-collapsing in landscape) — that was answered with the "Always compact" setting. This makes that setting selectable.
