### PR TITLE
fix(spaces): unify shared-space album sort options across web and mobile (#966)

### DIFF
--- a/docs/superpowers/plans/2026-08-10-space-album-sort-parity.md
+++ b/docs/superpowers/plans/2026-08-10-space-album-sort-parity.md
@@ -492,8 +492,16 @@ it('defaults sort to RecentlyLinked desc and group to None', () => {
   expect(s.collapsedGroups).toEqual({});
 });
 
-// S23 — a stored preference must survive the default change
-it('prefers a stored sortBy over the new default', () => {
+// S23 — a stored preference must survive the default change.
+//
+// `persisted()` reads localStorage once, when the module is evaluated. Writing
+// to localStorage afterwards and calling `.update()` does NOT re-read it — this
+// was verified empirically against this repo: the naive version leaves sortBy at
+// the default and fails. The store must be re-imported after seeding storage.
+//
+// Keep this test LAST in the file: vi.resetModules() means later tests would
+// otherwise get a different store instance than the one imported at the top.
+it('prefers a stored sortBy over the new default', async () => {
   localStorage.setItem(
     'space-album-view-settings',
     JSON.stringify({
@@ -505,8 +513,10 @@ it('prefers a stored sortBy over the new default', () => {
       collapsedGroups: {},
     }),
   );
-  spaceAlbumViewSettings.update((s) => ({ ...s }));
-  expect(get(spaceAlbumViewSettings).sortBy).toBe(AlbumSortBy.Title);
+  vi.resetModules();
+  const reloaded = await import('$lib/stores/space-album-view-settings.store');
+  expect(get(reloaded.spaceAlbumViewSettings).sortBy).toBe(AlbumSortBy.Title);
+  expect(get(reloaded.spaceAlbumViewSettings).sortOrder).toBe(SortOrder.Asc);
 });
 ```
 
@@ -730,9 +740,10 @@ Implements S21, S27, S28, S29, and S10–S12 at the list level.
 
 In `web/src/lib/utils/space-album-grouping.spec.ts`, add the import and these tests:
 
+Add `spaceGroupOptionsMetadata` to the file's **existing** `$lib/utils/space-album-grouping` import rather than adding a second import statement for the same module (ESLint's zero-warning policy flags duplicate imports), and add one new import:
+
 ```ts
 import { SpaceAlbumSortBy } from '$lib/utils/space-album-sort';
-import { spaceGroupOptionsMetadata } from '$lib/utils/space-album-grouping';
 ```
 
 ```ts
@@ -773,9 +784,13 @@ describe('grouped lists sort within each group by Recently linked', () => {
       A({ id: '1', albumName: 'OwnerA-Early', ownerId: 'a', linkedAt: '2026-01-01T00:00:00Z' }),
       A({ id: '2', albumName: 'OwnerA-Late', ownerId: 'a', linkedAt: '2026-06-01T00:00:00Z' }),
     ];
+    // buildSpaceAlbumGroups returns SpaceAlbumGroup[] = { id, name, albums }.
+    // Owner grouping keys the group by ownerId, so select it by id rather than
+    // by album count — a length-based lookup would silently pick the wrong
+    // group if grouping ever changed.
     const groups = buildSpaceAlbumGroups(albums, settings, CTX);
-    const ownerAGroup = groups.find((g) => g.albums.length === 2)!;
-    expect(ownerAGroup.albums.map((a) => a.albumName)).toEqual(['OwnerA-Late', 'OwnerA-Early']);
+    const ownerAGroup = groups.find((g) => g.id === 'a');
+    expect(ownerAGroup?.albums.map((a) => a.albumName)).toEqual(['OwnerA-Late', 'OwnerA-Early']);
   });
 });
 ```
@@ -783,7 +798,9 @@ describe('grouped lists sort within each group by Recently linked', () => {
 In `web/src/lib/components/spaces/space-albums-list.spec.ts`, add a list-level ordering test (place it beside the existing render tests, reusing that file's `makeAlbum` factory and its render harness):
 
 ```ts
-// S10 at list level — the empty album renders last even though the sort is descending
+// S10 at list level — the empty album renders last even though the sort is
+// descending. `canManage` is a REQUIRED prop on this component; omitting it
+// breaks the render.
 it('renders albums with no photos last when sorting by Most recent photo', async () => {
   spaceAlbumViewSettings.update((s) => ({
     ...s,
@@ -793,6 +810,8 @@ it('renders albums with no photos last when sorting by Most recent photo', async
   }));
   render(SpaceAlbumsList, {
     props: {
+      spaceId: 'space-1',
+      canManage: false,
       albums: [
         makeAlbum({ id: 'empty', albumName: 'Empty', startDate: undefined, endDate: undefined }),
         makeAlbum({
@@ -803,12 +822,15 @@ it('renders albums with no photos last when sorting by Most recent photo', async
         }),
       ],
       members: [] as SharedSpaceMemberResponseDto[],
-      spaceId: 'space-1',
     },
   });
-  await waitFor(() => expect(screen.getByText('HasPhotos')).toBeInTheDocument());
-  const rendered = screen.getAllByText(/Empty|HasPhotos/).map((el) => el.textContent);
-  expect(rendered).toEqual(['HasPhotos', 'Empty']);
+
+  // Assert DOM order via the card testid rather than a text regex, so the
+  // assertion cannot be satisfied by incidental matches elsewhere in the tree.
+  await waitFor(() => expect(screen.getAllByTestId('space-album-card')).toHaveLength(2));
+  const order = screen.getAllByTestId('space-album-card').map((card) => card.textContent);
+  expect(order[0]).toContain('HasPhotos');
+  expect(order[1]).toContain('Empty');
 });
 ```
 
@@ -1075,7 +1097,7 @@ Add to the `watchLinkedAlbums` group in `mobile/test/medium/repositories/space_a
     });
 ```
 
-If `insertSharedSpaceAlbumLink` does not already accept `createdAt`, add an optional `DateTime? createdAt` parameter to it in `mobile/test/medium/repository_context.dart`, defaulting to `TestUtils.date(createdAt)` the same way `newSharedSpaceAlbum` does.
+No helper changes are needed: `insertSharedSpaceAlbumLink` already accepts `createdAt` (`mobile/test/medium/repository_context.dart:484`), `newSharedSpaceAlbum` already accepts `createdAt` (`:460`), and `newRemoteAsset` sets `localDateTime` from the `createdAt` you pass (`:137`), so passing `createdAt:` is how you control an asset's photo date.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -1172,6 +1194,8 @@ Run: `cd mobile && dart analyze lib test`
 ```
 
 For `mobile/test/pages/library/spaces/collection_sort_test.dart`, give the six `sample` entries distinct `createdAt` values so Task 7 can assert Date-created ordering, and add `createdAt` (plus optional `startDate`/`endDate`) parameters to its `_album` helper.
+
+For `mobile/test/presentation/pages/space_albums_page_test.dart`, add `createdAt` to its `_album` helper — Task 8 reuses that helper.
 
 Repeat `dart analyze lib test` until clean.
 
@@ -1487,30 +1511,36 @@ No production change — the menu is built from `SpaceAlbumSortMode.values` at `
 
 - [ ] **Step 1: Update the label assertions and add the new coverage**
 
-The suite asserts the literal `'Sort: Photo count'`; that label is now `'Sort: Number of items'`. Update it, then add:
+The existing `picking a different sort mode reorders the grid and persists the choice` test both taps `find.text('Photo count')` and asserts the literal `'Sort: Photo count'`. Both become `'Number of items'` / `'Sort: Number of items'`. Then add, using the same harness the file already uses (`tester.pumpConsumerWidget` + the file's `_overrides` and `_album` helpers):
 
 ```dart
-    testWidgets('offers all seven sort options in the menu', (tester) async {
-      await tester.pumpWidget(buildPage());
-      await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const Key('collection-sort-button-pill')));
-      await tester.pumpAndSettle();
+  testWidgets('offers all seven sort options in the menu', (tester) async {
+    await tester.pumpConsumerWidget(
+      const SpaceAlbumsPage(spaceId: spaceId, canEdit: true),
+      overrides: _overrides(
+        spaceId: spaceId,
+        albums: [_album(id: 'a1', name: 'Alpha'), _album(id: 'a2', name: 'Bravo')],
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('collection-sort-button-pill')));
+    await tester.pumpAndSettle();
 
-      for (final label in [
-        'Title',
-        'Number of items',
-        'Date modified',
-        'Date created',
-        'Most recent photo',
-        'Oldest photo',
-        'Recently linked',
-      ]) {
-        expect(find.text(label), findsWidgets, reason: 'missing sort option $label');
-      }
-    });
+    for (final label in [
+      'Title',
+      'Number of items',
+      'Date modified',
+      'Date created',
+      'Most recent photo',
+      'Oldest photo',
+      'Recently linked',
+    ]) {
+      expect(find.text(label), findsWidgets, reason: 'missing sort option $label');
+    }
+  });
 ```
 
-Use whatever page-building helper the file already defines in place of `buildPage()`.
+The menu needs at least one album to render — the page hides the search/sort chrome entirely when a space has zero linked albums (see the existing `a genuinely empty space still shows the empty state` test).
 
 - [ ] **Step 2: Run test to verify it fails, then passes**
 

--- a/docs/superpowers/plans/2026-08-10-space-album-sort-parity.md
+++ b/docs/superpowers/plans/2026-08-10-space-album-sort-parity.md
@@ -1,0 +1,1632 @@
+# Shared-Space Album Sort Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give a shared space's linked-album list the same seven sort options, in the same order, with the same default, on web and mobile (issue #966).
+
+**Architecture:** No server change — `GET /shared-spaces/{id}/albums` already returns every field needed. Web gains a fork-only sort layer (`space-album-sort.ts`) that adds `RecentlyLinked` and delegates the other six to upstream's `sortAlbums`, leaving upstream files byte-clean. Mobile derives `createdAt` and truncated photo-date aggregates from the Drift query that already runs, then extends its sort enum from four options to seven.
+
+**Tech Stack:** SvelteKit 5 + vitest + @testing-library/svelte (web); Flutter/Dart + Drift + flutter_test (mobile); shared `i18n/` at repo root.
+
+**Spec:** `docs/superpowers/specs/2026-08-10-space-album-sort-parity-design.md`. Scenario ids (S1–S29) below refer to its "Behaviour specification" section.
+
+## Global Constraints
+
+- **The unified contract is seven options in this exact order**, identical on both platforms: `Title` (`sort_title`, Asc), `ItemCount` (`sort_items`, Desc), `DateModified` (`sort_modified`, Desc), `DateCreated` (`sort_created`, Desc), `MostRecentPhoto` (`sort_recent`, Desc), `OldestPhoto` (`sort_oldest`, Desc), `RecentlyLinked` (`sort_recently_linked`, Desc).
+- **Default sort on both platforms: `RecentlyLinked`, descending.**
+- **Never rename an existing `SpaceAlbumSortMode` Dart identifier.** `EnumCodec` persists `value.name` and `decode` currently throws on an unknown name during app startup. `name`, `photoCount`, `recentlyUpdated`, `recentlyLinked` must keep their identifiers; only their labels change. New identifiers are `dateCreated`, `mostRecentPhoto`, `oldestPhoto`.
+- **Do not modify `web/src/lib/utils/album-utils.ts` or `web/src/lib/stores/preferences.store.ts`.** They are byte-identical to `upstream/main` and must stay that way.
+- **Do not modify `web/src/lib/components/spaces/space-albums-table.svelte`.** Out of scope.
+- **No new i18n keys.** All seven already exist in all ten maintained locales. Do not delete the now-unused `sort_photo_count` / `sort_recently_updated`.
+- **Mobile photo dates are truncated to a UTC calendar day** to match the server's `MIN/MAX((localDateTime AT TIME ZONE 'UTC')::date)`.
+- **Commit after every task.** Never use `git stash` (shared across worktrees); never add `Co-Authored-By` / `Generated-with` trailers.
+
+### One-time environment setup
+
+Run once before Task 1; not part of any task's commit.
+
+```bash
+# Repo root. The web suite cannot resolve `@immich/sdk` until this is built.
+pnpm install
+pnpm --filter @immich/sdk build
+
+# Mobile. Flutter is pinned to 3.44.8 in mobile/mise.toml; `mise install` can
+# symlink a different patch, so invoke the pinned binaries directly if `flutter
+# --version` disagrees:
+#   ~/.local/share/mise/installs/aqua-flutter-flutter/3.44.8/flutter/bin/flutter
+cd mobile
+flutter pub get
+dart run easy_localization:generate -S ../i18n
+dart run bin/generate_keys.dart
+```
+
+`mobile/lib/generated/*.g.dart` is gitignored; without those two `dart run` steps every mobile test fails to compile. Drift and OpenAPI generated code is committed, so `build_runner` is not needed.
+
+### Verification gates (run before opening the PR)
+
+```bash
+cd web    && pnpm exec vitest run && pnpm check:typescript && pnpm check:svelte && pnpm lint
+cd mobile && dart format --set-exit-if-changed lib test && dart analyze --fatal-infos lib test && flutter test
+npx prettier --check docs/superpowers/**/*.md
+```
+
+`dart format` and `dart analyze --fatal-infos` are **two separate CI gates**; passing one does not imply the other.
+
+---
+
+## File Structure
+
+**Web — create:**
+
+- `web/src/lib/utils/space-album-sort.ts` — the fork-only seven-option metadata, the finder, and `sortSpaceAlbums`. Sole owner of "what sort options a space album list has".
+- `web/src/lib/utils/space-album-sort.spec.ts` — unit tests for the above.
+
+**Web — modify:**
+
+- `web/src/lib/stores/space-album-view-settings.store.ts` — default `sortBy`.
+- `web/src/lib/components/spaces/space-albums-controls.svelte` — render seven options; fix the wrong-label bug.
+- `web/src/lib/components/spaces/space-albums-list.svelte` — call `sortSpaceAlbums`.
+- `web/src/lib/utils/space-album-grouping.ts` — disable Year for `RecentlyLinked`; per-group sort via `sortSpaceAlbums`.
+
+**Mobile — modify:**
+
+- `mobile/lib/domain/models/value_codec.dart` — `EnumCodec` fallback instead of throw.
+- `mobile/lib/domain/models/settings_key.dart` — declare the fallback for the two space sort keys.
+- `mobile/lib/domain/models/space_album.model.dart` — `createdAt`, `startDate`, `endDate`.
+- `mobile/lib/infrastructure/repositories/space_album.repository.dart` — project `createdAt`; add truncated `min`/`max` aggregates.
+- `mobile/lib/pages/library/spaces/collection_sort.dart` — seven modes; three new comparator arms; empty-album rule.
+
+---
+
+## Task 1: Web sort module
+
+Implements S1, S4–S12, S14, S17–S19, S26 (comparator half).
+
+**Files:**
+
+- Create: `web/src/lib/utils/space-album-sort.ts`
+- Create: `web/src/lib/utils/space-album-sort.spec.ts`
+
+**Interfaces:**
+
+- Consumes: upstream `sortAlbums`, `sortOptionsMetadata`, `stringToSortOrder` from `$lib/utils/album-utils`; `AlbumSortBy`, `SortOrder` from `$lib/stores/preferences.store`.
+- Produces:
+  - `SpaceAlbumSortBy` — const object; `AlbumSortBy`'s six values plus `RecentlyLinked: 'RecentlyLinked'`.
+  - `type SpaceAlbumSortOptionMetadata = { id: string; defaultOrder: SortOrder; columnStyle: string }`
+  - `spaceAlbumSortOptionsMetadata: SpaceAlbumSortOptionMetadata[]` — seven entries in contract order.
+  - `findSpaceAlbumSortOptionMetadata(sortBy: string): SpaceAlbumSortOptionMetadata`
+  - `sortSpaceAlbums(albums: SharedSpaceLinkedAlbumDto[], opts: { sortBy: string; orderBy: string }): SharedSpaceLinkedAlbumDto[]`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/lib/utils/space-album-sort.spec.ts`:
+
+```ts
+import type { SharedSpaceLinkedAlbumDto } from '@immich/sdk';
+import { AlbumSortBy, SortOrder } from '$lib/stores/preferences.store';
+import {
+  SpaceAlbumSortBy,
+  findSpaceAlbumSortOptionMetadata,
+  sortSpaceAlbums,
+  spaceAlbumSortOptionsMetadata,
+} from '$lib/utils/space-album-sort';
+
+const A = (o: Partial<SharedSpaceLinkedAlbumDto>): SharedSpaceLinkedAlbumDto => ({
+  id: 'x',
+  ownerId: 'owner-1',
+  albumName: 'A',
+  assetCount: 0,
+  albumThumbnailAssetId: null,
+  showInTimeline: true,
+  addedById: null,
+  linkedAt: '2026-01-01T00:00:00.000Z',
+  description: '',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  shared: false,
+  hasSharedLink: false,
+  isActivityEnabled: false,
+  ...o,
+});
+
+const names = (albums: SharedSpaceLinkedAlbumDto[]) => albums.map((a) => a.albumName);
+
+describe('spaceAlbumSortOptionsMetadata', () => {
+  it('lists the seven contract options in order', () => {
+    expect(spaceAlbumSortOptionsMetadata.map(({ id }) => id)).toEqual([
+      AlbumSortBy.Title,
+      AlbumSortBy.ItemCount,
+      AlbumSortBy.DateModified,
+      AlbumSortBy.DateCreated,
+      AlbumSortBy.MostRecentPhoto,
+      AlbumSortBy.OldestPhoto,
+      SpaceAlbumSortBy.RecentlyLinked,
+    ]);
+  });
+
+  it('defaults Title to ascending and every other option to descending', () => {
+    const byId = new Map(spaceAlbumSortOptionsMetadata.map((o) => [o.id, o.defaultOrder]));
+    expect(byId.get(AlbumSortBy.Title)).toBe(SortOrder.Asc);
+    for (const id of [
+      AlbumSortBy.ItemCount,
+      AlbumSortBy.DateModified,
+      AlbumSortBy.DateCreated,
+      AlbumSortBy.MostRecentPhoto,
+      AlbumSortBy.OldestPhoto,
+      SpaceAlbumSortBy.RecentlyLinked,
+    ]) {
+      expect(byId.get(id)).toBe(SortOrder.Desc);
+    }
+  });
+});
+
+describe('findSpaceAlbumSortOptionMetadata', () => {
+  it('finds a known option', () => {
+    expect(findSpaceAlbumSortOptionMetadata(AlbumSortBy.Title).id).toBe(AlbumSortBy.Title);
+    expect(findSpaceAlbumSortOptionMetadata(SpaceAlbumSortBy.RecentlyLinked).id).toBe(SpaceAlbumSortBy.RecentlyLinked);
+  });
+
+  // S26
+  it('falls back to RecentlyLinked for an unrecognised value', () => {
+    expect(findSpaceAlbumSortOptionMetadata('NotASort').id).toBe(SpaceAlbumSortBy.RecentlyLinked);
+    expect(findSpaceAlbumSortOptionMetadata('').id).toBe(SpaceAlbumSortBy.RecentlyLinked);
+  });
+});
+
+describe('sortSpaceAlbums delegates the six upstream options', () => {
+  // S1
+  it('sorts by Title ascending, case-insensitively', () => {
+    const albums = [A({ albumName: 'beach' }), A({ albumName: 'Apple' }), A({ albumName: 'Zoo' })];
+    expect(names(sortSpaceAlbums(albums, { sortBy: AlbumSortBy.Title, orderBy: SortOrder.Asc }))).toEqual([
+      'Apple',
+      'beach',
+      'Zoo',
+    ]);
+  });
+
+  // S4
+  it('sorts by Number of items descending', () => {
+    const albums = [
+      A({ albumName: 'Small', assetCount: 1 }),
+      A({ albumName: 'Big', assetCount: 9 }),
+      A({ albumName: 'Mid', assetCount: 5 }),
+    ];
+    expect(names(sortSpaceAlbums(albums, { sortBy: AlbumSortBy.ItemCount, orderBy: SortOrder.Desc }))).toEqual([
+      'Big',
+      'Mid',
+      'Small',
+    ]);
+  });
+
+  // S5
+  it('sorts by Date modified descending', () => {
+    const albums = [
+      A({ albumName: 'Jan3', updatedAt: '2026-01-03T00:00:00.000Z' }),
+      A({ albumName: 'Jan1', updatedAt: '2026-01-01T00:00:00.000Z' }),
+      A({ albumName: 'Jan2', updatedAt: '2026-01-02T00:00:00.000Z' }),
+    ];
+    expect(names(sortSpaceAlbums(albums, { sortBy: AlbumSortBy.DateModified, orderBy: SortOrder.Desc }))).toEqual([
+      'Jan3',
+      'Jan2',
+      'Jan1',
+    ]);
+  });
+
+  // S6 — createdAt order is the reverse of linkedAt order for this fixture
+  it('sorts by Date created descending, independently of linkedAt', () => {
+    const albums = [
+      A({ albumName: 'Old', createdAt: '2026-01-01T00:00:00.000Z', linkedAt: '2026-03-01T00:00:00.000Z' }),
+      A({ albumName: 'New', createdAt: '2026-02-01T00:00:00.000Z', linkedAt: '2026-02-02T00:00:00.000Z' }),
+    ];
+    expect(names(sortSpaceAlbums(albums, { sortBy: AlbumSortBy.DateCreated, orderBy: SortOrder.Desc }))).toEqual([
+      'New',
+      'Old',
+    ]);
+  });
+
+  // S7 — B's newest is later than A's, but B's oldest is earlier than A's,
+  // so a comparator wired to the wrong field produces the opposite order.
+  it('sorts by Most recent photo descending', () => {
+    const albums = [
+      A({ albumName: 'A', startDate: '2026-01-05T00:00:00.000Z', endDate: '2026-01-10T00:00:00.000Z' }),
+      A({ albumName: 'B', startDate: '2026-01-01T00:00:00.000Z', endDate: '2026-01-20T00:00:00.000Z' }),
+    ];
+    expect(names(sortSpaceAlbums(albums, { sortBy: AlbumSortBy.MostRecentPhoto, orderBy: SortOrder.Desc }))).toEqual([
+      'B',
+      'A',
+    ]);
+  });
+
+  // S8 — same fixture, opposite field. Descending is asserted too: it yields
+  // ['A','B'] where MostRecentPhoto descending yields ['B','A'], so a
+  // comparator reading endDate here would fail rather than coincidentally pass.
+  it('sorts by Oldest photo in both directions', () => {
+    const albums = () => [
+      A({ albumName: 'A', startDate: '2026-01-05T00:00:00.000Z', endDate: '2026-01-10T00:00:00.000Z' }),
+      A({ albumName: 'B', startDate: '2026-01-01T00:00:00.000Z', endDate: '2026-01-20T00:00:00.000Z' }),
+    ];
+    expect(names(sortSpaceAlbums(albums(), { sortBy: AlbumSortBy.OldestPhoto, orderBy: SortOrder.Asc }))).toEqual([
+      'B',
+      'A',
+    ]);
+    expect(names(sortSpaceAlbums(albums(), { sortBy: AlbumSortBy.OldestPhoto, orderBy: SortOrder.Desc }))).toEqual([
+      'A',
+      'B',
+    ]);
+  });
+});
+
+describe('sortSpaceAlbums RecentlyLinked', () => {
+  const albums = () => [
+    A({ albumName: 'Old', createdAt: '2026-01-01T00:00:00.000Z', linkedAt: '2026-03-01T00:00:00.000Z' }),
+    A({ albumName: 'New', createdAt: '2026-02-01T00:00:00.000Z', linkedAt: '2026-02-02T00:00:00.000Z' }),
+  ];
+
+  // S9
+  it('puts the most recently linked album first when descending', () => {
+    expect(
+      names(sortSpaceAlbums(albums(), { sortBy: SpaceAlbumSortBy.RecentlyLinked, orderBy: SortOrder.Desc })),
+    ).toEqual(['Old', 'New']);
+  });
+
+  // S2 (comparator half)
+  it('reverses when ascending', () => {
+    expect(
+      names(sortSpaceAlbums(albums(), { sortBy: SpaceAlbumSortBy.RecentlyLinked, orderBy: SortOrder.Asc })),
+    ).toEqual(['New', 'Old']);
+  });
+
+  // S17 — bulk-linked albums share a linkedAt; order must be stable, not arbitrary
+  it('keeps a stable order for identical linkedAt values', () => {
+    const tied = [
+      A({ id: 'a', albumName: 'First', linkedAt: '2026-01-01T00:00:00.000Z' }),
+      A({ id: 'b', albumName: 'Second', linkedAt: '2026-01-01T00:00:00.000Z' }),
+      A({ id: 'c', albumName: 'Third', linkedAt: '2026-01-01T00:00:00.000Z' }),
+    ];
+    const once = names(sortSpaceAlbums(tied, { sortBy: SpaceAlbumSortBy.RecentlyLinked, orderBy: SortOrder.Desc }));
+    const twice = names(sortSpaceAlbums(tied, { sortBy: SpaceAlbumSortBy.RecentlyLinked, orderBy: SortOrder.Desc }));
+    expect(once).toEqual(['First', 'Second', 'Third']);
+    expect(twice).toEqual(once);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = albums();
+    sortSpaceAlbums(input, { sortBy: SpaceAlbumSortBy.RecentlyLinked, orderBy: SortOrder.Desc });
+    expect(names(input)).toEqual(['Old', 'New']);
+  });
+});
+
+// S26 — the pill label and the applied ordering must agree
+describe('sortSpaceAlbums unknown sortBy', () => {
+  it('orders by RecentlyLinked, matching what the finder reports', () => {
+    // updatedAt and linkedAt deliberately disagree, so falling through to
+    // upstream's DateModified fallback produces the opposite order.
+    const albums = [
+      A({ albumName: 'ByUpdated', updatedAt: '2026-09-01T00:00:00.000Z', linkedAt: '2026-01-01T00:00:00.000Z' }),
+      A({ albumName: 'ByLinked', updatedAt: '2026-01-01T00:00:00.000Z', linkedAt: '2026-09-01T00:00:00.000Z' }),
+    ];
+    expect(names(sortSpaceAlbums(albums, { sortBy: 'NotASort', orderBy: SortOrder.Desc }))).toEqual([
+      'ByLinked',
+      'ByUpdated',
+    ]);
+    expect(findSpaceAlbumSortOptionMetadata('NotASort').id).toBe(SpaceAlbumSortBy.RecentlyLinked);
+  });
+});
+
+// S10–S12, S14
+describe('sortSpaceAlbums albums without photo dates', () => {
+  const mixed = () => [
+    A({ albumName: 'Empty', startDate: undefined, endDate: undefined }),
+    A({ albumName: 'HasPhotos', startDate: '2026-01-01T00:00:00.000Z', endDate: '2026-01-10T00:00:00.000Z' }),
+  ];
+
+  it('puts the album with no photos last, descending (S10)', () => {
+    expect(names(sortSpaceAlbums(mixed(), { sortBy: AlbumSortBy.MostRecentPhoto, orderBy: SortOrder.Desc }))).toEqual([
+      'HasPhotos',
+      'Empty',
+    ]);
+  });
+
+  it('puts the album with no photos last, ascending too (S11)', () => {
+    expect(names(sortSpaceAlbums(mixed(), { sortBy: AlbumSortBy.MostRecentPhoto, orderBy: SortOrder.Asc }))).toEqual([
+      'HasPhotos',
+      'Empty',
+    ]);
+  });
+
+  it('applies the same rule to Oldest photo in both directions (S12)', () => {
+    expect(names(sortSpaceAlbums(mixed(), { sortBy: AlbumSortBy.OldestPhoto, orderBy: SortOrder.Desc }))).toEqual([
+      'HasPhotos',
+      'Empty',
+    ]);
+    expect(names(sortSpaceAlbums(mixed(), { sortBy: AlbumSortBy.OldestPhoto, orderBy: SortOrder.Asc }))).toEqual([
+      'HasPhotos',
+      'Empty',
+    ]);
+  });
+
+  it('keeps every album when none has photo dates (S14)', () => {
+    const none = [A({ albumName: 'One' }), A({ albumName: 'Two' }), A({ albumName: 'Three' })];
+    const sorted = sortSpaceAlbums(none, { sortBy: AlbumSortBy.MostRecentPhoto, orderBy: SortOrder.Desc });
+    expect(sorted).toHaveLength(3);
+    expect(new Set(names(sorted))).toEqual(new Set(['One', 'Two', 'Three']));
+  });
+});
+
+// S18, S19
+describe('sortSpaceAlbums boundary inputs', () => {
+  const everyOption = spaceAlbumSortOptionsMetadata.map(({ id }) => id);
+
+  it('returns an empty array for every option and direction', () => {
+    for (const sortBy of everyOption) {
+      for (const orderBy of [SortOrder.Asc, SortOrder.Desc]) {
+        expect(sortSpaceAlbums([], { sortBy, orderBy })).toEqual([]);
+      }
+    }
+  });
+
+  it('returns a single album unchanged for every option and direction', () => {
+    for (const sortBy of everyOption) {
+      for (const orderBy of [SortOrder.Asc, SortOrder.Desc]) {
+        expect(names(sortSpaceAlbums([A({ albumName: 'Only' })], { sortBy, orderBy }))).toEqual(['Only']);
+      }
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && pnpm exec vitest run src/lib/utils/space-album-sort.spec.ts`
+Expected: FAIL — `Failed to resolve import "$lib/utils/space-album-sort"`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `web/src/lib/utils/space-album-sort.ts`:
+
+```ts
+import type { AlbumResponseDto, SharedSpaceLinkedAlbumDto } from '@immich/sdk';
+import { orderBy } from 'lodash-es';
+import { AlbumSortBy, SortOrder } from '$lib/stores/preferences.store';
+import { sortAlbums, sortOptionsMetadata, stringToSortOrder } from '$lib/utils/album-utils';
+
+/**
+ * Space album lists offer everything the regular album list offers, plus
+ * `RecentlyLinked` — when the album was linked into *this* space. That option
+ * lives here rather than in upstream's `AlbumSortBy` on purpose: the regular
+ * /albums page iterates upstream's `sortOptionsMetadata`, and `linkedAt` does
+ * not exist on `AlbumResponseDto`, so adding it upstream would surface a dead
+ * option there (and dirty a file we keep byte-clean for rebases).
+ */
+export const SpaceAlbumSortBy = {
+  ...AlbumSortBy,
+  RecentlyLinked: 'RecentlyLinked',
+} as const;
+
+export interface SpaceAlbumSortOptionMetadata {
+  id: string;
+  defaultOrder: SortOrder;
+  columnStyle: string;
+}
+
+export const spaceAlbumSortOptionsMetadata: SpaceAlbumSortOptionMetadata[] = [
+  ...sortOptionsMetadata,
+  {
+    id: SpaceAlbumSortBy.RecentlyLinked,
+    defaultOrder: SortOrder.Desc,
+    columnStyle: 'text-center hidden xl:block xl:w-[15%] 2xl:w-[12%]',
+  },
+];
+
+const defaultSortOption = spaceAlbumSortOptionsMetadata.at(-1) as SpaceAlbumSortOptionMetadata;
+
+export const findSpaceAlbumSortOptionMetadata = (sortBy: string): SpaceAlbumSortOptionMetadata =>
+  spaceAlbumSortOptionsMetadata.find(({ id }) => id === sortBy) ?? defaultSortOption;
+
+/**
+ * Resolve `sortBy` through the finder *before* delegating. Upstream's
+ * `sortAlbums` falls back to `DateModified` for an unknown key while upstream's
+ * `findSortOptionMetadata` falls back to `MostRecentPhoto` — passing an unknown
+ * key straight through would show one option's label while applying another's
+ * order.
+ */
+export const sortSpaceAlbums = (
+  albums: SharedSpaceLinkedAlbumDto[],
+  { sortBy, orderBy: order }: { sortBy: string; orderBy: string },
+): SharedSpaceLinkedAlbumDto[] => {
+  const { id } = findSpaceAlbumSortOptionMetadata(sortBy);
+
+  if (id === SpaceAlbumSortBy.RecentlyLinked) {
+    return orderBy(albums, [({ linkedAt }) => new Date(linkedAt)], [stringToSortOrder(order)]);
+  }
+
+  return sortAlbums(albums as unknown as AlbumResponseDto[], {
+    sortBy: id,
+    orderBy: order,
+  }) as unknown as SharedSpaceLinkedAlbumDto[];
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd web && pnpm exec vitest run src/lib/utils/space-album-sort.spec.ts`
+Expected: PASS, all tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/lib/utils/space-album-sort.ts web/src/lib/utils/space-album-sort.spec.ts
+git commit -m "feat(web): add fork-only space album sort layer with Recently linked (#966)"
+```
+
+---
+
+## Task 2: Web store default
+
+Implements S22, S23.
+
+**Files:**
+
+- Modify: `web/src/lib/stores/space-album-view-settings.store.ts:22`
+- Test: `web/src/lib/stores/space-album-view-settings.store.spec.ts:14`
+
+**Interfaces:**
+
+- Consumes: `SpaceAlbumSortBy` from Task 1.
+- Produces: `spaceAlbumViewSettings` store whose default `sortBy` is `'RecentlyLinked'`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `web/src/lib/stores/space-album-view-settings.store.spec.ts`, add the import and replace the existing `defaults sort to MostRecentPhoto desc and group to None` test (line 14) with:
+
+```ts
+import { SpaceAlbumSortBy } from '$lib/utils/space-album-sort';
+```
+
+```ts
+it('defaults sort to RecentlyLinked desc and group to None', () => {
+  const s = get(spaceAlbumViewSettings);
+  expect(s.sortBy).toBe(SpaceAlbumSortBy.RecentlyLinked);
+  expect(s.sortOrder).toBe(SortOrder.Desc);
+  expect(s.groupBy).toBe(SpaceAlbumGroupBy.None);
+  expect(s.collapsedGroups).toEqual({});
+});
+
+// S23 — a stored preference must survive the default change
+it('prefers a stored sortBy over the new default', () => {
+  localStorage.setItem(
+    'space-album-view-settings',
+    JSON.stringify({
+      view: AlbumViewMode.Cover,
+      sortBy: AlbumSortBy.Title,
+      sortOrder: SortOrder.Asc,
+      groupBy: SpaceAlbumGroupBy.None,
+      groupOrder: SortOrder.Desc,
+      collapsedGroups: {},
+    }),
+  );
+  spaceAlbumViewSettings.update((s) => ({ ...s }));
+  expect(get(spaceAlbumViewSettings).sortBy).toBe(AlbumSortBy.Title);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && pnpm exec vitest run src/lib/stores/space-album-view-settings.store.spec.ts`
+Expected: FAIL — `expected 'MostRecentPhoto' to be 'RecentlyLinked'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `web/src/lib/stores/space-album-view-settings.store.ts`, change the import line and the default:
+
+```ts
+import { persisted } from 'svelte-persisted-store';
+import { AlbumViewMode, SortOrder } from '$lib/stores/preferences.store';
+import { SpaceAlbumSortBy } from '$lib/utils/space-album-sort';
+```
+
+```ts
+export const spaceAlbumViewSettings = persisted<SpaceAlbumViewSettings>('space-album-view-settings', {
+  view: AlbumViewMode.Cover,
+  sortBy: SpaceAlbumSortBy.RecentlyLinked,
+  sortOrder: SortOrder.Desc,
+  groupBy: SpaceAlbumGroupBy.None,
+  groupOrder: SortOrder.Desc,
+  collapsedGroups: {},
+});
+```
+
+`AlbumSortBy` is no longer referenced in this file — remove it from the import to keep `pnpm lint` (zero-warnings) green.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd web && pnpm exec vitest run src/lib/stores/space-album-view-settings.store.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/lib/stores/space-album-view-settings.store.ts web/src/lib/stores/space-album-view-settings.store.spec.ts
+git commit -m "feat(web): default space album sort to Recently linked (#966)"
+```
+
+---
+
+## Task 3: Web controls
+
+Implements S2, S3, and the label half of S26.
+
+**Files:**
+
+- Modify: `web/src/lib/components/spaces/space-albums-controls.svelte` (lines 2–4, 45, 80, 86–93, 127, 136, 144)
+- Test: `web/src/lib/components/spaces/space-albums-controls.spec.ts`
+
+**Interfaces:**
+
+- Consumes: `spaceAlbumSortOptionsMetadata`, `findSpaceAlbumSortOptionMetadata`, `SpaceAlbumSortBy`, `type SpaceAlbumSortOptionMetadata` from Task 1.
+
+- [ ] **Step 1: Write the failing test**
+
+In `web/src/lib/components/spaces/space-albums-controls.spec.ts`: add the import, change `freshSpaceSettings()` to the new default, rename the six-label test, and add the label-correctness test.
+
+```ts
+import { SpaceAlbumSortBy } from '$lib/utils/space-album-sort';
+```
+
+```ts
+const freshSpaceSettings = () => ({
+  view: AlbumViewMode.Cover,
+  sortBy: SpaceAlbumSortBy.RecentlyLinked,
+  sortOrder: SortOrder.Desc,
+  groupBy: SpaceAlbumGroupBy.None,
+  groupOrder: SortOrder.Desc,
+  collapsedGroups: {},
+});
+```
+
+Replace the `renders all six sort option labels when dropdown is opened` test with:
+
+```ts
+it('renders all seven sort option labels when dropdown is opened', async () => {
+  render(SpaceAlbumsControls);
+  await userEvent.click(screen.getByTestId('space-albums-sort-btn'));
+  const menu = screen.getByTestId('space-albums-sort-menu');
+  expect(within(menu).getByText('Title')).toBeInTheDocument();
+  expect(within(menu).getByText('Number of items')).toBeInTheDocument();
+  expect(within(menu).getByText('Date modified')).toBeInTheDocument();
+  expect(within(menu).getByText('Date created')).toBeInTheDocument();
+  expect(within(menu).getByText('Most recent photo')).toBeInTheDocument();
+  expect(within(menu).getByText('Oldest photo')).toBeInTheDocument();
+  expect(within(menu).getByText('Recently linked')).toBeInTheDocument();
+});
+
+it('writes RecentlyLinked to the space store when "Recently linked" is selected', async () => {
+  spaceAlbumViewSettings.set({ ...freshSpaceSettings(), sortBy: AlbumSortBy.Title, sortOrder: SortOrder.Asc });
+  render(SpaceAlbumsControls);
+  await userEvent.click(screen.getByTestId('space-albums-sort-btn'));
+  await userEvent.click(screen.getByTestId('space-albums-sort-option-RecentlyLinked'));
+  expect(get(spaceAlbumViewSettings).sortBy).toBe(SpaceAlbumSortBy.RecentlyLinked);
+  // S3 — a newly selected option applies its own default direction
+  expect(get(spaceAlbumViewSettings).sortOrder).toBe(SortOrder.Desc);
+});
+
+// The trigger previously resolved its label through upstream's
+// findSortOptionMetadata, which falls back to MostRecentPhoto for any id it
+// does not know — so RecentlyLinked rendered as "Most recent photo".
+it('shows the Recently linked label on the trigger when that option is active', () => {
+  spaceAlbumViewSettings.set({ ...freshSpaceSettings(), sortBy: SpaceAlbumSortBy.RecentlyLinked });
+  render(SpaceAlbumsControls);
+  expect(screen.getByTestId('space-albums-sort-btn')).toHaveTextContent('Recently linked');
+});
+
+// S2
+it('toggles sort order when Recently linked is re-selected', async () => {
+  spaceAlbumViewSettings.set({
+    ...freshSpaceSettings(),
+    sortBy: SpaceAlbumSortBy.RecentlyLinked,
+    sortOrder: SortOrder.Desc,
+  });
+  render(SpaceAlbumsControls);
+  await userEvent.click(screen.getByTestId('space-albums-sort-btn'));
+  await userEvent.click(screen.getByTestId('space-albums-sort-option-RecentlyLinked'));
+  expect(get(spaceAlbumViewSettings).sortOrder).toBe(SortOrder.Asc);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && pnpm exec vitest run src/lib/components/spaces/space-albums-controls.spec.ts`
+Expected: FAIL — `Unable to find an element by: [data-testid="space-albums-sort-option-RecentlyLinked"]`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `web/src/lib/components/spaces/space-albums-controls.svelte`:
+
+Replace the album-utils import (line 4) with the fork-only one:
+
+```svelte
+  import {
+    type SpaceAlbumSortOptionMetadata,
+    SpaceAlbumSortBy,
+    findSpaceAlbumSortOptionMetadata,
+    spaceAlbumSortOptionsMetadata,
+  } from '$lib/utils/space-album-sort';
+```
+
+Change `handleChangeSortBy`'s parameter type (line 45):
+
+```svelte
+  const handleChangeSortBy = ({ id, defaultOrder }: SpaceAlbumSortOptionMetadata) => {
+```
+
+Change the derived selection (line 80):
+
+```svelte
+  let selectedSortOption = $derived(findSpaceAlbumSortOptionMetadata($spaceAlbumViewSettings.sortBy));
+```
+
+Replace the label record (lines 86–93):
+
+```svelte
+  let albumSortByNames: Record<string, string> = $derived({
+    [SpaceAlbumSortBy.Title]: $t('sort_title'),
+    [SpaceAlbumSortBy.ItemCount]: $t('sort_items'),
+    [SpaceAlbumSortBy.DateModified]: $t('sort_modified'),
+    [SpaceAlbumSortBy.DateCreated]: $t('sort_created'),
+    [SpaceAlbumSortBy.MostRecentPhoto]: $t('sort_recent'),
+    [SpaceAlbumSortBy.OldestPhoto]: $t('sort_oldest'),
+    [SpaceAlbumSortBy.RecentlyLinked]: $t('sort_recently_linked'),
+  });
+```
+
+Drop the now-invalid casts at the two usage sites (lines 127 and 144):
+
+```svelte
+        <span class="hidden sm:inline">{albumSortByNames[selectedSortOption.id]}</span>
+```
+
+```svelte
+              {albumSortByNames[option.id]}
+```
+
+And iterate the fork-only metadata (line 136):
+
+```svelte
+          {#each spaceAlbumSortOptionsMetadata as option (option.id)}
+```
+
+`AlbumSortBy` is still imported from `preferences.store` for other uses in this file; if `pnpm lint` reports it unused after these edits, remove it from the import.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd web && pnpm exec vitest run src/lib/components/spaces/space-albums-controls.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/lib/components/spaces/space-albums-controls.svelte web/src/lib/components/spaces/space-albums-controls.spec.ts
+git commit -m "feat(web): offer Recently linked in the space album sort menu (#966)"
+```
+
+---
+
+## Task 4: Web list and grouping
+
+Implements S21, S27, S28, S29, and S10–S12 at the list level.
+
+**Files:**
+
+- Modify: `web/src/lib/components/spaces/space-albums-list.svelte:53-58`
+- Modify: `web/src/lib/utils/space-album-grouping.ts:40`, `:268-274`
+- Test: `web/src/lib/utils/space-album-grouping.spec.ts`
+- Test: `web/src/lib/components/spaces/space-albums-list.spec.ts`
+
+**Interfaces:**
+
+- Consumes: `sortSpaceAlbums`, `SpaceAlbumSortBy` from Task 1.
+
+- [ ] **Step 1: Write the failing test**
+
+In `web/src/lib/utils/space-album-grouping.spec.ts`, add the import and these tests:
+
+```ts
+import { SpaceAlbumSortBy } from '$lib/utils/space-album-sort';
+import { spaceGroupOptionsMetadata } from '$lib/utils/space-album-grouping';
+```
+
+```ts
+// S27
+describe('Year grouping availability', () => {
+  const yearOption = () => spaceGroupOptionsMetadata.find(({ id }) => id === SpaceAlbumGroupBy.Year)!;
+
+  it('is disabled while sorting by Recently linked', () => {
+    spaceAlbumViewSettings.update((s) => ({ ...s, sortBy: SpaceAlbumSortBy.RecentlyLinked }));
+    expect(yearOption().isDisabled()).toBe(true);
+  });
+
+  it('stays disabled for Date created and Date modified', () => {
+    spaceAlbumViewSettings.update((s) => ({ ...s, sortBy: AlbumSortBy.DateCreated }));
+    expect(yearOption().isDisabled()).toBe(true);
+    spaceAlbumViewSettings.update((s) => ({ ...s, sortBy: AlbumSortBy.DateModified }));
+    expect(yearOption().isDisabled()).toBe(true);
+  });
+
+  it('is enabled for the photo-date sorts', () => {
+    spaceAlbumViewSettings.update((s) => ({ ...s, sortBy: AlbumSortBy.MostRecentPhoto }));
+    expect(yearOption().isDisabled()).toBe(false);
+    spaceAlbumViewSettings.update((s) => ({ ...s, sortBy: AlbumSortBy.OldestPhoto }));
+    expect(yearOption().isDisabled()).toBe(false);
+  });
+});
+
+// S28
+describe('grouped lists sort within each group by Recently linked', () => {
+  it('orders each group by linkedAt descending', () => {
+    const settings = {
+      ...get(spaceAlbumViewSettings),
+      groupBy: SpaceAlbumGroupBy.Owner,
+      sortBy: SpaceAlbumSortBy.RecentlyLinked,
+      sortOrder: SortOrder.Desc,
+    };
+    const albums = [
+      A({ id: '1', albumName: 'OwnerA-Early', ownerId: 'a', linkedAt: '2026-01-01T00:00:00Z' }),
+      A({ id: '2', albumName: 'OwnerA-Late', ownerId: 'a', linkedAt: '2026-06-01T00:00:00Z' }),
+    ];
+    const groups = buildSpaceAlbumGroups(albums, settings, CTX);
+    const ownerAGroup = groups.find((g) => g.albums.length === 2)!;
+    expect(ownerAGroup.albums.map((a) => a.albumName)).toEqual(['OwnerA-Late', 'OwnerA-Early']);
+  });
+});
+```
+
+In `web/src/lib/components/spaces/space-albums-list.spec.ts`, add a list-level ordering test (place it beside the existing render tests, reusing that file's `makeAlbum` factory and its render harness):
+
+```ts
+// S10 at list level — the empty album renders last even though the sort is descending
+it('renders albums with no photos last when sorting by Most recent photo', async () => {
+  spaceAlbumViewSettings.update((s) => ({
+    ...s,
+    sortBy: AlbumSortBy.MostRecentPhoto,
+    sortOrder: SortOrder.Desc,
+    groupBy: SpaceAlbumGroupBy.None,
+  }));
+  render(SpaceAlbumsList, {
+    props: {
+      albums: [
+        makeAlbum({ id: 'empty', albumName: 'Empty', startDate: undefined, endDate: undefined }),
+        makeAlbum({
+          id: 'full',
+          albumName: 'HasPhotos',
+          startDate: '2026-01-01T00:00:00.000Z',
+          endDate: '2026-01-10T00:00:00.000Z',
+        }),
+      ],
+      members: [] as SharedSpaceMemberResponseDto[],
+      spaceId: 'space-1',
+    },
+  });
+  await waitFor(() => expect(screen.getByText('HasPhotos')).toBeInTheDocument());
+  const rendered = screen.getAllByText(/Empty|HasPhotos/).map((el) => el.textContent);
+  expect(rendered).toEqual(['HasPhotos', 'Empty']);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && pnpm exec vitest run src/lib/utils/space-album-grouping.spec.ts src/lib/components/spaces/space-albums-list.spec.ts`
+Expected: FAIL — `expected false to be true` on the Recently-linked Year-disabled test.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `web/src/lib/utils/space-album-grouping.ts`, add the import, extend the disabled list (line 40), and switch the per-group sort (around line 268):
+
+```ts
+import { sortSpaceAlbums, SpaceAlbumSortBy } from '$lib/utils/space-album-sort';
+```
+
+```ts
+    isDisabled() {
+      const disabledWithSortOptions: string[] = [
+        AlbumSortBy.DateCreated,
+        AlbumSortBy.DateModified,
+        SpaceAlbumSortBy.RecentlyLinked,
+      ];
+      return disabledWithSortOptions.includes(get(spaceAlbumViewSettings).sortBy);
+    },
+```
+
+Replace the `sortAlbums(...)` call in the per-group re-sort with `sortSpaceAlbums(...)`, dropping the `AlbumResponseDto` casts that call site currently needs.
+
+In `web/src/lib/components/spaces/space-albums-list.svelte`, replace lines 53–58 with:
+
+```svelte
+  const sorted = $derived(
+    sortSpaceAlbums(filtered, {
+      sortBy: $spaceAlbumViewSettings.sortBy,
+      orderBy: $spaceAlbumViewSettings.sortOrder,
+    }),
+  );
+```
+
+and update its imports: drop `sortAlbums` from `$lib/utils/album-utils` and the now-unused `AlbumResponseDto` type import, adding `import { sortSpaceAlbums } from '$lib/utils/space-album-sort';`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd web && pnpm exec vitest run src/lib/utils/space-album-grouping.spec.ts src/lib/components/spaces/space-albums-list.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Run the whole web suite and the type gates**
+
+Run: `cd web && pnpm exec vitest run && pnpm check:typescript && pnpm check:svelte && pnpm lint`
+Expected: all green. `check:svelte` can scan zero files locally — if it reports 0 files, rely on CI for that gate and note it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/lib/components/spaces/space-albums-list.svelte web/src/lib/components/spaces/space-albums-list.spec.ts web/src/lib/utils/space-album-grouping.ts web/src/lib/utils/space-album-grouping.spec.ts
+git commit -m "feat(web): apply the space album sort layer to the list and groups (#966)"
+```
+
+---
+
+## Task 5: Harden `EnumCodec` against unknown stored values
+
+Implements S25. This protects the downgrade path that Task 7 creates by adding new enum values.
+
+**Files:**
+
+- Modify: `mobile/lib/domain/models/value_codec.dart:36-46`
+- Modify: `mobile/lib/domain/models/settings_key.dart:44,46`
+- Test: `mobile/test/domain/models/value_codec_test.dart` (create if absent)
+
+**Interfaces:**
+
+- Produces: `EnumCodec<T>(List<T> values, {T? fallback})` whose `decode` returns `fallback ?? values.first` instead of throwing.
+
+- [ ] **Step 1: Write the failing test**
+
+Create (or extend) `mobile/test/domain/models/value_codec_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/domain/models/value_codec.dart';
+import 'package:immich_mobile/pages/library/spaces/collection_sort.dart';
+
+void main() {
+  group('EnumCodec', () {
+    test('round-trips a known value', () {
+      const codec = EnumCodec(SpaceAlbumSortMode.values);
+      expect(codec.encode(SpaceAlbumSortMode.photoCount), 'photoCount');
+      expect(codec.decode('photoCount'), SpaceAlbumSortMode.photoCount);
+    });
+
+    // S25 — a value written by a newer build must not crash an older one at
+    // startup. CachedKeyValueRepository._build calls decode unguarded and
+    // SettingsRepository.ensureInitialized awaits it during app launch.
+    test('returns the declared fallback for an unrecognised name', () {
+      const codec = EnumCodec(SpaceAlbumSortMode.values, fallback: SpaceAlbumSortMode.recentlyLinked);
+      expect(codec.decode('aModeFromTheFuture'), SpaceAlbumSortMode.recentlyLinked);
+      expect(codec.decode(''), SpaceAlbumSortMode.recentlyLinked);
+    });
+
+    test('falls back to the first value when no fallback is declared', () {
+      const codec = EnumCodec(SpaceAlbumSortMode.values);
+      expect(codec.decode('nope'), SpaceAlbumSortMode.values.first);
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mobile && flutter test test/domain/models/value_codec_test.dart`
+Expected: FAIL — first on the compile error `No named parameter with the name 'fallback'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `mobile/lib/domain/models/value_codec.dart`:
+
+```dart
+final class EnumCodec<T extends Enum> extends ValueCodec<T> {
+  final List<T> values;
+
+  /// Value returned when a persisted name matches no enum value — e.g. after a
+  /// downgrade, where an older build reads a mode a newer build wrote. Without
+  /// this, `decode` threw `StateError` and `SettingsRepository`'s unguarded
+  /// startup `refresh()` turned that into a launch crash.
+  final T? fallback;
+
+  const EnumCodec(this.values, {this.fallback});
+
+  @override
+  String encode(T value) => value.name;
+
+  @override
+  T decode(String raw) => values.firstWhere((v) => v.name == raw, orElse: () => fallback ?? values.first);
+}
+```
+
+In `mobile/lib/domain/models/settings_key.dart`, declare the fallbacks so the space keys land on their real defaults rather than `values.first`:
+
+```dart
+  spaceAlbumsSortMode<SpaceAlbumSortMode>(
+    codec: EnumCodec(SpaceAlbumSortMode.values, fallback: SpaceAlbumSortMode.recentlyLinked),
+  ),
+  spaceAlbumsIsReverse<bool>(),
+  spacesSortMode<SpaceSortMode>(codec: EnumCodec(SpaceSortMode.values, fallback: SpaceSortMode.recentActivity)),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mobile && flutter test test/domain/models/value_codec_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/domain/models/value_codec.dart mobile/lib/domain/models/settings_key.dart mobile/test/domain/models/value_codec_test.dart
+git commit -m "fix(mobile): fall back instead of crashing on an unknown persisted enum (#966)"
+```
+
+---
+
+## Task 6: Mobile model and query
+
+Implements S13, S15 (query half), S20.
+
+**Files:**
+
+- Modify: `mobile/lib/domain/models/space_album.model.dart`
+- Modify: `mobile/lib/infrastructure/repositories/space_album.repository.dart:25-72`
+- Test: `mobile/test/medium/repositories/space_album_repository_test.dart`
+- Modify (fixtures, compile-driven): `mobile/test/pages/library/spaces/collection_sort_test.dart`, `mobile/test/providers/infrastructure/collection_dispatch_test.dart`, `mobile/test/presentation/pages/space_detail_top_sliver_test.dart`, `mobile/test/presentation/pages/space_album_detail_page_test.dart`, `mobile/test/presentation/pages/space_albums_link_wiring_test.dart`, `mobile/test/presentation/pages/space_albums_page_test.dart`, `mobile/test/presentation/pages/space_b6_mutations_test.dart`, `mobile/test/presentation/widgets/collection/space_collection_section_test.dart`, `mobile/test/presentation/widgets/spaces/space_albums_shelf_test.dart`
+
+**Interfaces:**
+
+- Produces: `SpaceAlbum` with `required DateTime createdAt`, `DateTime? startDate`, `DateTime? endDate`, where the two date fields are truncated to a UTC calendar day.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `watchLinkedAlbums` group in `mobile/test/medium/repositories/space_album_repository_test.dart`:
+
+```dart
+    test('projects the album createdAt from the metadata row', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      final album = await ctx.newSharedSpaceAlbum(name: 'Hawaii', createdAt: DateTime.utc(2025, 6, 1));
+      await ctx.insertSharedSpaceAlbumLink(spaceId: space.id, albumId: album.id);
+
+      final albums = await repo.watchLinkedAlbums(space.id).first;
+      expect(albums.single.createdAt, album.createdAt);
+    });
+
+    test('derives startDate/endDate from the album assets, truncated to a UTC day', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      final album = await ctx.newSharedSpaceAlbum(name: 'Hawaii');
+      await ctx.insertSharedSpaceAlbumLink(spaceId: space.id, albumId: album.id);
+
+      for (final at in [
+        DateTime.utc(2026, 1, 5, 9, 30),
+        DateTime.utc(2026, 1, 20, 17, 45),
+        DateTime.utc(2026, 1, 12, 3, 0),
+      ]) {
+        final asset = await ctx.newRemoteAsset(ownerId: user.id, createdAt: at);
+        await ctx.insertSharedSpaceAlbumAsset(albumId: album.id, assetId: asset.id);
+      }
+
+      final albums = await repo.watchLinkedAlbums(space.id).first;
+      // S15 — day precision, matching the server's ::date cast. Times of day gone.
+      expect(albums.single.startDate, DateTime.utc(2026, 1, 5));
+      expect(albums.single.endDate, DateTime.utc(2026, 1, 20));
+    });
+
+    test('leaves startDate/endDate null for an album with no assets', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      final album = await ctx.newSharedSpaceAlbum(name: 'Empty');
+      await ctx.insertSharedSpaceAlbumLink(spaceId: space.id, albumId: album.id);
+
+      final albums = await repo.watchLinkedAlbums(space.id).first;
+      expect(albums.single.assetCount, 0);
+      expect(albums.single.startDate, isNull);
+      expect(albums.single.endDate, isNull);
+    });
+
+    test('excludes deleted and hidden assets from the date range', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      final album = await ctx.newSharedSpaceAlbum(name: 'Hawaii');
+      await ctx.insertSharedSpaceAlbumLink(spaceId: space.id, albumId: album.id);
+
+      final visible = await ctx.newRemoteAsset(ownerId: user.id, createdAt: DateTime.utc(2026, 1, 10));
+      final deleted = await ctx.newRemoteAsset(
+        ownerId: user.id,
+        createdAt: DateTime.utc(2026, 5, 1),
+        deletedAt: DateTime.utc(2026, 5, 2),
+      );
+      final hidden = await ctx.newRemoteAsset(
+        ownerId: user.id,
+        createdAt: DateTime.utc(2026, 6, 1),
+        visibility: AssetVisibility.hidden,
+      );
+      for (final a in [visible, deleted, hidden]) {
+        await ctx.insertSharedSpaceAlbumAsset(albumId: album.id, assetId: a.id);
+      }
+
+      final albums = await repo.watchLinkedAlbums(space.id).first;
+      expect(albums.single.assetCount, 1);
+      expect(albums.single.endDate, DateTime.utc(2026, 1, 10));
+    });
+
+    // S20
+    test('reports the per-space link date when an album is linked to two spaces', () async {
+      final user = await ctx.newUser();
+      final s1 = await ctx.newSharedSpace(createdById: user.id);
+      final s2 = await ctx.newSharedSpace(createdById: user.id);
+      final album = await ctx.newSharedSpaceAlbum(name: 'Shared');
+      await ctx.insertSharedSpaceAlbumLink(spaceId: s1.id, albumId: album.id, createdAt: DateTime.utc(2026, 1, 1));
+      await ctx.insertSharedSpaceAlbumLink(spaceId: s2.id, albumId: album.id, createdAt: DateTime.utc(2026, 3, 1));
+
+      final inS1 = await repo.watchLinkedAlbums(s1.id).first;
+      final inS2 = await repo.watchLinkedAlbums(s2.id).first;
+      expect(inS1.single.linkedAt, isNot(inS2.single.linkedAt));
+    });
+```
+
+If `insertSharedSpaceAlbumLink` does not already accept `createdAt`, add an optional `DateTime? createdAt` parameter to it in `mobile/test/medium/repository_context.dart`, defaulting to `TestUtils.date(createdAt)` the same way `newSharedSpaceAlbum` does.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mobile && flutter test test/medium/repositories/space_album_repository_test.dart`
+Expected: FAIL — compile error, `The getter 'createdAt' isn't defined for the type 'SpaceAlbum'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`mobile/lib/domain/models/space_album.model.dart`:
+
+```dart
+class SpaceAlbum {
+  final String id;
+  final String name;
+  final String? thumbnailAssetId;
+  final bool showInTimeline;
+  final int assetCount;
+  final DateTime linkedAt;
+  final DateTime updatedAt;
+  final DateTime createdAt;
+
+  /// Oldest / newest photo in the album, truncated to a UTC calendar day to
+  /// match the server's `MIN/MAX((localDateTime AT TIME ZONE 'UTC')::date)`.
+  /// Null when the album has no visible assets, or when none of them carries a
+  /// `localDateTime`.
+  final DateTime? startDate;
+  final DateTime? endDate;
+
+  const SpaceAlbum({
+    required this.id,
+    required this.name,
+    this.thumbnailAssetId,
+    required this.showInTimeline,
+    this.assetCount = 0,
+    required this.linkedAt,
+    required this.updatedAt,
+    required this.createdAt,
+    this.startDate,
+    this.endDate,
+  });
+}
+```
+
+`mobile/lib/infrastructure/repositories/space_album.repository.dart` — add the aggregates and the mapper helper:
+
+```dart
+    final assetCountExp = asset.id.count();
+    final minDateExp = asset.localDateTime.min();
+    final maxDateExp = asset.localDateTime.max();
+```
+
+```dart
+          ..addColumns([assetCountExp, minDateExp, maxDateExp])
+```
+
+```dart
+        return SpaceAlbum(
+          id: m.id,
+          name: m.name,
+          thumbnailAssetId: m.thumbnailAssetId,
+          showInTimeline: l.showInTimeline,
+          assetCount: row.read(assetCountExp) ?? 0,
+          linkedAt: l.createdAt,
+          updatedAt: m.updatedAt,
+          createdAt: m.createdAt,
+          startDate: _utcDay(row.read(minDateExp)),
+          endDate: _utcDay(row.read(maxDateExp)),
+        );
+```
+
+and at file scope:
+
+```dart
+/// Truncate to a UTC calendar day so the sort key matches the server's
+/// `::date` cast (see the #966 design spec). Truncating in Dart rather than SQL
+/// keeps this independent of how Drift stores `DateTime`.
+DateTime? _utcDay(DateTime? value) {
+  if (value == null) {
+    return null;
+  }
+  final utc = value.toUtc();
+  return DateTime.utc(utc.year, utc.month, utc.day);
+}
+```
+
+- [ ] **Step 4: Fix every `SpaceAlbum(...)` construction site the compiler reports**
+
+Run: `cd mobile && dart analyze lib test`
+
+`createdAt` is now required, so each site listed under **Files** above needs it. Most are inside a single test factory, so one edit covers many call sites. Use a value that keeps each test's intent — for fixtures where creation date is irrelevant, mirror the existing `updatedAt`:
+
+```dart
+    createdAt: DateTime.utc(2026, 1, 1),
+```
+
+For `mobile/test/pages/library/spaces/collection_sort_test.dart`, give the six `sample` entries distinct `createdAt` values so Task 7 can assert Date-created ordering, and add `createdAt` (plus optional `startDate`/`endDate`) parameters to its `_album` helper.
+
+Repeat `dart analyze lib test` until clean.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd mobile && flutter test test/medium/repositories/space_album_repository_test.dart`
+Expected: PASS.
+
+Run: `cd mobile && flutter test`
+Expected: PASS — the fixture updates must leave the whole suite green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile/lib/domain/models/space_album.model.dart mobile/lib/infrastructure/repositories/space_album.repository.dart mobile/test
+git commit -m "feat(mobile): expose album createdAt and photo date range on SpaceAlbum (#966)"
+```
+
+---
+
+## Task 7: Mobile sort modes
+
+Implements S1–S12, S14–S19, S21 on mobile.
+
+**Files:**
+
+- Modify: `mobile/lib/pages/library/spaces/collection_sort.dart:6-19`, `:47-67`
+- Test: `mobile/test/pages/library/spaces/collection_sort_test.dart`
+
+**Interfaces:**
+
+- Produces: `SpaceAlbumSortMode` with seven values — `name`, `photoCount`, `recentlyUpdated`, `dateCreated`, `mostRecentPhoto`, `oldestPhoto`, `recentlyLinked` — declared in contract order, and `filterAndSortSpaceAlbums` handling all seven.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mobile/test/pages/library/spaces/collection_sort_test.dart`:
+
+```dart
+  group('space-album sort parity (#966)', () {
+    SpaceAlbum a({
+      required String id,
+      required String name,
+      DateTime? createdAt,
+      DateTime? linkedAt,
+      DateTime? startDate,
+      DateTime? endDate,
+      int assetCount = 0,
+    }) => SpaceAlbum(
+      id: id,
+      name: name,
+      showInTimeline: true,
+      assetCount: assetCount,
+      linkedAt: linkedAt ?? DateTime.utc(2026, 1, 1),
+      updatedAt: DateTime.utc(2026, 1, 1),
+      createdAt: createdAt ?? DateTime.utc(2026, 1, 1),
+      startDate: startDate,
+      endDate: endDate,
+    );
+
+    // The contract order from the design spec — the menu is built from
+    // SpaceAlbumSortMode.values, so declaration order IS menu order.
+    test('offers the seven contract options in order with the contract labels', () {
+      expect(SpaceAlbumSortMode.values.map((m) => m.name), [
+        'name',
+        'photoCount',
+        'recentlyUpdated',
+        'dateCreated',
+        'mostRecentPhoto',
+        'oldestPhoto',
+        'recentlyLinked',
+      ]);
+      expect(SpaceAlbumSortMode.values.map((m) => m.label), [
+        'sort_title',
+        'sort_items',
+        'sort_modified',
+        'sort_created',
+        'sort_recent',
+        'sort_oldest',
+        'sort_recently_linked',
+      ]);
+    });
+
+    test('defaults Title to ascending and every other option to descending', () {
+      expect(SpaceAlbumSortMode.name.defaultOrder, SortOrder.asc);
+      for (final mode in SpaceAlbumSortMode.values.where((m) => m != SpaceAlbumSortMode.name)) {
+        expect(mode.defaultOrder, SortOrder.desc, reason: '${mode.name} should default to descending');
+      }
+    });
+
+    // S6 / S9 — createdAt order is the reverse of linkedAt order here
+    test('Date created and Recently linked read different fields', () {
+      final items = [
+        a(id: 'old', name: 'Old', createdAt: DateTime.utc(2026, 1, 1), linkedAt: DateTime.utc(2026, 3, 1)),
+        a(id: 'new', name: 'New', createdAt: DateTime.utc(2026, 2, 1), linkedAt: DateTime.utc(2026, 2, 2)),
+      ];
+      expect(names(filterAndSortSpaceAlbums(items, '', SpaceAlbumSortMode.dateCreated, false)), ['New', 'Old']);
+      expect(names(filterAndSortSpaceAlbums(items, '', SpaceAlbumSortMode.recentlyLinked, false)), ['Old', 'New']);
+    });
+
+    // S7 / S8 — B has the newest photo but also the oldest, so the two modes
+    // must disagree at the same direction. Both default to descending:
+    //   mostRecentPhoto desc -> B (Jan 20) then A (Jan 10)
+    //   oldestPhoto     desc -> A (Jan 5)  then B (Jan 1)
+    // A comparator reading the wrong field therefore fails rather than passing
+    // by coincidence.
+    test('Most recent photo and Oldest photo read different fields', () {
+      final items = [
+        a(id: 'a', name: 'A', startDate: DateTime.utc(2026, 1, 5), endDate: DateTime.utc(2026, 1, 10)),
+        a(id: 'b', name: 'B', startDate: DateTime.utc(2026, 1, 1), endDate: DateTime.utc(2026, 1, 20)),
+      ];
+      expect(names(filterAndSortSpaceAlbums(items, '', SpaceAlbumSortMode.mostRecentPhoto, false)), ['B', 'A']);
+      expect(names(filterAndSortSpaceAlbums(items, '', SpaceAlbumSortMode.oldestPhoto, false)), ['A', 'B']);
+      // reversed
+      expect(names(filterAndSortSpaceAlbums(items, '', SpaceAlbumSortMode.mostRecentPhoto, true)), ['A', 'B']);
+      expect(names(filterAndSortSpaceAlbums(items, '', SpaceAlbumSortMode.oldestPhoto, true)), ['B', 'A']);
+    });
+
+    // S10 / S11 / S12 — matches upstream sortUnknownYearAlbums: last in BOTH directions
+    test('albums with no photo dates sort last regardless of direction', () {
+      final items = [
+        a(id: 'empty', name: 'Empty'),
+        a(id: 'full', name: 'HasPhotos', startDate: DateTime.utc(2026, 1, 1), endDate: DateTime.utc(2026, 1, 10)),
+      ];
+      for (final mode in [SpaceAlbumSortMode.mostRecentPhoto, SpaceAlbumSortMode.oldestPhoto]) {
+        for (final isReverse in [false, true]) {
+          expect(
+            names(filterAndSortSpaceAlbums(items, '', mode, isReverse)),
+            ['HasPhotos', 'Empty'],
+            reason: '$mode isReverse=$isReverse',
+          );
+        }
+      }
+    });
+
+    // S14
+    test('keeps every album when none has photo dates', () {
+      final items = [a(id: '1', name: 'One'), a(id: '2', name: 'Two'), a(id: '3', name: 'Three')];
+      final sorted = filterAndSortSpaceAlbums(items, '', SpaceAlbumSortMode.mostRecentPhoto, false);
+      expect(sorted, hasLength(3));
+      expect(names(sorted).toSet(), {'One', 'Two', 'Three'});
+    });
+
+    // S15 — the repository truncates to a UTC day, so same-day albums arrive equal
+    // and must fall through to the name/id tie-break rather than to time of day.
+    test('same-day albums fall through to the tie-break', () {
+      final items = [
+        a(id: 'z', name: 'Zebra', endDate: DateTime.utc(2026, 1, 10)),
+        a(id: 'a', name: 'Antelope', endDate: DateTime.utc(2026, 1, 10)),
+      ];
+      expect(names(filterAndSortSpaceAlbums(items, '', SpaceAlbumSortMode.mostRecentPhoto, false)), [
+        'Antelope',
+        'Zebra',
+      ]);
+    });
+
+    // S17
+    test('bulk-linked albums sharing a linkedAt tie-break by name then id', () {
+      final linked = DateTime.utc(2026, 4, 1);
+      final items = [
+        a(id: 'c', name: 'Charlie', linkedAt: linked),
+        a(id: 'a', name: 'Alpha', linkedAt: linked),
+        a(id: 'b', name: 'Bravo', linkedAt: linked),
+      ];
+      expect(names(filterAndSortSpaceAlbums(items, '', SpaceAlbumSortMode.recentlyLinked, false)), [
+        'Alpha',
+        'Bravo',
+        'Charlie',
+      ]);
+    });
+
+    // S18 / S19
+    test('handles empty and single-item lists for every mode and direction', () {
+      final one = [a(id: 'only', name: 'Only')];
+      for (final mode in SpaceAlbumSortMode.values) {
+        for (final isReverse in [false, true]) {
+          expect(filterAndSortSpaceAlbums(const [], '', mode, isReverse), isEmpty);
+          expect(names(filterAndSortSpaceAlbums(one, '', mode, isReverse)), ['Only']);
+        }
+      }
+    });
+
+    // S21 — filtering still runs before sorting, for the new modes too
+    test('filters by query before sorting', () {
+      final items = [
+        a(id: '1', name: 'Italy 2022', endDate: DateTime.utc(2026, 1, 20)),
+        a(id: '2', name: 'Alps Weekend', endDate: DateTime.utc(2026, 1, 10)),
+      ];
+      expect(names(filterAndSortSpaceAlbums(items, 'alps', SpaceAlbumSortMode.mostRecentPhoto, false)), [
+        'Alps Weekend',
+      ]);
+    });
+  });
+```
+
+Also update the existing `sort-mode enum shape` group so its `storeIndex` expectations match the reordered enum.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mobile && flutter test test/pages/library/spaces/collection_sort_test.dart`
+Expected: FAIL — compile error, `The getter 'dateCreated' isn't defined for the type 'SpaceAlbumSortMode'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `mobile/lib/pages/library/spaces/collection_sort.dart`, replace the enum:
+
+```dart
+/// Sort modes for a space's linked-albums grid ([SpaceAlbumsPage]).
+///
+/// Declaration order IS menu order — [SpaceAlbumsPage] builds the menu from
+/// `values`. The set and order match the web sort dropdown (see the #966 design
+/// spec).
+///
+/// The identifiers are persisted verbatim by `EnumCodec` (`value.name`), so
+/// renaming one silently resets every user who had it selected. That is why
+/// `name` is labelled "Title" and `recentlyUpdated` is labelled "Date modified"
+/// rather than being renamed to match.
+enum SpaceAlbumSortMode {
+  name(0, 'sort_title', SortOrder.asc),
+  photoCount(1, 'sort_items', SortOrder.desc),
+  recentlyUpdated(3, 'sort_modified', SortOrder.desc),
+  dateCreated(4, 'sort_created', SortOrder.desc),
+  mostRecentPhoto(5, 'sort_recent', SortOrder.desc),
+  oldestPhoto(6, 'sort_oldest', SortOrder.desc),
+  recentlyLinked(2, 'sort_recently_linked', SortOrder.desc);
+
+  const SpaceAlbumSortMode(this.storeIndex, this.label, this.defaultOrder);
+
+  final int storeIndex;
+  final String label;
+  final SortOrder defaultOrder;
+
+  SortOrder effectiveOrder(bool isReverse) => isReverse ? defaultOrder.reverse() : defaultOrder;
+}
+```
+
+and the comparator:
+
+```dart
+/// Albums with no photo dates sort last in BOTH directions, matching upstream
+/// web's `sortUnknownYearAlbums`. Returns null when neither side is missing, so
+/// the caller can fall through to the normal comparison.
+///
+/// Upstream checks `endDate` for both photo-date sorts, including the one that
+/// orders by `startDate`. This checks each mode's own field instead. The two
+/// are equivalent in practice — both dates come from the same aggregate, so an
+/// album has both or neither — so do not "fix" this to match upstream's quirk.
+int? _unknownDateLast(DateTime? a, DateTime? b) {
+  if (a == null && b == null) return null;
+  if (a == null) return 1;
+  if (b == null) return -1;
+  return null;
+}
+
+List<SpaceAlbum> filterAndSortSpaceAlbums(
+  List<SpaceAlbum> items,
+  String query,
+  SpaceAlbumSortMode mode,
+  bool isReverse,
+) {
+  final sign = mode.effectiveOrder(isReverse) == SortOrder.asc ? 1 : -1;
+  final out = items.where((a) => _matches(a.name, query)).toList();
+  out.sort((a, b) {
+    // Applied outside the sign so empty albums stay last in both directions.
+    final unknown = switch (mode) {
+      SpaceAlbumSortMode.mostRecentPhoto => _unknownDateLast(a.endDate, b.endDate),
+      SpaceAlbumSortMode.oldestPhoto => _unknownDateLast(a.startDate, b.startDate),
+      _ => null,
+    };
+    if (unknown != null) return unknown;
+
+    final c = switch (mode) {
+      SpaceAlbumSortMode.name => _byName(a.name, b.name),
+      SpaceAlbumSortMode.photoCount => a.assetCount.compareTo(b.assetCount),
+      SpaceAlbumSortMode.recentlyLinked => a.linkedAt.compareTo(b.linkedAt),
+      SpaceAlbumSortMode.recentlyUpdated => a.updatedAt.compareTo(b.updatedAt),
+      SpaceAlbumSortMode.dateCreated => a.createdAt.compareTo(b.createdAt),
+      SpaceAlbumSortMode.mostRecentPhoto => a.endDate!.compareTo(b.endDate!),
+      SpaceAlbumSortMode.oldestPhoto => a.startDate!.compareTo(b.startDate!),
+    };
+    if (c != 0) return sign * c;
+    final n = _byName(a.name, b.name);
+    return n != 0 ? n : a.id.compareTo(b.id);
+  });
+  return out;
+}
+```
+
+The `!` assertions are safe: `_unknownDateLast` has already returned for every case where either side is null.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd mobile && flutter test test/pages/library/spaces/collection_sort_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/pages/library/spaces/collection_sort.dart mobile/test/pages/library/spaces/collection_sort_test.dart
+git commit -m "feat(mobile): offer the full seven space album sort options (#966)"
+```
+
+---
+
+## Task 8: Mobile page assertions
+
+Implements S2, S3 on mobile.
+
+**Files:**
+
+- Test: `mobile/test/presentation/pages/space_albums_page_test.dart` (the sort group, around lines 248–360)
+
+No production change — the menu is built from `SpaceAlbumSortMode.values` at `mobile/lib/pages/library/spaces/space_albums.page.dart:206`, so Task 7 already surfaced the new options.
+
+- [ ] **Step 1: Update the label assertions and add the new coverage**
+
+The suite asserts the literal `'Sort: Photo count'`; that label is now `'Sort: Number of items'`. Update it, then add:
+
+```dart
+    testWidgets('offers all seven sort options in the menu', (tester) async {
+      await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('collection-sort-button-pill')));
+      await tester.pumpAndSettle();
+
+      for (final label in [
+        'Title',
+        'Number of items',
+        'Date modified',
+        'Date created',
+        'Most recent photo',
+        'Oldest photo',
+        'Recently linked',
+      ]) {
+        expect(find.text(label), findsWidgets, reason: 'missing sort option $label');
+      }
+    });
+```
+
+Use whatever page-building helper the file already defines in place of `buildPage()`.
+
+- [ ] **Step 2: Run test to verify it fails, then passes**
+
+Run: `cd mobile && flutter test test/presentation/pages/space_albums_page_test.dart`
+Expected: initially FAIL on the stale `'Sort: Photo count'` literal; PASS after the label update.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/test/presentation/pages/space_albums_page_test.dart
+git commit -m "test(mobile): assert the seven space album sort options on the page (#966)"
+```
+
+---
+
+## Task 9: Mobile persistence
+
+Implements S22, S23, S24.
+
+**Files:**
+
+- Test: `mobile/test/domain/models/config/app_config_test.dart`
+
+No production change expected — `SpaceAlbumsConfig` already defaults to `recentlyLinked`. This task proves the default survived and that old and new stored values both round-trip.
+
+- [ ] **Step 1: Write the test**
+
+Add to the `AppConfig spaces & space-albums sort prefs` group:
+
+```dart
+    // S22
+    test('space-album sort still defaults to recentlyLinked', () {
+      const c = AppConfig();
+      expect(c.spaceAlbums.sortMode, SpaceAlbumSortMode.recentlyLinked);
+      expect(c.spaceAlbums.isReverse, false);
+    });
+
+    // S23 / S24 — every mode round-trips, including the pre-#966 identifiers
+    // (name, photoCount, recentlyUpdated) that must never be renamed.
+    test('every space-album sort mode round-trips', () {
+      const c = AppConfig();
+      for (final mode in SpaceAlbumSortMode.values) {
+        final w = c.write(SettingsKey.spaceAlbumsSortMode, mode);
+        expect(w.read(SettingsKey.spaceAlbumsSortMode), mode, reason: '${mode.name} did not round-trip');
+      }
+    });
+
+    test('the persisted identifiers of the pre-existing modes are unchanged', () {
+      expect(SpaceAlbumSortMode.name.name, 'name');
+      expect(SpaceAlbumSortMode.photoCount.name, 'photoCount');
+      expect(SpaceAlbumSortMode.recentlyUpdated.name, 'recentlyUpdated');
+      expect(SpaceAlbumSortMode.recentlyLinked.name, 'recentlyLinked');
+    });
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cd mobile && flutter test test/domain/models/config/app_config_test.dart`
+Expected: PASS.
+
+- [ ] **Step 3: Run the full mobile gates**
+
+Run: `cd mobile && dart format --set-exit-if-changed lib test && dart analyze --fatal-infos lib test && flutter test`
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/test/domain/models/config/app_config_test.dart
+git commit -m "test(mobile): cover space album sort persistence across all modes (#966)"
+```
+
+---
+
+## Task 10: Final verification and PR
+
+- [ ] **Step 1: Run every gate**
+
+```bash
+cd web && pnpm exec vitest run && pnpm check:typescript && pnpm check:svelte && pnpm lint
+cd ../mobile && dart format --set-exit-if-changed lib test && dart analyze --fatal-infos lib test && flutter test
+cd .. && npx prettier --check "docs/superpowers/**/*.md"
+```
+
+- [ ] **Step 2: Confirm upstream files are untouched**
+
+```bash
+git diff --name-only origin/main...HEAD
+```
+
+Expected: the list must NOT contain `web/src/lib/utils/album-utils.ts`, `web/src/lib/stores/preferences.store.ts`, `web/src/lib/components/spaces/space-albums-table.svelte`, any `server/` path, or any `i18n/` path.
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "fix(spaces): unify shared-space album sort options across web and mobile (#966)" --body "..."
+```
+
+The body should state the seven-option contract, the new shared default, that mobile now derives `createdAt` and truncated photo dates locally, and that no server or i18n change was needed. Link issue #966.
+
+- [ ] **Step 4: Babysit CI to green**
+
+Use the `babysit` skill.
+
+- [ ] **Step 5: File the two follow-up issues**
+
+- Web space-album table headers are static and non-clickable (`space-albums-table.svelte:80`), unlike `/albums`.
+- Search scope differs: web matches album name or description, mobile matches name only.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every scenario S1–S29 in the spec's coverage map has a task: S1/S4–S12/S14/S17–S19/S26 → Task 1 and Task 7; S2/S3 → Task 3 and Task 8; S13/S15/S20 → Task 6 and Task 7; S16 → Task 7; S21 → Task 4 and Task 7; S22–S24 → Task 2 and Task 9; S25 → Task 5; S27–S29 → Task 4. The spec's slice M0–M4 / W1–W4 map onto Tasks 5, 6, 7, 8, 9 and 1, 2, 3, 4 respectively.
+
+**Type consistency.** `sortSpaceAlbums`, `findSpaceAlbumSortOptionMetadata`, `spaceAlbumSortOptionsMetadata`, `SpaceAlbumSortBy` and `SpaceAlbumSortOptionMetadata` are defined in Task 1 and used under those exact names in Tasks 2, 3 and 4. `SpaceAlbum.createdAt` / `.startDate` / `.endDate` are defined in Task 6 and consumed in Task 7. `EnumCodec(values, {fallback})` is defined in Task 5 and used in `settings_key.dart` in the same task.
+
+**Known deviation from the spec's slice list.** The spec ordered M0 after W4; this plan keeps that relative order (Task 5 follows Task 4) but makes Task 5 a prerequisite of Task 7 rather than of Task 6, since it is Task 7 that adds the new enum values.

--- a/docs/superpowers/specs/2026-08-10-space-album-sort-parity-design.md
+++ b/docs/superpowers/specs/2026-08-10-space-album-sort-parity-design.md
@@ -1,0 +1,296 @@
+# Shared-space album sort parity between web and mobile
+
+**Issue:** [#966](https://github.com/open-noodle/gallery/issues/966) — _Album sorting options in Shared Space are inconsistent between Web and Mobile_
+**Date:** 2026-08-10
+**Status:** approved, ready for implementation
+
+## Problem
+
+The sort options offered for a shared space's linked-album list differ per platform:
+
+| Web (6)           | Mobile (4)       |
+| ----------------- | ---------------- |
+| Title             | Name             |
+| Number of items   | Photo count      |
+| Date modified     | Recently updated |
+| Date created      | Recently linked  |
+| Most recent photo | —                |
+| Oldest photo      | —                |
+
+Two of those apparent differences are cosmetic: mobile's _Name_ is web's _Title_ (`albumName`), and mobile's
+_Recently updated_ is web's _Date modified_ (`updatedAt`). The genuine gaps are that mobile lacks the three
+date-based sorts, and web lacks _Recently linked_.
+
+The platforms also open on different defaults — web on _Most recent photo_, mobile on _Recently linked_.
+
+## Decisions
+
+1. **Unify on the union of seven options** (web's six plus _Recently linked_). Nobody loses a capability, and
+   _Recently linked_ answers a question specific to a shared space — "what did someone just add here?" — that no
+   other sort answers.
+2. **Both platforms default to _Recently linked_, descending.** This is the most useful opening order for a
+   collaborative surface. Web changes its default; mobile's is already this.
+3. **No server change.** `GET /shared-spaces/{id}/albums` already returns every field required
+   (`server/src/dtos/shared-space.dto.ts:167` — `AlbumResponseSchema` minus `albumUsers`, plus `ownerId`,
+   `showInTimeline`, `addedById`, `linkedAt`).
+4. **No new i18n strings.** All seven label keys already exist in every locale.
+5. **Upstream files stay byte-clean.** Web's new option lives in a fork-only layer, not in upstream's
+   `AlbumSortBy` enum. See "Why not extend the upstream enum" below.
+6. **Mobile derives photo dates locally** from the Drift query that already runs, rather than switching the
+   surface to REST. This preserves offline and reactive behaviour.
+
+## The unified sort contract
+
+Seven options, identical order, identical labels, identical default direction on both platforms.
+
+| #   | Web id            | Dart identifier   | i18n key               | Default dir | Web field    | Mobile source                      |
+| --- | ----------------- | ----------------- | ---------------------- | ----------- | ------------ | ---------------------------------- |
+| 1   | `Title`           | `name`            | `sort_title`           | Asc         | `albumName`  | `meta.name`                        |
+| 2   | `ItemCount`       | `photoCount`      | `sort_items`           | Desc        | `assetCount` | `count(asset.id)`                  |
+| 3   | `DateModified`    | `recentlyUpdated` | `sort_modified`        | Desc        | `updatedAt`  | `meta.updatedAt`                   |
+| 4   | `DateCreated`     | `dateCreated`     | `sort_created`         | Desc        | `createdAt`  | `meta.createdAt` _(new)_           |
+| 5   | `MostRecentPhoto` | `mostRecentPhoto` | `sort_recent`          | Desc        | `endDate`    | `max(asset.localDateTime)` _(new)_ |
+| 6   | `OldestPhoto`     | `oldestPhoto`     | `sort_oldest`          | Desc        | `startDate`  | `min(asset.localDateTime)` _(new)_ |
+| 7   | `RecentlyLinked`  | `recentlyLinked`  | `sort_recently_linked` | Desc        | `linkedAt`   | `link.createdAt`                   |
+
+**Default: `RecentlyLinked` / descending, both platforms.**
+
+### Dart identifiers are load-bearing — do not rename them
+
+`SettingsKey.spaceAlbumsSortMode` persists through `EnumCodec`
+(`mobile/lib/domain/models/value_codec.dart:45`), which encodes `value.name` and decodes with:
+
+```dart
+T decode(String raw) => values.firstWhere((v) => v.name == raw);
+```
+
+`firstWhere` has **no `orElse`**, and no layer between it and app startup catches the throw:
+`CachedKeyValueRepository._build` (`cached_key_value_repository.dart:26`) calls it unguarded, `refresh()` is
+awaited inside `SettingsRepository.ensureInitialized`. An unrecognised stored value therefore throws
+`StateError` during startup rather than falling back to a default.
+
+Consequences:
+
+- Renaming `name` → `title` or `recentlyUpdated` → `dateModified` would crash on launch for every user who had
+  selected that option. **Only the labels change; the identifiers stay.** `name` therefore renders "Title" and
+  `recentlyUpdated` renders "Date modified"; both get an explanatory comment.
+- Adding `dateCreated` / `mostRecentPhoto` / `oldestPhoto` creates a **downgrade** crash: a user who selects one
+  and then installs an older build (RC rollback, PR RC images, TestFlight rollback) hits the same unguarded
+  `firstWhere`. This risk is introduced by this change, so hardening `EnumCodec.decode` to fall back instead of
+  throwing is in scope — see slice M0.
+
+`storeIndex` on these enums is vestigial for `SpaceAlbumSortMode` (only the legacy `AlbumSortMode` consults it,
+in `mobile/lib/utils/migration.dart:151`), so menu order can change freely.
+
+### Unused keys left in place
+
+`sort_photo_count` and `sort_recently_updated` become unreferenced. They are deliberately **not** deleted:
+removing them cleanly would mean editing ~90 locale files, and `CLAUDE.md` states the ~80 translator-owned
+locales must not be hand-edited. Unused keys are inert.
+
+## Behaviour specification
+
+Written as scenarios so each maps to one test. "Album list" means a shared space's linked-album list on either
+platform.
+
+### Ordering
+
+- **S1 — Title ascending.** _Given_ albums "beach", "Apple", "Zoo"; _when_ sorted by Title ascending; _then_ the
+  order is Apple, beach, Zoo. Comparison is case-insensitive.
+- **S2 — Direction flips.** _Given_ any option; _when_ the same option is re-selected; _then_ the direction
+  inverts and the order reverses.
+- **S3 — Selecting a new option applies its default direction.** _Given_ sort is Title (asc); _when_ the user
+  picks Number of items; _then_ direction becomes descending, not ascending.
+- **S4 — Number of items.** Orders by asset count.
+- **S5 — Date modified.** Orders by the album's `updatedAt`.
+- **S6 — Date created.** Orders by the album's `createdAt`, which is distinct from `linkedAt`.
+- **S7 — Most recent photo.** Orders by the newest photo in the album.
+- **S8 — Oldest photo.** Orders by the oldest photo in the album.
+- **S9 — Recently linked.** Orders by when the album was linked into _this_ space, which is distinct from the
+  album's own `createdAt`. An album created long ago but linked today sorts first descending.
+
+### Albums with no photo dates
+
+Upstream's `sortUnknownYearAlbums` (`web/src/lib/utils/album-utils.ts:211`) pushes albums with no `endDate` to
+the end **irrespective of sort direction**, and it is applied to both photo-date sorts — including
+`OldestPhoto`, which orders by `startDate` but null-checks `endDate`. Web inherits this unchanged because the
+fork layer delegates to it. Mobile must reproduce it.
+
+- **S10 — Empty albums sort last, descending.** _Given_ one album with photos and one with none; _when_ sorted
+  by Most recent photo descending; _then_ the empty album is last.
+- **S11 — Empty albums sort last, ascending too.** Same setup, ascending; the empty album is _still_ last.
+- **S12 — Same rule for Oldest photo**, both directions.
+- **S13 — Null `localDateTime` counts as no date.** `remote_asset.localDateTime` is nullable
+  (`remote_asset.entity.dart:39`), so `MIN`/`MAX` can be null even for an album that has assets. Such an album
+  is treated exactly like an empty one for S10–S12, and its asset count is unaffected.
+
+### Tiebreaks
+
+- **S14 — Mobile tiebreak is deterministic.** Equal sort keys tie-break by name, then id. Preserved from the
+  current implementation.
+- Web's tiebreak is input (server) order, because lodash `orderBy` and `Array.sort` are stable. This difference
+  is accepted: the option sets and primary ordering match, which is what #966 asks for. Matching mobile would
+  require post-sorting the six delegated options and changing web behaviour for no user-visible benefit.
+
+### Accepted divergences
+
+These are pre-existing, unchanged by this work, and recorded so they are informed omissions rather than
+oversights:
+
+- **Title collation.** Web sorts titles with `albumName.localeCompare(other, locale)` (`album-utils.ts:229`),
+  which is locale-aware; mobile uses `toLowerCase().compareTo()` (`collection_sort.dart:45`), which is code-unit
+  order. The two agree on ASCII but can disagree on diacritics and non-Latin scripts. Dart has no built-in
+  locale collator, so closing this would mean pulling in a collation dependency — out of proportion to a sort
+  label parity fix.
+- **Search scope.** Web's filter matches album name **or description** (`space-albums-list.svelte:49`); mobile's
+  matches name only (`collection_sort.dart:42`). #966 is about sort options; this is filed separately rather
+  than folded in.
+- **Photo-date corpus.** Web's `startDate`/`endDate` are server-computed over all album assets; mobile's are
+  derived from locally synced assets. See "Mobile design".
+
+### Filtering
+
+- **S15 — Search filters before sorting** and is case-insensitive, trimmed, literal-substring, with no
+  diacritic folding. Unchanged behaviour; asserted to prevent regression.
+
+### Selection, persistence, defaults
+
+- **S16 — Fresh install opens on Recently linked, descending.**
+- **S17 — A stored preference wins over the new default.**
+- **S18 — A stored preference from before this change still loads.** A device with `recentlyUpdated` or
+  `photoCount` persisted must load without error and show the relabelled option.
+- **S19 — An unrecognised stored value falls back to the default instead of throwing** (slice M0).
+
+### Grouping (web only)
+
+- **S20 — Year grouping is disabled for Recently linked.** Year buckets albums by photo date
+  (`space-album-grouping.ts:154`), so pairing it with a link-date sort is as incoherent as with Date created or
+  Date modified, which are already disabled (`space-album-grouping.ts:40`).
+- **S21 — Grouped lists sort within each group** using the same comparator, including Recently linked.
+- **S22 — No user gets stuck in a disabled combination.** `svelte-persisted-store` writes the whole settings
+  object whenever any field changes, so anyone who had set `groupBy: Year` already has their `sortBy` persisted
+  alongside it and keeps it. Only users who never touched any space-album view setting receive the new default,
+  and those have `groupBy: None`.
+
+## Web design
+
+### Why not extend the upstream enum
+
+Adding `RecentlyLinked` to `AlbumSortBy` and `sortOptionsMetadata` would be less code, but
+`web/src/routes/(user)/albums/AlbumsControls.svelte:104` iterates that same metadata array. The option would
+appear on the regular `/albums` page, where `AlbumResponseDto` has no `linkedAt` — a visible option that
+silently does nothing. It would also introduce a fork diff into two files that are currently byte-identical to
+`upstream/main`, creating a permanent rebase conflict surface. Rejected on correctness first, rebase hygiene
+second.
+
+### New fork-only module
+
+`web/src/lib/utils/space-album-sort.ts`:
+
+- `SpaceAlbumSortBy` — the six `AlbumSortBy` values plus `RecentlyLinked`.
+- `spaceAlbumSortOptionsMetadata` — upstream's `sortOptionsMetadata` entries followed by a `RecentlyLinked`
+  entry (`defaultOrder: Desc`), reusing upstream's `AlbumSortOptionMetadata` shape.
+- `findSpaceAlbumSortOptionMetadata(sortBy)` — like upstream's finder but defaulting to `RecentlyLinked`.
+- `sortSpaceAlbums(albums, { sortBy, orderBy })` — handles `RecentlyLinked` with lodash `orderBy` on
+  `new Date(linkedAt)` (the same shape upstream uses for `DateModified`), and delegates every other value to
+  upstream's `sortAlbums`. Delegation is possible without any upstream change because `sortAlbums` accepts
+  `sortBy: string` and `sortOptions` is a plain string-keyed record (`album-utils.ts:260`).
+
+  It is typed to take and return `SharedSpaceLinkedAlbumDto[]`, absorbing the `AlbumResponseDto` cast that the
+  delegation requires. That removes the existing double `as unknown as` cast at
+  `space-albums-list.svelte:54-57` rather than propagating it.
+
+### Call-site changes
+
+| File                                                         | Change                                                                                                |
+| ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `web/src/lib/stores/space-album-view-settings.store.ts:22`   | Default `sortBy` → `RecentlyLinked`                                                                   |
+| `web/src/lib/components/spaces/space-albums-controls.svelte` | Iterate `spaceAlbumSortOptionsMetadata`; add the `sort_recently_linked` label; widen the label record |
+| `web/src/lib/components/spaces/space-albums-list.svelte:53`  | Call `sortSpaceAlbums`                                                                                |
+| `web/src/lib/utils/space-album-grouping.ts:40`               | Add `RecentlyLinked` to the Year-disabled list                                                        |
+| `web/src/lib/utils/space-album-grouping.ts:268`              | Per-group re-sort calls `sortSpaceAlbums`                                                             |
+
+Two latent bugs in `space-albums-controls.svelte` must be fixed as part of this, or the seventh option renders
+incorrectly:
+
+- Line 80 uses upstream `findSortOptionMetadata`, which returns `MostRecentPhoto` for any unrecognised id. With
+  `sortBy: 'RecentlyLinked'` the pill would display the wrong label. Must use
+  `findSpaceAlbumSortOptionMetadata`.
+- `albumSortByNames` is typed `Record<AlbumSortBy, string>` and indexed via `option.id as AlbumSortBy`
+  (lines 86, 127, 144). The cast must be widened to the new union rather than left to lie about the seventh
+  value.
+
+**Not touched:** `album-utils.ts`, `preferences.store.ts`, `space-albums-table.svelte`.
+
+## Mobile design
+
+`SpaceAlbumRepository.watchLinkedAlbums` (`space_album.repository.dart:25`) already `LEFT JOIN`s
+`remoteAssetEntity` through the membership table and `groupBy`s to compute `assetCount`. The two photo-date
+aggregates come from that same grouped query — no extra statement, no extra round trip, and the stream stays
+reactive.
+
+| File                                                                 | Change                                                                                            |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `mobile/lib/domain/models/space_album.model.dart`                    | Add `createdAt`, nullable `startDate`, nullable `endDate`                                         |
+| `mobile/lib/infrastructure/repositories/space_album.repository.dart` | Add `min`/`max` of `asset.localDateTime` to `addColumns`; project `meta.createdAt`                |
+| `mobile/lib/pages/library/spaces/collection_sort.dart`               | Extend `SpaceAlbumSortMode` to seven; relabel; add three comparator arms and the empty-album rule |
+| `mobile/lib/domain/models/value_codec.dart`                          | `EnumCodec.decode` falls back instead of throwing (slice M0)                                      |
+
+The asset join carries the existing visibility predicate (`deletedAt IS NULL AND visibility IN (timeline,
+archive)`), so the photo-date range covers exactly the assets the count already reflects and the detail view
+already shows.
+
+**Known and accepted divergence:** web's `startDate`/`endDate` are computed server-side across all album
+assets; mobile's `MIN`/`MAX` cover locally synced assets only. On a partially synced device the two can
+disagree. Fixing this would mean moving the surface to REST and losing offline support — not worth it. The
+option sets and semantics match; only the underlying corpus can lag.
+
+## Implementation slices
+
+Each slice is test-first: write the failing test, watch it fail for the right reason, implement, confirm green.
+
+**W1 — Web sort module.** New `space-album-sort.spec.ts` → new `space-album-sort.ts`. Covers S1–S9 for
+`RecentlyLinked`, delegation for the other six, metadata order and default directions, and the unknown-key
+fallback.
+
+**W2 — Web store default.** `space-album-view-settings.store.spec.ts` → store change. Covers S16, S17.
+
+**W3 — Web controls.** `space-albums-controls.spec.ts` → component change. Covers the menu rendering seven
+labels, the pill showing the correct label for `RecentlyLinked` (the `findSortOptionMetadata` bug), S2, S3.
+
+**W4 — Web list and grouping.** `space-albums-list.spec.ts` and `space-album-grouping.spec.ts` → call-site
+changes. Covers S10–S12 at the list level, S20, S21.
+
+**M0 — Harden `EnumCodec`.** Test that decoding an unrecognised name yields the default rather than throwing,
+then add the fallback. Covers S19; protects S18 and the downgrade path.
+
+**M1 — Mobile model and query.** `space_album_repository_test.dart` (medium, real DB) → model and repository
+changes. Covers `createdAt` projection, `MIN`/`MAX` over the visibility-filtered join, an album with no assets
+yielding nulls, and S13.
+
+**M2 — Mobile sort modes.** `collection_sort_test.dart` → `collection_sort.dart`. Covers S1–S15 for all seven
+modes.
+
+**M3 — Mobile page assertions.** `space_albums_page_test.dart`. The menu is built from
+`SpaceAlbumSortMode.values` (`space_albums.page.dart:206`), so the three new options appear with no wiring
+change; this slice updates the label assertions (the suite asserts the literal `'Sort: Photo count'`, which
+becomes `'Sort: Number of items'`) and covers persistence round-tripping (S17, S18).
+
+Existing `SpaceAlbum` fixtures gain `createdAt`, so stubs under `mobile/test/` are updated with M1.
+
+## Out of scope
+
+- **Web space-album table headers.** `space-albums-table.svelte:80` hardcodes four static, non-clickable
+  `<th>`s, whereas `/albums` renders a clickable sort button per option (`AlbumsTableHeader.svelte:31`). This is
+  web-internal parity, not web↔mobile parity — mobile has no table view. A follow-up issue will be filed.
+- **Search-scope parity.** Web matches name or description, mobile matches name only. A separate follow-up.
+- Server changes; the API already returns everything needed.
+- Sorting the Spaces grid itself (`SpaceSortMode`), a different surface.
+- Removing the two orphaned i18n keys.
+- Title collation parity (see "Accepted divergences").
+
+## Verification gates
+
+- Web: `pnpm test`, `pnpm check:typescript`, `pnpm check:svelte`, `pnpm lint`, prettier.
+- Mobile: `flutter test`, `dart format`, `dart analyze --fatal-infos lib test` (both are separate CI gates).
+- Docs: prettier over this file — CI Docs Build is strict about `docs/`.

--- a/docs/superpowers/specs/2026-08-10-space-album-sort-parity-design.md
+++ b/docs/superpowers/specs/2026-08-10-space-album-sort-parity-design.md
@@ -217,9 +217,14 @@ oversights:
 
 ### Grouping (web only)
 
-- **S27 — Year grouping is disabled for Recently linked.** Year buckets albums by photo date
-  (`space-album-grouping.ts:154`), so pairing it with a link-date sort is as incoherent as with Date created or
-  Date modified, which are already disabled (`space-album-grouping.ts:40`).
+- **S27 — Year grouping stays ENABLED for Recently linked.** Revised during implementation. The original
+  reasoning was that Year buckets albums by photo date, so pairing it with a link-date sort is as incoherent as
+  with Date created or Date modified, which upstream already disables. That is defensible in isolation, but
+  Recently linked is now the _default_ sort, so disabling Year for it puts the most useful grouping out of reach
+  until the user changes sort — a discoverability regression for every new user. The `spaces-albums` e2e suite
+  caught it immediately: its Year-grouping test lands on the page with fresh storage and the option is disabled.
+  Year buckets by photo year and orders within each bucket by the active sort, which reads fine as "2024 albums,
+  most recently linked first". Only `DateCreated` and `DateModified` disable Year.
 - **S28 — Grouped lists sort within each group** using the same comparator, including Recently linked.
 - **S29 — No user gets stuck in a disabled combination.** `svelte-persisted-store` writes the whole settings
   object whenever any field changes, so anyone who had set `groupBy: Year` already has their `sortBy` persisted
@@ -352,35 +357,35 @@ Existing `SpaceAlbum` fixtures gain `createdAt`, so stubs under `mobile/test/` a
 
 Every scenario has a named home; no row may be left blank at review time.
 
-| Scenario                        | Web slice / file                             | Mobile slice / file                   |
-| ------------------------------- | -------------------------------------------- | ------------------------------------- |
-| S1 Title asc                    | W1 `space-album-sort.spec.ts`                | M2 `collection_sort_test.dart`        |
-| S2 Direction flips              | W3 `space-albums-controls.spec.ts`           | M3 `space_albums_page_test.dart`      |
-| S3 New option → default dir     | W3 `space-albums-controls.spec.ts`           | M3 `space_albums_page_test.dart`      |
-| S4 Number of items              | W1                                           | M2                                    |
-| S5 Date modified                | W1                                           | M2                                    |
-| S6 Date created ≠ linked        | W1                                           | M2                                    |
-| S7 Most recent photo            | W1                                           | M2                                    |
-| S8 Oldest photo                 | W1                                           | M2                                    |
-| S9 Recently linked              | W1                                           | M2                                    |
-| S10–S12 Empty albums last       | W1 + W4 `space-albums-list.spec.ts`          | M2                                    |
-| S13 Null `localDateTime`        | n/a (server-computed)                        | M1 `space_album_repository_test.dart` |
-| S14 All albums date-less        | W1                                           | M2                                    |
-| S15 Same-day albums tie         | n/a (server truncates)                       | M1 + M2                               |
-| S16 Mobile tiebreak             | n/a                                          | M2                                    |
-| S17 Identical `linkedAt`        | W1                                           | M2                                    |
-| S18 Empty list                  | W1                                           | M2                                    |
-| S19 Single album                | W1                                           | M2                                    |
-| S20 `linkedAt` per space        | n/a (endpoint is per-space)                  | M1                                    |
-| S21 Search before sort          | W4                                           | M2                                    |
-| S22 Fresh default               | W2 `space-album-view-settings.store.spec.ts` | M4 `app_config_test.dart`             |
-| S23 Stored beats default        | W2                                           | M4                                    |
-| S24 Pre-change stored value     | W2                                           | M4                                    |
-| S25 Unrecognised stored value   | n/a                                          | M0 `value_codec` test                 |
-| S26 Unknown `sortBy` consistent | W1 + W3                                      | n/a (enum-typed)                      |
-| S27 Year disabled               | W4 `space-album-grouping.spec.ts`            | n/a (web-only)                        |
-| S28 Sort within group           | W4                                           | n/a                                   |
-| S29 No stuck combination        | W4                                           | n/a                                   |
+| Scenario                            | Web slice / file                             | Mobile slice / file                   |
+| ----------------------------------- | -------------------------------------------- | ------------------------------------- |
+| S1 Title asc                        | W1 `space-album-sort.spec.ts`                | M2 `collection_sort_test.dart`        |
+| S2 Direction flips                  | W3 `space-albums-controls.spec.ts`           | M3 `space_albums_page_test.dart`      |
+| S3 New option → default dir         | W3 `space-albums-controls.spec.ts`           | M3 `space_albums_page_test.dart`      |
+| S4 Number of items                  | W1                                           | M2                                    |
+| S5 Date modified                    | W1                                           | M2                                    |
+| S6 Date created ≠ linked            | W1                                           | M2                                    |
+| S7 Most recent photo                | W1                                           | M2                                    |
+| S8 Oldest photo                     | W1                                           | M2                                    |
+| S9 Recently linked                  | W1                                           | M2                                    |
+| S10–S12 Empty albums last           | W1 + W4 `space-albums-list.spec.ts`          | M2                                    |
+| S13 Null `localDateTime`            | n/a (server-computed)                        | M1 `space_album_repository_test.dart` |
+| S14 All albums date-less            | W1                                           | M2                                    |
+| S15 Same-day albums tie             | n/a (server truncates)                       | M1 + M2                               |
+| S16 Mobile tiebreak                 | n/a                                          | M2                                    |
+| S17 Identical `linkedAt`            | W1                                           | M2                                    |
+| S18 Empty list                      | W1                                           | M2                                    |
+| S19 Single album                    | W1                                           | M2                                    |
+| S20 `linkedAt` per space            | n/a (endpoint is per-space)                  | M1                                    |
+| S21 Search before sort              | W4                                           | M2                                    |
+| S22 Fresh default                   | W2 `space-album-view-settings.store.spec.ts` | M4 `app_config_test.dart`             |
+| S23 Stored beats default            | W2                                           | M4                                    |
+| S24 Pre-change stored value         | W2                                           | M4                                    |
+| S25 Unrecognised stored value       | n/a                                          | M0 `value_codec` test                 |
+| S26 Unknown `sortBy` consistent     | W1 + W3                                      | n/a (enum-typed)                      |
+| S27 Year enabled for RecentlyLinked | W4 `space-album-grouping.spec.ts`            | n/a (web-only)                        |
+| S28 Sort within group               | W4                                           | n/a                                   |
+| S29 No stuck combination            | W4                                           | n/a                                   |
 
 ## Out of scope
 
@@ -392,10 +397,12 @@ Every scenario has a named home; no row may be left blank at review time.
 - Sorting the Spaces grid itself (`SpaceSortMode`), a different surface.
 - Removing the two orphaned i18n keys.
 - Title collation parity (see "Accepted divergences").
-- **E2E coverage.** `e2e/src/ui/specs` currently holds only `asset-viewer`, `memory`, `search`, `sidebar` and
-  `timeline` — there is no Playwright coverage of the Spaces surface at all. Establishing it for a sort-option
-  change is disproportionate; the web behaviour is covered by component tests via `@testing-library/svelte`.
-  Recorded so the absence is a decision, not an oversight.
+- **New E2E coverage.** An earlier draft of this spec claimed there was no Playwright coverage of the Spaces
+  surface at all. That was wrong — it looked at `e2e/src/ui/specs` when the web specs live in
+  `e2e/src/specs/web/`, where `spaces-albums.e2e-spec.ts` already covers the albums-tab controls including sort
+  and grouping. No new e2e is added here; the existing suite already exercises this surface, and it is what
+  caught the S27 problem (see S27). The correction is recorded rather than quietly edited out, because the
+  original claim was used to justify not looking further.
 
 ## Verification gates
 

--- a/docs/superpowers/specs/2026-08-10-space-album-sort-parity-design.md
+++ b/docs/superpowers/specs/2026-08-10-space-album-sort-parity-design.md
@@ -33,7 +33,8 @@ The platforms also open on different defaults — web on _Most recent photo_, mo
 3. **No server change.** `GET /shared-spaces/{id}/albums` already returns every field required
    (`server/src/dtos/shared-space.dto.ts:167` — `AlbumResponseSchema` minus `albumUsers`, plus `ownerId`,
    `showInTimeline`, `addedById`, `linkedAt`).
-4. **No new i18n strings.** All seven label keys already exist in every locale.
+4. **No new i18n strings.** All seven label keys were verified present in each of the ten maintained locales
+   (`en`, `de`, `fr`, `it`, `nl`, `pl`, `es`, `ru`, `zh_Hans`, `zh_Hant`).
 5. **Upstream files stay byte-clean.** Web's new option lives in a fork-only layer, not in upstream's
    `AlbumSortBy` enum. See "Why not extend the upstream enum" below.
 6. **Mobile derives photo dates locally** from the Drift query that already runs, rather than switching the
@@ -43,15 +44,15 @@ The platforms also open on different defaults — web on _Most recent photo_, mo
 
 Seven options, identical order, identical labels, identical default direction on both platforms.
 
-| #   | Web id            | Dart identifier   | i18n key               | Default dir | Web field    | Mobile source                      |
-| --- | ----------------- | ----------------- | ---------------------- | ----------- | ------------ | ---------------------------------- |
-| 1   | `Title`           | `name`            | `sort_title`           | Asc         | `albumName`  | `meta.name`                        |
-| 2   | `ItemCount`       | `photoCount`      | `sort_items`           | Desc        | `assetCount` | `count(asset.id)`                  |
-| 3   | `DateModified`    | `recentlyUpdated` | `sort_modified`        | Desc        | `updatedAt`  | `meta.updatedAt`                   |
-| 4   | `DateCreated`     | `dateCreated`     | `sort_created`         | Desc        | `createdAt`  | `meta.createdAt` _(new)_           |
-| 5   | `MostRecentPhoto` | `mostRecentPhoto` | `sort_recent`          | Desc        | `endDate`    | `max(asset.localDateTime)` _(new)_ |
-| 6   | `OldestPhoto`     | `oldestPhoto`     | `sort_oldest`          | Desc        | `startDate`  | `min(asset.localDateTime)` _(new)_ |
-| 7   | `RecentlyLinked`  | `recentlyLinked`  | `sort_recently_linked` | Desc        | `linkedAt`   | `link.createdAt`                   |
+| #   | Web id            | Dart identifier   | i18n key               | Default dir | Web field    | Mobile source                          |
+| --- | ----------------- | ----------------- | ---------------------- | ----------- | ------------ | -------------------------------------- |
+| 1   | `Title`           | `name`            | `sort_title`           | Asc         | `albumName`  | `meta.name`                            |
+| 2   | `ItemCount`       | `photoCount`      | `sort_items`           | Desc        | `assetCount` | `count(asset.id)`                      |
+| 3   | `DateModified`    | `recentlyUpdated` | `sort_modified`        | Desc        | `updatedAt`  | `meta.updatedAt`                       |
+| 4   | `DateCreated`     | `dateCreated`     | `sort_created`         | Desc        | `createdAt`  | `meta.createdAt` _(new)_               |
+| 5   | `MostRecentPhoto` | `mostRecentPhoto` | `sort_recent`          | Desc        | `endDate`    | `max(localDateTime)` → UTC day _(new)_ |
+| 6   | `OldestPhoto`     | `oldestPhoto`     | `sort_oldest`          | Desc        | `startDate`  | `min(localDateTime)` → UTC day _(new)_ |
+| 7   | `RecentlyLinked`  | `recentlyLinked`  | `sort_recently_linked` | Desc        | `linkedAt`   | `link.createdAt`                       |
 
 **Default: `RecentlyLinked` / descending, both platforms.**
 
@@ -101,13 +102,21 @@ platform.
   inverts and the order reverses.
 - **S3 — Selecting a new option applies its default direction.** _Given_ sort is Title (asc); _when_ the user
   picks Number of items; _then_ direction becomes descending, not ascending.
-- **S4 — Number of items.** Orders by asset count.
-- **S5 — Date modified.** Orders by the album's `updatedAt`.
-- **S6 — Date created.** Orders by the album's `createdAt`, which is distinct from `linkedAt`.
-- **S7 — Most recent photo.** Orders by the newest photo in the album.
-- **S8 — Oldest photo.** Orders by the oldest photo in the album.
-- **S9 — Recently linked.** Orders by when the album was linked into _this_ space, which is distinct from the
-  album's own `createdAt`. An album created long ago but linked today sorts first descending.
+- **S4 — Number of items descending.** _Given_ albums Small (1 asset), Big (9), Mid (5); _when_ sorted by Number
+  of items descending; _then_ the order is Big, Mid, Small.
+- **S5 — Date modified descending.** _Given_ albums with `updatedAt` of Jan 3, Jan 1, Jan 2; _when_ sorted by
+  Date modified descending; _then_ the newest `updatedAt` is first.
+- **S6 — Date created is distinct from linked date.** _Given_ album Old (`createdAt` Jan 1, `linkedAt` Mar 1)
+  and album New (`createdAt` Feb 1, `linkedAt` Feb 2); _when_ sorted by Date created descending; _then_ New is
+  first — the opposite of the Recently linked order for the same two albums (see S9).
+- **S7 — Most recent photo descending.** _Given_ album A whose newest photo is Jan 10 and album B whose newest
+  is Jan 20 (B's oldest photo being Jan 1, earlier than A's); _when_ sorted by Most recent photo descending;
+  _then_ B is first. The fixture deliberately makes the oldest-photo order the reverse, so a comparator wired to
+  the wrong field fails.
+- **S8 — Oldest photo ascending.** Same fixture as S7; _when_ sorted by Oldest photo ascending; _then_ B is
+  first, because B's oldest photo (Jan 1) precedes A's.
+- **S9 — Recently linked.** _Given_ the S6 fixture; _when_ sorted by Recently linked descending; _then_ Old is
+  first. An album created long ago but linked today sorts first.
 
 ### Albums with no photo dates
 
@@ -123,14 +132,49 @@ fork layer delegates to it. Mobile must reproduce it.
 - **S13 — Null `localDateTime` counts as no date.** `remote_asset.localDateTime` is nullable
   (`remote_asset.entity.dart:39`), so `MIN`/`MAX` can be null even for an album that has assets. Such an album
   is treated exactly like an empty one for S10–S12, and its asset count is unaffected.
+- **S14 — Every album lacking photo dates.** _Given_ three albums, none with photo dates; _when_ sorted by Most
+  recent photo in either direction; _then_ no album is dropped or duplicated and the order is the platform's
+  tiebreak order (S16). This is the branch where the "unknown last" rule fires for every element.
+
+### Photo-date precision
+
+The server derives album photo dates as a **UTC calendar day**, not a timestamp
+(`server/src/repositories/album.repository.ts:236`):
+
+```sql
+MIN(("asset"."localDateTime" AT TIME ZONE 'UTC'::text)::date)
+```
+
+Mobile must truncate its `MIN`/`MAX` of `remote_asset.localDateTime` to the same UTC day, so both platforms sort
+on an identical key. Without this, two albums whose newest photos fall on the same UTC day compare **equal on
+web** but are **time-ordered on mobile** — a visible ordering difference on the very sorts being added for
+parity.
+
+- **S15 — Same-day albums tie.** _Given_ two albums whose newest photos are 09:00 and 17:00 on the same UTC day;
+  _when_ sorted by Most recent photo; _then_ they compare equal and the tiebreak (S16) decides. Mobile must not
+  order them by time of day.
 
 ### Tiebreaks
 
-- **S14 — Mobile tiebreak is deterministic.** Equal sort keys tie-break by name, then id. Preserved from the
+- **S16 — Mobile tiebreak is deterministic.** Equal sort keys tie-break by name, then id. Preserved from the
   current implementation.
-- Web's tiebreak is input (server) order, because lodash `orderBy` and `Array.sort` are stable. This difference
-  is accepted: the option sets and primary ordering match, which is what #966 asks for. Matching mobile would
-  require post-sorting the six delegated options and changing web behaviour for no user-visible benefit.
+- **S17 — Ties are common under the new default.** _Given_ several albums bulk-linked in one action, so their
+  `linkedAt` values are identical; _when_ sorted by Recently linked (the new default); _then_ the order is
+  stable and deterministic, not arbitrary.
+- Web's tiebreak is the server's ordering, which `getLinkedAlbums` pins explicitly as
+  `album.createdAt DESC, album.id ASC` (`server/src/repositories/shared-space.repository.ts:1018`); lodash
+  `orderBy` and `Array.sort` are stable, so that ordering survives. Mobile ties break by name then id. This
+  difference is accepted: both are deterministic, and the option sets and primary ordering match, which is what
+  #966 asks for. Matching them would mean post-sorting the six delegated options and changing web behaviour for
+  no user-visible benefit.
+
+### Boundary inputs
+
+- **S18 — Empty list.** Sorting zero albums returns zero albums, for every option and direction.
+- **S19 — Single album.** Sorting one album returns it unchanged, for every option and direction.
+- **S20 — `linkedAt` is per space.** _Given_ one album linked into space A on Jan 1 and space B on Mar 1; _when_
+  each space's list is sorted by Recently linked; _then_ each uses its own link date. Mobile's query filters on
+  `link.spaceId`; web's endpoint is already per-space.
 
 ### Accepted divergences
 
@@ -146,28 +190,38 @@ oversights:
   matches name only (`collection_sort.dart:42`). #966 is about sort options; this is filed separately rather
   than folded in.
 - **Photo-date corpus.** Web's `startDate`/`endDate` are server-computed over all album assets; mobile's are
-  derived from locally synced assets. See "Mobile design".
+  derived from locally synced assets. See "Mobile design". (The _precision_ half of this divergence is **not**
+  accepted — mobile truncates to match; see S15.)
 
 ### Filtering
 
-- **S15 — Search filters before sorting** and is case-insensitive, trimmed, literal-substring, with no
+- **S21 — Search filters before sorting** and is case-insensitive, trimmed, literal-substring, with no
   diacritic folding. Unchanged behaviour; asserted to prevent regression.
 
 ### Selection, persistence, defaults
 
-- **S16 — Fresh install opens on Recently linked, descending.**
-- **S17 — A stored preference wins over the new default.**
-- **S18 — A stored preference from before this change still loads.** A device with `recentlyUpdated` or
+- **S22 — Fresh install opens on Recently linked, descending.**
+- **S23 — A stored preference wins over the new default.**
+- **S24 — A stored preference from before this change still loads.** A device with `recentlyUpdated` or
   `photoCount` persisted must load without error and show the relabelled option.
-- **S19 — An unrecognised stored value falls back to the default instead of throwing** (slice M0).
+- **S25 — An unrecognised stored value falls back to the default instead of throwing** (slice M0).
+- **S26 — An unrecognised `sortBy` resolves consistently on web.** _Given_ `localStorage` holds a `sortBy` that
+  matches no option; _when_ the list renders; _then_ the pill label **and** the applied ordering are both
+  `RecentlyLinked`.
+
+  This needs stating because the two halves disagree by default: upstream's `sortAlbums` falls back to
+  `DateModified` (`album-utils.ts:261`) while upstream's `findSortOptionMetadata` falls back to
+  `MostRecentPhoto` (`album-utils.ts:94`) — so upstream shows one option's name while applying another's order.
+  `sortSpaceAlbums` must therefore resolve an unknown key to `RecentlyLinked` **itself**, before delegating,
+  rather than letting the delegate's own fallback apply.
 
 ### Grouping (web only)
 
-- **S20 — Year grouping is disabled for Recently linked.** Year buckets albums by photo date
+- **S27 — Year grouping is disabled for Recently linked.** Year buckets albums by photo date
   (`space-album-grouping.ts:154`), so pairing it with a link-date sort is as incoherent as with Date created or
   Date modified, which are already disabled (`space-album-grouping.ts:40`).
-- **S21 — Grouped lists sort within each group** using the same comparator, including Recently linked.
-- **S22 — No user gets stuck in a disabled combination.** `svelte-persisted-store` writes the whole settings
+- **S28 — Grouped lists sort within each group** using the same comparator, including Recently linked.
+- **S29 — No user gets stuck in a disabled combination.** `svelte-persisted-store` writes the whole settings
   object whenever any field changes, so anyone who had set `groupBy: Year` already has their `sortBy` persisted
   alongside it and keeps it. Only users who never touched any space-album view setting receive the new default,
   and those have `groupBy: None`.
@@ -191,10 +245,14 @@ second.
 - `spaceAlbumSortOptionsMetadata` — upstream's `sortOptionsMetadata` entries followed by a `RecentlyLinked`
   entry (`defaultOrder: Desc`), reusing upstream's `AlbumSortOptionMetadata` shape.
 - `findSpaceAlbumSortOptionMetadata(sortBy)` — like upstream's finder but defaulting to `RecentlyLinked`.
-- `sortSpaceAlbums(albums, { sortBy, orderBy })` — handles `RecentlyLinked` with lodash `orderBy` on
-  `new Date(linkedAt)` (the same shape upstream uses for `DateModified`), and delegates every other value to
+- `sortSpaceAlbums(albums, { sortBy, orderBy })` — resolves `sortBy` through
+  `findSpaceAlbumSortOptionMetadata` **first**, then handles `RecentlyLinked` with lodash `orderBy` on
+  `new Date(linkedAt)` (the same shape upstream uses for `DateModified`) and delegates every other value to
   upstream's `sortAlbums`. Delegation is possible without any upstream change because `sortAlbums` accepts
   `sortBy: string` and `sortOptions` is a plain string-keyed record (`album-utils.ts:260`).
+
+  Resolving before delegating is what makes S26 hold: passing an unknown key straight through would land on
+  upstream's `DateModified` fallback while the pill showed `RecentlyLinked`.
 
   It is typed to take and return `SharedSpaceLinkedAlbumDto[]`, absorbing the `AlbumResponseDto` cast that the
   delegation requires. That removes the existing double `as unknown as` cast at
@@ -237,46 +295,92 @@ reactive.
 | `mobile/lib/domain/models/value_codec.dart`                          | `EnumCodec.decode` falls back instead of throwing (slice M0)                                      |
 
 The asset join carries the existing visibility predicate (`deletedAt IS NULL AND visibility IN (timeline,
-archive)`), so the photo-date range covers exactly the assets the count already reflects and the detail view
-already shows.
+archive)`). This matches the server exactly — `withDefaultVisibility` is
+`visibility IN (Archive, Timeline)` (`server/src/utils/database.ts:159`) and `getMetadataForIds` adds
+`asset.deletedAt IS NULL` — so the photo-date range covers the same assets the count already reflects, on both
+platforms.
 
-**Known and accepted divergence:** web's `startDate`/`endDate` are computed server-side across all album
-assets; mobile's `MIN`/`MAX` cover locally synced assets only. On a partially synced device the two can
-disagree. Fixing this would mean moving the surface to REST and losing offline support — not worth it. The
-option sets and semantics match; only the underlying corpus can lag.
+**Truncate to a UTC day.** The server's aggregate is `MIN/MAX(("asset"."localDateTime" AT TIME ZONE 'UTC')::date)`
+(`album.repository.ts:236`), i.e. day precision. Mobile's `MIN`/`MAX` must be truncated the same way so both
+platforms sort on an identical key (S15). Both platforms read the same underlying column, `localDateTime`, so
+after truncation the keys agree.
+
+**Known and accepted divergence:** web's `startDate`/`endDate` are computed server-side across all album assets;
+mobile's cover locally synced assets only. On a partially synced device the two can disagree. Fixing this would
+mean moving the surface to REST and losing offline support — not worth it. The option sets, the sort key
+semantics and the precision all match; only the underlying corpus can lag.
 
 ## Implementation slices
 
 Each slice is test-first: write the failing test, watch it fail for the right reason, implement, confirm green.
 
-**W1 — Web sort module.** New `space-album-sort.spec.ts` → new `space-album-sort.ts`. Covers S1–S9 for
-`RecentlyLinked`, delegation for the other six, metadata order and default directions, and the unknown-key
-fallback.
+**W1 — Web sort module.** New `space-album-sort.spec.ts` → new `space-album-sort.ts`.
 
-**W2 — Web store default.** `space-album-view-settings.store.spec.ts` → store change. Covers S16, S17.
+**W2 — Web store default.** `space-album-view-settings.store.spec.ts` → store change. Note the existing test is
+named `defaults sort to MostRecentPhoto desc and group to None` (line 14) and must be renamed, not just
+re-asserted.
 
-**W3 — Web controls.** `space-albums-controls.spec.ts` → component change. Covers the menu rendering seven
-labels, the pill showing the correct label for `RecentlyLinked` (the `findSortOptionMetadata` bug), S2, S3.
+**W3 — Web controls.** `space-albums-controls.spec.ts` → component change. Includes the pill showing the correct
+label for `RecentlyLinked` (the `findSortOptionMetadata` bug). The existing test
+`renders all six sort option labels when dropdown is opened` (line 73) becomes seven.
 
 **W4 — Web list and grouping.** `space-albums-list.spec.ts` and `space-album-grouping.spec.ts` → call-site
-changes. Covers S10–S12 at the list level, S20, S21.
+changes.
 
 **M0 — Harden `EnumCodec`.** Test that decoding an unrecognised name yields the default rather than throwing,
-then add the fallback. Covers S19; protects S18 and the downgrade path.
+then add the fallback. Protects the downgrade path.
 
 **M1 — Mobile model and query.** `space_album_repository_test.dart` (medium, real DB) → model and repository
-changes. Covers `createdAt` projection, `MIN`/`MAX` over the visibility-filtered join, an album with no assets
-yielding nulls, and S13.
+changes: `createdAt` projection, truncated `MIN`/`MAX` over the visibility-filtered join, and an album with no
+assets yielding nulls.
 
-**M2 — Mobile sort modes.** `collection_sort_test.dart` → `collection_sort.dart`. Covers S1–S15 for all seven
-modes.
+**M2 — Mobile sort modes.** `collection_sort_test.dart` → `collection_sort.dart`. The existing
+`sort-mode enum shape` group (line 415) asserts per-mode `storeIndex`/`defaultOrder` and must grow to seven.
 
 **M3 — Mobile page assertions.** `space_albums_page_test.dart`. The menu is built from
 `SpaceAlbumSortMode.values` (`space_albums.page.dart:206`), so the three new options appear with no wiring
-change; this slice updates the label assertions (the suite asserts the literal `'Sort: Photo count'`, which
-becomes `'Sort: Number of items'`) and covers persistence round-tripping (S17, S18).
+change; this slice updates the label assertions — the suite asserts the literal `'Sort: Photo count'`, which
+becomes `'Sort: Number of items'`.
+
+**M4 — Mobile persistence.** `app_config_test.dart` already asserts the default
+(`c.spaceAlbums.sortMode == recentlyLinked`, line 10) and round-trips `SettingsKey.spaceAlbumsSortMode`
+(lines 14–18). Extend it to the new modes and to the pre-change stored values.
 
 Existing `SpaceAlbum` fixtures gain `createdAt`, so stubs under `mobile/test/` are updated with M1.
+
+### Scenario coverage map
+
+Every scenario has a named home; no row may be left blank at review time.
+
+| Scenario                        | Web slice / file                             | Mobile slice / file                   |
+| ------------------------------- | -------------------------------------------- | ------------------------------------- |
+| S1 Title asc                    | W1 `space-album-sort.spec.ts`                | M2 `collection_sort_test.dart`        |
+| S2 Direction flips              | W3 `space-albums-controls.spec.ts`           | M3 `space_albums_page_test.dart`      |
+| S3 New option → default dir     | W3 `space-albums-controls.spec.ts`           | M3 `space_albums_page_test.dart`      |
+| S4 Number of items              | W1                                           | M2                                    |
+| S5 Date modified                | W1                                           | M2                                    |
+| S6 Date created ≠ linked        | W1                                           | M2                                    |
+| S7 Most recent photo            | W1                                           | M2                                    |
+| S8 Oldest photo                 | W1                                           | M2                                    |
+| S9 Recently linked              | W1                                           | M2                                    |
+| S10–S12 Empty albums last       | W1 + W4 `space-albums-list.spec.ts`          | M2                                    |
+| S13 Null `localDateTime`        | n/a (server-computed)                        | M1 `space_album_repository_test.dart` |
+| S14 All albums date-less        | W1                                           | M2                                    |
+| S15 Same-day albums tie         | n/a (server truncates)                       | M1 + M2                               |
+| S16 Mobile tiebreak             | n/a                                          | M2                                    |
+| S17 Identical `linkedAt`        | W1                                           | M2                                    |
+| S18 Empty list                  | W1                                           | M2                                    |
+| S19 Single album                | W1                                           | M2                                    |
+| S20 `linkedAt` per space        | n/a (endpoint is per-space)                  | M1                                    |
+| S21 Search before sort          | W4                                           | M2                                    |
+| S22 Fresh default               | W2 `space-album-view-settings.store.spec.ts` | M4 `app_config_test.dart`             |
+| S23 Stored beats default        | W2                                           | M4                                    |
+| S24 Pre-change stored value     | W2                                           | M4                                    |
+| S25 Unrecognised stored value   | n/a                                          | M0 `value_codec` test                 |
+| S26 Unknown `sortBy` consistent | W1 + W3                                      | n/a (enum-typed)                      |
+| S27 Year disabled               | W4 `space-album-grouping.spec.ts`            | n/a (web-only)                        |
+| S28 Sort within group           | W4                                           | n/a                                   |
+| S29 No stuck combination        | W4                                           | n/a                                   |
 
 ## Out of scope
 
@@ -288,6 +392,10 @@ Existing `SpaceAlbum` fixtures gain `createdAt`, so stubs under `mobile/test/` a
 - Sorting the Spaces grid itself (`SpaceSortMode`), a different surface.
 - Removing the two orphaned i18n keys.
 - Title collation parity (see "Accepted divergences").
+- **E2E coverage.** `e2e/src/ui/specs` currently holds only `asset-viewer`, `memory`, `search`, `sidebar` and
+  `timeline` — there is no Playwright coverage of the Spaces surface at all. Establishing it for a sort-option
+  change is disproportionate; the web behaviour is covered by component tests via `@testing-library/svelte`.
+  Recorded so the absence is a decision, not an oversight.
 
 ## Verification gates
 

--- a/mobile/lib/domain/models/settings_key.dart
+++ b/mobile/lib/domain/models/settings_key.dart
@@ -42,9 +42,11 @@ enum SettingsKey<T> {
   peopleSortBy<PeopleSortBy>(codec: EnumCodec(PeopleSortBy.values)),
 
   // Spaces
-  spaceAlbumsSortMode<SpaceAlbumSortMode>(codec: EnumCodec(SpaceAlbumSortMode.values)),
+  spaceAlbumsSortMode<SpaceAlbumSortMode>(
+    codec: EnumCodec(SpaceAlbumSortMode.values, fallback: SpaceAlbumSortMode.recentlyLinked),
+  ),
   spaceAlbumsIsReverse<bool>(),
-  spacesSortMode<SpaceSortMode>(codec: EnumCodec(SpaceSortMode.values)),
+  spacesSortMode<SpaceSortMode>(codec: EnumCodec(SpaceSortMode.values, fallback: SpaceSortMode.recentActivity)),
   spacesIsReverse<bool>(),
 
   // Backup

--- a/mobile/lib/domain/models/space_album.model.dart
+++ b/mobile/lib/domain/models/space_album.model.dart
@@ -8,6 +8,12 @@
 class SpaceAlbum {
   final String id;
   final String name;
+
+  /// Album description. Nullable because the Drift column is — a row synced
+  /// from a `SyncAlbumV2` with no description stores NULL. Carried purely so
+  /// the album search box can match it, which is what web does
+  /// (`space-albums-list.svelte` filters on name OR description, #973).
+  final String? description;
   final String? thumbnailAssetId;
   final bool showInTimeline;
   final int assetCount;
@@ -25,6 +31,7 @@ class SpaceAlbum {
   const SpaceAlbum({
     required this.id,
     required this.name,
+    this.description,
     this.thumbnailAssetId,
     required this.showInTimeline,
     this.assetCount = 0,

--- a/mobile/lib/domain/models/space_album.model.dart
+++ b/mobile/lib/domain/models/space_album.model.dart
@@ -13,6 +13,14 @@ class SpaceAlbum {
   final int assetCount;
   final DateTime linkedAt;
   final DateTime updatedAt;
+  final DateTime createdAt;
+
+  /// Oldest / newest photo in the album, truncated to a UTC calendar day to
+  /// match the server's `MIN/MAX((localDateTime AT TIME ZONE 'UTC')::date)`.
+  /// Null when the album has no visible assets, or when none of them carries a
+  /// `localDateTime`.
+  final DateTime? startDate;
+  final DateTime? endDate;
 
   const SpaceAlbum({
     required this.id,
@@ -22,5 +30,8 @@ class SpaceAlbum {
     this.assetCount = 0,
     required this.linkedAt,
     required this.updatedAt,
+    required this.createdAt,
+    this.startDate,
+    this.endDate,
   });
 }

--- a/mobile/lib/domain/models/value_codec.dart
+++ b/mobile/lib/domain/models/value_codec.dart
@@ -36,13 +36,19 @@ sealed class ValueCodec<T> {
 final class EnumCodec<T extends Enum> extends ValueCodec<T> {
   final List<T> values;
 
-  const EnumCodec(this.values);
+  /// Value returned when a persisted name matches no enum value — e.g. after a
+  /// downgrade, where an older build reads a mode a newer build wrote. Without
+  /// this, `decode` threw `StateError` and `SettingsRepository`'s unguarded
+  /// startup `refresh()` turned that into a launch crash.
+  final T? fallback;
+
+  const EnumCodec(this.values, {this.fallback});
 
   @override
   String encode(T value) => value.name;
 
   @override
-  T decode(String raw) => values.firstWhere((v) => v.name == raw);
+  T decode(String raw) => values.firstWhere((v) => v.name == raw, orElse: () => fallback ?? values.first);
 }
 
 final class DateTimeCodec extends ValueCodec<DateTime> {

--- a/mobile/lib/infrastructure/repositories/space_album.repository.dart
+++ b/mobile/lib/infrastructure/repositories/space_album.repository.dart
@@ -35,6 +35,8 @@ class SpaceAlbumRepository extends DriftDatabaseRepository {
     // WHERE, so an album with zero visible assets still surfaces with count 0.
     // remote_asset.id.count() ignores the NULLs a LEFT JOIN produces.
     final assetCountExp = asset.id.count();
+    final minDateExp = asset.localDateTime.min();
+    final maxDateExp = asset.localDateTime.max();
 
     final query =
         _db.select(link).join([
@@ -50,7 +52,7 @@ class SpaceAlbumRepository extends DriftDatabaseRepository {
             ),
           ])
           ..where(link.spaceId.equals(spaceId))
-          ..addColumns([assetCountExp])
+          ..addColumns([assetCountExp, minDateExp, maxDateExp])
           ..groupBy([link.spaceId, link.albumId, meta.id])
           ..orderBy([OrderingTerm.asc(meta.name)]);
 
@@ -66,6 +68,9 @@ class SpaceAlbumRepository extends DriftDatabaseRepository {
           assetCount: row.read(assetCountExp) ?? 0,
           linkedAt: l.createdAt,
           updatedAt: m.updatedAt,
+          createdAt: m.createdAt,
+          startDate: _utcDay(row.read(minDateExp)),
+          endDate: _utcDay(row.read(maxDateExp)),
         );
       }).toList(),
     );
@@ -84,4 +89,15 @@ class SpaceAlbumRepository extends DriftDatabaseRepository {
       _db.sharedSpaceAlbumLinkEntity,
     )..where((t) => t.spaceId.equals(spaceId) & t.albumId.equals(albumId))).go();
   }
+}
+
+/// Truncate to a UTC calendar day so the sort key matches the server's
+/// `::date` cast (see the #966 design spec). Truncating in Dart rather than SQL
+/// keeps this independent of how Drift stores `DateTime`.
+DateTime? _utcDay(DateTime? value) {
+  if (value == null) {
+    return null;
+  }
+  final utc = value.toUtc();
+  return DateTime.utc(utc.year, utc.month, utc.day);
 }

--- a/mobile/lib/infrastructure/repositories/space_album.repository.dart
+++ b/mobile/lib/infrastructure/repositories/space_album.repository.dart
@@ -63,6 +63,7 @@ class SpaceAlbumRepository extends DriftDatabaseRepository {
         return SpaceAlbum(
           id: m.id,
           name: m.name,
+          description: m.description,
           thumbnailAssetId: m.thumbnailAssetId,
           showInTimeline: l.showInTimeline,
           assetCount: row.read(assetCountExp) ?? 0,

--- a/mobile/lib/infrastructure/repositories/space_album.repository.dart
+++ b/mobile/lib/infrastructure/repositories/space_album.repository.dart
@@ -92,8 +92,17 @@ class SpaceAlbumRepository extends DriftDatabaseRepository {
 }
 
 /// Truncate to a UTC calendar day so the sort key matches the server's
-/// `::date` cast (see the #966 design spec). Truncating in Dart rather than SQL
-/// keeps this independent of how Drift stores `DateTime`.
+/// `MIN/MAX(("asset"."localDateTime" AT TIME ZONE 'UTC')::date)` — both
+/// platforms sort on the same day, not a timestamp.
+///
+/// `.toUtc()` is load-bearing, do not remove it: Drift hands back
+/// `localDateTime` with `isUtc == false` (the column is stored as ISO-8601
+/// text with an offset suffix — `storeDateTimeAsText: true`), so reading
+/// year/month/day straight off `value` would truncate to the *device's*
+/// local calendar day, which can be a day off from the UTC day the server
+/// computed. No test guards this call: mobile CI runs on ubuntu-latest with
+/// no TZ override, where local and UTC digits happen to coincide, so a
+/// dropped `.toUtc()` would pass CI and only misbehave on a non-UTC device.
 DateTime? _utcDay(DateTime? value) {
   if (value == null) {
     return null;

--- a/mobile/lib/infrastructure/repositories/space_album.repository.dart
+++ b/mobile/lib/infrastructure/repositories/space_album.repository.dart
@@ -95,14 +95,18 @@ class SpaceAlbumRepository extends DriftDatabaseRepository {
 /// `MIN/MAX(("asset"."localDateTime" AT TIME ZONE 'UTC')::date)` — both
 /// platforms sort on the same day, not a timestamp.
 ///
-/// `.toUtc()` is load-bearing, do not remove it: Drift hands back
-/// `localDateTime` with `isUtc == false` (the column is stored as ISO-8601
-/// text with an offset suffix — `storeDateTimeAsText: true`), so reading
-/// year/month/day straight off `value` would truncate to the *device's*
-/// local calendar day, which can be a day off from the UTC day the server
-/// computed. No test guards this call: mobile CI runs on ubuntu-latest with
-/// no TZ override, where local and UTC digits happen to coincide, so a
-/// dropped `.toUtc()` would pass CI and only misbehave on a non-UTC device.
+/// `.toUtc()` is load-bearing, do not remove it: for synced rows,
+/// `mapDateTime` parses the server's `Z`-suffixed ISO-8601 string with
+/// `DateTime.tryParse`, which yields `isUtc == true`, so those already read
+/// back from Drift as UTC and `.toUtc()` is a no-op on them. It is genuinely
+/// load-bearing for locally-constructed `DateTime`s that are *not* already
+/// UTC — e.g. the medium-test fixture, which writes `createdAt.toLocal()` —
+/// where reading year/month/day straight off `value` would truncate to the
+/// *device's* local calendar day, which can be a day off from the UTC day
+/// the server computed. No test guards this call: mobile CI runs on
+/// ubuntu-latest with no TZ override, where local and UTC digits happen to
+/// coincide, so a dropped `.toUtc()` would pass CI and only misbehave on a
+/// non-UTC device (or a non-UTC locally-constructed row).
 DateTime? _utcDay(DateTime? value) {
   if (value == null) {
     return null;

--- a/mobile/lib/pages/library/spaces/collection_sort.dart
+++ b/mobile/lib/pages/library/spaces/collection_sort.dart
@@ -57,8 +57,10 @@ bool _matches(String name, String query) {
 int _byName(String a, String b) => a.toLowerCase().compareTo(b.toLowerCase());
 
 /// Albums with no photo dates sort last in BOTH directions, matching upstream
-/// web's `sortUnknownYearAlbums`. Returns null when neither side is missing, so
-/// the caller can fall through to the normal comparison.
+/// web's `sortUnknownYearAlbums`. Returns null — deferring to the caller's
+/// normal comparison — in the two cases where "one side is missing" doesn't
+/// apply: both sides null (a tie; the caller falls through to the name/id
+/// tie-break) and both sides present (the caller does the real comparison).
 ///
 /// Upstream checks `endDate` for both photo-date sorts, including the one that
 /// orders by `startDate`. This checks each mode's own field instead. The two

--- a/mobile/lib/pages/library/spaces/collection_sort.dart
+++ b/mobile/lib/pages/library/spaces/collection_sort.dart
@@ -49,9 +49,17 @@ enum SpaceSortMode {
 
 /// Case-insensitive, trimmed, literal-substring match — no regex, no
 /// diacritic folding (intentional; see the design spec).
-bool _matches(String name, String query) {
+///
+/// [fields] are OR-ed: a row matches when *any* of them contains the query.
+/// Nulls are skipped, so an absent field can never match. Which fields get
+/// passed is the per-collection decision — albums search name + description to
+/// match web (#973), spaces search the name only.
+bool _matches(Iterable<String?> fields, String query) {
   final q = query.trim().toLowerCase();
-  return q.isEmpty || name.toLowerCase().contains(q);
+  if (q.isEmpty) {
+    return true;
+  }
+  return fields.any((field) => field != null && field.toLowerCase().contains(q));
 }
 
 int _byName(String a, String b) => a.toLowerCase().compareTo(b.toLowerCase());
@@ -80,7 +88,8 @@ List<SpaceAlbum> filterAndSortSpaceAlbums(
   bool isReverse,
 ) {
   final sign = mode.effectiveOrder(isReverse) == SortOrder.asc ? 1 : -1;
-  final out = items.where((a) => _matches(a.name, query)).toList();
+  // Name OR description, matching web's `space-albums-list.svelte` filter.
+  final out = items.where((a) => _matches([a.name, a.description], query)).toList();
   out.sort((a, b) {
     // Applied outside the sign so empty albums stay last in both directions.
     final unknown = switch (mode) {
@@ -132,7 +141,7 @@ List<SharedSpaceResponseDto> filterAndSortSpaces(
   bool isReverse,
 ) {
   final sign = mode.effectiveOrder(isReverse) == SortOrder.asc ? 1 : -1;
-  final out = items.where((s) => _matches(s.name, query)).toList();
+  final out = items.where((s) => _matches([s.name], query)).toList();
   out.sort((a, b) {
     final c = switch (mode) {
       SpaceSortMode.name => _byName(a.name, b.name),

--- a/mobile/lib/pages/library/spaces/collection_sort.dart
+++ b/mobile/lib/pages/library/spaces/collection_sort.dart
@@ -3,11 +3,23 @@ import 'package:immich_mobile/domain/models/space_album.model.dart';
 import 'package:openapi/api.dart';
 
 /// Sort modes for a space's linked-albums grid ([SpaceAlbumsPage]).
+///
+/// Declaration order IS menu order — [SpaceAlbumsPage] builds the menu from
+/// `values`. The set and order match the web sort dropdown (see the #966 design
+/// spec).
+///
+/// The identifiers are persisted verbatim by `EnumCodec` (`value.name`), so
+/// renaming one silently resets every user who had it selected. That is why
+/// `name` is labelled "Title" and `recentlyUpdated` is labelled "Date modified"
+/// rather than being renamed to match.
 enum SpaceAlbumSortMode {
-  name(0, 'name', SortOrder.asc),
-  photoCount(1, 'sort_photo_count', SortOrder.desc),
-  recentlyLinked(2, 'sort_recently_linked', SortOrder.desc),
-  recentlyUpdated(3, 'sort_recently_updated', SortOrder.desc);
+  name(0, 'sort_title', SortOrder.asc),
+  photoCount(1, 'sort_items', SortOrder.desc),
+  recentlyUpdated(3, 'sort_modified', SortOrder.desc),
+  dateCreated(4, 'sort_created', SortOrder.desc),
+  mostRecentPhoto(5, 'sort_recent', SortOrder.desc),
+  oldestPhoto(6, 'sort_oldest', SortOrder.desc),
+  recentlyLinked(2, 'sort_recently_linked', SortOrder.desc);
 
   const SpaceAlbumSortMode(this.storeIndex, this.label, this.defaultOrder);
 
@@ -44,6 +56,21 @@ bool _matches(String name, String query) {
 
 int _byName(String a, String b) => a.toLowerCase().compareTo(b.toLowerCase());
 
+/// Albums with no photo dates sort last in BOTH directions, matching upstream
+/// web's `sortUnknownYearAlbums`. Returns null when neither side is missing, so
+/// the caller can fall through to the normal comparison.
+///
+/// Upstream checks `endDate` for both photo-date sorts, including the one that
+/// orders by `startDate`. This checks each mode's own field instead. The two
+/// are equivalent in practice — both dates come from the same aggregate, so an
+/// album has both or neither — so do not "fix" this to match upstream's quirk.
+int? _unknownDateLast(DateTime? a, DateTime? b) {
+  if (a == null && b == null) return null;
+  if (a == null) return 1;
+  if (b == null) return -1;
+  return null;
+}
+
 List<SpaceAlbum> filterAndSortSpaceAlbums(
   List<SpaceAlbum> items,
   String query,
@@ -53,11 +80,25 @@ List<SpaceAlbum> filterAndSortSpaceAlbums(
   final sign = mode.effectiveOrder(isReverse) == SortOrder.asc ? 1 : -1;
   final out = items.where((a) => _matches(a.name, query)).toList();
   out.sort((a, b) {
+    // Applied outside the sign so empty albums stay last in both directions.
+    final unknown = switch (mode) {
+      SpaceAlbumSortMode.mostRecentPhoto => _unknownDateLast(a.endDate, b.endDate),
+      SpaceAlbumSortMode.oldestPhoto => _unknownDateLast(a.startDate, b.startDate),
+      _ => null,
+    };
+    if (unknown != null) return unknown;
+
     final c = switch (mode) {
       SpaceAlbumSortMode.name => _byName(a.name, b.name),
       SpaceAlbumSortMode.photoCount => a.assetCount.compareTo(b.assetCount),
       SpaceAlbumSortMode.recentlyLinked => a.linkedAt.compareTo(b.linkedAt),
       SpaceAlbumSortMode.recentlyUpdated => a.updatedAt.compareTo(b.updatedAt),
+      SpaceAlbumSortMode.dateCreated => a.createdAt.compareTo(b.createdAt),
+      // _unknownDateLast has already returned for the case where exactly one
+      // side is null. Reaching here means both are null (tie — fall through to
+      // the name/id tie-break below) or both are present (real comparison).
+      SpaceAlbumSortMode.mostRecentPhoto => a.endDate == null ? 0 : a.endDate!.compareTo(b.endDate!),
+      SpaceAlbumSortMode.oldestPhoto => a.startDate == null ? 0 : a.startDate!.compareTo(b.startDate!),
     };
     if (c != 0) return sign * c;
     final n = _byName(a.name, b.name);

--- a/mobile/test/domain/models/config/app_config_test.dart
+++ b/mobile/test/domain/models/config/app_config_test.dart
@@ -26,5 +26,29 @@ void main() {
       final w = c.write(SettingsKey.spacesIsReverse, true);
       expect(w.read(SettingsKey.spacesIsReverse), true);
     });
+
+    // S22
+    test('space-album sort still defaults to recentlyLinked', () {
+      const c = AppConfig();
+      expect(c.spaceAlbums.sortMode, SpaceAlbumSortMode.recentlyLinked);
+      expect(c.spaceAlbums.isReverse, false);
+    });
+
+    // S23 / S24 — every mode round-trips, including the pre-#966 identifiers
+    // (name, photoCount, recentlyUpdated) that must never be renamed.
+    test('every space-album sort mode round-trips', () {
+      const c = AppConfig();
+      for (final mode in SpaceAlbumSortMode.values) {
+        final w = c.write(SettingsKey.spaceAlbumsSortMode, mode);
+        expect(w.read(SettingsKey.spaceAlbumsSortMode), mode, reason: '${mode.name} did not round-trip');
+      }
+    });
+
+    test('the persisted identifiers of the pre-existing modes are unchanged', () {
+      expect(SpaceAlbumSortMode.name.name, 'name');
+      expect(SpaceAlbumSortMode.photoCount.name, 'photoCount');
+      expect(SpaceAlbumSortMode.recentlyUpdated.name, 'recentlyUpdated');
+      expect(SpaceAlbumSortMode.recentlyLinked.name, 'recentlyLinked');
+    });
   });
 }

--- a/mobile/test/domain/models/value_codec_test.dart
+++ b/mobile/test/domain/models/value_codec_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/domain/models/value_codec.dart';
+import 'package:immich_mobile/pages/library/spaces/collection_sort.dart';
+
+void main() {
+  group('EnumCodec', () {
+    test('round-trips a known value', () {
+      const codec = EnumCodec(SpaceAlbumSortMode.values);
+      expect(codec.encode(SpaceAlbumSortMode.photoCount), 'photoCount');
+      expect(codec.decode('photoCount'), SpaceAlbumSortMode.photoCount);
+    });
+
+    // S25 — a value written by a newer build must not crash an older one at
+    // startup. CachedKeyValueRepository._build calls decode unguarded and
+    // SettingsRepository.ensureInitialized awaits it during app launch.
+    test('returns the declared fallback for an unrecognised name', () {
+      const codec = EnumCodec(SpaceAlbumSortMode.values, fallback: SpaceAlbumSortMode.recentlyLinked);
+      expect(codec.decode('aModeFromTheFuture'), SpaceAlbumSortMode.recentlyLinked);
+      expect(codec.decode(''), SpaceAlbumSortMode.recentlyLinked);
+    });
+
+    test('falls back to the first value when no fallback is declared', () {
+      const codec = EnumCodec(SpaceAlbumSortMode.values);
+      expect(codec.decode('nope'), SpaceAlbumSortMode.values.first);
+    });
+  });
+}

--- a/mobile/test/domain/models/value_codec_test.dart
+++ b/mobile/test/domain/models/value_codec_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/domain/models/settings_key.dart';
 import 'package:immich_mobile/domain/models/value_codec.dart';
 import 'package:immich_mobile/pages/library/spaces/collection_sort.dart';
 
@@ -22,6 +23,14 @@ void main() {
     test('falls back to the first value when no fallback is declared', () {
       const codec = EnumCodec(SpaceAlbumSortMode.values);
       expect(codec.decode('nope'), SpaceAlbumSortMode.values.first);
+    });
+
+    // S25, asserted on the actual wired key rather than a local EnumCodec —
+    // deleting the `fallback:` argument from
+    // SettingsKey.spaceAlbumsSortMode's declaration must fail this test.
+    test('SettingsKey.spaceAlbumsSortMode falls back to recentlyLinked for an unrecognised name', () {
+      expect(SettingsKey.spaceAlbumsSortMode.decode('aModeFromTheFuture'), SpaceAlbumSortMode.recentlyLinked);
+      expect(SettingsKey.spaceAlbumsSortMode.decode('recentlyUpdated'), SpaceAlbumSortMode.recentlyUpdated);
     });
   });
 }

--- a/mobile/test/medium/repositories/space_album_repository_test.dart
+++ b/mobile/test/medium/repositories/space_album_repository_test.dart
@@ -135,6 +135,21 @@ void main() {
       expect(albums.single.createdAt, album.createdAt);
     });
 
+    // #973 — the album search box matches the description, so the join has to
+    // carry it. It is only ever read for search, hence no other coverage.
+    test('projects the album description from the metadata row, null when unset', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      final described = await ctx.newSharedSpaceAlbum(name: 'Hawaii', description: 'Reef dives, 2025');
+      final bare = await ctx.newSharedSpaceAlbum(name: 'Reef');
+      await ctx.insertSharedSpaceAlbumLink(spaceId: space.id, albumId: described.id);
+      await ctx.insertSharedSpaceAlbumLink(spaceId: space.id, albumId: bare.id);
+
+      final albums = await repo.watchLinkedAlbums(space.id).first;
+      expect(albums.firstWhere((a) => a.id == described.id).description, 'Reef dives, 2025');
+      expect(albums.firstWhere((a) => a.id == bare.id).description, isNull);
+    });
+
     test('derives startDate/endDate from the album assets, truncated to a UTC day', () async {
       final user = await ctx.newUser();
       final space = await ctx.newSharedSpace(createdById: user.id);

--- a/mobile/test/medium/repositories/space_album_repository_test.dart
+++ b/mobile/test/medium/repositories/space_album_repository_test.dart
@@ -1,3 +1,4 @@
+import 'package:drift/drift.dart' show Value;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/infrastructure/repositories/remote_album.repository.dart';
@@ -167,6 +168,26 @@ void main() {
       expect(albums.single.endDate, isNull);
     });
 
+    // S13 — remote_asset.localDateTime is nullable, so MIN/MAX can be null even
+    // for an album that has assets. Such an album must be treated exactly like
+    // an empty one for the date range, but its asset count is unaffected.
+    test('startDate/endDate stay null when every asset has a null localDateTime (S13)', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      final album = await ctx.newSharedSpaceAlbum(name: 'NoDates');
+      await ctx.insertSharedSpaceAlbumLink(spaceId: space.id, albumId: album.id);
+
+      final asset1 = await ctx.newRemoteAsset(ownerId: user.id, localDateTime: const Value(null));
+      final asset2 = await ctx.newRemoteAsset(ownerId: user.id, localDateTime: const Value(null));
+      await ctx.insertSharedSpaceAlbumAsset(albumId: album.id, assetId: asset1.id);
+      await ctx.insertSharedSpaceAlbumAsset(albumId: album.id, assetId: asset2.id);
+
+      final albums = await repo.watchLinkedAlbums(space.id).first;
+      expect(albums.single.assetCount, 2, reason: 'asset count must be unaffected by missing localDateTime');
+      expect(albums.single.startDate, isNull);
+      expect(albums.single.endDate, isNull);
+    });
+
     test('excludes deleted and hidden assets from the date range', () async {
       final user = await ctx.newUser();
       final space = await ctx.newSharedSpace(createdById: user.id);
@@ -204,7 +225,8 @@ void main() {
 
       final inS1 = await repo.watchLinkedAlbums(s1.id).first;
       final inS2 = await repo.watchLinkedAlbums(s2.id).first;
-      expect(inS1.single.linkedAt, isNot(inS2.single.linkedAt));
+      expect(inS1.single.linkedAt, DateTime.utc(2026, 1, 1));
+      expect(inS2.single.linkedAt, DateTime.utc(2026, 3, 1));
     });
   });
 

--- a/mobile/test/medium/repositories/space_album_repository_test.dart
+++ b/mobile/test/medium/repositories/space_album_repository_test.dart
@@ -123,6 +123,89 @@ void main() {
       expect(albums.single.linkedAt, linked);
       expect(albums.single.updatedAt, updated);
     });
+
+    test('projects the album createdAt from the metadata row', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      final album = await ctx.newSharedSpaceAlbum(name: 'Hawaii', createdAt: DateTime.utc(2025, 6, 1));
+      await ctx.insertSharedSpaceAlbumLink(spaceId: space.id, albumId: album.id);
+
+      final albums = await repo.watchLinkedAlbums(space.id).first;
+      expect(albums.single.createdAt, album.createdAt);
+    });
+
+    test('derives startDate/endDate from the album assets, truncated to a UTC day', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      final album = await ctx.newSharedSpaceAlbum(name: 'Hawaii');
+      await ctx.insertSharedSpaceAlbumLink(spaceId: space.id, albumId: album.id);
+
+      for (final at in [
+        DateTime.utc(2026, 1, 5, 9, 30),
+        DateTime.utc(2026, 1, 20, 17, 45),
+        DateTime.utc(2026, 1, 12, 3, 0),
+      ]) {
+        final asset = await ctx.newRemoteAsset(ownerId: user.id, createdAt: at);
+        await ctx.insertSharedSpaceAlbumAsset(albumId: album.id, assetId: asset.id);
+      }
+
+      final albums = await repo.watchLinkedAlbums(space.id).first;
+      // S15 — day precision, matching the server's ::date cast. Times of day gone.
+      expect(albums.single.startDate, DateTime.utc(2026, 1, 5));
+      expect(albums.single.endDate, DateTime.utc(2026, 1, 20));
+    });
+
+    test('leaves startDate/endDate null for an album with no assets', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      final album = await ctx.newSharedSpaceAlbum(name: 'Empty');
+      await ctx.insertSharedSpaceAlbumLink(spaceId: space.id, albumId: album.id);
+
+      final albums = await repo.watchLinkedAlbums(space.id).first;
+      expect(albums.single.assetCount, 0);
+      expect(albums.single.startDate, isNull);
+      expect(albums.single.endDate, isNull);
+    });
+
+    test('excludes deleted and hidden assets from the date range', () async {
+      final user = await ctx.newUser();
+      final space = await ctx.newSharedSpace(createdById: user.id);
+      final album = await ctx.newSharedSpaceAlbum(name: 'Hawaii');
+      await ctx.insertSharedSpaceAlbumLink(spaceId: space.id, albumId: album.id);
+
+      final visible = await ctx.newRemoteAsset(ownerId: user.id, createdAt: DateTime.utc(2026, 1, 10));
+      final deleted = await ctx.newRemoteAsset(
+        ownerId: user.id,
+        createdAt: DateTime.utc(2026, 5, 1),
+        deletedAt: DateTime.utc(2026, 5, 2),
+      );
+      final hidden = await ctx.newRemoteAsset(
+        ownerId: user.id,
+        createdAt: DateTime.utc(2026, 6, 1),
+        visibility: AssetVisibility.hidden,
+      );
+      for (final a in [visible, deleted, hidden]) {
+        await ctx.insertSharedSpaceAlbumAsset(albumId: album.id, assetId: a.id);
+      }
+
+      final albums = await repo.watchLinkedAlbums(space.id).first;
+      expect(albums.single.assetCount, 1);
+      expect(albums.single.endDate, DateTime.utc(2026, 1, 10));
+    });
+
+    // S20
+    test('reports the per-space link date when an album is linked to two spaces', () async {
+      final user = await ctx.newUser();
+      final s1 = await ctx.newSharedSpace(createdById: user.id);
+      final s2 = await ctx.newSharedSpace(createdById: user.id);
+      final album = await ctx.newSharedSpaceAlbum(name: 'Shared');
+      await ctx.insertSharedSpaceAlbumLink(spaceId: s1.id, albumId: album.id, createdAt: DateTime.utc(2026, 1, 1));
+      await ctx.insertSharedSpaceAlbumLink(spaceId: s2.id, albumId: album.id, createdAt: DateTime.utc(2026, 3, 1));
+
+      final inS1 = await repo.watchLinkedAlbums(s1.id).first;
+      final inS2 = await repo.watchLinkedAlbums(s2.id).first;
+      expect(inS1.single.linkedAt, isNot(inS2.single.linkedAt));
+    });
   });
 
   test('deleteAlbumMetadata removes metadata + membership but keeps remote_asset', () async {

--- a/mobile/test/medium/repository_context.dart
+++ b/mobile/test/medium/repository_context.dart
@@ -458,6 +458,7 @@ class MediumRepositoryContext {
   Future<SharedSpaceAlbumEntityData> newSharedSpaceAlbum({
     String? id,
     String? name,
+    String? description,
     String? thumbnailAssetId,
     bool? isActivityEnabled,
     int? order,
@@ -471,6 +472,9 @@ class MediumRepositoryContext {
           SharedSpaceAlbumEntityCompanion(
             id: .new(id),
             name: .new(name ?? 'space_album_$id'),
+            // Left NULL by default — the column is nullable and a SyncAlbumV2
+            // with no description stores NULL, so that is the realistic default.
+            description: .new(description),
             thumbnailAssetId: .new(thumbnailAssetId),
             isActivityEnabled: .new(isActivityEnabled ?? true),
             order: .new(order ?? 0),

--- a/mobile/test/medium/repository_context.dart
+++ b/mobile/test/medium/repository_context.dart
@@ -111,6 +111,10 @@ class MediumRepositoryContext {
     String? stackId,
     String? thumbHash,
     String? libraryId,
+    // Defaults to createdAt.toLocal() (the pre-existing behaviour). Pass
+    // Value(null) explicitly to simulate an asset synced with no
+    // localDateTime — remote_asset.localDateTime is nullable (S13).
+    Value<DateTime?> localDateTime = const Value.absent(),
   }) async {
     id ??= TestUtils.uuid();
     createdAt ??= TestUtils.date();
@@ -134,7 +138,7 @@ class MediumRepositoryContext {
             isEdited: .new(isEdited ?? false),
             livePhotoVideoId: .new(livePhotoVideoId),
             stackId: .new(stackId),
-            localDateTime: .new(createdAt.toLocal()),
+            localDateTime: localDateTime.present ? localDateTime : Value(createdAt.toLocal()),
             thumbHash: .new(TestUtils.uuid(thumbHash)),
             libraryId: .new(TestUtils.uuid(libraryId)),
           ),

--- a/mobile/test/pages/library/spaces/collection_sort_test.dart
+++ b/mobile/test/pages/library/spaces/collection_sort_test.dart
@@ -76,6 +76,7 @@ final sample = <SpaceAlbum>[
 SpaceAlbum _album({
   required String id,
   required String name,
+  String? description,
   int assetCount = 0,
   DateTime? linkedAt,
   DateTime? updatedAt,
@@ -85,6 +86,7 @@ SpaceAlbum _album({
 }) => SpaceAlbum(
   id: id,
   name: name,
+  description: description,
   assetCount: assetCount,
   showInTimeline: true,
   linkedAt: linkedAt ?? DateTime.utc(2026, 1, 1),
@@ -198,6 +200,53 @@ void main() {
         );
       }
       expect(filterAndSortSpaceAlbums(sample, '.*', SpaceAlbumSortMode.name, false), isEmpty);
+    });
+  });
+
+  // #973 — web's album search box matches name OR description
+  // (`space-albums-list.svelte`). Mobile matched the name only, so a query that
+  // hit only a description found the album on web and nothing here.
+  //
+  // Kept on its own fixtures: the shared `sample` list has null descriptions
+  // throughout, which is what keeps the group above honest about names.
+  group('filterAndSortSpaceAlbums — description search', () {
+    // 'chamonix' deliberately appears in one row's description and another's
+    // name; 'City Break' carries no description at all.
+    final described = <SpaceAlbum>[
+      _album(id: 'd-alps', name: 'Alps Weekend', description: 'Hiking above Chamonix'),
+      _album(id: 'd-city', name: 'City Break'),
+      _album(id: 'd-market', name: 'Chamonix Market', description: 'Sunday stalls'),
+    ];
+
+    test('matches a description when the name does not', () {
+      expect(names(filterAndSortSpaceAlbums(described, 'hiking', SpaceAlbumSortMode.name, false)), ['Alps Weekend']);
+    });
+
+    test('description matching is case-insensitive and trimmed, like the name', () {
+      expect(names(filterAndSortSpaceAlbums(described, '  SUNDAY  ', SpaceAlbumSortMode.name, false)), [
+        'Chamonix Market',
+      ]);
+    });
+
+    test('name and description hits union without duplicating a row', () {
+      expect(names(filterAndSortSpaceAlbums(described, 'chamonix', SpaceAlbumSortMode.name, false)), [
+        'Alps Weekend',
+        'Chamonix Market',
+      ]);
+    });
+
+    test('a null description is skipped, not matched or thrown on', () {
+      // The null-description row is still reachable by name...
+      expect(names(filterAndSortSpaceAlbums(described, 'city', SpaceAlbumSortMode.name, false)), ['City Break']);
+      // ...and a query that matches nothing anywhere stays empty rather than
+      // matching the null row or blowing up on it.
+      expect(filterAndSortSpaceAlbums(described, 'zzz-no-such-text', SpaceAlbumSortMode.name, false), isEmpty);
+    });
+
+    test('descriptions are not diacritic-folded either', () {
+      final accented = [_album(id: 'd-a', name: 'Trip', description: 'Sächsische Schweiz')];
+      expect(filterAndSortSpaceAlbums(accented, 'sächsische', SpaceAlbumSortMode.name, false), isNotEmpty);
+      expect(filterAndSortSpaceAlbums(accented, 'sachsische', SpaceAlbumSortMode.name, false), isEmpty);
     });
   });
 
@@ -411,10 +460,10 @@ void main() {
 
       // members desc by default: present-but-null memberCount treated as 0,
       // sorting after the space with 3 members.
-      expect(
-        filterAndSortSpaces(items, '', SpaceSortMode.members, false).map((s) => s.id).toList(),
-        ['has-members', 'present-null'],
-      );
+      expect(filterAndSortSpaces(items, '', SpaceSortMode.members, false).map((s) => s.id).toList(), [
+        'has-members',
+        'present-null',
+      ]);
 
       // recentActivity: present-but-null lastActivityAt falls back to
       // updatedAt (not a crash on a null `.value`); hasMembers' real
@@ -511,11 +560,10 @@ void main() {
       ];
       for (final mode in [SpaceAlbumSortMode.mostRecentPhoto, SpaceAlbumSortMode.oldestPhoto]) {
         for (final isReverse in [false, true]) {
-          expect(
-            names(filterAndSortSpaceAlbums(items, '', mode, isReverse)),
-            ['HasPhotos', 'Empty'],
-            reason: '$mode isReverse=$isReverse',
-          );
+          expect(names(filterAndSortSpaceAlbums(items, '', mode, isReverse)), [
+            'HasPhotos',
+            'Empty',
+          ], reason: '$mode isReverse=$isReverse');
         }
       }
     });

--- a/mobile/test/pages/library/spaces/collection_sort_test.dart
+++ b/mobile/test/pages/library/spaces/collection_sort_test.dart
@@ -424,6 +424,161 @@ void main() {
     });
   });
 
+  group('space-album sort parity (#966)', () {
+    SpaceAlbum a({
+      required String id,
+      required String name,
+      DateTime? createdAt,
+      DateTime? linkedAt,
+      DateTime? startDate,
+      DateTime? endDate,
+      int assetCount = 0,
+    }) => SpaceAlbum(
+      id: id,
+      name: name,
+      showInTimeline: true,
+      assetCount: assetCount,
+      linkedAt: linkedAt ?? DateTime.utc(2026, 1, 1),
+      updatedAt: DateTime.utc(2026, 1, 1),
+      createdAt: createdAt ?? DateTime.utc(2026, 1, 1),
+      startDate: startDate,
+      endDate: endDate,
+    );
+
+    // The contract order from the design spec — the menu is built from
+    // SpaceAlbumSortMode.values, so declaration order IS menu order.
+    test('offers the seven contract options in order with the contract labels', () {
+      expect(SpaceAlbumSortMode.values.map((m) => m.name), [
+        'name',
+        'photoCount',
+        'recentlyUpdated',
+        'dateCreated',
+        'mostRecentPhoto',
+        'oldestPhoto',
+        'recentlyLinked',
+      ]);
+      expect(SpaceAlbumSortMode.values.map((m) => m.label), [
+        'sort_title',
+        'sort_items',
+        'sort_modified',
+        'sort_created',
+        'sort_recent',
+        'sort_oldest',
+        'sort_recently_linked',
+      ]);
+    });
+
+    test('defaults Title to ascending and every other option to descending', () {
+      expect(SpaceAlbumSortMode.name.defaultOrder, SortOrder.asc);
+      for (final mode in SpaceAlbumSortMode.values.where((m) => m != SpaceAlbumSortMode.name)) {
+        expect(mode.defaultOrder, SortOrder.desc, reason: '${mode.name} should default to descending');
+      }
+    });
+
+    // S6 / S9 — createdAt order is the reverse of linkedAt order here
+    test('Date created and Recently linked read different fields', () {
+      final items = [
+        a(id: 'old', name: 'Old', createdAt: DateTime.utc(2026, 1, 1), linkedAt: DateTime.utc(2026, 3, 1)),
+        a(id: 'new', name: 'New', createdAt: DateTime.utc(2026, 2, 1), linkedAt: DateTime.utc(2026, 2, 2)),
+      ];
+      expect(names(filterAndSortSpaceAlbums(items, '', SpaceAlbumSortMode.dateCreated, false)), ['New', 'Old']);
+      expect(names(filterAndSortSpaceAlbums(items, '', SpaceAlbumSortMode.recentlyLinked, false)), ['Old', 'New']);
+    });
+
+    // S7 / S8 — B has the newest photo but also the oldest, so the two modes
+    // must disagree at the same direction. Both default to descending:
+    //   mostRecentPhoto desc -> B (Jan 20) then A (Jan 10)
+    //   oldestPhoto     desc -> A (Jan 5)  then B (Jan 1)
+    // A comparator reading the wrong field therefore fails rather than passing
+    // by coincidence.
+    test('Most recent photo and Oldest photo read different fields', () {
+      final items = [
+        a(id: 'a', name: 'A', startDate: DateTime.utc(2026, 1, 5), endDate: DateTime.utc(2026, 1, 10)),
+        a(id: 'b', name: 'B', startDate: DateTime.utc(2026, 1, 1), endDate: DateTime.utc(2026, 1, 20)),
+      ];
+      expect(names(filterAndSortSpaceAlbums(items, '', SpaceAlbumSortMode.mostRecentPhoto, false)), ['B', 'A']);
+      expect(names(filterAndSortSpaceAlbums(items, '', SpaceAlbumSortMode.oldestPhoto, false)), ['A', 'B']);
+      // reversed
+      expect(names(filterAndSortSpaceAlbums(items, '', SpaceAlbumSortMode.mostRecentPhoto, true)), ['A', 'B']);
+      expect(names(filterAndSortSpaceAlbums(items, '', SpaceAlbumSortMode.oldestPhoto, true)), ['B', 'A']);
+    });
+
+    // S10 / S11 / S12 — matches upstream sortUnknownYearAlbums: last in BOTH directions
+    test('albums with no photo dates sort last regardless of direction', () {
+      final items = [
+        a(id: 'empty', name: 'Empty'),
+        a(id: 'full', name: 'HasPhotos', startDate: DateTime.utc(2026, 1, 1), endDate: DateTime.utc(2026, 1, 10)),
+      ];
+      for (final mode in [SpaceAlbumSortMode.mostRecentPhoto, SpaceAlbumSortMode.oldestPhoto]) {
+        for (final isReverse in [false, true]) {
+          expect(
+            names(filterAndSortSpaceAlbums(items, '', mode, isReverse)),
+            ['HasPhotos', 'Empty'],
+            reason: '$mode isReverse=$isReverse',
+          );
+        }
+      }
+    });
+
+    // S14
+    test('keeps every album when none has photo dates', () {
+      final items = [a(id: '1', name: 'One'), a(id: '2', name: 'Two'), a(id: '3', name: 'Three')];
+      final sorted = filterAndSortSpaceAlbums(items, '', SpaceAlbumSortMode.mostRecentPhoto, false);
+      expect(sorted, hasLength(3));
+      expect(names(sorted).toSet(), {'One', 'Two', 'Three'});
+    });
+
+    // S15 — the repository truncates to a UTC day, so same-day albums arrive equal
+    // and must fall through to the name/id tie-break rather than to time of day.
+    test('same-day albums fall through to the tie-break', () {
+      final items = [
+        a(id: 'z', name: 'Zebra', endDate: DateTime.utc(2026, 1, 10)),
+        a(id: 'a', name: 'Antelope', endDate: DateTime.utc(2026, 1, 10)),
+      ];
+      expect(names(filterAndSortSpaceAlbums(items, '', SpaceAlbumSortMode.mostRecentPhoto, false)), [
+        'Antelope',
+        'Zebra',
+      ]);
+    });
+
+    // S17
+    test('bulk-linked albums sharing a linkedAt tie-break by name then id', () {
+      final linked = DateTime.utc(2026, 4, 1);
+      final items = [
+        a(id: 'c', name: 'Charlie', linkedAt: linked),
+        a(id: 'a', name: 'Alpha', linkedAt: linked),
+        a(id: 'b', name: 'Bravo', linkedAt: linked),
+      ];
+      expect(names(filterAndSortSpaceAlbums(items, '', SpaceAlbumSortMode.recentlyLinked, false)), [
+        'Alpha',
+        'Bravo',
+        'Charlie',
+      ]);
+    });
+
+    // S18 / S19
+    test('handles empty and single-item lists for every mode and direction', () {
+      final one = [a(id: 'only', name: 'Only')];
+      for (final mode in SpaceAlbumSortMode.values) {
+        for (final isReverse in [false, true]) {
+          expect(filterAndSortSpaceAlbums(const [], '', mode, isReverse), isEmpty);
+          expect(names(filterAndSortSpaceAlbums(one, '', mode, isReverse)), ['Only']);
+        }
+      }
+    });
+
+    // S21 — filtering still runs before sorting, for the new modes too
+    test('filters by query before sorting', () {
+      final items = [
+        a(id: '1', name: 'Italy 2022', endDate: DateTime.utc(2026, 1, 20)),
+        a(id: '2', name: 'Alps Weekend', endDate: DateTime.utc(2026, 1, 10)),
+      ];
+      expect(names(filterAndSortSpaceAlbums(items, 'alps', SpaceAlbumSortMode.mostRecentPhoto, false)), [
+        'Alps Weekend',
+      ]);
+    });
+  });
+
   group('sort-mode enum shape', () {
     test('SpaceAlbumSortMode carries storeIndex/label/defaultOrder and effectiveOrder', () {
       expect(SpaceAlbumSortMode.name.storeIndex, 0);
@@ -431,9 +586,18 @@ void main() {
       expect(SpaceAlbumSortMode.name.effectiveOrder(false), SortOrder.asc);
       expect(SpaceAlbumSortMode.name.effectiveOrder(true), SortOrder.desc);
 
+      expect(SpaceAlbumSortMode.photoCount.storeIndex, 1);
       expect(SpaceAlbumSortMode.photoCount.defaultOrder, SortOrder.desc);
+      expect(SpaceAlbumSortMode.recentlyLinked.storeIndex, 2);
       expect(SpaceAlbumSortMode.recentlyLinked.defaultOrder, SortOrder.desc);
+      expect(SpaceAlbumSortMode.recentlyUpdated.storeIndex, 3);
       expect(SpaceAlbumSortMode.recentlyUpdated.defaultOrder, SortOrder.desc);
+      expect(SpaceAlbumSortMode.dateCreated.storeIndex, 4);
+      expect(SpaceAlbumSortMode.dateCreated.defaultOrder, SortOrder.desc);
+      expect(SpaceAlbumSortMode.mostRecentPhoto.storeIndex, 5);
+      expect(SpaceAlbumSortMode.mostRecentPhoto.defaultOrder, SortOrder.desc);
+      expect(SpaceAlbumSortMode.oldestPhoto.storeIndex, 6);
+      expect(SpaceAlbumSortMode.oldestPhoto.defaultOrder, SortOrder.desc);
 
       // storeIndex is stable/unique (persisted later — must not collide).
       final indices = SpaceAlbumSortMode.values.map((m) => m.storeIndex).toSet();

--- a/mobile/test/pages/library/spaces/collection_sort_test.dart
+++ b/mobile/test/pages/library/spaces/collection_sort_test.dart
@@ -24,6 +24,7 @@ final sample = <SpaceAlbum>[
     showInTimeline: true,
     linkedAt: DateTime.utc(2026, 1, 5),
     updatedAt: DateTime.utc(2026, 1, 20),
+    createdAt: DateTime.utc(2025, 3, 10),
   ),
   SpaceAlbum(
     id: 'album-a-italy-summary',
@@ -32,6 +33,7 @@ final sample = <SpaceAlbum>[
     showInTimeline: true,
     linkedAt: DateTime.utc(2026, 1, 5),
     updatedAt: DateTime.utc(2026, 1, 25),
+    createdAt: DateTime.utc(2025, 5, 22),
   ),
   SpaceAlbum(
     id: 'album-sachsen',
@@ -40,6 +42,7 @@ final sample = <SpaceAlbum>[
     showInTimeline: true,
     linkedAt: DateTime.utc(2026, 2, 1),
     updatedAt: DateTime.utc(2026, 1, 10),
+    createdAt: DateTime.utc(2024, 11, 3),
   ),
   SpaceAlbum(
     id: 'album-alps',
@@ -48,6 +51,7 @@ final sample = <SpaceAlbum>[
     showInTimeline: true,
     linkedAt: DateTime.utc(2026, 1, 15),
     updatedAt: DateTime.utc(2026, 2, 10),
+    createdAt: DateTime.utc(2026, 1, 2),
   ),
   SpaceAlbum(
     id: 'dup-2',
@@ -56,6 +60,7 @@ final sample = <SpaceAlbum>[
     showInTimeline: true,
     linkedAt: DateTime.utc(2026, 1, 1),
     updatedAt: DateTime.utc(2026, 1, 1),
+    createdAt: DateTime.utc(2025, 8, 15),
   ),
   SpaceAlbum(
     id: 'dup-1',
@@ -64,6 +69,7 @@ final sample = <SpaceAlbum>[
     showInTimeline: true,
     linkedAt: DateTime.utc(2026, 1, 1),
     updatedAt: DateTime.utc(2026, 1, 1),
+    createdAt: DateTime.utc(2025, 12, 30),
   ),
 ];
 
@@ -73,6 +79,9 @@ SpaceAlbum _album({
   int assetCount = 0,
   DateTime? linkedAt,
   DateTime? updatedAt,
+  DateTime? createdAt,
+  DateTime? startDate,
+  DateTime? endDate,
 }) => SpaceAlbum(
   id: id,
   name: name,
@@ -80,6 +89,9 @@ SpaceAlbum _album({
   showInTimeline: true,
   linkedAt: linkedAt ?? DateTime.utc(2026, 1, 1),
   updatedAt: updatedAt ?? DateTime.utc(2026, 1, 1),
+  createdAt: createdAt ?? DateTime.utc(2026, 1, 1),
+  startDate: startDate,
+  endDate: endDate,
 );
 
 /// Space fixtures. `space-d` has `lastActivityAt`/`memberCount`/`assetCount`

--- a/mobile/test/presentation/pages/space_album_detail_page_test.dart
+++ b/mobile/test/presentation/pages/space_album_detail_page_test.dart
@@ -27,6 +27,7 @@ SpaceAlbum _album({required String id, String? name, bool showInTimeline = true,
   assetCount: assetCount,
   linkedAt: DateTime.utc(2026, 1, 1),
   updatedAt: DateTime.utc(2026, 1, 1),
+  createdAt: DateTime.utc(2026, 1, 1),
 );
 
 // ---------------------------------------------------------------------------

--- a/mobile/test/presentation/pages/space_albums_link_wiring_test.dart
+++ b/mobile/test/presentation/pages/space_albums_link_wiring_test.dart
@@ -65,6 +65,7 @@ void main() {
             showInTimeline: true,
             linkedAt: DateTime.utc(2026, 1, 1),
             updatedAt: DateTime.utc(2026, 1, 1),
+            createdAt: DateTime.utc(2026, 1, 1),
           ),
         ],
       ),

--- a/mobile/test/presentation/pages/space_albums_page_test.dart
+++ b/mobile/test/presentation/pages/space_albums_page_test.dart
@@ -329,6 +329,31 @@ void main() {
     expect(find.text('Sort: Number of items'), findsOneWidget);
   });
 
+  testWidgets('offers all seven sort options in the menu', (tester) async {
+    await tester.pumpConsumerWidget(
+      const SpaceAlbumsPage(spaceId: spaceId, canEdit: true),
+      overrides: _overrides(
+        spaceId: spaceId,
+        albums: [_album(id: 'a1', name: 'Alpha'), _album(id: 'a2', name: 'Bravo')],
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('collection-sort-button-pill')));
+    await tester.pumpAndSettle();
+
+    for (final label in [
+      'Title',
+      'Number of items',
+      'Date modified',
+      'Date created',
+      'Most recent photo',
+      'Oldest photo',
+      'Recently linked',
+    ]) {
+      expect(find.text(label), findsWidgets, reason: 'missing sort option $label');
+    }
+  });
+
   // ---------------------------------------------------------------------
   // Regression: search + sort chrome doesn't affect role gating
   // ---------------------------------------------------------------------

--- a/mobile/test/presentation/pages/space_albums_page_test.dart
+++ b/mobile/test/presentation/pages/space_albums_page_test.dart
@@ -272,7 +272,7 @@ void main() {
 
     await tester.tap(find.byKey(const Key('collection-sort-button-pill')));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Photo count'));
+    await tester.tap(find.text('Number of items'));
     await tester.pumpAndSettle();
 
     // Now sorted by asset count desc -> r1 (50) sorts before r2 (5).
@@ -326,7 +326,7 @@ void main() {
     // (recentlyLinked) would instead put r2 first, so this proves the
     // persisted mode was actually read, not just the default applied.
     expect(_firstCardByPosition(tester, ['r1', 'r2']), 'r1');
-    expect(find.text('Sort: Photo count'), findsOneWidget);
+    expect(find.text('Sort: Number of items'), findsOneWidget);
   });
 
   // ---------------------------------------------------------------------

--- a/mobile/test/presentation/pages/space_albums_page_test.dart
+++ b/mobile/test/presentation/pages/space_albums_page_test.dart
@@ -30,6 +30,7 @@ SpaceAlbum _album({
   bool showInTimeline = true,
   DateTime? linkedAt,
   DateTime? updatedAt,
+  DateTime? createdAt,
 }) => SpaceAlbum(
   id: id,
   name: name ?? 'Album $id',
@@ -37,6 +38,7 @@ SpaceAlbum _album({
   showInTimeline: showInTimeline,
   linkedAt: linkedAt ?? DateTime.utc(2026, 1, 1),
   updatedAt: updatedAt ?? DateTime.utc(2026, 1, 1),
+  createdAt: createdAt ?? DateTime.utc(2026, 1, 1),
 );
 
 /// Overrides [spaceAlbumsProvider] with a fixed list, for use with

--- a/mobile/test/presentation/pages/space_b6_mutations_test.dart
+++ b/mobile/test/presentation/pages/space_b6_mutations_test.dart
@@ -45,6 +45,7 @@ SpaceAlbum _album({required String id, String name = 'Album', int assetCount = 0
       showInTimeline: showInTimeline,
       linkedAt: DateTime.utc(2026, 1, 1),
       updatedAt: DateTime.utc(2026, 1, 1),
+      createdAt: DateTime.utc(2026, 1, 1),
     );
 
 List<Override> _overrides({required String spaceId, required List<SpaceAlbum> albums}) => [

--- a/mobile/test/presentation/pages/space_detail_top_sliver_test.dart
+++ b/mobile/test/presentation/pages/space_detail_top_sliver_test.dart
@@ -24,6 +24,7 @@ SpaceAlbum _album(String id) => SpaceAlbum(
   showInTimeline: true,
   linkedAt: DateTime.utc(2026, 1, 1),
   updatedAt: DateTime.utc(2026, 1, 1),
+  createdAt: DateTime.utc(2026, 1, 1),
 );
 
 Widget _wrap({

--- a/mobile/test/presentation/widgets/collection/space_collection_section_test.dart
+++ b/mobile/test/presentation/widgets/collection/space_collection_section_test.dart
@@ -62,6 +62,7 @@ void main() {
     showInTimeline: true,
     linkedAt: DateTime(2026, 1, 1),
     updatedAt: DateTime(2026, 1, 1),
+    createdAt: DateTime(2026, 1, 1),
   );
 
   RemoteAsset asset(String id, {String ownerId = 'user-1'}) => RemoteAsset(

--- a/mobile/test/presentation/widgets/spaces/space_albums_shelf_test.dart
+++ b/mobile/test/presentation/widgets/spaces/space_albums_shelf_test.dart
@@ -43,6 +43,7 @@ SpaceAlbum _album({required String id, String? name, String? thumbnailAssetId, b
       showInTimeline: showInTimeline,
       linkedAt: DateTime.utc(2026, 1, 1),
       updatedAt: DateTime.utc(2026, 1, 1),
+      createdAt: DateTime.utc(2026, 1, 1),
     );
 
 /// Overrides [spaceAlbumsProvider] with a fixed list, for use with

--- a/mobile/test/providers/infrastructure/collection_dispatch_test.dart
+++ b/mobile/test/providers/infrastructure/collection_dispatch_test.dart
@@ -87,6 +87,7 @@ void main() {
     showInTimeline: true,
     linkedAt: DateTime(2026, 1, 1),
     updatedAt: DateTime(2026, 1, 1),
+    createdAt: DateTime(2026, 1, 1),
   );
 
   RemoteAsset remote(String id) => RemoteAsset(

--- a/web/src/lib/components/spaces/space-albums-controls.spec.ts
+++ b/web/src/lib/components/spaces/space-albums-controls.spec.ts
@@ -6,12 +6,13 @@ import SpaceAlbumsControls from '$lib/components/spaces/space-albums-controls.sv
 import SpaceAlbumsControlsWrapper from '$lib/components/spaces/space-albums-controls.test-wrapper.svelte';
 import { AlbumSortBy, AlbumViewMode, SortOrder, albumViewSettings } from '$lib/stores/preferences.store';
 import { SpaceAlbumGroupBy, spaceAlbumViewSettings } from '$lib/stores/space-album-view-settings.store';
+import { SpaceAlbumSortBy } from '$lib/utils/space-album-sort';
 
 // The persisted store's reset() re-uses its initial object by reference, and in-place field
 // writes (groupBy/collapsedGroups) can leak across tests. Set a fresh object each time.
 const freshSpaceSettings = () => ({
   view: AlbumViewMode.Cover,
-  sortBy: AlbumSortBy.MostRecentPhoto,
+  sortBy: SpaceAlbumSortBy.RecentlyLinked,
   sortOrder: SortOrder.Desc,
   groupBy: SpaceAlbumGroupBy.None,
   groupOrder: SortOrder.Desc,
@@ -71,7 +72,7 @@ describe('SpaceAlbumsControls sort dropdown', () => {
     expect(screen.getByTestId('space-albums-sort-btn')).toBeInTheDocument();
   });
 
-  it('renders all six sort option labels when dropdown is opened', async () => {
+  it('renders all seven sort option labels when dropdown is opened', async () => {
     render(SpaceAlbumsControls);
     await userEvent.click(screen.getByTestId('space-albums-sort-btn'));
     const menu = screen.getByTestId('space-albums-sort-menu');
@@ -81,6 +82,39 @@ describe('SpaceAlbumsControls sort dropdown', () => {
     expect(within(menu).getByText('Date created')).toBeInTheDocument();
     expect(within(menu).getByText('Most recent photo')).toBeInTheDocument();
     expect(within(menu).getByText('Oldest photo')).toBeInTheDocument();
+    expect(within(menu).getByText('Recently linked')).toBeInTheDocument();
+  });
+
+  it('writes RecentlyLinked to the space store when "Recently linked" is selected', async () => {
+    spaceAlbumViewSettings.set({ ...freshSpaceSettings(), sortBy: AlbumSortBy.Title, sortOrder: SortOrder.Asc });
+    render(SpaceAlbumsControls);
+    await userEvent.click(screen.getByTestId('space-albums-sort-btn'));
+    await userEvent.click(screen.getByTestId('space-albums-sort-option-RecentlyLinked'));
+    expect(get(spaceAlbumViewSettings).sortBy).toBe(SpaceAlbumSortBy.RecentlyLinked);
+    // S3 — a newly selected option applies its own default direction
+    expect(get(spaceAlbumViewSettings).sortOrder).toBe(SortOrder.Desc);
+  });
+
+  // The trigger previously resolved its label through upstream's
+  // findSortOptionMetadata, which falls back to MostRecentPhoto for any id it
+  // does not know — so RecentlyLinked rendered as "Most recent photo".
+  it('shows the Recently linked label on the trigger when that option is active', () => {
+    spaceAlbumViewSettings.set({ ...freshSpaceSettings(), sortBy: SpaceAlbumSortBy.RecentlyLinked });
+    render(SpaceAlbumsControls);
+    expect(screen.getByTestId('space-albums-sort-btn')).toHaveTextContent('Recently linked');
+  });
+
+  // S2
+  it('toggles sort order when Recently linked is re-selected', async () => {
+    spaceAlbumViewSettings.set({
+      ...freshSpaceSettings(),
+      sortBy: SpaceAlbumSortBy.RecentlyLinked,
+      sortOrder: SortOrder.Desc,
+    });
+    render(SpaceAlbumsControls);
+    await userEvent.click(screen.getByTestId('space-albums-sort-btn'));
+    await userEvent.click(screen.getByTestId('space-albums-sort-option-RecentlyLinked'));
+    expect(get(spaceAlbumViewSettings).sortOrder).toBe(SortOrder.Asc);
   });
 
   it('writes AlbumSortBy.Title to the space store when "Title" is selected', async () => {

--- a/web/src/lib/components/spaces/space-albums-controls.spec.ts
+++ b/web/src/lib/components/spaces/space-albums-controls.spec.ts
@@ -159,6 +159,9 @@ describe('SpaceAlbumsControls group dropdown', () => {
   });
 
   it('writes the selected groupBy to the space store', async () => {
+    // Year is disabled under the default RecentlyLinked sort (S27); pin a
+    // Year-compatible sortBy so the option this test selects is clickable.
+    spaceAlbumViewSettings.update((s) => ({ ...s, sortBy: AlbumSortBy.MostRecentPhoto }));
     render(SpaceAlbumsControls);
     await userEvent.click(screen.getByTestId('space-albums-group-btn'));
     await userEvent.click(screen.getByTestId('space-albums-group-option-Year'));
@@ -187,14 +190,24 @@ describe('SpaceAlbumsControls group dropdown', () => {
   });
 
   it('shows expand/collapse-all buttons when a group is selected', () => {
-    spaceAlbumViewSettings.update((s) => ({ ...s, groupBy: SpaceAlbumGroupBy.Year }));
+    // Year is disabled under the default RecentlyLinked sort (S27); pin a
+    // Year-compatible sortBy so getSelectedSpaceAlbumGroupOption doesn't fall back to None.
+    spaceAlbumViewSettings.update((s) => ({
+      ...s,
+      groupBy: SpaceAlbumGroupBy.Year,
+      sortBy: AlbumSortBy.MostRecentPhoto,
+    }));
     render(SpaceAlbumsControls, { groupIds: ['2024', '2020'] });
     expect(screen.getByTestId('space-albums-expand-all')).toBeInTheDocument();
     expect(screen.getByTestId('space-albums-collapse-all')).toBeInTheDocument();
   });
 
   it('collapse-all collapses the provided group ids in the space store', async () => {
-    spaceAlbumViewSettings.update((s) => ({ ...s, groupBy: SpaceAlbumGroupBy.Year }));
+    spaceAlbumViewSettings.update((s) => ({
+      ...s,
+      groupBy: SpaceAlbumGroupBy.Year,
+      sortBy: AlbumSortBy.MostRecentPhoto,
+    }));
     render(SpaceAlbumsControls, { groupIds: ['2024', '2020'] });
     await userEvent.click(screen.getByTestId('space-albums-collapse-all'));
     expect(get(spaceAlbumViewSettings).collapsedGroups.Year.sort()).toEqual(['2020', '2024']);
@@ -204,6 +217,7 @@ describe('SpaceAlbumsControls group dropdown', () => {
     spaceAlbumViewSettings.update((s) => ({
       ...s,
       groupBy: SpaceAlbumGroupBy.Year,
+      sortBy: AlbumSortBy.MostRecentPhoto,
       collapsedGroups: { Year: ['2024', '2020'] },
     }));
     render(SpaceAlbumsControls, { groupIds: ['2024', '2020'] });

--- a/web/src/lib/components/spaces/space-albums-controls.spec.ts
+++ b/web/src/lib/components/spaces/space-albums-controls.spec.ts
@@ -183,6 +183,31 @@ describe('SpaceAlbumsControls group dropdown', () => {
     expect(screen.getByTestId('space-albums-group-option-Year')).toBeDisabled();
   });
 
+  // #974 — the stored groupBy survives a sort change that disables it, so the
+  // trigger must report the *effective* grouping. Resolving the raw stored
+  // groupBy made the button claim "Group by year" over a flat list.
+  it('shows the effective grouping on the trigger when the stored one is disabled by the sort', () => {
+    spaceAlbumViewSettings.update((s) => ({
+      ...s,
+      groupBy: SpaceAlbumGroupBy.Year,
+      sortBy: AlbumSortBy.DateCreated,
+    }));
+    render(SpaceAlbumsControls);
+    const trigger = screen.getByTestId('space-albums-group-btn');
+    expect(trigger).toHaveTextContent('No grouping');
+    expect(trigger).not.toHaveTextContent('Group by year');
+  });
+
+  it('keeps the stored grouping on the trigger while the sort still allows it', () => {
+    spaceAlbumViewSettings.update((s) => ({
+      ...s,
+      groupBy: SpaceAlbumGroupBy.Year,
+      sortBy: AlbumSortBy.MostRecentPhoto,
+    }));
+    render(SpaceAlbumsControls);
+    expect(screen.getByTestId('space-albums-group-btn')).toHaveTextContent('Group by year');
+  });
+
   it('hides expand/collapse-all buttons when groupBy is None', () => {
     render(SpaceAlbumsControls);
     expect(screen.queryByTestId('space-albums-expand-all')).not.toBeInTheDocument();

--- a/web/src/lib/components/spaces/space-albums-controls.svelte
+++ b/web/src/lib/components/spaces/space-albums-controls.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-  import { AlbumSortBy, AlbumViewMode, SortOrder } from '$lib/stores/preferences.store';
+  import { AlbumViewMode, SortOrder } from '$lib/stores/preferences.store';
   import { SpaceAlbumGroupBy, spaceAlbumViewSettings } from '$lib/stores/space-album-view-settings.store';
-  import { type AlbumSortOptionMetadata, findSortOptionMetadata, sortOptionsMetadata } from '$lib/utils/album-utils';
   import {
     collapseAllSpaceAlbumGroups,
     expandAllSpaceAlbumGroups,
@@ -10,6 +9,12 @@
     spaceGroupOptionsMetadata,
     type SpaceAlbumGroupOptionMetadata,
   } from '$lib/utils/space-album-grouping';
+  import {
+    type SpaceAlbumSortOptionMetadata,
+    SpaceAlbumSortBy,
+    findSpaceAlbumSortOptionMetadata,
+    spaceAlbumSortOptionsMetadata,
+  } from '$lib/utils/space-album-sort';
   import { Button, Icon, Text } from '@immich/ui';
   import {
     mdiArrowDownThin,
@@ -42,7 +47,7 @@
     return ordering === SortOrder.Asc ? SortOrder.Desc : SortOrder.Asc;
   };
 
-  const handleChangeSortBy = ({ id, defaultOrder }: AlbumSortOptionMetadata) => {
+  const handleChangeSortBy = ({ id, defaultOrder }: SpaceAlbumSortOptionMetadata) => {
     if ($spaceAlbumViewSettings.sortBy === id) {
       $spaceAlbumViewSettings.sortOrder = flipOrdering($spaceAlbumViewSettings.sortOrder);
     } else {
@@ -77,19 +82,20 @@
     }
   }
 
-  let selectedSortOption = $derived(findSortOptionMetadata($spaceAlbumViewSettings.sortBy));
+  let selectedSortOption = $derived(findSpaceAlbumSortOptionMetadata($spaceAlbumViewSettings.sortBy));
   let sortIcon = $derived($spaceAlbumViewSettings.sortOrder === SortOrder.Desc ? mdiArrowDownThin : mdiArrowUpThin);
 
   let selectedGroupOption = $derived(findSpaceGroupOptionMetadata($spaceAlbumViewSettings.groupBy));
   let isGrouped = $derived(getSelectedSpaceAlbumGroupOption($spaceAlbumViewSettings) !== SpaceAlbumGroupBy.None);
 
-  let albumSortByNames: Record<AlbumSortBy, string> = $derived({
-    [AlbumSortBy.Title]: $t('sort_title'),
-    [AlbumSortBy.ItemCount]: $t('sort_items'),
-    [AlbumSortBy.DateModified]: $t('sort_modified'),
-    [AlbumSortBy.DateCreated]: $t('sort_created'),
-    [AlbumSortBy.MostRecentPhoto]: $t('sort_recent'),
-    [AlbumSortBy.OldestPhoto]: $t('sort_oldest'),
+  let albumSortByNames: Record<string, string> = $derived({
+    [SpaceAlbumSortBy.Title]: $t('sort_title'),
+    [SpaceAlbumSortBy.ItemCount]: $t('sort_items'),
+    [SpaceAlbumSortBy.DateModified]: $t('sort_modified'),
+    [SpaceAlbumSortBy.DateCreated]: $t('sort_created'),
+    [SpaceAlbumSortBy.MostRecentPhoto]: $t('sort_recent'),
+    [SpaceAlbumSortBy.OldestPhoto]: $t('sort_oldest'),
+    [SpaceAlbumSortBy.RecentlyLinked]: $t('sort_recently_linked'),
   });
 
   let spaceGroupByNames: Record<SpaceAlbumGroupBy, string> = $derived({
@@ -124,7 +130,7 @@
         onclick={() => (showSortMenu = !showSortMenu)}
       >
         <Icon icon={sortIcon} size="18" />
-        <span class="hidden sm:inline">{albumSortByNames[selectedSortOption.id as AlbumSortBy]}</span>
+        <span class="hidden sm:inline">{albumSortByNames[selectedSortOption.id]}</span>
         <Icon icon={mdiChevronDown} size="14" />
       </button>
 
@@ -133,7 +139,7 @@
           class="absolute top-full right-0 z-10 mt-1 min-w-[180px] rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
           data-testid="space-albums-sort-menu"
         >
-          {#each sortOptionsMetadata as option (option.id)}
+          {#each spaceAlbumSortOptionsMetadata as option (option.id)}
             <button
               type="button"
               class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-gray-800"
@@ -141,7 +147,7 @@
               onclick={() => handleChangeSortBy(option)}
               data-testid="space-albums-sort-option-{option.id}"
             >
-              {albumSortByNames[option.id as AlbumSortBy]}
+              {albumSortByNames[option.id]}
             </button>
           {/each}
         </div>

--- a/web/src/lib/components/spaces/space-albums-controls.svelte
+++ b/web/src/lib/components/spaces/space-albums-controls.svelte
@@ -10,6 +10,7 @@
     type SpaceAlbumGroupOptionMetadata,
   } from '$lib/utils/space-album-grouping';
   import {
+    type SpaceAlbumSortByValue,
     type SpaceAlbumSortOptionMetadata,
     SpaceAlbumSortBy,
     findSpaceAlbumSortOptionMetadata,
@@ -88,7 +89,7 @@
   let selectedGroupOption = $derived(findSpaceGroupOptionMetadata($spaceAlbumViewSettings.groupBy));
   let isGrouped = $derived(getSelectedSpaceAlbumGroupOption($spaceAlbumViewSettings) !== SpaceAlbumGroupBy.None);
 
-  let albumSortByNames: Record<string, string> = $derived({
+  let albumSortByNames: Record<SpaceAlbumSortByValue, string> = $derived({
     [SpaceAlbumSortBy.Title]: $t('sort_title'),
     [SpaceAlbumSortBy.ItemCount]: $t('sort_items'),
     [SpaceAlbumSortBy.DateModified]: $t('sort_modified'),

--- a/web/src/lib/components/spaces/space-albums-controls.svelte
+++ b/web/src/lib/components/spaces/space-albums-controls.svelte
@@ -86,7 +86,15 @@
   let selectedSortOption = $derived(findSpaceAlbumSortOptionMetadata($spaceAlbumViewSettings.sortBy));
   let sortIcon = $derived($spaceAlbumViewSettings.sortOrder === SortOrder.Desc ? mdiArrowDownThin : mdiArrowUpThin);
 
-  let selectedGroupOption = $derived(findSpaceGroupOptionMetadata($spaceAlbumViewSettings.groupBy));
+  // Resolve the *effective* grouping, not the raw stored one. A stored groupBy
+  // survives a sort change that disables it — the menu greys the option out and
+  // the list falls back to flat, so a trigger reading the stored value would
+  // claim "Group by year" over an ungrouped list (#974). Upstream's
+  // AlbumsControls has the same defect; fixing it there would dirty a file we
+  // keep byte-clean for rebases, so the fork only fixes its own copy.
+  let selectedGroupOption = $derived(
+    findSpaceGroupOptionMetadata(getSelectedSpaceAlbumGroupOption($spaceAlbumViewSettings)),
+  );
   let isGrouped = $derived(getSelectedSpaceAlbumGroupOption($spaceAlbumViewSettings) !== SpaceAlbumGroupBy.None);
 
   let albumSortByNames: Record<SpaceAlbumSortByValue, string> = $derived({

--- a/web/src/lib/components/spaces/space-albums-list.spec.ts
+++ b/web/src/lib/components/spaces/space-albums-list.spec.ts
@@ -207,7 +207,13 @@ describe('SpaceAlbumsList', () => {
         makeAlbum({ id: 'y2020', endDate: '2020-06-01T00:00:00.000Z' }),
         makeAlbum({ id: 'y2024', endDate: '2024-06-01T00:00:00.000Z' }),
       ];
-      spaceAlbumViewSettings.update((s) => ({ ...s, groupBy: SpaceAlbumGroupBy.Year }));
+      // Year is disabled for the default RecentlyLinked sort (S27), so this test
+      // pins a Year-compatible sortBy to exercise the grouping it's actually testing.
+      spaceAlbumViewSettings.update((s) => ({
+        ...s,
+        groupBy: SpaceAlbumGroupBy.Year,
+        sortBy: AlbumSortBy.MostRecentPhoto,
+      }));
       render(SpaceAlbumsList, { spaceId: 's-1', albums, canManage: false });
       expect(screen.getByTestId('space-album-group-2020')).toHaveAttribute('aria-expanded', 'true');
       toggleSpaceAlbumGroupCollapsing('2020');
@@ -224,5 +230,40 @@ describe('SpaceAlbumsList', () => {
       expect(screen.getByTestId('space-album-group-u1')).toHaveTextContent('Alice');
       expect(screen.getByTestId('space-album-group-Unassigned')).toHaveTextContent('Unassigned');
     });
+  });
+
+  // S10 at list level — the empty album renders last even though the sort is
+  // descending. `canManage` is a REQUIRED prop on this component; omitting it
+  // breaks the render.
+  it('renders albums with no photos last when sorting by Most recent photo', async () => {
+    spaceAlbumViewSettings.update((s) => ({
+      ...s,
+      sortBy: AlbumSortBy.MostRecentPhoto,
+      sortOrder: SortOrder.Desc,
+      groupBy: SpaceAlbumGroupBy.None,
+    }));
+    render(SpaceAlbumsList, {
+      props: {
+        spaceId: 'space-1',
+        canManage: false,
+        albums: [
+          makeAlbum({ id: 'empty', albumName: 'Empty', startDate: undefined, endDate: undefined }),
+          makeAlbum({
+            id: 'full',
+            albumName: 'HasPhotos',
+            startDate: '2026-01-01T00:00:00.000Z',
+            endDate: '2026-01-10T00:00:00.000Z',
+          }),
+        ],
+        members: [] as SharedSpaceMemberResponseDto[],
+      },
+    });
+
+    // Assert DOM order via the card testid rather than a text regex, so the
+    // assertion cannot be satisfied by incidental matches elsewhere in the tree.
+    await waitFor(() => expect(screen.getAllByTestId('space-album-card')).toHaveLength(2));
+    const order = screen.getAllByTestId('space-album-card').map((card) => card.textContent);
+    expect(order[0]).toContain('HasPhotos');
+    expect(order[1]).toContain('Empty');
   });
 });

--- a/web/src/lib/components/spaces/space-albums-list.spec.ts
+++ b/web/src/lib/components/spaces/space-albums-list.spec.ts
@@ -7,6 +7,7 @@ import { authManager } from '$lib/managers/auth-manager.svelte';
 import { AlbumSortBy, AlbumViewMode, SortOrder, albumViewSettings } from '$lib/stores/preferences.store';
 import { SpaceAlbumGroupBy, spaceAlbumViewSettings } from '$lib/stores/space-album-view-settings.store';
 import { toggleSpaceAlbumGroupCollapsing } from '$lib/utils/space-album-grouping';
+import { SpaceAlbumSortBy } from '$lib/utils/space-album-sort';
 import { userAdminFactory } from '@test-data/factories/user-factory';
 
 vi.mock('$app/navigation', () => ({ goto: vi.fn(), invalidateAll: vi.fn() }));
@@ -265,5 +266,45 @@ describe('SpaceAlbumsList', () => {
     const order = screen.getAllByTestId('space-album-card').map((card) => card.textContent);
     expect(order[0]).toContain('HasPhotos');
     expect(order[1]).toContain('Empty');
+  });
+
+  // Discriminates the list-level fix: upstream's sortAlbums has no entry for
+  // RecentlyLinked and silently falls back to DateModified (updatedAt)
+  // ordering. These two albums' linkedAt and updatedAt orders disagree, so a
+  // DateModified fallback would render them in the opposite order from what
+  // Recently linked descending requires.
+  it('sorts by Recently linked descending, even when it disagrees with Date modified order', async () => {
+    spaceAlbumViewSettings.update((s) => ({
+      ...s,
+      sortBy: SpaceAlbumSortBy.RecentlyLinked,
+      sortOrder: SortOrder.Desc,
+      groupBy: SpaceAlbumGroupBy.None,
+    }));
+    render(SpaceAlbumsList, {
+      props: {
+        spaceId: 'space-1',
+        canManage: false,
+        albums: [
+          makeAlbum({
+            id: 'recent-link',
+            albumName: 'RecentLink',
+            linkedAt: '2026-06-01T00:00:00.000Z',
+            updatedAt: '2020-01-01T00:00:00.000Z',
+          }),
+          makeAlbum({
+            id: 'old-link',
+            albumName: 'OldLink',
+            linkedAt: '2020-01-01T00:00:00.000Z',
+            updatedAt: '2026-06-01T00:00:00.000Z',
+          }),
+        ],
+        members: [] as SharedSpaceMemberResponseDto[],
+      },
+    });
+
+    await waitFor(() => expect(screen.getAllByTestId('space-album-card')).toHaveLength(2));
+    const order = screen.getAllByTestId('space-album-card').map((card) => card.textContent);
+    expect(order[0]).toContain('RecentLink');
+    expect(order[1]).toContain('OldLink');
   });
 });

--- a/web/src/lib/components/spaces/space-albums-list.svelte
+++ b/web/src/lib/components/spaces/space-albums-list.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-  import type { AlbumResponseDto, SharedSpaceLinkedAlbumDto, SharedSpaceMemberResponseDto } from '@immich/sdk';
+  import type { SharedSpaceLinkedAlbumDto, SharedSpaceMemberResponseDto } from '@immich/sdk';
   import { authManager } from '$lib/managers/auth-manager.svelte';
   import { AlbumViewMode } from '$lib/stores/preferences.store';
   import { SpaceAlbumGroupBy, spaceAlbumViewSettings } from '$lib/stores/space-album-view-settings.store';
-  import { sortAlbums } from '$lib/utils/album-utils';
   import {
     buildSpaceAlbumGroups,
     getSelectedSpaceAlbumGroupOption,
     isSpaceAlbumGroupCollapsed,
     toggleSpaceAlbumGroupCollapsing,
   } from '$lib/utils/space-album-grouping';
+  import { sortSpaceAlbums } from '$lib/utils/space-album-sort';
   import SpaceAlbumCard from '$lib/components/spaces/space-album-card.svelte';
   import SpaceAlbumsTable from '$lib/components/spaces/space-albums-table.svelte';
   import { Icon } from '@immich/ui';
@@ -51,10 +51,10 @@
   });
 
   const sorted = $derived(
-    sortAlbums(filtered as unknown as AlbumResponseDto[], {
+    sortSpaceAlbums(filtered, {
       sortBy: $spaceAlbumViewSettings.sortBy,
       orderBy: $spaceAlbumViewSettings.sortOrder,
-    }) as unknown as SharedSpaceLinkedAlbumDto[],
+    }),
   );
 
   const groups = $derived(

--- a/web/src/lib/stores/space-album-view-settings.store.spec.ts
+++ b/web/src/lib/stores/space-album-view-settings.store.spec.ts
@@ -1,6 +1,7 @@
 import { get } from 'svelte/store';
 import { AlbumSortBy, AlbumViewMode, SortOrder } from '$lib/stores/preferences.store';
 import { SpaceAlbumGroupBy, spaceAlbumViewSettings } from '$lib/stores/space-album-view-settings.store';
+import { SpaceAlbumSortBy } from '$lib/utils/space-album-sort';
 
 describe('space-album-view-settings store', () => {
   beforeEach(() => {
@@ -11,12 +12,39 @@ describe('space-album-view-settings store', () => {
   it('defaults view to Cover', () => {
     expect(get(spaceAlbumViewSettings).view).toBe(AlbumViewMode.Cover);
   });
-  it('defaults sort to MostRecentPhoto desc and group to None', () => {
+  it('defaults sort to RecentlyLinked desc and group to None', () => {
     const s = get(spaceAlbumViewSettings);
-    expect(s.sortBy).toBe(AlbumSortBy.MostRecentPhoto);
+    expect(s.sortBy).toBe(SpaceAlbumSortBy.RecentlyLinked);
     expect(s.sortOrder).toBe(SortOrder.Desc);
     expect(s.groupBy).toBe(SpaceAlbumGroupBy.None);
     expect(s.collapsedGroups).toEqual({});
+  });
+
+  // S23 — a stored preference must survive the default change.
+  //
+  // `persisted()` reads localStorage once, when the module is evaluated. Writing
+  // to localStorage afterwards and calling `.update()` does NOT re-read it — this
+  // was verified empirically against this repo: the naive version leaves sortBy at
+  // the default and fails. The store must be re-imported after seeding storage.
+  //
+  // Keep this test LAST in the file: vi.resetModules() means later tests would
+  // otherwise get a different store instance than the one imported at the top.
+  it('prefers a stored sortBy over the new default', async () => {
+    localStorage.setItem(
+      'space-album-view-settings',
+      JSON.stringify({
+        view: AlbumViewMode.Cover,
+        sortBy: AlbumSortBy.Title,
+        sortOrder: SortOrder.Asc,
+        groupBy: SpaceAlbumGroupBy.None,
+        groupOrder: SortOrder.Desc,
+        collapsedGroups: {},
+      }),
+    );
+    vi.resetModules();
+    const reloaded = await import('$lib/stores/space-album-view-settings.store');
+    expect(get(reloaded.spaceAlbumViewSettings).sortBy).toBe(AlbumSortBy.Title);
+    expect(get(reloaded.spaceAlbumViewSettings).sortOrder).toBe(SortOrder.Asc);
   });
   it('persists under a key distinct from album-view-settings', () => {
     spaceAlbumViewSettings.update((s) => ({ ...s, view: AlbumViewMode.List }));

--- a/web/src/lib/stores/space-album-view-settings.store.spec.ts
+++ b/web/src/lib/stores/space-album-view-settings.store.spec.ts
@@ -19,6 +19,11 @@ describe('space-album-view-settings store', () => {
     expect(s.groupBy).toBe(SpaceAlbumGroupBy.None);
     expect(s.collapsedGroups).toEqual({});
   });
+  it('persists under a key distinct from album-view-settings', () => {
+    spaceAlbumViewSettings.update((s) => ({ ...s, view: AlbumViewMode.List }));
+    expect(localStorage.getItem('space-album-view-settings')).toContain('List');
+    expect(localStorage.getItem('album-view-settings')).toBeNull();
+  });
 
   // S23 — a stored preference must survive the default change.
   //
@@ -45,10 +50,5 @@ describe('space-album-view-settings store', () => {
     const reloaded = await import('$lib/stores/space-album-view-settings.store');
     expect(get(reloaded.spaceAlbumViewSettings).sortBy).toBe(AlbumSortBy.Title);
     expect(get(reloaded.spaceAlbumViewSettings).sortOrder).toBe(SortOrder.Asc);
-  });
-  it('persists under a key distinct from album-view-settings', () => {
-    spaceAlbumViewSettings.update((s) => ({ ...s, view: AlbumViewMode.List }));
-    expect(localStorage.getItem('space-album-view-settings')).toContain('List');
-    expect(localStorage.getItem('album-view-settings')).toBeNull();
   });
 });

--- a/web/src/lib/stores/space-album-view-settings.store.ts
+++ b/web/src/lib/stores/space-album-view-settings.store.ts
@@ -1,5 +1,6 @@
 import { persisted } from 'svelte-persisted-store';
-import { AlbumSortBy, AlbumViewMode, SortOrder } from '$lib/stores/preferences.store';
+import { AlbumViewMode, SortOrder } from '$lib/stores/preferences.store';
+import { SpaceAlbumSortBy } from '$lib/utils/space-album-sort';
 
 export enum SpaceAlbumGroupBy {
   None = 'None',
@@ -19,7 +20,7 @@ export interface SpaceAlbumViewSettings {
 
 export const spaceAlbumViewSettings = persisted<SpaceAlbumViewSettings>('space-album-view-settings', {
   view: AlbumViewMode.Cover,
-  sortBy: AlbumSortBy.MostRecentPhoto,
+  sortBy: SpaceAlbumSortBy.RecentlyLinked,
   sortOrder: SortOrder.Desc,
   groupBy: SpaceAlbumGroupBy.None,
   groupOrder: SortOrder.Desc,

--- a/web/src/lib/utils/space-album-grouping.spec.ts
+++ b/web/src/lib/utils/space-album-grouping.spec.ts
@@ -9,8 +9,10 @@ import {
   toggleSpaceAlbumGroupCollapsing,
   collapseAllSpaceAlbumGroups,
   expandAllSpaceAlbumGroups,
+  spaceGroupOptionsMetadata,
   type SpaceAlbumGroupingCtx,
 } from '$lib/utils/space-album-grouping';
+import { SpaceAlbumSortBy } from '$lib/utils/space-album-sort';
 
 const CTX: SpaceAlbumGroupingCtx = {
   ungrouped: 'Albums',
@@ -59,6 +61,9 @@ it('Year buckets by endDate, unknown-year last', () => {
     A({ id: 'y2020', endDate: '2020-06-01T00:00:00Z' }),
     A({ id: 'y2024', endDate: '2024-06-01T00:00:00Z' }),
   ];
+  // Year's isDisabled() reads the store directly, so the store (not just the
+  // locally-built settings object below) must carry a Year-compatible sortBy.
+  spaceAlbumViewSettings.update((s) => ({ ...s, sortBy: AlbumSortBy.MostRecentPhoto }));
   const g = buildSpaceAlbumGroups(
     albums,
     {
@@ -74,6 +79,9 @@ it('Year buckets by endDate, unknown-year last', () => {
 
 it('Year uses startDate under Oldest-photo sort', () => {
   const albums = [A({ id: 's', startDate: '2019-01-01T00:00:00Z', endDate: '2025-01-01T00:00:00Z' })];
+  // Year's isDisabled() reads the store directly, so the store (not just the
+  // locally-built settings object below) must carry a Year-compatible sortBy.
+  spaceAlbumViewSettings.update((s) => ({ ...s, sortBy: AlbumSortBy.OldestPhoto }));
   const g = buildSpaceAlbumGroups(
     albums,
     { ...get(spaceAlbumViewSettings), groupBy: SpaceAlbumGroupBy.Year, sortBy: AlbumSortBy.OldestPhoto },
@@ -131,4 +139,51 @@ it('collapse mutators write only the space store, keyed by groupBy', () => {
   expect(get(spaceAlbumViewSettings).collapsedGroups.Year.sort()).toEqual(['2020', '2024']);
   expandAllSpaceAlbumGroups();
   expect(get(spaceAlbumViewSettings).collapsedGroups.Year).toEqual([]);
+});
+
+// S27
+describe('Year grouping availability', () => {
+  const yearOption = () => spaceGroupOptionsMetadata.find(({ id }) => id === SpaceAlbumGroupBy.Year)!;
+
+  it('is disabled while sorting by Recently linked', () => {
+    spaceAlbumViewSettings.update((s) => ({ ...s, sortBy: SpaceAlbumSortBy.RecentlyLinked }));
+    expect(yearOption().isDisabled()).toBe(true);
+  });
+
+  it('stays disabled for Date created and Date modified', () => {
+    spaceAlbumViewSettings.update((s) => ({ ...s, sortBy: AlbumSortBy.DateCreated }));
+    expect(yearOption().isDisabled()).toBe(true);
+    spaceAlbumViewSettings.update((s) => ({ ...s, sortBy: AlbumSortBy.DateModified }));
+    expect(yearOption().isDisabled()).toBe(true);
+  });
+
+  it('is enabled for the photo-date sorts', () => {
+    spaceAlbumViewSettings.update((s) => ({ ...s, sortBy: AlbumSortBy.MostRecentPhoto }));
+    expect(yearOption().isDisabled()).toBe(false);
+    spaceAlbumViewSettings.update((s) => ({ ...s, sortBy: AlbumSortBy.OldestPhoto }));
+    expect(yearOption().isDisabled()).toBe(false);
+  });
+});
+
+// S28
+describe('grouped lists sort within each group by Recently linked', () => {
+  it('orders each group by linkedAt descending', () => {
+    const settings = {
+      ...get(spaceAlbumViewSettings),
+      groupBy: SpaceAlbumGroupBy.Owner,
+      sortBy: SpaceAlbumSortBy.RecentlyLinked,
+      sortOrder: SortOrder.Desc,
+    };
+    const albums = [
+      A({ id: '1', albumName: 'OwnerA-Early', ownerId: 'a', linkedAt: '2026-01-01T00:00:00Z' }),
+      A({ id: '2', albumName: 'OwnerA-Late', ownerId: 'a', linkedAt: '2026-06-01T00:00:00Z' }),
+    ];
+    // buildSpaceAlbumGroups returns SpaceAlbumGroup[] = { id, name, albums }.
+    // Owner grouping keys the group by ownerId, so select it by id rather than
+    // by album count — a length-based lookup would silently pick the wrong
+    // group if grouping ever changed.
+    const groups = buildSpaceAlbumGroups(albums, settings, CTX);
+    const ownerAGroup = groups.find((g) => g.id === 'a');
+    expect(ownerAGroup?.albums.map((a) => a.albumName)).toEqual(['OwnerA-Late', 'OwnerA-Early']);
+  });
 });

--- a/web/src/lib/utils/space-album-grouping.spec.ts
+++ b/web/src/lib/utils/space-album-grouping.spec.ts
@@ -145,9 +145,12 @@ it('collapse mutators write only the space store, keyed by groupBy', () => {
 describe('Year grouping availability', () => {
   const yearOption = () => spaceGroupOptionsMetadata.find(({ id }) => id === SpaceAlbumGroupBy.Year)!;
 
-  it('is disabled while sorting by Recently linked', () => {
+  // Recently linked is the default sort, so disabling Year for it would leave
+  // Year grouping unreachable out of the box — the e2e suite caught exactly
+  // that. It stays enabled even though it is an album-metadata date.
+  it('is enabled while sorting by Recently linked', () => {
     spaceAlbumViewSettings.update((s) => ({ ...s, sortBy: SpaceAlbumSortBy.RecentlyLinked }));
-    expect(yearOption().isDisabled()).toBe(true);
+    expect(yearOption().isDisabled()).toBe(false);
   });
 
   it('stays disabled for Date created and Date modified', () => {

--- a/web/src/lib/utils/space-album-grouping.ts
+++ b/web/src/lib/utils/space-album-grouping.ts
@@ -1,4 +1,4 @@
-import type { AlbumResponseDto, SharedSpaceLinkedAlbumDto } from '@immich/sdk';
+import type { SharedSpaceLinkedAlbumDto } from '@immich/sdk';
 import { groupBy } from 'lodash-es';
 import { get } from 'svelte/store';
 import { AlbumSortBy, SortOrder } from '$lib/stores/preferences.store';
@@ -7,7 +7,8 @@ import {
   spaceAlbumViewSettings,
   type SpaceAlbumViewSettings,
 } from '$lib/stores/space-album-view-settings.store';
-import { sortAlbums, stringToSortOrder } from '$lib/utils/album-utils';
+import { stringToSortOrder } from '$lib/utils/album-utils';
+import { sortSpaceAlbums, SpaceAlbumSortBy } from '$lib/utils/space-album-sort';
 
 /**
  * ----------------------
@@ -37,7 +38,11 @@ export const spaceGroupOptionsMetadata: SpaceAlbumGroupOptionMetadata[] = [
     id: SpaceAlbumGroupBy.Year,
     defaultOrder: SortOrder.Desc,
     isDisabled() {
-      const disabledWithSortOptions: string[] = [AlbumSortBy.DateCreated, AlbumSortBy.DateModified];
+      const disabledWithSortOptions: string[] = [
+        AlbumSortBy.DateCreated,
+        AlbumSortBy.DateModified,
+        SpaceAlbumSortBy.RecentlyLinked,
+      ];
       return disabledWithSortOptions.includes(get(spaceAlbumViewSettings).sortBy);
     },
   },
@@ -267,10 +272,10 @@ export const buildSpaceAlbumGroups = (
 
   // Re-sort each group's albums by the current sort settings
   for (const group of groups) {
-    group.albums = sortAlbums(group.albums as unknown as AlbumResponseDto[], {
+    group.albums = sortSpaceAlbums(group.albums, {
       sortBy: settings.sortBy,
       orderBy: settings.sortOrder,
-    }) as unknown as SharedSpaceLinkedAlbumDto[];
+    });
   }
 
   return groups;

--- a/web/src/lib/utils/space-album-grouping.ts
+++ b/web/src/lib/utils/space-album-grouping.ts
@@ -8,7 +8,7 @@ import {
   type SpaceAlbumViewSettings,
 } from '$lib/stores/space-album-view-settings.store';
 import { stringToSortOrder } from '$lib/utils/album-utils';
-import { sortSpaceAlbums, SpaceAlbumSortBy } from '$lib/utils/space-album-sort';
+import { sortSpaceAlbums } from '$lib/utils/space-album-sort';
 
 /**
  * ----------------------
@@ -38,11 +38,13 @@ export const spaceGroupOptionsMetadata: SpaceAlbumGroupOptionMetadata[] = [
     id: SpaceAlbumGroupBy.Year,
     defaultOrder: SortOrder.Desc,
     isDisabled() {
-      const disabledWithSortOptions: string[] = [
-        AlbumSortBy.DateCreated,
-        AlbumSortBy.DateModified,
-        SpaceAlbumSortBy.RecentlyLinked,
-      ];
+      // Recently linked is deliberately NOT here, even though it is an
+      // album-metadata date like the two that are. It is the default sort, so
+      // disabling Year for it would put the most useful grouping out of reach
+      // until the user changed sort. Year buckets by photo year and orders
+      // within each bucket by the active sort, which reads fine as "2024
+      // albums, most recently linked first".
+      const disabledWithSortOptions: string[] = [AlbumSortBy.DateCreated, AlbumSortBy.DateModified];
       return disabledWithSortOptions.includes(get(spaceAlbumViewSettings).sortBy);
     },
   },

--- a/web/src/lib/utils/space-album-sort.spec.ts
+++ b/web/src/lib/utils/space-album-sort.spec.ts
@@ -1,0 +1,271 @@
+import type { SharedSpaceLinkedAlbumDto } from '@immich/sdk';
+import { AlbumSortBy, SortOrder } from '$lib/stores/preferences.store';
+import {
+  SpaceAlbumSortBy,
+  findSpaceAlbumSortOptionMetadata,
+  sortSpaceAlbums,
+  spaceAlbumSortOptionsMetadata,
+} from '$lib/utils/space-album-sort';
+
+const A = (o: Partial<SharedSpaceLinkedAlbumDto>): SharedSpaceLinkedAlbumDto => ({
+  id: 'x',
+  ownerId: 'owner-1',
+  albumName: 'A',
+  assetCount: 0,
+  albumThumbnailAssetId: null,
+  showInTimeline: true,
+  addedById: null,
+  linkedAt: '2026-01-01T00:00:00.000Z',
+  description: '',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  shared: false,
+  hasSharedLink: false,
+  isActivityEnabled: false,
+  ...o,
+});
+
+const names = (albums: SharedSpaceLinkedAlbumDto[]) => albums.map((a) => a.albumName);
+
+describe('spaceAlbumSortOptionsMetadata', () => {
+  it('lists the seven contract options in order', () => {
+    expect(spaceAlbumSortOptionsMetadata.map(({ id }) => id)).toEqual([
+      AlbumSortBy.Title,
+      AlbumSortBy.ItemCount,
+      AlbumSortBy.DateModified,
+      AlbumSortBy.DateCreated,
+      AlbumSortBy.MostRecentPhoto,
+      AlbumSortBy.OldestPhoto,
+      SpaceAlbumSortBy.RecentlyLinked,
+    ]);
+  });
+
+  it('defaults Title to ascending and every other option to descending', () => {
+    const byId = new Map(spaceAlbumSortOptionsMetadata.map((o) => [o.id, o.defaultOrder]));
+    expect(byId.get(AlbumSortBy.Title)).toBe(SortOrder.Asc);
+    for (const id of [
+      AlbumSortBy.ItemCount,
+      AlbumSortBy.DateModified,
+      AlbumSortBy.DateCreated,
+      AlbumSortBy.MostRecentPhoto,
+      AlbumSortBy.OldestPhoto,
+      SpaceAlbumSortBy.RecentlyLinked,
+    ]) {
+      expect(byId.get(id)).toBe(SortOrder.Desc);
+    }
+  });
+});
+
+describe('findSpaceAlbumSortOptionMetadata', () => {
+  it('finds a known option', () => {
+    expect(findSpaceAlbumSortOptionMetadata(AlbumSortBy.Title).id).toBe(AlbumSortBy.Title);
+    expect(findSpaceAlbumSortOptionMetadata(SpaceAlbumSortBy.RecentlyLinked).id).toBe(SpaceAlbumSortBy.RecentlyLinked);
+  });
+
+  // S26
+  it('falls back to RecentlyLinked for an unrecognised value', () => {
+    expect(findSpaceAlbumSortOptionMetadata('NotASort').id).toBe(SpaceAlbumSortBy.RecentlyLinked);
+    expect(findSpaceAlbumSortOptionMetadata('').id).toBe(SpaceAlbumSortBy.RecentlyLinked);
+  });
+});
+
+describe('sortSpaceAlbums delegates the six upstream options', () => {
+  // S1
+  it('sorts by Title ascending, case-insensitively', () => {
+    const albums = [A({ albumName: 'beach' }), A({ albumName: 'Apple' }), A({ albumName: 'Zoo' })];
+    expect(names(sortSpaceAlbums(albums, { sortBy: AlbumSortBy.Title, orderBy: SortOrder.Asc }))).toEqual([
+      'Apple',
+      'beach',
+      'Zoo',
+    ]);
+  });
+
+  // S4
+  it('sorts by Number of items descending', () => {
+    const albums = [
+      A({ albumName: 'Small', assetCount: 1 }),
+      A({ albumName: 'Big', assetCount: 9 }),
+      A({ albumName: 'Mid', assetCount: 5 }),
+    ];
+    expect(names(sortSpaceAlbums(albums, { sortBy: AlbumSortBy.ItemCount, orderBy: SortOrder.Desc }))).toEqual([
+      'Big',
+      'Mid',
+      'Small',
+    ]);
+  });
+
+  // S5
+  it('sorts by Date modified descending', () => {
+    const albums = [
+      A({ albumName: 'Jan3', updatedAt: '2026-01-03T00:00:00.000Z' }),
+      A({ albumName: 'Jan1', updatedAt: '2026-01-01T00:00:00.000Z' }),
+      A({ albumName: 'Jan2', updatedAt: '2026-01-02T00:00:00.000Z' }),
+    ];
+    expect(names(sortSpaceAlbums(albums, { sortBy: AlbumSortBy.DateModified, orderBy: SortOrder.Desc }))).toEqual([
+      'Jan3',
+      'Jan2',
+      'Jan1',
+    ]);
+  });
+
+  // S6 — createdAt order is the reverse of linkedAt order for this fixture
+  it('sorts by Date created descending, independently of linkedAt', () => {
+    const albums = [
+      A({ albumName: 'Old', createdAt: '2026-01-01T00:00:00.000Z', linkedAt: '2026-03-01T00:00:00.000Z' }),
+      A({ albumName: 'New', createdAt: '2026-02-01T00:00:00.000Z', linkedAt: '2026-02-02T00:00:00.000Z' }),
+    ];
+    expect(names(sortSpaceAlbums(albums, { sortBy: AlbumSortBy.DateCreated, orderBy: SortOrder.Desc }))).toEqual([
+      'New',
+      'Old',
+    ]);
+  });
+
+  // S7 — B's newest is later than A's, but B's oldest is earlier than A's,
+  // so a comparator wired to the wrong field produces the opposite order.
+  it('sorts by Most recent photo descending', () => {
+    const albums = [
+      A({ albumName: 'A', startDate: '2026-01-05T00:00:00.000Z', endDate: '2026-01-10T00:00:00.000Z' }),
+      A({ albumName: 'B', startDate: '2026-01-01T00:00:00.000Z', endDate: '2026-01-20T00:00:00.000Z' }),
+    ];
+    expect(names(sortSpaceAlbums(albums, { sortBy: AlbumSortBy.MostRecentPhoto, orderBy: SortOrder.Desc }))).toEqual([
+      'B',
+      'A',
+    ]);
+  });
+
+  // S8 — same fixture, opposite field. Descending is asserted too: it yields
+  // ['A','B'] where MostRecentPhoto descending yields ['B','A'], so a
+  // comparator reading endDate here would fail rather than coincidentally pass.
+  it('sorts by Oldest photo in both directions', () => {
+    const albums = () => [
+      A({ albumName: 'A', startDate: '2026-01-05T00:00:00.000Z', endDate: '2026-01-10T00:00:00.000Z' }),
+      A({ albumName: 'B', startDate: '2026-01-01T00:00:00.000Z', endDate: '2026-01-20T00:00:00.000Z' }),
+    ];
+    expect(names(sortSpaceAlbums(albums(), { sortBy: AlbumSortBy.OldestPhoto, orderBy: SortOrder.Asc }))).toEqual([
+      'B',
+      'A',
+    ]);
+    expect(names(sortSpaceAlbums(albums(), { sortBy: AlbumSortBy.OldestPhoto, orderBy: SortOrder.Desc }))).toEqual([
+      'A',
+      'B',
+    ]);
+  });
+});
+
+describe('sortSpaceAlbums RecentlyLinked', () => {
+  const albums = () => [
+    A({ albumName: 'Old', createdAt: '2026-01-01T00:00:00.000Z', linkedAt: '2026-03-01T00:00:00.000Z' }),
+    A({ albumName: 'New', createdAt: '2026-02-01T00:00:00.000Z', linkedAt: '2026-02-02T00:00:00.000Z' }),
+  ];
+
+  // S9
+  it('puts the most recently linked album first when descending', () => {
+    expect(
+      names(sortSpaceAlbums(albums(), { sortBy: SpaceAlbumSortBy.RecentlyLinked, orderBy: SortOrder.Desc })),
+    ).toEqual(['Old', 'New']);
+  });
+
+  // S2 (comparator half)
+  it('reverses when ascending', () => {
+    expect(
+      names(sortSpaceAlbums(albums(), { sortBy: SpaceAlbumSortBy.RecentlyLinked, orderBy: SortOrder.Asc })),
+    ).toEqual(['New', 'Old']);
+  });
+
+  // S17 — bulk-linked albums share a linkedAt; order must be stable, not arbitrary
+  it('keeps a stable order for identical linkedAt values', () => {
+    const tied = [
+      A({ id: 'a', albumName: 'First', linkedAt: '2026-01-01T00:00:00.000Z' }),
+      A({ id: 'b', albumName: 'Second', linkedAt: '2026-01-01T00:00:00.000Z' }),
+      A({ id: 'c', albumName: 'Third', linkedAt: '2026-01-01T00:00:00.000Z' }),
+    ];
+    const once = names(sortSpaceAlbums(tied, { sortBy: SpaceAlbumSortBy.RecentlyLinked, orderBy: SortOrder.Desc }));
+    const twice = names(sortSpaceAlbums(tied, { sortBy: SpaceAlbumSortBy.RecentlyLinked, orderBy: SortOrder.Desc }));
+    expect(once).toEqual(['First', 'Second', 'Third']);
+    expect(twice).toEqual(once);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = albums();
+    sortSpaceAlbums(input, { sortBy: SpaceAlbumSortBy.RecentlyLinked, orderBy: SortOrder.Desc });
+    expect(names(input)).toEqual(['Old', 'New']);
+  });
+});
+
+// S26 — the pill label and the applied ordering must agree
+describe('sortSpaceAlbums unknown sortBy', () => {
+  it('orders by RecentlyLinked, matching what the finder reports', () => {
+    // updatedAt and linkedAt deliberately disagree, so falling through to
+    // upstream's DateModified fallback produces the opposite order.
+    const albums = [
+      A({ albumName: 'ByUpdated', updatedAt: '2026-09-01T00:00:00.000Z', linkedAt: '2026-01-01T00:00:00.000Z' }),
+      A({ albumName: 'ByLinked', updatedAt: '2026-01-01T00:00:00.000Z', linkedAt: '2026-09-01T00:00:00.000Z' }),
+    ];
+    expect(names(sortSpaceAlbums(albums, { sortBy: 'NotASort', orderBy: SortOrder.Desc }))).toEqual([
+      'ByLinked',
+      'ByUpdated',
+    ]);
+    expect(findSpaceAlbumSortOptionMetadata('NotASort').id).toBe(SpaceAlbumSortBy.RecentlyLinked);
+  });
+});
+
+// S10–S12, S14
+describe('sortSpaceAlbums albums without photo dates', () => {
+  const mixed = () => [
+    A({ albumName: 'Empty', startDate: undefined, endDate: undefined }),
+    A({ albumName: 'HasPhotos', startDate: '2026-01-01T00:00:00.000Z', endDate: '2026-01-10T00:00:00.000Z' }),
+  ];
+
+  it('puts the album with no photos last, descending (S10)', () => {
+    expect(names(sortSpaceAlbums(mixed(), { sortBy: AlbumSortBy.MostRecentPhoto, orderBy: SortOrder.Desc }))).toEqual([
+      'HasPhotos',
+      'Empty',
+    ]);
+  });
+
+  it('puts the album with no photos last, ascending too (S11)', () => {
+    expect(names(sortSpaceAlbums(mixed(), { sortBy: AlbumSortBy.MostRecentPhoto, orderBy: SortOrder.Asc }))).toEqual([
+      'HasPhotos',
+      'Empty',
+    ]);
+  });
+
+  it('applies the same rule to Oldest photo in both directions (S12)', () => {
+    expect(names(sortSpaceAlbums(mixed(), { sortBy: AlbumSortBy.OldestPhoto, orderBy: SortOrder.Desc }))).toEqual([
+      'HasPhotos',
+      'Empty',
+    ]);
+    expect(names(sortSpaceAlbums(mixed(), { sortBy: AlbumSortBy.OldestPhoto, orderBy: SortOrder.Asc }))).toEqual([
+      'HasPhotos',
+      'Empty',
+    ]);
+  });
+
+  it('keeps every album when none has photo dates (S14)', () => {
+    const none = [A({ albumName: 'One' }), A({ albumName: 'Two' }), A({ albumName: 'Three' })];
+    const sorted = sortSpaceAlbums(none, { sortBy: AlbumSortBy.MostRecentPhoto, orderBy: SortOrder.Desc });
+    expect(sorted).toHaveLength(3);
+    expect(new Set(names(sorted))).toEqual(new Set(['One', 'Two', 'Three']));
+  });
+});
+
+// S18, S19
+describe('sortSpaceAlbums boundary inputs', () => {
+  const everyOption = spaceAlbumSortOptionsMetadata.map(({ id }) => id);
+
+  it('returns an empty array for every option and direction', () => {
+    for (const sortBy of everyOption) {
+      for (const orderBy of [SortOrder.Asc, SortOrder.Desc]) {
+        expect(sortSpaceAlbums([], { sortBy, orderBy })).toEqual([]);
+      }
+    }
+  });
+
+  it('returns a single album unchanged for every option and direction', () => {
+    for (const sortBy of everyOption) {
+      for (const orderBy of [SortOrder.Asc, SortOrder.Desc]) {
+        expect(names(sortSpaceAlbums([A({ albumName: 'Only' })], { sortBy, orderBy }))).toEqual(['Only']);
+      }
+    }
+  });
+});

--- a/web/src/lib/utils/space-album-sort.ts
+++ b/web/src/lib/utils/space-album-sort.ts
@@ -16,8 +16,16 @@ export const SpaceAlbumSortBy = {
   RecentlyLinked: 'RecentlyLinked',
 } as const;
 
+/**
+ * The union of every value `SpaceAlbumSortBy` can hold. Used to key the
+ * label records that back the sort dropdown, so adding a new option to
+ * `SpaceAlbumSortBy` without adding its label is a compile error instead of
+ * a blank menu row (Svelte stringifies `undefined` to `''`).
+ */
+export type SpaceAlbumSortByValue = (typeof SpaceAlbumSortBy)[keyof typeof SpaceAlbumSortBy];
+
 export interface SpaceAlbumSortOptionMetadata {
-  id: string;
+  id: SpaceAlbumSortByValue;
   defaultOrder: SortOrder;
   columnStyle: string;
 }

--- a/web/src/lib/utils/space-album-sort.ts
+++ b/web/src/lib/utils/space-album-sort.ts
@@ -1,0 +1,60 @@
+import type { AlbumResponseDto, SharedSpaceLinkedAlbumDto } from '@immich/sdk';
+import { orderBy } from 'lodash-es';
+import { AlbumSortBy, SortOrder } from '$lib/stores/preferences.store';
+import { sortAlbums, sortOptionsMetadata, stringToSortOrder } from '$lib/utils/album-utils';
+
+/**
+ * Space album lists offer everything the regular album list offers, plus
+ * `RecentlyLinked` — when the album was linked into *this* space. That option
+ * lives here rather than in upstream's `AlbumSortBy` on purpose: the regular
+ * /albums page iterates upstream's `sortOptionsMetadata`, and `linkedAt` does
+ * not exist on `AlbumResponseDto`, so adding it upstream would surface a dead
+ * option there (and dirty a file we keep byte-clean for rebases).
+ */
+export const SpaceAlbumSortBy = {
+  ...AlbumSortBy,
+  RecentlyLinked: 'RecentlyLinked',
+} as const;
+
+export interface SpaceAlbumSortOptionMetadata {
+  id: string;
+  defaultOrder: SortOrder;
+  columnStyle: string;
+}
+
+export const spaceAlbumSortOptionsMetadata: SpaceAlbumSortOptionMetadata[] = [
+  ...sortOptionsMetadata,
+  {
+    id: SpaceAlbumSortBy.RecentlyLinked,
+    defaultOrder: SortOrder.Desc,
+    columnStyle: 'text-center hidden xl:block xl:w-[15%] 2xl:w-[12%]',
+  },
+];
+
+const defaultSortOption = spaceAlbumSortOptionsMetadata.at(-1) as SpaceAlbumSortOptionMetadata;
+
+export const findSpaceAlbumSortOptionMetadata = (sortBy: string): SpaceAlbumSortOptionMetadata =>
+  spaceAlbumSortOptionsMetadata.find(({ id }) => id === sortBy) ?? defaultSortOption;
+
+/**
+ * Resolve `sortBy` through the finder *before* delegating. Upstream's
+ * `sortAlbums` falls back to `DateModified` for an unknown key while upstream's
+ * `findSortOptionMetadata` falls back to `MostRecentPhoto` — passing an unknown
+ * key straight through would show one option's label while applying another's
+ * order.
+ */
+export const sortSpaceAlbums = (
+  albums: SharedSpaceLinkedAlbumDto[],
+  { sortBy, orderBy: order }: { sortBy: string; orderBy: string },
+): SharedSpaceLinkedAlbumDto[] => {
+  const { id } = findSpaceAlbumSortOptionMetadata(sortBy);
+
+  if (id === SpaceAlbumSortBy.RecentlyLinked) {
+    return orderBy(albums, [({ linkedAt }) => new Date(linkedAt)], [stringToSortOrder(order)]);
+  }
+
+  return sortAlbums(albums as unknown as AlbumResponseDto[], {
+    sortBy: id,
+    orderBy: order,
+  }) as unknown as SharedSpaceLinkedAlbumDto[];
+};


### PR DESCRIPTION
Fixes #966.

The sort options for a shared space's album list differed per platform: web offered six, mobile four. Two of those differences turned out to be cosmetic — mobile's "Name" is web's "Title" (`albumName`), and mobile's "Recently updated" is web's "Date modified" (`updatedAt`). Both platforms now offer the same seven options, in the same order, with the same default.

## The unified contract

| # | Option | Field | Default dir |
| - | ------ | ----- | ----------- |
| 1 | Title | `albumName` | Asc |
| 2 | Number of items | `assetCount` | Desc |
| 3 | Date modified | `updatedAt` | Desc |
| 4 | Date created | `createdAt` | Desc |
| 5 | Most recent photo | `endDate` | Desc |
| 6 | Oldest photo | `startDate` | Desc |
| 7 | Recently linked | `linkedAt` | Desc |

Mobile gains Date created / Most recent photo / Oldest photo; web gains Recently linked. **Both platforms now default to Recently linked, descending** — the most useful opening order for a collaborative surface. Only users who never touched a space-album view setting see the change; anyone with a stored preference keeps it.

## No server and no i18n change

`GET /shared-spaces/{id}/albums` already returned every field needed, and all seven label keys already existed in all ten maintained locales. This is a client-only change.

## Web: a fork-only layer, upstream untouched

`web/src/lib/utils/album-utils.ts` and `web/src/lib/stores/preferences.store.ts` are byte-identical to `upstream/main` and stay that way. The seventh option lives in a new fork-only `web/src/lib/utils/space-album-sort.ts` that handles `RecentlyLinked` itself and delegates the other six to upstream's `sortAlbums`.

Adding `RecentlyLinked` to upstream's `AlbumSortBy` would have been less code but wrong on correctness: `AlbumsControls.svelte` iterates the same metadata array, so the option would also have appeared on the regular `/albums` page, where `linkedAt` does not exist and the sort would silently do nothing.

Delegating rather than reimplementing also means a future rebase that changes upstream's comparators changes both surfaces together, and the delegation tests notice if the semantics move.

## Mobile: derived from the query that already runs

`watchLinkedAlbums` already LEFT JOINs the assets and `GROUP BY`s to compute `assetCount`, so the two photo-date aggregates come from that same statement — no extra round trip, and the stream stays reactive.

Photo dates are truncated to a **UTC calendar day** to match the server's `MIN/MAX(("asset"."localDateTime" AT TIME ZONE 'UTC')::date)`. Without that, two albums whose newest photos share a UTC day would tie on web but be time-ordered on mobile — a visible ordering difference on the very sorts added for parity.

## Two bugs found and fixed along the way

- **A latent upstream inconsistency**: on an unrecognised `sortBy`, upstream's `sortAlbums` falls back to `DateModified` while `findSortOptionMetadata` falls back to `MostRecentPhoto` — so the pill showed one option's name while applying another's order. `sortSpaceAlbums` resolves through the finder before delegating, so both halves land on `RecentlyLinked`.
- **A startup-crash hazard**: `EnumCodec.decode` used `values.firstWhere(...)` with no `orElse`, and nothing between it and `SettingsRepository.ensureInitialized` caught the throw — an unrecognised persisted value crashed the app at launch. Adding three new sort modes would have made that reachable on downgrade, so `EnumCodec` now falls back instead of throwing.

The four pre-existing Dart enum identifiers are deliberately **not** renamed (only relabelled) — `EnumCodec` persists `value.name`, so a rename would silently reset every user who had that option selected.

## Testing

Web: 4372 passing. Mobile: 3039 passing. `check:typescript`, `check:svelte` (585 files), `eslint --max-warnings 0`, `dart analyze --fatal-infos` and the `dart format` gate all clean.

The design spec (`docs/superpowers/specs/2026-08-10-space-album-sort-parity-design.md`) defines 29 numbered behaviour scenarios with a scenario-to-test map; each has a named home in the suites. Photo-date fixtures are built so the two date sorts disagree at the same direction — a comparator wired to the wrong field fails rather than coincidentally passing — and the same fixture is used on both platforms, which is what makes "parity" a checked claim.

Edge cases covered: albums with no photos sort last in **both** directions (matching upstream's `sortUnknownYearAlbums`); assets with a null `localDateTime` count toward `assetCount` but yield no date range; bulk-linked albums sharing a `linkedAt` order deterministically; empty and single-album lists across all seven options and both directions.

## Known divergences, deliberately not closed

- Title collation: web uses locale-aware `localeCompare`, mobile code-unit `toLowerCase()` — Dart has no built-in collator.
- Search scope: web matches album name or description, mobile name only.
- Photo-date corpus: web's dates are server-computed over all assets, mobile's over locally synced ones.
- Web's space album table headers remain static and non-clickable, unlike `/albums`.

The last two are filed as follow-ups.
