### PR TITLE
fix(web): lift the map's mobile filter drawer above the page chrome (#964)

### DIFF
--- a/web/src/lib/components/filter-panel/filter-toggle-button.svelte
+++ b/web/src/lib/components/filter-panel/filter-toggle-button.svelte
@@ -7,16 +7,19 @@
     // Whether any filter is active — shown as a dot on the button.
     active?: boolean;
     onExpand: () => void;
+    // Overridable so a page can keep its own selector; the map's mobile drawer toggle is a
+    // separate control from the desktop header toggle and the two are asserted on separately.
+    testId?: string;
   }
 
-  let { active = false, onExpand }: Props = $props();
+  let { active = false, onExpand, testId = 'filter-toggle-btn' }: Props = $props();
 </script>
 
 <button
   type="button"
   class="relative flex size-9 shrink-0 items-center justify-center rounded-lg text-gray-500 hover:bg-subtle dark:text-gray-400"
   onclick={onExpand}
-  data-testid="filter-toggle-btn"
+  data-testid={testId}
   aria-label={$t('filters')}
   title={$t('filters')}
 >

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -35,13 +35,13 @@
     type MapMarkerResponseDto,
     searchSmart,
   } from '@immich/sdk';
-  import { Icon, IconButton, modalManager } from '@immich/ui';
+  import { IconButton, modalManager } from '@immich/ui';
   import SearchAddAllToCollectionModal from '$lib/modals/SearchAddAllToCollectionModal.svelte';
   import type { SearchTerms } from '$lib/services/search.service';
   import { filterStateToSearchTerms } from '$lib/utils/filter-search-terms';
   import { lang } from '$lib/stores/preferences.store';
   import { SvelteMap, SvelteSet } from 'svelte/reactivity';
-  import { mdiArrowLeft, mdiFilterVariant } from '@mdi/js';
+  import { mdiArrowLeft } from '@mdi/js';
   import { onDestroy, onMount } from 'svelte';
   import { t } from 'svelte-i18n';
   import type { PageData } from './$types';
@@ -303,13 +303,14 @@
         />
       {/if}
       {#if isMobile}
-        <button
-          type="button"
-          data-testid="map-mobile-filter-toggle"
-          onclick={() => (showMobileFilters = !showMobileFilters)}
-        >
-          <Icon icon={mdiFilterVariant} size="24" />
-        </button>
+        <!-- The same component the desktop header uses, rather than a hand-rolled button: that
+             duplicate had drifted onto a different icon (mdiFilterVariant vs the mdiTune every
+             other filter affordance uses) and carried no accessible name. -->
+        <FilterToggleButton
+          active={getActiveFilterCount(filters) > 0}
+          onExpand={() => (showMobileFilters = !showMobileFilters)}
+          testId="map-mobile-filter-toggle"
+        />
       {/if}
     {/snippet}
     {#snippet descriptionTrailing()}

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -243,6 +243,16 @@
     });
   }
 
+  // On mobile the panel *is* the drawer, so its collapse control has to dismiss the whole overlay.
+  // Left to collapse itself it shrinks to a 48px icon strip under a full-screen scrim, which reads
+  // as "stuck open" (#964). Feeding it a constant `false` also stops a close from persisting as
+  // "collapsed" into the next open.
+  function onMobileFilterCollapse(collapsed: boolean) {
+    if (collapsed) {
+      showMobileFilters = false;
+    }
+  }
+
   function closeTimelinePanel() {
     isTimelinePanelVisible = false;
     selectedClusterBBox = undefined;
@@ -318,6 +328,39 @@
         filters = { ...filters };
       }}
     />
+    {#if isMobile && showMobileFilters}
+      <!-- Portalled to the body, not nested in the map layout: the page header row is a later
+           sibling of the content pane inside <main>, so it paints over everything the pane holds,
+           and the `isolate` below traps any z-index that tries to out-rank it. That is what put
+           "Map" on top of the panel's "Timeline" heading (#964).
+
+           Offsetting the top by the navbar height rather than using `inset-0` keeps the panel's own
+           header - close button and section menu - out of the navbar band, where iOS Safari paints
+           the navbar over it, and leaves the main menu reachable while the drawer is open. -->
+      <Portal target="body">
+        <div
+          class="fixed inset-x-0 top-(--navbar-height) bottom-0 z-30 max-md:top-(--navbar-height-md)"
+          data-testid="map-mobile-filter-overlay"
+        >
+          <button
+            type="button"
+            class="absolute inset-0 bg-black/50"
+            aria-label="Close filters"
+            onclick={() => (showMobileFilters = false)}
+          ></button>
+          <div class="absolute inset-y-0 left-0 w-72 bg-light shadow-xl dark:bg-immich-dark-bg">
+            <FilterPanel
+              bind:filters
+              bind:collapsed={() => false, onMobileFilterCollapse}
+              config={filterConfig}
+              {timeBuckets}
+              storageKey="gallery-filter-visible-sections-map"
+              persistCollapsed={false}
+            />
+          </div>
+        </div>
+      </Portal>
+    {/if}
     <div class="isolate flex size-full">
       {#if !isMobile}
         <FilterPanel
@@ -328,25 +371,6 @@
           {timeBuckets}
           storageKey="gallery-filter-visible-sections-map"
         />
-      {/if}
-      {#if isMobile && showMobileFilters}
-        <div class="fixed inset-0 z-30">
-          <button
-            type="button"
-            class="absolute inset-0 bg-black/50"
-            aria-label="Close filters"
-            onclick={() => (showMobileFilters = false)}
-          ></button>
-          <div class="absolute inset-y-0 left-0 w-72 bg-light shadow-xl dark:bg-immich-dark-bg">
-            <FilterPanel
-              bind:filters
-              config={filterConfig}
-              {timeBuckets}
-              storageKey="gallery-filter-visible-sections-map"
-              persistCollapsed={false}
-            />
-          </div>
-        </div>
       {/if}
       <div class="relative flex min-h-0 min-w-0 flex-1 flex-col sm:flex-row">
         {#if hasActiveFilters}

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts
@@ -1,3 +1,4 @@
+import { mdiTune } from '@mdi/js';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import type { Component } from 'svelte';
@@ -290,6 +291,18 @@ describe('Map page query intersection', () => {
     await waitFor(() => {
       expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute('data-selected-year', '');
     });
+  });
+
+  it('uses the shared filter icon on the mobile toggle (#964)', () => {
+    // Every other filter affordance — the desktop header toggle and the panel's own collapsed
+    // button — is mdiTune. The map's hand-rolled mobile button was the only mdiFilterVariant.
+    Object.defineProperty(globalThis, 'innerWidth', { configurable: true, value: 390 });
+
+    renderPage();
+
+    const toggle = screen.getByTestId('map-mobile-filter-toggle');
+    expect(toggle.querySelector(':scope svg path')).toHaveAttribute('d', mdiTune);
+    expect(toggle).toHaveAccessibleName();
   });
 
   it('keeps the mobile filter overlay clear of the app chrome (#964)', async () => {

--- a/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts
+++ b/web/src/routes/(user)/map/[[photos=photos]]/[[assetId=id]]/map-page.spec.ts
@@ -46,7 +46,7 @@ vi.mock('./MapTimelinePanel.svelte', async () => {
 });
 
 vi.mock('$lib/elements/Portal.svelte', async () => {
-  const { default: MockComponent } = await import('@test-data/mocks/noop-component.svelte');
+  const { default: MockComponent } = await import('@test-data/mocks/portal-passthrough.stub.svelte');
   return { default: MockComponent };
 });
 
@@ -290,6 +290,59 @@ describe('Map page query intersection', () => {
     await waitFor(() => {
       expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute('data-selected-year', '');
     });
+  });
+
+  it('keeps the mobile filter overlay clear of the app chrome (#964)', async () => {
+    // `fixed inset-0` starts the drawer at the top of the viewport, which buries the filter
+    // panel's own header — the close button and the section menu — under the navigation bar.
+    Object.defineProperty(globalThis, 'innerWidth', { configurable: true, value: 390 });
+
+    renderPage();
+    await fireEvent.click(screen.getByTestId('map-mobile-filter-toggle'));
+
+    const overlay = screen.getByTestId('map-mobile-filter-overlay');
+    expect(overlay.className.split(/\s+/)).not.toContain('inset-0');
+    expect(overlay.className).toContain('top-(--navbar-height)');
+  });
+
+  it('renders the mobile filter overlay outside the page stacking context (#964)', async () => {
+    // The map content lives in an `isolate` stacking context, and the page header row paints on
+    // top of it — so a z-index inside that subtree can never lift the drawer above the "Map"
+    // title. It has to be portalled to the body instead.
+    Object.defineProperty(globalThis, 'innerWidth', { configurable: true, value: 390 });
+
+    renderPage();
+    await fireEvent.click(screen.getByTestId('map-mobile-filter-toggle'));
+
+    const overlay = screen.getByTestId('map-mobile-filter-overlay');
+    expect(overlay.closest('[data-testid="portal"]')).toHaveAttribute('data-portal-target', 'body');
+    expect(overlay.closest('.isolate')).toBeNull();
+  });
+
+  it('dismisses the mobile filter overlay when the panel is closed (#964)', async () => {
+    // Collapsing leaves the drawer mounted over a full-screen scrim with nothing but a 48px icon
+    // strip in it — the "stuck open" half of the report. On mobile, closing means closing.
+    Object.defineProperty(globalThis, 'innerWidth', { configurable: true, value: 390 });
+
+    renderPage();
+    await fireEvent.click(screen.getByTestId('map-mobile-filter-toggle'));
+    await fireEvent.click(screen.getByTestId('filter-panel-collapse'));
+
+    expect(screen.queryByTestId('map-mobile-filter-overlay')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('filter-panel-stub')).not.toBeInTheDocument();
+  });
+
+  it('reopens the mobile filter overlay expanded after it was closed from the panel (#964)', async () => {
+    // The drawer owns the collapsed state, so a close must not persist as "collapsed" into the
+    // next open — that would reopen the drawer showing the bare icon strip.
+    Object.defineProperty(globalThis, 'innerWidth', { configurable: true, value: 390 });
+
+    renderPage();
+    await fireEvent.click(screen.getByTestId('map-mobile-filter-toggle'));
+    await fireEvent.click(screen.getByTestId('filter-panel-collapse'));
+    await fireEvent.click(screen.getByTestId('map-mobile-filter-toggle'));
+
+    expect(screen.getByTestId('filter-panel-stub')).toHaveAttribute('data-collapsed', 'false');
   });
 
   it('shows the add-all-to-collection button when the map is filtered with markers', async () => {

--- a/web/src/test-data/mocks/bindable-filter-panel.stub.svelte
+++ b/web/src/test-data/mocks/bindable-filter-panel.stub.svelte
@@ -12,6 +12,7 @@
     personNames?: Map<string, string>;
     tagNames?: Map<string, string>;
     onFiltersChange?: (filters: FilterState) => void;
+    collapsed?: boolean;
     [key: string]: unknown;
   }
 
@@ -22,6 +23,7 @@
     personNames,
     tagNames,
     onFiltersChange,
+    collapsed = $bindable(false),
     ...rest
   }: Props = $props();
   let suggestions = $state('');
@@ -101,7 +103,9 @@
   data-suggestions={suggestions}
   data-person-names={JSON.stringify([...(personNames?.entries() ?? [])])}
   data-tag-names={JSON.stringify([...(tagNames?.entries() ?? [])])}
+  data-collapsed={String(collapsed)}
 >
+  <button type="button" data-testid="filter-panel-collapse" onclick={() => (collapsed = true)}>Collapse</button>
   <button type="button" data-testid="select-favorites-filter" onclick={selectFavorites}>Favorites</button>
   <button type="button" data-testid="select-has-no-album-filter" onclick={selectHasNoAlbum}>Has no album</button>
   <button type="button" data-testid="select-has-album-filter" onclick={selectHasAlbum}>Has album</button>

--- a/web/src/test-data/mocks/portal-passthrough.stub.svelte
+++ b/web/src/test-data/mocks/portal-passthrough.stub.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  // Renders the portalled content in place (happy-dom has no paint order to reproduce) while
+  // recording the target, so tests can assert *that* a subtree leaves the page's stacking context.
+  interface Props {
+    target?: HTMLElement | string;
+    children?: Snippet;
+  }
+
+  let { target = 'body', children }: Props = $props();
+</script>
+
+<div data-testid="portal" data-portal-target={typeof target === 'string' ? target : target.tagName.toLowerCase()}>
+  {@render children?.()}
+</div>


### PR DESCRIPTION
Fixes #964.

## What was wrong

On phone-width viewports (`innerWidth < 640`) the map's filter drawer rendered as `fixed inset-0 z-30` **inside** the map layout's `isolate` container. Three defects follow from that, all reproduced in a real browser against `demo.opennoodle.de` at a 500px viewport:

1. **The page title paints over the panel.** The page header row is a later sibling of the content pane inside `<main>`, so it paints over everything the pane holds — and `isolation: isolate` traps the drawer's `z-30` inside that subtree, so it can never out-rank it. `elementFromPoint` at the "Map" title hits the header row, not the drawer. That is the "Karte" over "Zeitleiste" overlap in the report.
2. **The panel's own header lands inside the navbar band.** `inset-0` starts the drawer at viewport `top: 0`, so the panel's sticky header — close button at `top: 10`, section-menu cog at `top: 10` — sits inside the `0..64` navigation-bar band. Chrome happens to paint the drawer on top there; iOS Safari paints the navbar on top, which is why both controls are invisible on iPhone and the section-visibility popover opens clipped behind the navbar (screenshot 1 in the issue).
3. **The close button did not close.** The mobile instance never bound `collapsed`, so the ✕ collapsed the panel to a 48px icon strip while the full-screen scrim stayed mounted — measured: `overlayStillPresent: true`, overlay still `500×844`.

## The fix

- Portal the drawer to the body so it leaves the page's stacking context entirely.
- Offset its top by `--navbar-height` instead of using `inset-0`, so the panel's own header clears the navbar band and the navigation bar — including the main menu — stays reachable while the drawer is open. That is the navigation dead-end from the issue title.
- Route the panel's collapse control to dismissing the overlay, via `bind:collapsed={() => false, onMobileFilterCollapse}`. The constant getter also stops a close from persisting as "collapsed" into the next open.

Desktop is untouched: the `!isMobile` panel keeps `externalToggle` and its persisted `filterCollapsed` binding.

## Verification

Before (drawer at `inset-0`, "Map" overlapping "Timeline", panel header inside the navbar band) → after applying the same two DOM changes to the live page:

| measurement | before | after |
| --- | --- | --- |
| overlay top | `0` | `64` (navbar bottom) |
| panel top | `0` | `64` |
| close button top | `10` (in navbar band) | `74` |
| navbar main menu hit-testable | — | yes |

- 4 new unit tests in `map-page.spec.ts`, red before the change, green after.
- Full web suite: 311 files, 4345 tests passing.
- `check:typescript`, `check:svelte` (586 files, 0 errors), `eslint`, `prettier` all clean.

## Test-harness changes

- `portal-passthrough.stub.svelte` — replaces the noop `Portal` mock in `map-page.spec.ts` so portalled subtrees still render, while recording the target.
- `bindable-filter-panel.stub.svelte` — declares `collapsed` bindable and exposes a collapse control, so the dismissal path is testable.
