### PR TITLE
fix(fork): green the ownership coverage check on main

### DIFF
--- a/docs/fork/ownership.yml
+++ b/docs/fork/ownership.yml
@@ -5,7 +5,7 @@ metadata:
   upstream_branch: main
   fork_remote: origin
   fork_branch: main
-  last_verified_fork_head: e60a6616a0f4f2edd17618b86ba89187f6449c4b
+  last_verified_fork_head: 99ce9f8b46e7f86d1320eac87c30f70942404aca
 
 coverage_ignore:
   - docs/superpowers/**
@@ -288,6 +288,7 @@ features:
       - server/src/schema/migrations-gallery/**
       - server/bin/sync-gallery-migrations.mjs
       - tools/upstream-preflight/**
+      - Template/**
     upstream_extension_paths:
       - .github/workflows/**
       - packages/sdk/src/fetch-client.ts


### PR DESCRIPTION
`make fork-ownership-coverage-check` currently fails on `main` with two errors:

```
Ownership manifest last_verified_fork_head e60a6616a0f4… is not an ancestor of 99ce9f8b46e7…;
reconcile docs/fork/ownership.yml before rebasing.
Ownership manifest does not cover 1 fork files:
Template/Stack/noodle-gallery.yml
```

## Changes

- **Declare `Template/**`** under `release-ci-and-infrastructure`. #942 added a new top-level
  directory, which no glob covered. Confirmed fork-only — the path is absent from `upstream/main`.
- **Bump `last_verified_fork_head`** to `99ce9f8b46e`. The previous value (`e60a6616a0f`, #777) was
  orphaned: every upstream rebase rewrites fork SHAs, so a cursor pointing at a fork commit stops
  being an ancestor of `origin/main` after the next cycle.

## Verification

| Check | Before | After |
|---|---|---|
| `make fork-ownership-coverage-check` | exit 1, 2 errors | exit 0 — `covers 3321 fork files` |
| `make ci-invariants-check` | — | exit 0, 3/3 invariants |
| `make fork-patches-check` | — | exit 0 |
| `prettier --check docs/fork/ownership.yml` | — | clean |

`tools/upstream-preflight` tests: 232/235. The 3 `batch.spec.ts` failures reproduce identically on
an unmodified tree and `test.yml` is green on `main` at the same SHA, so they are local-environment
only and untouched here.

## Notes

The cursor bump is a treadmill, not a cure — the next rebase orphans `99ce9f8b46e` the same way, and
this is the third recorded occurrence. Keying the cursor on something rebase-stable would fix the
class; that is a design change and deliberately out of scope here.

None of these checks run in CI today (they fire only when a rebase starts), so `main` can drift red
again unnoticed. Wiring the three cheap ones into `test.yml` is a separate follow-up.