### PR TITLE
fix(web): make the space hero edit control legible on any cover (#946)

### DIFF
--- a/e2e/src/specs/rebase-smoke/permission-matrix.e2e-spec.ts
+++ b/e2e/src/specs/rebase-smoke/permission-matrix.e2e-spec.ts
@@ -86,9 +86,8 @@ test.describe('Rebase Smoke — UI Permission Matrix', () => {
   }) => {
     await utils.setAuthCookies(context, owner.accessToken);
     await page.goto(`/spaces/${space.id}`);
-    // hero-role-badge renders the raw lowercase SharedSpaceRole enum ('owner')
-    // with CSS `capitalize` (which does not change textContent), so the match
-    // must be case-insensitive.
+    // hero-role-badge renders the translated role label ('Owner' in English) with CSS
+    // `capitalize` (which does not change textContent), so the match must be case-insensitive.
     await expect(page.locator('[data-testid="hero-role-badge"]')).toContainText('owner', { ignoreCase: true });
     await expect(page.getByLabel('Add photos')).toBeVisible();
     await page.getByRole('button', { name: 'More' }).click();

--- a/e2e/src/specs/web/spaces-albums-journey.e2e-spec.ts
+++ b/e2e/src/specs/web/spaces-albums-journey.e2e-spec.ts
@@ -137,8 +137,8 @@ test.describe('Spaces — Albums UI journey & permission matrix', () => {
 
     await gotoSpacesList(page); // hop 1
     await openSpaceFromList(page, space.id); // hops 2–3
-    // hero-role-badge renders the RAW enum ('owner') with CSS `capitalize`,
-    // which does NOT change textContent — so match case-insensitively.
+    // hero-role-badge renders the translated role label, which in English is 'Owner' — plus CSS
+    // `capitalize`, which does NOT change textContent. Match case-insensitively either way.
     await expect(page.locator('[data-testid="hero-role-badge"]')).toContainText('owner', { ignoreCase: true });
 
     await openAlbumsTab(page, space.id); // hop 4

--- a/web/src/lib/components/spaces/role-badge.svelte
+++ b/web/src/lib/components/spaces/role-badge.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { spaceRoleLabelKey } from '$lib/utils/space-utils';
   import type { UserAvatarColor } from '@immich/sdk';
   import { t } from 'svelte-i18n';
 
@@ -39,9 +40,7 @@
     return `bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300 ${sizeClasses[size]}`;
   });
 
-  const roleLabel = $derived(
-    role === 'owner' ? $t('owner') : role === 'editor' ? $t('role_editor') : $t('role_viewer'),
-  );
+  const roleLabel = $derived($t(spaceRoleLabelKey(role)));
 </script>
 
 <span class="inline-flex items-center rounded-full font-medium capitalize {badgeClass}" data-testid="role-badge-{role}">

--- a/web/src/lib/components/spaces/space-hero.spec.ts
+++ b/web/src/lib/components/spaces/space-hero.spec.ts
@@ -72,9 +72,17 @@ describe('SpaceHero component', () => {
     expect(screen.getByTestId('hero-role-badge')).toBeInTheDocument();
   });
 
-  it('should display role badge text when currentRole is provided', () => {
+  // The badge used to print the raw SharedSpaceRole enum, which is English-only in every locale
+  // (#946). `$t` has no dictionary under test, so it echoes the key back — a badge reading
+  // `role_editor` rather than `editor` is the proof that the value went through i18n at all.
+  it('should display a translated role label, not the raw enum value, for an editor', () => {
     render(SpaceHero, { space: makeSpace(), currentRole: 'editor' });
-    expect(screen.getByTestId('hero-role-badge')).toHaveTextContent('editor');
+    expect(screen.getByTestId('hero-role-badge')).toHaveTextContent(/^role_editor$/);
+  });
+
+  it('should display a translated role label, not the raw enum value, for a viewer', () => {
+    render(SpaceHero, { space: makeSpace(), currentRole: 'viewer' });
+    expect(screen.getByTestId('hero-role-badge')).toHaveTextContent(/^role_viewer$/);
   });
 
   it('should not display role badge when currentRole is not provided', () => {
@@ -105,6 +113,22 @@ describe('SpaceHero component', () => {
   });
 
   // --- Edit control (✎) ---
+
+  // #946: the cover is a photo, not a themed surface, so a control tinted with a theme colour is
+  // a coin toss. `variant="ghost"` painted the ✎ with `text-dark` — near-black in the light theme —
+  // on a transparent background, which vanished against a dark cover. An opaque chip brings its own
+  // background, so it contrasts with itself whatever the photo underneath happens to be.
+  it('paints the edit control as an opaque chip rather than dark ink on the bare cover', () => {
+    render(SpaceHero, {
+      space: makeSpace({ thumbnailAssetId: 'a1' }),
+      canEdit: true,
+      onChangeCover: () => {},
+      onReposition: () => {},
+    });
+    const button = within(screen.getByTestId('hero-edit-menu')).getByLabelText('edit');
+    expect(button.className).not.toContain('text-dark');
+    expect(button.className).toMatch(/(^|\s)bg-\S/);
+  });
 
   it('shows the edit control immediately for an editor with a cover, with no hover interaction', () => {
     render(SpaceHero, {

--- a/web/src/lib/components/spaces/space-hero.svelte
+++ b/web/src/lib/components/spaces/space-hero.svelte
@@ -2,6 +2,7 @@
   import ButtonContextMenu from '$lib/components/shared-components/context-menu/ButtonContextMenu.svelte';
   import MenuOption from '$lib/components/shared-components/context-menu/MenuOption.svelte';
   import { getAssetMediaUrl } from '$lib/utils';
+  import { spaceRoleLabelKey } from '$lib/utils/space-utils';
   import { AssetMediaSize, type SharedSpaceResponseDto } from '@immich/sdk';
   import { Icon } from '@immich/ui';
   import { mdiCameraOutline, mdiCursorMove, mdiImageEditOutline, mdiPencilOutline } from '@mdi/js';
@@ -172,10 +173,18 @@
     <div class="absolute top-3 right-3 flex items-center gap-2">
       {#if canEdit}
         <div class="transition" data-testid="hero-edit-menu">
+          <!--
+            The cover is a photo, not a themed surface, so the default ghost variant — theme-coloured
+            ink on a transparent background — is a coin toss against it: in the light theme it painted
+            a near-black ✎ that disappeared into a dark cover (#946). A filled chip carries its own
+            background, the same recipe every other over-image menu in the app uses.
+          -->
           <ButtonContextMenu
             icon={mdiPencilOutline}
             title={$t('edit')}
             color="secondary"
+            variant="filled"
+            buttonClass="icon-white-drop-shadow"
             align="top-right"
             direction="left"
           >
@@ -193,7 +202,7 @@
           class="inline-flex items-center rounded-full bg-white/20 px-2.5 py-0.5 text-xs font-medium text-white capitalize backdrop-blur-sm"
           data-testid="hero-role-badge"
         >
-          {currentRole}
+          {$t(spaceRoleLabelKey(currentRole))}
         </span>
       {/if}
     </div>

--- a/web/src/lib/utils/space-utils.spec.ts
+++ b/web/src/lib/utils/space-utils.spec.ts
@@ -1,5 +1,24 @@
-import { splitPinnedSpaces } from '$lib/utils/space-utils';
+import { SharedSpaceRole } from '@immich/sdk';
+import { spaceRoleLabelKey, splitPinnedSpaces } from '$lib/utils/space-utils';
 import { sharedSpaceFactory } from '@test-data/factories/shared-space-factory';
+
+describe('spaceRoleLabelKey', () => {
+  it('maps owner to the existing owner key', () => {
+    expect(spaceRoleLabelKey(SharedSpaceRole.Owner)).toBe('owner');
+  });
+
+  it('maps editor to the existing role_editor key', () => {
+    expect(spaceRoleLabelKey(SharedSpaceRole.Editor)).toBe('role_editor');
+  });
+
+  it('maps viewer to the existing role_viewer key', () => {
+    expect(spaceRoleLabelKey(SharedSpaceRole.Viewer)).toBe('role_viewer');
+  });
+
+  it('falls back to the least-privileged label for an unknown role', () => {
+    expect(spaceRoleLabelKey('something-new')).toBe('role_viewer');
+  });
+});
 
 describe('splitPinnedSpaces', () => {
   it('should return empty pinned and all unpinned when no IDs pinned', () => {

--- a/web/src/lib/utils/space-utils.ts
+++ b/web/src/lib/utils/space-utils.ts
@@ -1,4 +1,32 @@
-import type { SharedSpaceResponseDto } from '@immich/sdk';
+import { SharedSpaceRole, type SharedSpaceResponseDto } from '@immich/sdk';
+
+/**
+ * The literal key union rather than `string`, so `$t()` still type-checks these against `en.json`.
+ * (`Translations` itself is declared inside `declare module 'svelte-i18n'`, so it cannot be named
+ * here.)
+ */
+export type SpaceRoleLabelKey = 'owner' | 'role_editor' | 'role_viewer';
+
+/**
+ * i18n key for a member's role in a space.
+ *
+ * `SharedSpaceRole` is a lowercase English enum (`owner` / `editor` / `viewer`); printing it — even
+ * dressed up with CSS `capitalize` — leaves the role untranslated in every locale (#946). Unknown
+ * roles fall back to the least-privileged label rather than leaking the raw value.
+ */
+export function spaceRoleLabelKey(role: string): SpaceRoleLabelKey {
+  switch (role) {
+    case SharedSpaceRole.Owner: {
+      return 'owner';
+    }
+    case SharedSpaceRole.Editor: {
+      return 'role_editor';
+    }
+    default: {
+      return 'role_viewer';
+    }
+  }
+}
 
 export interface SplitResult {
   pinned: SharedSpaceResponseDto[];


### PR DESCRIPTION
Fixes #946.

## The ✎ was invisible on a dark cover

`space-hero.svelte` rendered the edit menu with `ButtonContextMenu`'s default `ghost` variant. Ghost paints the icon with the **theme's** ink on a transparent background — `@immich/ui` resolves `ghost` + `secondary` to `text-dark`, which is near-black in the light theme.

The hero cover is a *photo*, not a themed surface, so a theme-tinted control is a coin toss against it. On the reporter's dark green cover the pencil all but vanished. (Dark theme has the mirror-image problem: a near-white icon that would disappear on a bright cover.)

Rather than nudge the opacity, this switches the control to `variant="filled"` + `buttonClass="icon-white-drop-shadow"` — the same recipe every other over-image context menu in the app already uses (`space-album-card.svelte`, both people pages). A filled chip carries its own background, so it contrasts with **itself** whatever the photo underneath happens to be, in both themes and on any cover.

Verified by rendering the top-right chrome through the app's real compiled Tailwind + `@immich/ui` theme over the cover from the issue:

| | before (`ghost`) | after (`filled`) |
|---|---|---|
| light theme | near-black ✎, no background — lost in the foliage | dark chip, white ✎ |
| dark theme | near-white ✎, no background — would vanish on a bright cover | light chip, dark ✎ |

## The role badge was untranslated

Reported in the same issue. The badge printed the raw lowercase `SharedSpaceRole` enum (`owner`), dressed up with CSS `capitalize` — which is why it read `Owner` in every locale.

It now goes through the `owner` / `role_editor` / `role_viewer` keys, which already exist and are already translated in all nine maintained locales, so **no i18n changes were needed**. `role-badge.svelte` had the same mapping inline, so both now share a `spaceRoleLabelKey` helper. Its return type is the literal key union rather than `string`, so `$t()` still type-checks the keys against `en.json`.

## Tests

TDD — all seven tests were watched failing first, including the `text-dark` assertion that pins the reported bug:

- `spaceRoleLabelKey` unit tests (three roles + unknown-role fallback to the least-privileged label)
- hero role badge renders `role_editor` / `role_viewer` rather than the raw enum. `$t` echoes keys back under test, so a badge reading `role_editor` is the proof it went through i18n at all. Deliberately **not** asserted for owner: the key and the raw enum value are both `owner`, so that test could not fail.
- hero edit control carries a background and is not painted `text-dark`

The e2e assertions on `hero-role-badge` (`permission-matrix`, `spaces-albums-journey`, `spaces-p1`) already matched case-insensitively and stay green — English renders `Owner` / `Editor` / `Viewer`. Their comments claiming a raw enum are updated.

Green: web unit suite 4347 passed, `check:typescript`, `check:svelte`, `lint`, prettier (web + e2e).

## Noted, not changed

The role badge itself is `bg-white/20 text-white`, which has the same weakness on a *bright* cover. It is not what was reported and darkening it is a design change rather than a bugfix, so it is left for a follow-up.