### PR TITLE
perf(server): cut the People page's database work (hydrate recompute, dead space predicate, third counts query)

### DIFF
--- a/server/src/queries/face.identity.repository.sql
+++ b/server/src/queries/face.identity.repository.sql
@@ -98,6 +98,15 @@ LIMIT
 commit
 
 -- FaceIdentityRepository.searchAccessiblePeople
+select
+  "shared_space_member"."spaceId"
+from
+  "shared_space_member"
+where
+  "shared_space_member"."userId" = $1
+  and "shared_space_member"."showInTimeline" = $2
+limit
+  $3
 WITH
   timeline_spaces AS (
     SELECT
@@ -122,56 +131,7 @@ WITH
       AND asset."deletedAt" IS NULL
       AND asset."isOffline" = false
       AND asset.visibility = $2
-      AND (
-        asset."ownerId" = $3
-        OR EXISTS (
-          SELECT
-            1
-          FROM
-            shared_space_asset
-            INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_asset."spaceId"
-          WHERE
-            shared_space_asset."assetId" = asset.id
-        )
-        OR EXISTS (
-          SELECT
-            1
-          FROM
-            shared_space_library
-            INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_library."spaceId"
-          WHERE
-            shared_space_library."libraryId" = asset."libraryId"
-        )
-        OR (
-          EXISTS (
-            SELECT
-              1
-            FROM
-              shared_space_album
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"
-              INNER JOIN album ON album.id = shared_space_album."albumId"
-              AND album."deletedAt" IS NULL
-              INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
-            WHERE
-              album_asset."assetId" = asset.id
-              AND "shared_space_album"."showInTimeline" = true
-          )
-          OR EXISTS (
-            SELECT
-              1
-            FROM
-              shared_space_album
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"
-              INNER JOIN album ON album.id = shared_space_album."albumId"
-              AND album."deletedAt" IS NULL
-              INNER JOIN album_space_asset ON album_space_asset."albumId" = shared_space_album."albumId"
-              AND album_space_asset."spaceId" = shared_space_album."spaceId"
-            WHERE
-              album_space_asset."assetId" = asset.id
-              AND "shared_space_album"."showInTimeline" = true
-          )
-        )
-      )
+      AND (asset."ownerId" = $3)
   ),
   accessible_profiles AS (
     SELECT
@@ -318,6 +278,15 @@ OFFSET
   $11
 
 -- FaceIdentityRepository.getAccessiblePersonFilterSuggestions
+select
+  "shared_space_member"."spaceId"
+from
+  "shared_space_member"
+where
+  "shared_space_member"."userId" = $1
+  and "shared_space_member"."showInTimeline" = $2
+limit
+  $3
 WITH
   timeline_spaces AS (
     SELECT
@@ -342,56 +311,7 @@ WITH
       AND asset."deletedAt" IS NULL
       AND asset."isOffline" = false
       AND asset.visibility = $2
-      AND (
-        asset."ownerId" = $3
-        OR EXISTS (
-          SELECT
-            1
-          FROM
-            shared_space_asset
-            INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_asset."spaceId"
-          WHERE
-            shared_space_asset."assetId" = asset.id
-        )
-        OR EXISTS (
-          SELECT
-            1
-          FROM
-            shared_space_library
-            INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_library."spaceId"
-          WHERE
-            shared_space_library."libraryId" = asset."libraryId"
-        )
-        OR (
-          EXISTS (
-            SELECT
-              1
-            FROM
-              shared_space_album
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"
-              INNER JOIN album ON album.id = shared_space_album."albumId"
-              AND album."deletedAt" IS NULL
-              INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
-            WHERE
-              album_asset."assetId" = asset.id
-              AND "shared_space_album"."showInTimeline" = true
-          )
-          OR EXISTS (
-            SELECT
-              1
-            FROM
-              shared_space_album
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"
-              INNER JOIN album ON album.id = shared_space_album."albumId"
-              AND album."deletedAt" IS NULL
-              INNER JOIN album_space_asset ON album_space_asset."albumId" = shared_space_album."albumId"
-              AND album_space_asset."spaceId" = shared_space_album."spaceId"
-            WHERE
-              album_space_asset."assetId" = asset.id
-              AND "shared_space_album"."showInTimeline" = true
-          )
-        )
-      )
+      AND (asset."ownerId" = $3)
   ),
   accessible_profiles AS (
     SELECT
@@ -538,6 +458,15 @@ OFFSET
   $11
 
 -- FaceIdentityRepository.getAccessiblePeopleStatistics
+select
+  "shared_space_member"."spaceId"
+from
+  "shared_space_member"
+where
+  "shared_space_member"."userId" = $1
+  and "shared_space_member"."showInTimeline" = $2
+limit
+  $3
 WITH
   timeline_spaces AS (
     SELECT
@@ -561,56 +490,7 @@ WITH
       AND asset."deletedAt" IS NULL
       AND asset."isOffline" = false
       AND asset.visibility IN ($2, $3)
-      AND (
-        asset."ownerId" = $4
-        OR EXISTS (
-          SELECT
-            1
-          FROM
-            shared_space_asset
-            INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_asset."spaceId"
-          WHERE
-            shared_space_asset."assetId" = asset.id
-        )
-        OR EXISTS (
-          SELECT
-            1
-          FROM
-            shared_space_library
-            INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_library."spaceId"
-          WHERE
-            shared_space_library."libraryId" = asset."libraryId"
-        )
-        OR (
-          EXISTS (
-            SELECT
-              1
-            FROM
-              shared_space_album
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"
-              INNER JOIN album ON album.id = shared_space_album."albumId"
-              AND album."deletedAt" IS NULL
-              INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
-            WHERE
-              album_asset."assetId" = asset.id
-              AND "shared_space_album"."showInTimeline" = true
-          )
-          OR EXISTS (
-            SELECT
-              1
-            FROM
-              shared_space_album
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"
-              INNER JOIN album ON album.id = shared_space_album."albumId"
-              AND album."deletedAt" IS NULL
-              INNER JOIN album_space_asset ON album_space_asset."albumId" = shared_space_album."albumId"
-              AND album_space_asset."spaceId" = shared_space_album."spaceId"
-            WHERE
-              album_space_asset."assetId" = asset.id
-              AND "shared_space_album"."showInTimeline" = true
-          )
-        )
-      )
+      AND (asset."ownerId" = $4)
   ),
   accessible_faces AS (
     SELECT
@@ -727,6 +607,15 @@ SELECT
   ) AS "detectedFaceCount"
 
 -- FaceIdentityRepository.getAccessiblePeopleFaceStatistics
+select
+  "shared_space_member"."spaceId"
+from
+  "shared_space_member"
+where
+  "shared_space_member"."userId" = $1
+  and "shared_space_member"."showInTimeline" = $2
+limit
+  $3
 WITH
   timeline_spaces AS (
     SELECT
@@ -750,56 +639,7 @@ WITH
       AND asset."deletedAt" IS NULL
       AND asset."isOffline" = false
       AND asset.visibility IN ($2, $3)
-      AND (
-        asset."ownerId" = $4
-        OR EXISTS (
-          SELECT
-            1
-          FROM
-            shared_space_asset
-            INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_asset."spaceId"
-          WHERE
-            shared_space_asset."assetId" = asset.id
-        )
-        OR EXISTS (
-          SELECT
-            1
-          FROM
-            shared_space_library
-            INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_library."spaceId"
-          WHERE
-            shared_space_library."libraryId" = asset."libraryId"
-        )
-        OR (
-          EXISTS (
-            SELECT
-              1
-            FROM
-              shared_space_album
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"
-              INNER JOIN album ON album.id = shared_space_album."albumId"
-              AND album."deletedAt" IS NULL
-              INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
-            WHERE
-              album_asset."assetId" = asset.id
-              AND "shared_space_album"."showInTimeline" = true
-          )
-          OR EXISTS (
-            SELECT
-              1
-            FROM
-              shared_space_album
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"
-              INNER JOIN album ON album.id = shared_space_album."albumId"
-              AND album."deletedAt" IS NULL
-              INNER JOIN album_space_asset ON album_space_asset."albumId" = shared_space_album."albumId"
-              AND album_space_asset."spaceId" = shared_space_album."spaceId"
-            WHERE
-              album_space_asset."assetId" = asset.id
-              AND "shared_space_album"."showInTimeline" = true
-          )
-        )
-      )
+      AND (asset."ownerId" = $4)
   ),
   accessible_faces AS (
     SELECT DISTINCT
@@ -945,6 +785,15 @@ FROM
   face_classification
 
 -- FaceIdentityRepository.getAccessiblePersonStatistics
+select
+  "shared_space_member"."spaceId"
+from
+  "shared_space_member"
+where
+  "shared_space_member"."userId" = $1
+  and "shared_space_member"."showInTimeline" = $2
+limit
+  $3
 WITH
   timeline_spaces AS (
     SELECT
@@ -970,56 +819,7 @@ WITH
       AND asset."deletedAt" IS NULL
       AND asset."isOffline" = false
       AND asset.visibility = $3
-      AND (
-        asset."ownerId" = $4
-        OR EXISTS (
-          SELECT
-            1
-          FROM
-            shared_space_asset
-            INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_asset."spaceId"
-          WHERE
-            shared_space_asset."assetId" = asset.id
-        )
-        OR EXISTS (
-          SELECT
-            1
-          FROM
-            shared_space_library
-            INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_library."spaceId"
-          WHERE
-            shared_space_library."libraryId" = asset."libraryId"
-        )
-        OR (
-          EXISTS (
-            SELECT
-              1
-            FROM
-              shared_space_album
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"
-              INNER JOIN album ON album.id = shared_space_album."albumId"
-              AND album."deletedAt" IS NULL
-              INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
-            WHERE
-              album_asset."assetId" = asset.id
-              AND "shared_space_album"."showInTimeline" = true
-          )
-          OR EXISTS (
-            SELECT
-              1
-            FROM
-              shared_space_album
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"
-              INNER JOIN album ON album.id = shared_space_album."albumId"
-              AND album."deletedAt" IS NULL
-              INNER JOIN album_space_asset ON album_space_asset."albumId" = shared_space_album."albumId"
-              AND album_space_asset."spaceId" = shared_space_album."spaceId"
-            WHERE
-              album_space_asset."assetId" = asset.id
-              AND "shared_space_album"."showInTimeline" = true
-          )
-        )
-      )
+      AND (asset."ownerId" = $4)
   )
 SELECT
   COUNT(DISTINCT "assetId")::int AS assets,

--- a/server/src/queries/face.identity.repository.sql
+++ b/server/src/queries/face.identity.repository.sql
@@ -1545,7 +1545,7 @@ SELECT
   primary_profiles."updatedAt",
   primary_profiles.type,
   primary_profiles.species,
-  asset_counts."numberOfAssets"
+  asset_counts."numberOfAssets" AS "numberOfAssets"
 FROM
   requested_identities
   INNER JOIN ranked_profiles AS primary_profiles ON primary_profiles."identityId" = requested_identities."identityId"

--- a/server/src/queries/face.identity.repository.sql
+++ b/server/src/queries/face.identity.repository.sql
@@ -253,29 +253,48 @@ WITH
       eligible_profiles
     GROUP BY
       "identityId"
+  ),
+  page_rows AS (
+    SELECT
+      identity_counts."identityId",
+      identity_counts."visibleAssetCount",
+      ROW_NUMBER() OVER (
+        ORDER BY
+          COALESCE(identity_favorites."isFavorite", false) DESC,
+          NULLIF(BTRIM(best_profiles.name), '') IS NULL,
+          lower(NULLIF(BTRIM(best_profiles.name), '')) ASC NULLS LAST,
+          CASE
+            WHEN NULLIF(BTRIM(best_profiles.name), '') IS NULL THEN identity_counts."visibleAssetCount"
+          END DESC NULLS LAST,
+          identity_counts."identityId"
+      ) AS ord
+    FROM
+      identity_counts
+      INNER JOIN best_profiles ON best_profiles."identityId" = identity_counts."identityId"
+      INNER JOIN identity_favorites ON identity_favorites."identityId" = identity_counts."identityId"
+    WHERE
+      NULLIF(BTRIM(best_profiles.name), '') IS NOT NULL
+      OR identity_counts."visibleAssetCount" >= $9
+    ORDER BY
+      COALESCE(identity_favorites."isFavorite", false) DESC,
+      NULLIF(BTRIM(best_profiles.name), '') IS NULL,
+      lower(NULLIF(BTRIM(best_profiles.name), '')) ASC NULLS LAST,
+      CASE
+        WHEN NULLIF(BTRIM(best_profiles.name), '') IS NULL THEN identity_counts."visibleAssetCount"
+      END DESC NULLS LAST,
+      identity_counts."identityId"
+    LIMIT
+      $10
+    OFFSET
+      $11
   )
 SELECT
-  identity_counts."identityId",
-  identity_counts."visibleAssetCount"
+  page_rows."identityId",
+  page_rows."visibleAssetCount"
 FROM
-  identity_counts
-  INNER JOIN best_profiles ON best_profiles."identityId" = identity_counts."identityId"
-  INNER JOIN identity_favorites ON identity_favorites."identityId" = identity_counts."identityId"
-WHERE
-  NULLIF(BTRIM(best_profiles.name), '') IS NOT NULL
-  OR identity_counts."visibleAssetCount" >= $9
+  page_rows
 ORDER BY
-  COALESCE(identity_favorites."isFavorite", false) DESC,
-  NULLIF(BTRIM(best_profiles.name), '') IS NULL,
-  lower(NULLIF(BTRIM(best_profiles.name), '')) ASC NULLS LAST,
-  CASE
-    WHEN NULLIF(BTRIM(best_profiles.name), '') IS NULL THEN identity_counts."visibleAssetCount"
-  END DESC NULLS LAST,
-  identity_counts."identityId"
-LIMIT
-  $10
-OFFSET
-  $11
+  page_rows.ord
 
 -- FaceIdentityRepository.getAccessiblePersonFilterSuggestions
 select
@@ -433,29 +452,48 @@ WITH
       eligible_profiles
     GROUP BY
       "identityId"
+  ),
+  page_rows AS (
+    SELECT
+      identity_counts."identityId",
+      identity_counts."visibleAssetCount",
+      ROW_NUMBER() OVER (
+        ORDER BY
+          COALESCE(identity_favorites."isFavorite", false) DESC,
+          NULLIF(BTRIM(best_profiles.name), '') IS NULL,
+          lower(NULLIF(BTRIM(best_profiles.name), '')) ASC NULLS LAST,
+          CASE
+            WHEN NULLIF(BTRIM(best_profiles.name), '') IS NULL THEN identity_counts."visibleAssetCount"
+          END DESC NULLS LAST,
+          identity_counts."identityId"
+      ) AS ord
+    FROM
+      identity_counts
+      INNER JOIN best_profiles ON best_profiles."identityId" = identity_counts."identityId"
+      INNER JOIN identity_favorites ON identity_favorites."identityId" = identity_counts."identityId"
+    WHERE
+      NULLIF(BTRIM(best_profiles.name), '') IS NOT NULL
+      OR identity_counts."visibleAssetCount" >= $9
+    ORDER BY
+      COALESCE(identity_favorites."isFavorite", false) DESC,
+      NULLIF(BTRIM(best_profiles.name), '') IS NULL,
+      lower(NULLIF(BTRIM(best_profiles.name), '')) ASC NULLS LAST,
+      CASE
+        WHEN NULLIF(BTRIM(best_profiles.name), '') IS NULL THEN identity_counts."visibleAssetCount"
+      END DESC NULLS LAST,
+      identity_counts."identityId"
+    LIMIT
+      $10
+    OFFSET
+      $11
   )
 SELECT
-  identity_counts."identityId",
-  identity_counts."visibleAssetCount"
+  page_rows."identityId",
+  page_rows."visibleAssetCount"
 FROM
-  identity_counts
-  INNER JOIN best_profiles ON best_profiles."identityId" = identity_counts."identityId"
-  INNER JOIN identity_favorites ON identity_favorites."identityId" = identity_counts."identityId"
-WHERE
-  NULLIF(BTRIM(best_profiles.name), '') IS NOT NULL
-  OR identity_counts."visibleAssetCount" >= $9
+  page_rows
 ORDER BY
-  COALESCE(identity_favorites."isFavorite", false) DESC,
-  NULLIF(BTRIM(best_profiles.name), '') IS NULL,
-  lower(NULLIF(BTRIM(best_profiles.name), '')) ASC NULLS LAST,
-  CASE
-    WHEN NULLIF(BTRIM(best_profiles.name), '') IS NULL THEN identity_counts."visibleAssetCount"
-  END DESC NULLS LAST,
-  identity_counts."identityId"
-LIMIT
-  $10
-OFFSET
-  $11
+  page_rows.ord
 
 -- FaceIdentityRepository.getAccessiblePeopleStatistics
 select
@@ -1075,29 +1113,323 @@ WITH
       eligible_profiles
     GROUP BY
       "identityId"
+  ),
+  page_rows AS (
+    SELECT
+      identity_counts."identityId",
+      identity_counts."visibleAssetCount",
+      ROW_NUMBER() OVER (
+        ORDER BY
+          COALESCE(identity_favorites."isFavorite", false) DESC,
+          NULLIF(BTRIM(best_profiles.name), '') IS NULL,
+          lower(NULLIF(BTRIM(best_profiles.name), '')) ASC NULLS LAST,
+          CASE
+            WHEN NULLIF(BTRIM(best_profiles.name), '') IS NULL THEN identity_counts."visibleAssetCount"
+          END DESC NULLS LAST,
+          identity_counts."identityId"
+      ) AS ord
+    FROM
+      identity_counts
+      INNER JOIN best_profiles ON best_profiles."identityId" = identity_counts."identityId"
+      INNER JOIN identity_favorites ON identity_favorites."identityId" = identity_counts."identityId"
+    WHERE
+      NULLIF(BTRIM(best_profiles.name), '') IS NOT NULL
+      OR identity_counts."visibleAssetCount" >= $9
+    ORDER BY
+      COALESCE(identity_favorites."isFavorite", false) DESC,
+      NULLIF(BTRIM(best_profiles.name), '') IS NULL,
+      lower(NULLIF(BTRIM(best_profiles.name), '')) ASC NULLS LAST,
+      CASE
+        WHEN NULLIF(BTRIM(best_profiles.name), '') IS NULL THEN identity_counts."visibleAssetCount"
+      END DESC NULLS LAST,
+      identity_counts."identityId"
+    LIMIT
+      $10
+    OFFSET
+      $11
   )
 SELECT
-  identity_counts."identityId",
-  identity_counts."visibleAssetCount"
+  page_rows."identityId",
+  page_rows."visibleAssetCount"
 FROM
-  identity_counts
-  INNER JOIN best_profiles ON best_profiles."identityId" = identity_counts."identityId"
-  INNER JOIN identity_favorites ON identity_favorites."identityId" = identity_counts."identityId"
-WHERE
-  NULLIF(BTRIM(best_profiles.name), '') IS NOT NULL
-  OR identity_counts."visibleAssetCount" >= $9
+  page_rows
 ORDER BY
-  COALESCE(identity_favorites."isFavorite", false) DESC,
-  NULLIF(BTRIM(best_profiles.name), '') IS NULL,
-  lower(NULLIF(BTRIM(best_profiles.name), '')) ASC NULLS LAST,
-  CASE
-    WHEN NULLIF(BTRIM(best_profiles.name), '') IS NULL THEN identity_counts."visibleAssetCount"
-  END DESC NULLS LAST,
-  identity_counts."identityId"
-LIMIT
-  $10
-OFFSET
-  $11
+  page_rows.ord
+
+-- FaceIdentityRepository.getAccessiblePeoplePageWithTotals
+WITH
+  timeline_spaces AS (
+    SELECT
+      "spaceId"
+    FROM
+      shared_space_member
+    WHERE
+      "userId" = $1
+      AND "showInTimeline" = true
+  ),
+  accessible_faces AS (
+    SELECT
+      face_identity_face."identityId",
+      asset_face."assetId"
+    FROM
+      face_identity_face
+      INNER JOIN asset_face ON asset_face.id = face_identity_face."assetFaceId"
+      INNER JOIN asset ON asset.id = asset_face."assetId"
+    WHERE
+      asset_face."deletedAt" IS NULL
+      AND asset_face."isVisible" = true
+      AND asset."deletedAt" IS NULL
+      AND asset."isOffline" = false
+      AND asset.visibility = $2
+      AND (
+        asset."ownerId" = $3
+        OR EXISTS (
+          SELECT
+            1
+          FROM
+            shared_space_asset
+            INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_asset."spaceId"
+          WHERE
+            shared_space_asset."assetId" = asset.id
+        )
+        OR EXISTS (
+          SELECT
+            1
+          FROM
+            shared_space_library
+            INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_library."spaceId"
+          WHERE
+            shared_space_library."libraryId" = asset."libraryId"
+        )
+        OR (
+          EXISTS (
+            SELECT
+              1
+            FROM
+              shared_space_album
+              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"
+              INNER JOIN album ON album.id = shared_space_album."albumId"
+              AND album."deletedAt" IS NULL
+              INNER JOIN album_asset ON album_asset."albumId" = shared_space_album."albumId"
+            WHERE
+              album_asset."assetId" = asset.id
+              AND "shared_space_album"."showInTimeline" = true
+          )
+          OR EXISTS (
+            SELECT
+              1
+            FROM
+              shared_space_album
+              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"
+              INNER JOIN album ON album.id = shared_space_album."albumId"
+              AND album."deletedAt" IS NULL
+              INNER JOIN album_space_asset ON album_space_asset."albumId" = shared_space_album."albumId"
+              AND album_space_asset."spaceId" = shared_space_album."spaceId"
+            WHERE
+              album_space_asset."assetId" = asset.id
+              AND "shared_space_album"."showInTimeline" = true
+          )
+        )
+      )
+  ),
+  accessible_profiles AS (
+    SELECT
+      person."identityId",
+      person.name,
+      person."isHidden",
+      person."isFavorite",
+      person."updatedAt",
+      person.id AS "profileId",
+      0 AS "profileRank"
+    FROM
+      person
+    WHERE
+      person."ownerId" = $4
+      AND person."identityId" IS NOT NULL
+      AND EXISTS (
+        SELECT
+          1
+        FROM
+          accessible_faces
+        WHERE
+          accessible_faces."identityId" = person."identityId"
+      )
+    UNION ALL
+    SELECT
+      shared_space_person."identityId",
+      COALESCE(
+        NULLIF(shared_space_person_alias.alias, ''),
+        shared_space_person.name,
+        ''
+      ) AS name,
+      shared_space_person."isHidden",
+      NULL::boolean AS "isFavorite",
+      shared_space_person."updatedAt",
+      shared_space_person.id AS "profileId",
+      CASE
+        WHEN NULLIF(shared_space_person_alias.alias, '') IS NULL THEN 2
+        ELSE 1
+      END AS "profileRank"
+    FROM
+      shared_space_person
+      INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_person."spaceId"
+      LEFT JOIN shared_space_person_alias ON shared_space_person_alias."personId" = shared_space_person.id
+      AND shared_space_person_alias."userId" = $5
+    WHERE
+      shared_space_person."identityId" IS NOT NULL
+      AND EXISTS (
+        SELECT
+          1
+        FROM
+          shared_space_person_face
+          INNER JOIN asset_face AS profile_face ON profile_face.id = shared_space_person_face."assetFaceId"
+        WHERE
+          shared_space_person_face."personId" = shared_space_person.id
+          AND profile_face."deletedAt" IS NULL
+          AND profile_face."isVisible" = true
+      )
+      AND EXISTS (
+        SELECT
+          1
+        FROM
+          accessible_faces
+        WHERE
+          accessible_faces."identityId" = shared_space_person."identityId"
+      )
+  ),
+  eligible_profiles AS (
+    SELECT
+      *
+    FROM
+      accessible_profiles
+    WHERE
+      (
+        $6::boolean
+        OR "isHidden" = false
+      )
+      AND (
+        $7 = ''
+        OR name ILIKE $8
+      )
+  ),
+  identity_counts AS (
+    SELECT
+      accessible_faces."identityId",
+      COUNT(DISTINCT accessible_faces."assetId") AS "visibleAssetCount"
+    FROM
+      accessible_faces
+    WHERE
+      EXISTS (
+        SELECT
+          1
+        FROM
+          eligible_profiles
+        WHERE
+          eligible_profiles."identityId" = accessible_faces."identityId"
+      )
+    GROUP BY
+      accessible_faces."identityId"
+  ),
+  best_profiles AS (
+    SELECT DISTINCT
+      ON ("identityId") "identityId",
+      name
+    FROM
+      eligible_profiles
+    ORDER BY
+      "identityId",
+      NULLIF(BTRIM(name), '') IS NULL,
+      "profileRank",
+      lower(NULLIF(BTRIM(name), '')),
+      "updatedAt" DESC,
+      "profileId"
+  ),
+  identity_favorites AS (
+    SELECT
+      "identityId",
+      bool_or(COALESCE("isFavorite", false)) AS "isFavorite"
+    FROM
+      eligible_profiles
+    GROUP BY
+      "identityId"
+  ),
+  page_rows AS (
+    SELECT
+      identity_counts."identityId",
+      identity_counts."visibleAssetCount",
+      ROW_NUMBER() OVER (
+        ORDER BY
+          COALESCE(identity_favorites."isFavorite", false) DESC,
+          NULLIF(BTRIM(best_profiles.name), '') IS NULL,
+          lower(NULLIF(BTRIM(best_profiles.name), '')) ASC NULLS LAST,
+          CASE
+            WHEN NULLIF(BTRIM(best_profiles.name), '') IS NULL THEN identity_counts."visibleAssetCount"
+          END DESC NULLS LAST,
+          identity_counts."identityId"
+      ) AS ord
+    FROM
+      identity_counts
+      INNER JOIN best_profiles ON best_profiles."identityId" = identity_counts."identityId"
+      INNER JOIN identity_favorites ON identity_favorites."identityId" = identity_counts."identityId"
+    WHERE
+      NULLIF(BTRIM(best_profiles.name), '') IS NOT NULL
+      OR identity_counts."visibleAssetCount" >= $9
+    ORDER BY
+      COALESCE(identity_favorites."isFavorite", false) DESC,
+      NULLIF(BTRIM(best_profiles.name), '') IS NULL,
+      lower(NULLIF(BTRIM(best_profiles.name), '')) ASC NULLS LAST,
+      CASE
+        WHEN NULLIF(BTRIM(best_profiles.name), '') IS NULL THEN identity_counts."visibleAssetCount"
+      END DESC NULLS LAST,
+      identity_counts."identityId"
+    LIMIT
+      $10
+    OFFSET
+      $11
+  ),
+  all_identity_counts AS (
+    SELECT
+      accessible_faces."identityId",
+      COUNT(DISTINCT accessible_faces."assetId") AS "visibleAssetCount"
+    FROM
+      accessible_faces
+    GROUP BY
+      accessible_faces."identityId"
+  ),
+  identity_visibility AS (
+    SELECT
+      "identityId",
+      bool_or("isHidden" = false) AS "hasVisibleProfile",
+      bool_or(NULLIF(name, '') IS NOT NULL) AS "hasNamedProfile"
+    FROM
+      accessible_profiles
+    GROUP BY
+      "identityId"
+  ),
+  totals AS (
+    SELECT
+      COUNT(*) AS total,
+      COUNT(*) FILTER (
+        WHERE
+          "hasVisibleProfile" = false
+      ) AS hidden
+    FROM
+      identity_visibility
+      INNER JOIN all_identity_counts ON all_identity_counts."identityId" = identity_visibility."identityId"
+    WHERE
+      identity_visibility."hasNamedProfile" = true
+      OR all_identity_counts."visibleAssetCount" >= $12
+  )
+SELECT
+  page_rows."identityId",
+  page_rows."visibleAssetCount",
+  totals.total,
+  totals.hidden
+FROM
+  totals
+  LEFT JOIN page_rows ON true
+ORDER BY
+  page_rows.ord
 
 -- FaceIdentityRepository.hydrateAccessiblePeople
 WITH

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -201,6 +201,14 @@ type AccessiblePeopleIdentityPageRow = {
   visibleAssetCount: string | number;
 };
 
+/**
+ * Reshape the page query's rows into the map {@link FaceIdentityRepository.hydrateAccessiblePeople}
+ * takes, so hydrate does not recompute a count the page query already produced. `visibleAssetCount`
+ * arrives as a string when postgres returns the bigint aggregate.
+ */
+const toAssetCounts = (rows: AccessiblePeopleIdentityPageRow[]): ReadonlyMap<string, number> =>
+  new Map(rows.map((row) => [row.identityId, Number(row.visibleAssetCount)]));
+
 type AccessiblePeopleCountRow = {
   total: string | number | null;
   hidden: string | number | null;
@@ -862,6 +870,7 @@ export class FaceIdentityRepository {
       userId,
       identityIds: rows.map((row) => row.identityId),
       withHidden: options.withHidden ?? false,
+      assetCounts: toAssetCounts(rows),
     });
   }
 
@@ -901,6 +910,7 @@ export class FaceIdentityRepository {
       userId,
       identityIds: pageRows.map((row) => row.identityId),
       withHidden: options.withHidden,
+      assetCounts: toAssetCounts(pageRows),
     });
     const counts = await this.getAccessiblePeopleCounts(userId, minimumFaceCount);
 
@@ -1880,24 +1890,55 @@ export class FaceIdentityRepository {
     userId: string;
     identityIds: string[];
     withHidden: boolean;
+    /**
+     * Per-identity `COUNT(DISTINCT assetId)` the caller has already computed, keyed by identity id.
+     *
+     * `getAccessiblePeopleIdentityPage` produces exactly this number (its `visibleAssetCount`) for
+     * every identity it returns, so the two callers that page first — {@link getAccessiblePeople}
+     * and {@link searchAccessiblePeople} — can hand it over instead of making this query rebuild
+     * the `accessible_faces` CTE to recompute the identical value. On a large library that
+     * recomputation dominated `GET /api/people`.
+     *
+     * Supplying it must not change the result. Two invariants make that hold, and both are pinned
+     * by tests: the counts are the same aggregate over the same CTE definition, and an identity
+     * only reaches this method because the page query already established it is accessible — which
+     * is what the dropped `EXISTS (accessible_faces)` guard was re-checking. Identities absent from
+     * the map (or counted zero, which the page query never emits) are dropped, matching the
+     * uncounted path where they fall out of `ranked_profiles`.
+     */
+    assetCounts?: ReadonlyMap<string, number>;
   }): Promise<PersonResponseDto[]> {
-    if (input.identityIds.length === 0) {
+    const countedIdentities = input.assetCounts
+      ? input.identityIds
+          .map((identityId) => [identityId, input.assetCounts?.get(identityId)] as const)
+          .filter((entry): entry is readonly [string, number] => typeof entry[1] === 'number' && entry[1] > 0)
+      : undefined;
+
+    const requestedIds = countedIdentities ? countedIdentities.map(([identityId]) => identityId) : input.identityIds;
+    if (requestedIds.length === 0) {
       return [];
     }
 
-    const identityIds = sql`array[${sql.join(input.identityIds)}]::uuid[]`;
-    const result = await sql<HydratedAccessiblePersonRow>`
-      WITH requested_identities AS (
+    const identityIds = sql`array[${sql.join(requestedIds)}]::uuid[]`;
+
+    // With counts supplied, carry them alongside the ids through a parallel unnest so the whole
+    // accessible_faces/asset_counts pair can be dropped from the query.
+    const requestedIdentities = countedIdentities
+      ? sql`
+        SELECT *
+        FROM unnest(
+          ${identityIds},
+          array[${sql.join(countedIdentities.map(([, numberOfAssets]) => numberOfAssets))}]::bigint[]
+        ) WITH ORDINALITY AS requested("identityId", "numberOfAssets", ord)
+      `
+      : sql`
         SELECT *
         FROM unnest(${identityIds}) WITH ORDINALITY AS requested("identityId", ord)
-      ),
-      timeline_spaces AS (
-        SELECT "spaceId"
-        FROM shared_space_member
-        WHERE "userId" = ${input.userId}
-          AND "showInTimeline" = true
-      ),
-      accessible_faces AS (
+      `;
+
+    const accessibleFacesCte = countedIdentities
+      ? sql``
+      : sql`accessible_faces AS (
         SELECT
           face_identity_face."identityId",
           asset_face."assetId"
@@ -1937,7 +1978,29 @@ export class FaceIdentityRepository {
           COUNT(DISTINCT "assetId") AS "numberOfAssets"
         FROM accessible_faces
         GROUP BY "identityId"
+      ),`;
+
+    // Accessibility was already established by the page query for every identity we were handed,
+    // so the counted path drops the re-check that the accessible_faces CTE existed to answer.
+    const accessibilityFilter = countedIdentities
+      ? sql``
+      : sql`WHERE EXISTS (SELECT 1 FROM accessible_faces WHERE accessible_faces."identityId" = profiles."identityId")`;
+    const numberOfAssetsColumn = countedIdentities
+      ? sql`requested_identities."numberOfAssets"`
+      : sql`asset_counts."numberOfAssets"`;
+    const assetCountsJoin = countedIdentities
+      ? sql``
+      : sql`LEFT JOIN asset_counts ON asset_counts."identityId" = requested_identities."identityId"`;
+
+    const result = await sql<HydratedAccessiblePersonRow>`
+      WITH requested_identities AS (${requestedIdentities}),
+      timeline_spaces AS (
+        SELECT "spaceId"
+        FROM shared_space_member
+        WHERE "userId" = ${input.userId}
+          AND "showInTimeline" = true
       ),
+      ${accessibleFacesCte}
       profiles AS (
         SELECT
           'user-person'::text AS "profileType",
@@ -2034,7 +2097,7 @@ export class FaceIdentityRepository {
               profiles."profileId"
           ) AS birthdate_rn
         FROM profiles
-        WHERE EXISTS (SELECT 1 FROM accessible_faces WHERE accessible_faces."identityId" = profiles."identityId")
+        ${accessibilityFilter}
       )
       SELECT
         primary_profiles."profileType",
@@ -2049,7 +2112,7 @@ export class FaceIdentityRepository {
         primary_profiles."updatedAt",
         primary_profiles.type,
         primary_profiles.species,
-        asset_counts."numberOfAssets"
+        ${numberOfAssetsColumn} AS "numberOfAssets"
       FROM requested_identities
       INNER JOIN ranked_profiles AS primary_profiles
         ON primary_profiles."identityId" = requested_identities."identityId"
@@ -2060,7 +2123,7 @@ export class FaceIdentityRepository {
       INNER JOIN ranked_profiles AS birthdate_profiles
         ON birthdate_profiles."identityId" = requested_identities."identityId"
         AND birthdate_profiles.birthdate_rn = 1
-      LEFT JOIN asset_counts ON asset_counts."identityId" = requested_identities."identityId"
+      ${assetCountsJoin}
       ORDER BY requested_identities.ord
     `.execute(this.db);
 

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -202,6 +202,18 @@ type AccessiblePeopleIdentityPageRow = {
 };
 
 /**
+ * What the page query actually returns before the repository tidies it. `identityId` is null only
+ * on the placeholder row a `withTotals` query emits when the requested page is past the end — the
+ * row that still carries the header figures. Kept private so no consumer has to think about it.
+ */
+type AccessiblePeoplePageRawRow = {
+  identityId: string | null;
+  visibleAssetCount: string | number;
+  total?: string | number | null;
+  hidden?: string | number | null;
+};
+
+/**
  * Reshape the page query's rows into the map {@link FaceIdentityRepository.hydrateAccessiblePeople}
  * takes, so hydrate does not recompute a count the page query already produced. `visibleAssetCount`
  * arrives as a string when postgres returns the bigint aggregate.
@@ -920,7 +932,7 @@ export class FaceIdentityRepository {
     // Resolved once and shared by the queries below, so the endpoint pays one indexed lookup
     // rather than one per query.
     const hasTimelineSpaces = await this.hasTimelineSpaces(userId);
-    const rows = await this.getAccessiblePeopleIdentityPage({
+    const { rows, total, hidden } = await this.getAccessiblePeoplePageWithTotals({
       userId,
       withHidden: options.withHidden,
       limit: size + 1,
@@ -928,6 +940,7 @@ export class FaceIdentityRepository {
       minimumFaceCount,
       hasTimelineSpaces,
     });
+
     const pageRows = rows.slice(0, size);
     const people = await this.hydrateAccessiblePeople({
       userId,
@@ -936,11 +949,10 @@ export class FaceIdentityRepository {
       assetCounts: toAssetCounts(pageRows),
       hasTimelineSpaces,
     });
-    const counts = await this.getAccessiblePeopleCounts(userId, minimumFaceCount, { hasTimelineSpaces });
 
     return {
-      total: Number(counts.total ?? 0),
-      hidden: Number(counts.hidden ?? 0),
+      total,
+      hidden,
       hasNextPage: rows.length > size,
       people,
     };
@@ -1618,12 +1630,102 @@ export class FaceIdentityRepository {
     offset: number;
     minimumFaceCount: number;
     searchName?: string;
-    /** Resolved by the caller when it runs several of these queries, to avoid repeating the lookup. */
     hasTimelineSpaces?: boolean;
   }): Promise<AccessiblePeopleIdentityPageRow[]> {
+    const rows = await this.queryAccessiblePeoplePage({ ...input, withTotals: false });
+    return rows.filter((row): row is AccessiblePeopleIdentityPageRow => row.identityId !== null);
+  }
+
+  /**
+   * The page plus the library-wide header figures, from one query. See {@link withTotals} on
+   * {@link queryAccessiblePeoplePage} for why the totals are not simply the page's own numbers.
+   */
+  @GenerateSql({
+    params: [
+      { userId: DummyValue.UUID, withHidden: true, limit: 51, offset: 0, minimumFaceCount: 3, hasTimelineSpaces: true },
+    ],
+  })
+  async getAccessiblePeoplePageWithTotals(input: {
+    userId: string;
+    withHidden: boolean;
+    limit: number;
+    offset: number;
+    minimumFaceCount: number;
+    searchName?: string;
+    hasTimelineSpaces?: boolean;
+  }): Promise<{ rows: AccessiblePeopleIdentityPageRow[]; total: number; hidden: number }> {
+    const raw = await this.queryAccessiblePeoplePage({ ...input, withTotals: true });
+    return {
+      // The header figures ride on every row, including the placeholder row returned when the
+      // requested page is past the end — so read them before discarding it.
+      total: Number(raw[0]?.total ?? 0),
+      hidden: Number(raw[0]?.hidden ?? 0),
+      rows: raw.filter((row): row is AccessiblePeopleIdentityPageRow => row.identityId !== null),
+    };
+  }
+
+  private async queryAccessiblePeoplePage(input: {
+    userId: string;
+    withHidden: boolean;
+    limit: number;
+    offset: number;
+    minimumFaceCount: number;
+    searchName?: string;
+    /** Resolved by the caller when it runs several of these queries, to avoid repeating the lookup. */
+    hasTimelineSpaces?: boolean;
+    /**
+     * Also derive the library-wide total/hidden header figures from the CTEs this query already
+     * builds, instead of a third query that rebuilt them from scratch. Every
+     * returned row carries them; a page past the end returns a single row whose `identityId` is
+     * null and which carries only the totals.
+     */
+    withTotals?: boolean;
+  }): Promise<AccessiblePeoplePageRawRow[]> {
     const searchName = input.searchName ?? '';
     const hasTimelineSpaces = input.hasTimelineSpaces ?? (await this.hasTimelineSpaces(input.userId));
-    const result = await sql<AccessiblePeopleIdentityPageRow>`
+
+    // Fix C — the People header's total/hidden used to come from a third query that rebuilt
+    // `accessible_faces` and `accessible_profiles` from scratch. They are derived here instead,
+    // off the CTEs this query has already materialised.
+    //
+    // They are deliberately NOT the page's own figures: totals are library-wide and ignore
+    // `withHidden` (so they read off `accessible_profiles`, not `eligible_profiles`), and their
+    // "is this identity named" test omits the BTRIM the listing applies. Both asymmetries predate
+    // this change and are pinned by characterisation tests; reproducing them exactly is the point.
+    //
+    // The page is joined onto the totals rather than the other way round, so an empty page (a
+    // request past the last page) still returns the header numbers instead of collapsing to no rows.
+    const totalsCtes = input.withTotals
+      ? sql`,
+      all_identity_counts AS (
+        SELECT
+          accessible_faces."identityId",
+          COUNT(DISTINCT accessible_faces."assetId") AS "visibleAssetCount"
+        FROM accessible_faces
+        GROUP BY accessible_faces."identityId"
+      ),
+      identity_visibility AS (
+        SELECT
+          "identityId",
+          bool_or("isHidden" = false) AS "hasVisibleProfile",
+          bool_or(NULLIF(name, '') IS NOT NULL) AS "hasNamedProfile"
+        FROM accessible_profiles
+        GROUP BY "identityId"
+      ),
+      totals AS (
+        SELECT
+          COUNT(*) AS total,
+          COUNT(*) FILTER (WHERE "hasVisibleProfile" = false) AS hidden
+        FROM identity_visibility
+        INNER JOIN all_identity_counts ON all_identity_counts."identityId" = identity_visibility."identityId"
+        WHERE identity_visibility."hasNamedProfile" = true
+          OR all_identity_counts."visibleAssetCount" >= ${input.minimumFaceCount}
+      )`
+      : sql``;
+    const totalsColumns = input.withTotals ? sql`, totals.total, totals.hidden` : sql``;
+    const totalsFrom = input.withTotals ? sql`FROM totals LEFT JOIN page_rows ON true` : sql`FROM page_rows`;
+
+    const result = await sql<AccessiblePeoplePageRawRow>`
       WITH timeline_spaces AS (
         SELECT "spaceId"
         FROM shared_space_member
@@ -1724,115 +1826,45 @@ export class FaceIdentityRepository {
           bool_or(COALESCE("isFavorite", false)) AS "isFavorite"
         FROM eligible_profiles
         GROUP BY "identityId"
-      )
+      ),
+      page_rows AS (
+        SELECT
+          identity_counts."identityId",
+          identity_counts."visibleAssetCount",
+          ROW_NUMBER() OVER (
+            ORDER BY
+              COALESCE(identity_favorites."isFavorite", false) DESC,
+              NULLIF(BTRIM(best_profiles.name), '') IS NULL,
+              lower(NULLIF(BTRIM(best_profiles.name), '')) ASC NULLS LAST,
+              CASE
+                WHEN NULLIF(BTRIM(best_profiles.name), '') IS NULL THEN identity_counts."visibleAssetCount"
+              END DESC NULLS LAST,
+              identity_counts."identityId"
+          ) AS ord
+        FROM identity_counts
+        INNER JOIN best_profiles ON best_profiles."identityId" = identity_counts."identityId"
+        INNER JOIN identity_favorites ON identity_favorites."identityId" = identity_counts."identityId"
+        WHERE NULLIF(BTRIM(best_profiles.name), '') IS NOT NULL
+          OR identity_counts."visibleAssetCount" >= ${input.minimumFaceCount}
+        ORDER BY
+          COALESCE(identity_favorites."isFavorite", false) DESC,
+          NULLIF(BTRIM(best_profiles.name), '') IS NULL,
+          lower(NULLIF(BTRIM(best_profiles.name), '')) ASC NULLS LAST,
+          CASE
+            WHEN NULLIF(BTRIM(best_profiles.name), '') IS NULL THEN identity_counts."visibleAssetCount"
+          END DESC NULLS LAST,
+          identity_counts."identityId"
+        LIMIT ${input.limit}
+        OFFSET ${input.offset}
+      )${totalsCtes}
       SELECT
-        identity_counts."identityId",
-        identity_counts."visibleAssetCount"
-      FROM identity_counts
-      INNER JOIN best_profiles ON best_profiles."identityId" = identity_counts."identityId"
-      INNER JOIN identity_favorites ON identity_favorites."identityId" = identity_counts."identityId"
-      WHERE NULLIF(BTRIM(best_profiles.name), '') IS NOT NULL
-        OR identity_counts."visibleAssetCount" >= ${input.minimumFaceCount}
-      ORDER BY
-        COALESCE(identity_favorites."isFavorite", false) DESC,
-        NULLIF(BTRIM(best_profiles.name), '') IS NULL,
-        lower(NULLIF(BTRIM(best_profiles.name), '')) ASC NULLS LAST,
-        CASE
-          WHEN NULLIF(BTRIM(best_profiles.name), '') IS NULL THEN identity_counts."visibleAssetCount"
-        END DESC NULLS LAST,
-        identity_counts."identityId"
-      LIMIT ${input.limit}
-      OFFSET ${input.offset}
+        page_rows."identityId",
+        page_rows."visibleAssetCount"${totalsColumns}
+      ${totalsFrom}
+      ORDER BY page_rows.ord
     `.execute(this.db);
 
     return result.rows;
-  }
-
-  async getAccessiblePeopleCounts(
-    userId: string,
-    minimumFaceCount: number,
-    options: { hasTimelineSpaces?: boolean } = {},
-  ): Promise<{ total: number; hidden: number }> {
-    const hasTimelineSpaces = options.hasTimelineSpaces ?? (await this.hasTimelineSpaces(userId));
-    const result = await sql<AccessiblePeopleCountRow>`
-      WITH timeline_spaces AS (
-        SELECT "spaceId"
-        FROM shared_space_member
-        WHERE "userId" = ${userId}
-          AND "showInTimeline" = true
-      ),
-      accessible_faces AS (
-        SELECT
-          face_identity_face."identityId",
-          asset_face."assetId"
-        FROM face_identity_face
-        INNER JOIN asset_face ON asset_face.id = face_identity_face."assetFaceId"
-        INNER JOIN asset ON asset.id = asset_face."assetId"
-        WHERE asset_face."deletedAt" IS NULL
-          AND asset_face."isVisible" = true
-          AND asset."deletedAt" IS NULL
-          AND asset."isOffline" = false
-          AND asset.visibility = ${AssetVisibility.Timeline}
-          AND (
-            ${accessibleTimelineAssetPredicate({ userId, hasTimelineSpaces })}
-          )
-      ),
-      identity_counts AS (
-        SELECT
-          accessible_faces."identityId",
-          COUNT(DISTINCT accessible_faces."assetId") AS "visibleAssetCount"
-        FROM accessible_faces
-        GROUP BY accessible_faces."identityId"
-      ),
-      accessible_profiles AS (
-        SELECT person."identityId", person."isHidden", person.name
-        FROM person
-        WHERE person."ownerId" = ${userId}
-          AND person."identityId" IS NOT NULL
-          AND EXISTS (SELECT 1 FROM accessible_faces WHERE accessible_faces."identityId" = person."identityId")
-        UNION ALL
-        SELECT
-          shared_space_person."identityId",
-          shared_space_person."isHidden",
-          COALESCE(NULLIF(shared_space_person_alias.alias, ''), shared_space_person.name, '') AS name
-        FROM shared_space_person
-        INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_person."spaceId"
-        LEFT JOIN shared_space_person_alias
-          ON shared_space_person_alias."personId" = shared_space_person.id
-          AND shared_space_person_alias."userId" = ${userId}
-        WHERE shared_space_person."identityId" IS NOT NULL
-          AND EXISTS (
-            SELECT 1
-            FROM shared_space_person_face
-            INNER JOIN asset_face AS profile_face
-              ON profile_face.id = shared_space_person_face."assetFaceId"
-            WHERE shared_space_person_face."personId" = shared_space_person.id
-              AND profile_face."deletedAt" IS NULL
-              AND profile_face."isVisible" = true
-          )
-          AND EXISTS (
-            SELECT 1 FROM accessible_faces WHERE accessible_faces."identityId" = shared_space_person."identityId"
-          )
-      ),
-      identity_visibility AS (
-        SELECT
-          "identityId",
-          bool_or("isHidden" = false) AS "hasVisibleProfile",
-          bool_or(NULLIF(name, '') IS NOT NULL) AS "hasNamedProfile"
-        FROM accessible_profiles
-        GROUP BY "identityId"
-      )
-      SELECT
-        COUNT(*) AS total,
-        COUNT(*) FILTER (WHERE "hasVisibleProfile" = false) AS hidden
-      FROM identity_visibility
-      INNER JOIN identity_counts ON identity_counts."identityId" = identity_visibility."identityId"
-      WHERE identity_visibility."hasNamedProfile" = true
-        OR identity_counts."visibleAssetCount" >= ${minimumFaceCount}
-    `.execute(this.db);
-
-    const row = result.rows[0];
-    return { total: Number(row?.total ?? 0), hidden: Number(row?.hidden ?? 0) };
   }
 
   @GenerateSql({

--- a/server/src/repositories/face-identity.repository.ts
+++ b/server/src/repositories/face-identity.repository.ts
@@ -11,7 +11,7 @@ import { FaceIdentityFaceSource, FaceIdentityFaceTable } from 'src/schema/tables
 import { FaceIdentityTable } from 'src/schema/tables/face-identity.table';
 import { anyUuid, retryOnDeadlock } from 'src/utils/database';
 import { asDateString, asDateTimeString } from 'src/utils/date';
-import { spaceAlbumAssetExistsSql, spaceVisibleAssetVisibilities } from 'src/utils/shared-space-album-scope';
+import { accessibleTimelineAssetPredicate, spaceVisibleAssetVisibilities } from 'src/utils/shared-space-album-scope';
 
 export type FaceIdentity = Selectable<FaceIdentityTable>;
 export type FaceIdentityFace = Selectable<FaceIdentityFaceTable>;
@@ -894,16 +894,39 @@ export class FaceIdentityRepository {
     };
   }
 
+  /**
+   * Does this viewer belong to any space whose assets appear on their timeline surfaces?
+   *
+   * When they do not, every space arm of {@link accessibleTimelineAssetPredicate} is dead and the
+   * People-page aggregates can run a far cheaper predicate. This is a single indexed lookup, and
+   * it is resolved per request rather than cached so that joining or leaving a space takes effect
+   * on the next page load.
+   */
+  private async hasTimelineSpaces(userId: string): Promise<boolean> {
+    const row = await this.db
+      .selectFrom('shared_space_member')
+      .select('shared_space_member.spaceId')
+      .where('shared_space_member.userId', '=', userId)
+      .where('shared_space_member.showInTimeline', '=', true)
+      .limit(1)
+      .executeTakeFirst();
+    return row !== undefined;
+  }
+
   async getAccessiblePeople(userId: string, options: AccessiblePeopleOptions): Promise<PeopleResponseDto> {
     const page = Math.max(1, options.page);
     const size = Math.max(1, options.size);
     const minimumFaceCount = options.minimumFaceCount ?? 1;
+    // Resolved once and shared by the queries below, so the endpoint pays one indexed lookup
+    // rather than one per query.
+    const hasTimelineSpaces = await this.hasTimelineSpaces(userId);
     const rows = await this.getAccessiblePeopleIdentityPage({
       userId,
       withHidden: options.withHidden,
       limit: size + 1,
       offset: (page - 1) * size,
       minimumFaceCount,
+      hasTimelineSpaces,
     });
     const pageRows = rows.slice(0, size);
     const people = await this.hydrateAccessiblePeople({
@@ -911,8 +934,9 @@ export class FaceIdentityRepository {
       identityIds: pageRows.map((row) => row.identityId),
       withHidden: options.withHidden,
       assetCounts: toAssetCounts(pageRows),
+      hasTimelineSpaces,
     });
-    const counts = await this.getAccessiblePeopleCounts(userId, minimumFaceCount);
+    const counts = await this.getAccessiblePeopleCounts(userId, minimumFaceCount, { hasTimelineSpaces });
 
     return {
       total: Number(counts.total ?? 0),
@@ -928,6 +952,7 @@ export class FaceIdentityRepository {
     options: { minimumFaceCount?: number },
   ): Promise<{ total: number; hidden: number; detectedFaceCount: number }> {
     const minimumFaceCount = options.minimumFaceCount ?? 1;
+    const hasTimelineSpaces = await this.hasTimelineSpaces(userId);
     const result = await sql<AccessiblePeopleStatisticsRow>`
       WITH timeline_spaces AS (
         SELECT "spaceId"
@@ -947,24 +972,7 @@ export class FaceIdentityRepository {
           AND asset."isOffline" = false
           AND asset.visibility IN (${sql.join(peopleAssetVisibilities)})
           AND (
-            asset."ownerId" = ${userId}
-            OR EXISTS (
-              SELECT 1
-              FROM shared_space_asset
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_asset."spaceId"
-              WHERE shared_space_asset."assetId" = asset.id
-            )
-            OR EXISTS (
-              SELECT 1
-              FROM shared_space_library
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_library."spaceId"
-              WHERE shared_space_library."libraryId" = asset."libraryId"
-            )
-            OR ${spaceAlbumAssetExistsSql({
-              assetIdColumn: sql`asset.id`,
-              spaceScopeJoin: sql`INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"`,
-              requireShowInTimeline: true,
-            })}
+            ${accessibleTimelineAssetPredicate({ userId, hasTimelineSpaces })}
           )
       ),
       accessible_faces AS (
@@ -1048,6 +1056,7 @@ export class FaceIdentityRepository {
     options: { minimumFaceCount?: number },
   ): Promise<PeopleFaceStatistics> {
     const minimumFaceCount = options.minimumFaceCount ?? 1;
+    const hasTimelineSpaces = await this.hasTimelineSpaces(userId);
     const result = await sql<PeopleFaceStatistics>`
       WITH timeline_spaces AS (
         SELECT "spaceId"
@@ -1067,24 +1076,7 @@ export class FaceIdentityRepository {
           AND asset."isOffline" = false
           AND asset.visibility IN (${sql.join(peopleAssetVisibilities)})
           AND (
-            asset."ownerId" = ${userId}
-            OR EXISTS (
-              SELECT 1
-              FROM shared_space_asset
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_asset."spaceId"
-              WHERE shared_space_asset."assetId" = asset.id
-            )
-            OR EXISTS (
-              SELECT 1
-              FROM shared_space_library
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_library."spaceId"
-              WHERE shared_space_library."libraryId" = asset."libraryId"
-            )
-            OR ${spaceAlbumAssetExistsSql({
-              assetIdColumn: sql`asset.id`,
-              spaceScopeJoin: sql`INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"`,
-              requireShowInTimeline: true,
-            })}
+            ${accessibleTimelineAssetPredicate({ userId, hasTimelineSpaces })}
           )
       ),
       accessible_faces AS (
@@ -1188,6 +1180,7 @@ export class FaceIdentityRepository {
 
   @GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID] })
   async getAccessiblePersonStatistics(userId: string, identityId: string): Promise<PersonStatistics> {
+    const hasTimelineSpaces = await this.hasTimelineSpaces(userId);
     const result = await sql<PersonStatistics>`
       WITH timeline_spaces AS (
         SELECT "spaceId"
@@ -1209,24 +1202,7 @@ export class FaceIdentityRepository {
           AND asset."isOffline" = false
           AND asset.visibility = ${AssetVisibility.Timeline}
           AND (
-            asset."ownerId" = ${userId}
-            OR EXISTS (
-              SELECT 1
-              FROM shared_space_asset
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_asset."spaceId"
-              WHERE shared_space_asset."assetId" = asset.id
-            )
-            OR EXISTS (
-              SELECT 1
-              FROM shared_space_library
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_library."spaceId"
-              WHERE shared_space_library."libraryId" = asset."libraryId"
-            )
-            OR ${spaceAlbumAssetExistsSql({
-              assetIdColumn: sql`asset.id`,
-              spaceScopeJoin: sql`INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"`,
-              requireShowInTimeline: true,
-            })}
+            ${accessibleTimelineAssetPredicate({ userId, hasTimelineSpaces })}
           )
       )
       SELECT
@@ -1628,7 +1604,12 @@ export class FaceIdentityRepository {
   }
 
   @GenerateSql({
-    params: [{ userId: DummyValue.UUID, withHidden: true, limit: 51, offset: 0, minimumFaceCount: 3 }],
+    // Documented with the shared-space arms present: that is the superset worth reviewing. A
+    // viewer with no timeline-enabled space runs the collapsed predicate instead — see
+    // `accessibleTimelineAssetPredicate`.
+    params: [
+      { userId: DummyValue.UUID, withHidden: true, limit: 51, offset: 0, minimumFaceCount: 3, hasTimelineSpaces: true },
+    ],
   })
   async getAccessiblePeopleIdentityPage(input: {
     userId: string;
@@ -1637,8 +1618,11 @@ export class FaceIdentityRepository {
     offset: number;
     minimumFaceCount: number;
     searchName?: string;
+    /** Resolved by the caller when it runs several of these queries, to avoid repeating the lookup. */
+    hasTimelineSpaces?: boolean;
   }): Promise<AccessiblePeopleIdentityPageRow[]> {
     const searchName = input.searchName ?? '';
+    const hasTimelineSpaces = input.hasTimelineSpaces ?? (await this.hasTimelineSpaces(input.userId));
     const result = await sql<AccessiblePeopleIdentityPageRow>`
       WITH timeline_spaces AS (
         SELECT "spaceId"
@@ -1659,24 +1643,7 @@ export class FaceIdentityRepository {
           AND asset."isOffline" = false
           AND asset.visibility = ${AssetVisibility.Timeline}
           AND (
-            asset."ownerId" = ${input.userId}
-            OR EXISTS (
-              SELECT 1
-              FROM shared_space_asset
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_asset."spaceId"
-              WHERE shared_space_asset."assetId" = asset.id
-            )
-            OR EXISTS (
-              SELECT 1
-              FROM shared_space_library
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_library."spaceId"
-              WHERE shared_space_library."libraryId" = asset."libraryId"
-            )
-            OR ${spaceAlbumAssetExistsSql({
-              assetIdColumn: sql`asset.id`,
-              spaceScopeJoin: sql`INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"`,
-              requireShowInTimeline: true,
-            })}
+            ${accessibleTimelineAssetPredicate({ userId: input.userId, hasTimelineSpaces })}
           )
       ),
       accessible_profiles AS (
@@ -1784,7 +1751,9 @@ export class FaceIdentityRepository {
   async getAccessiblePeopleCounts(
     userId: string,
     minimumFaceCount: number,
+    options: { hasTimelineSpaces?: boolean } = {},
   ): Promise<{ total: number; hidden: number }> {
+    const hasTimelineSpaces = options.hasTimelineSpaces ?? (await this.hasTimelineSpaces(userId));
     const result = await sql<AccessiblePeopleCountRow>`
       WITH timeline_spaces AS (
         SELECT "spaceId"
@@ -1805,24 +1774,7 @@ export class FaceIdentityRepository {
           AND asset."isOffline" = false
           AND asset.visibility = ${AssetVisibility.Timeline}
           AND (
-            asset."ownerId" = ${userId}
-            OR EXISTS (
-              SELECT 1
-              FROM shared_space_asset
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_asset."spaceId"
-              WHERE shared_space_asset."assetId" = asset.id
-            )
-            OR EXISTS (
-              SELECT 1
-              FROM shared_space_library
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_library."spaceId"
-              WHERE shared_space_library."libraryId" = asset."libraryId"
-            )
-            OR ${spaceAlbumAssetExistsSql({
-              assetIdColumn: sql`asset.id`,
-              spaceScopeJoin: sql`INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"`,
-              requireShowInTimeline: true,
-            })}
+            ${accessibleTimelineAssetPredicate({ userId, hasTimelineSpaces })}
           )
       ),
       identity_counts AS (
@@ -1884,7 +1836,9 @@ export class FaceIdentityRepository {
   }
 
   @GenerateSql({
-    params: [{ userId: DummyValue.UUID, identityIds: [DummyValue.UUID], withHidden: true }],
+    // As above: documents the shared-space form, which is also the uncounted path (the counted
+    // path emits no accessibility predicate at all).
+    params: [{ userId: DummyValue.UUID, identityIds: [DummyValue.UUID], withHidden: true, hasTimelineSpaces: true }],
   })
   async hydrateAccessiblePeople(input: {
     userId: string;
@@ -1907,6 +1861,8 @@ export class FaceIdentityRepository {
      * uncounted path where they fall out of `ranked_profiles`.
      */
     assetCounts?: ReadonlyMap<string, number>;
+    /** Resolved by the caller when it runs several of these queries, to avoid repeating the lookup. */
+    hasTimelineSpaces?: boolean;
   }): Promise<PersonResponseDto[]> {
     const countedIdentities = input.assetCounts
       ? input.identityIds
@@ -1920,6 +1876,12 @@ export class FaceIdentityRepository {
     }
 
     const identityIds = sql`array[${sql.join(requestedIds)}]::uuid[]`;
+
+    // Only the uncounted path emits an accessibility predicate, so skip the lookup entirely on the
+    // hot path rather than paying a round-trip for a value that is never interpolated.
+    const hasTimelineSpaces = countedIdentities
+      ? false
+      : (input.hasTimelineSpaces ?? (await this.hasTimelineSpaces(input.userId)));
 
     // With counts supplied, carry them alongside the ids through a parallel unnest so the whole
     // accessible_faces/asset_counts pair can be dropped from the query.
@@ -1952,24 +1914,7 @@ export class FaceIdentityRepository {
           AND asset."isOffline" = false
           AND asset.visibility = ${AssetVisibility.Timeline}
           AND (
-            asset."ownerId" = ${input.userId}
-            OR EXISTS (
-              SELECT 1
-              FROM shared_space_asset
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_asset."spaceId"
-              WHERE shared_space_asset."assetId" = asset.id
-            )
-            OR EXISTS (
-              SELECT 1
-              FROM shared_space_library
-              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_library."spaceId"
-              WHERE shared_space_library."libraryId" = asset."libraryId"
-            )
-            OR ${spaceAlbumAssetExistsSql({
-              assetIdColumn: sql`asset.id`,
-              spaceScopeJoin: sql`INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"`,
-              requireShowInTimeline: true,
-            })}
+            ${accessibleTimelineAssetPredicate({ userId: input.userId, hasTimelineSpaces })}
           )
       ),
       asset_counts AS (

--- a/server/src/utils/shared-space-album-scope.ts
+++ b/server/src/utils/shared-space-album-scope.ts
@@ -366,6 +366,54 @@ export interface SpaceAlbumAssetSqlOptions {
  * this precedence-safe for every consumer that interpolates it into a larger `OR ${...}` / negates
  * it via `NOT (...)`.
  */
+/**
+ * "Can this viewer see `asset` on a timeline surface?" — the predicate the People-page aggregates
+ * correlate per face row. A viewer reaches an asset by owning it, or through one of three space
+ * paths: a directly-added asset, a linked library, or a linked album.
+ *
+ * **Every space arm joins the `timeline_spaces` CTE**, so a viewer who belongs to no
+ * timeline-enabled space cannot satisfy any of them, and the predicate is exactly
+ * `asset."ownerId" = <viewer>`. Postgres cannot deduce that at plan time — it evaluates the whole
+ * OR per candidate row, which on a large single-user library meant hundreds of thousands of index
+ * probes into `asset` that removed nothing. Passing `hasTimelineSpaces: false` emits the collapsed
+ * form instead.
+ *
+ * The caller is responsible for establishing `hasTimelineSpaces` (a `shared_space_member` lookup
+ * on `userId` + `showInTimeline`), and for defining the `timeline_spaces` CTE this correlates
+ * against when it is true.
+ *
+ * If a future space path is added here that is NOT gated on `timeline_spaces`, the collapsed form
+ * becomes wrong — `accessible-timeline-asset-predicate.medium.spec.ts` compares the two forms'
+ * result sets and will fail.
+ */
+export function accessibleTimelineAssetPredicate(options: {
+  userId: string;
+  hasTimelineSpaces: boolean;
+}): RawBuilder<SqlBool> {
+  if (!options.hasTimelineSpaces) {
+    return sql<SqlBool>`asset."ownerId" = ${options.userId}`;
+  }
+
+  return sql<SqlBool>`asset."ownerId" = ${options.userId}
+            OR EXISTS (
+              SELECT 1
+              FROM shared_space_asset
+              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_asset."spaceId"
+              WHERE shared_space_asset."assetId" = asset.id
+            )
+            OR EXISTS (
+              SELECT 1
+              FROM shared_space_library
+              INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_library."spaceId"
+              WHERE shared_space_library."libraryId" = asset."libraryId"
+            )
+            OR ${spaceAlbumAssetExistsSql({
+              assetIdColumn: sql`asset.id`,
+              spaceScopeJoin: sql`INNER JOIN timeline_spaces ON timeline_spaces."spaceId" = shared_space_album."spaceId"`,
+              requireShowInTimeline: true,
+            })}`;
+}
+
 export function spaceAlbumAssetExistsSql(options: SpaceAlbumAssetSqlOptions): RawBuilder<SqlBool> {
   const albumJoin =
     (options.requireAlbumNotDeleted ?? true)

--- a/server/test/medium/specs/repositories/face-identity-query-shape.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity-query-shape.spec.ts
@@ -89,16 +89,26 @@ describe('Face identity query shape', () => {
 
   it('does not run vector similarity for people, filters, or identity-token asset paths', () => {
     const sqlText = collectIdentityQueryText();
+    // Each slice is delimited by method names. A rename that stops one matching used to yield ''
+    // silently, which would make every `not.toContain` below pass while checking nothing — so a
+    // miss is a hard failure instead.
+    const slice = (pattern: RegExp): string => {
+      const matched = pattern.exec(sqlText)?.[0];
+      if (!matched) {
+        throw new Error(`query-shape slice matched nothing: ${pattern} — did a method get renamed?`);
+      }
+      return matched;
+    };
     const identityOnlyText = [
-      /async getAccessiblePeopleIdentityPage[\s\S]*?async getAccessiblePeopleCounts/.exec(sqlText)?.[0] ?? '',
-      /async getAccessiblePeopleStatistics[\s\S]*?async getAccessiblePeopleIdentityPage/.exec(sqlText)?.[0] ?? '',
-      /async getAccessiblePeopleFaceStatistics[\s\S]*?async getAccessiblePersonByProfileId/.exec(sqlText)?.[0] ?? '',
-      /async getAccessiblePersonStatistics[\s\S]*?async getAccessibleProfileIdentityId/.exec(sqlText)?.[0] ?? '',
-      /async hydrateAccessiblePeople[\s\S]*?private mapAccessiblePerson/.exec(sqlText)?.[0] ?? '',
-      /async getAccessiblePersonFilterSuggestions[\s\S]*?async getAccessiblePeople/.exec(sqlText)?.[0] ?? '',
-      /async searchAccessiblePeople[\s\S]*?async getAccessiblePersonFilterSuggestions/.exec(sqlText)?.[0] ?? '',
-      /private async getFilteredIdentityPeople[\s\S]*?private async getFilteredRatings/.exec(sqlText)?.[0] ?? '',
-      /identity-filter-suggestions[\s\S]*?async getFilterSuggestions/.exec(sqlText)?.[0] ?? '',
+      slice(/private async queryAccessiblePeoplePage[\s\S]*?async hydrateAccessiblePeople/),
+      slice(/async getAccessiblePeopleStatistics[\s\S]*?async getAccessiblePeopleIdentityPage/),
+      slice(/async getAccessiblePeopleFaceStatistics[\s\S]*?async getAccessiblePersonByProfileId/),
+      slice(/async getAccessiblePersonStatistics[\s\S]*?async getAccessibleProfileIdentityId/),
+      slice(/async hydrateAccessiblePeople[\s\S]*?private mapAccessiblePerson/),
+      slice(/async getAccessiblePersonFilterSuggestions[\s\S]*?async getAccessiblePeople/),
+      slice(/async searchAccessiblePeople[\s\S]*?async getAccessiblePersonFilterSuggestions/),
+      slice(/private async getFilteredIdentityPeople[\s\S]*?private async getFilteredRatings/),
+      slice(/identity-filter-suggestions[\s\S]*?async getFilterSuggestions/),
     ].join('\n');
 
     expect(identityOnlyText).toContain('face_identity_face');
@@ -124,7 +134,7 @@ describe('Face identity query shape', () => {
 
   it('keeps pagination in the identity page query instead of hydrating all identities first', () => {
     const sqlText = collectIdentityQueryText();
-    const identityPageQuery = /async getAccessiblePeopleIdentityPage[\s\S]*?async getAccessiblePeopleCounts/.exec(
+    const identityPageQuery = /private async queryAccessiblePeoplePage[\s\S]*?async hydrateAccessiblePeople/.exec(
       sqlText,
     )?.[0];
 

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -2632,6 +2632,126 @@ describe(FaceIdentityRepository.name, () => {
     });
   });
 
+  // Fix B — the no-timeline-spaces fast path, exercised through the repository rather than through
+  // the predicate helper alone (see accessible-timeline-asset-predicate.medium.spec.ts for the
+  // fragment-level equivalence proof).
+  describe('getAccessiblePeople without any timeline-enabled space', () => {
+    it('returns the viewer own people with correct counts', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { user: stranger } = await ctx.newUser();
+
+      try {
+        const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Solo' });
+        const identity = await sut.ensurePersonIdentity(person.id);
+        for (let index = 0; index < 2; index++) {
+          const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+          const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+          await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+        }
+
+        // A face belonging to someone else's library must stay invisible on the fast path.
+        const { person: theirs } = await ctx.newPerson({ ownerId: stranger.id, name: 'Theirs' });
+        const strangerIdentity = await sut.ensurePersonIdentity(theirs.id);
+        const { asset: strangerAsset } = await ctx.newAsset({
+          ownerId: stranger.id,
+          visibility: AssetVisibility.Timeline,
+        });
+        const { assetFace: strangerFace } = await ctx.newAssetFace({
+          assetId: strangerAsset.id,
+          personId: theirs.id,
+        });
+        await sut.linkFace({
+          assetFaceId: strangerFace.id,
+          identityId: strangerIdentity.id,
+          source: 'owner-person',
+        });
+
+        const result = await sut.getAccessiblePeople(user.id, {
+          withHidden: false,
+          page: 1,
+          size: 50,
+          minimumFaceCount: 1,
+        });
+
+        expect(result.people.map((candidate) => candidate.name)).toEqual(['Solo']);
+        expect(result.people[0].numberOfAssets).toBe(2);
+        expect(result.total).toBe(1);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+        await ctx.database.deleteFrom('user').where('id', '=', stranger.id).execute();
+      }
+    });
+
+    it('does not surface space people while the membership has showInTimeline off', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+
+      try {
+        const { space } = await createAccessibleSpaceIdentity(ctx, sut, {
+          memberUserId: member.id,
+          ownerUserId: owner.id,
+          showInTimeline: false,
+          embedding: newEmbedding(),
+        });
+        expect(space.id).toBeDefined();
+
+        const result = await sut.getAccessiblePeople(member.id, {
+          withHidden: false,
+          page: 1,
+          size: 50,
+          minimumFaceCount: 1,
+        });
+
+        expect(result.people).toEqual([]);
+        expect(result.total).toBe(0);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', owner.id).execute();
+        await ctx.database.deleteFrom('user').where('id', '=', member.id).execute();
+      }
+    });
+
+    // The fast path is chosen per request. If the decision were cached anywhere, enabling the
+    // timeline would not take effect and the member would stay blind to the space's people.
+    it('picks the space path up as soon as the membership timeline is switched on', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+
+      try {
+        const { space } = await createAccessibleSpaceIdentity(ctx, sut, {
+          memberUserId: member.id,
+          ownerUserId: owner.id,
+          showInTimeline: false,
+          embedding: newEmbedding(),
+        });
+
+        const before = await sut.getAccessiblePeople(member.id, {
+          withHidden: false,
+          page: 1,
+          size: 50,
+          minimumFaceCount: 1,
+        });
+        expect(before.people).toEqual([]);
+
+        await setMemberTimeline(ctx, { spaceId: space.id, userId: member.id, showInTimeline: true });
+
+        const after = await sut.getAccessiblePeople(member.id, {
+          withHidden: false,
+          page: 1,
+          size: 50,
+          minimumFaceCount: 1,
+        });
+        expect(after.people).toHaveLength(1);
+        expect(after.total).toBe(1);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', owner.id).execute();
+        await ctx.database.deleteFrom('user').where('id', '=', member.id).execute();
+      }
+    });
+  });
+
   describe('getAccessiblePeopleStatistics', () => {
     it('counts visible and hidden identity profiles and unassigned faces in owned global scope', async () => {
       const { ctx, sut } = setup();

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -35,6 +35,28 @@ beforeAll(async () => {
   defaultDatabase = await getKyselyDB();
 });
 
+// Seeds one owned identity with `assets` distinct timeline photos, for the total/hidden
+// characterisation cases. Declared at module scope: eslint's consistent-function-scoping rejects
+// helpers defined inside a describe block.
+const seedCharacterisationIdentity = async (
+  ctx: ReturnType<typeof setup>['ctx'],
+  sut: FaceIdentityRepository,
+  input: { userId: string; name: string; assets: number; isHidden?: boolean },
+) => {
+  const { person } = await ctx.newPerson({
+    ownerId: input.userId,
+    name: input.name,
+    isHidden: input.isHidden ?? false,
+  });
+  const identity = await sut.ensurePersonIdentity(person.id);
+  for (let index = 0; index < input.assets; index++) {
+    const { asset } = await ctx.newAsset({ ownerId: input.userId, visibility: AssetVisibility.Timeline });
+    const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+    await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+  }
+  return { person, identity };
+};
+
 const newSpacePerson = async (ctx: ReturnType<typeof setup>['ctx'], spaceId: string) => {
   return ctx.database.insertInto('shared_space_person').values({ spaceId }).returningAll().executeTakeFirstOrThrow();
 };
@@ -2745,6 +2767,175 @@ describe(FaceIdentityRepository.name, () => {
         });
         expect(after.people).toHaveLength(1);
         expect(after.total).toBe(1);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', owner.id).execute();
+        await ctx.database.deleteFrom('user').where('id', '=', member.id).execute();
+      }
+    });
+  });
+
+  // Fix C — characterisation of the total/hidden header numbers BEFORE folding the separate counts
+  // query into the page query. These pin behaviour that is deliberately NOT symmetric with the page
+  // itself, so the fold cannot quietly "tidy" it:
+  //   * total/hidden ignore withHidden entirely — they are library-wide figures, not page figures;
+  //   * eligibility for the totals uses NULLIF(name, '') while the page uses NULLIF(BTRIM(name), ''),
+  //     so a whitespace-only name counts as named for the total but as unnamed for the listing.
+  describe('getAccessiblePeople total/hidden characterisation', () => {
+    it.each([true, false])('reports the same library-wide totals for withHidden=%s', async (withHidden) => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+
+      try {
+        await seedCharacterisationIdentity(ctx, sut, { userId: user.id, name: 'Visible', assets: 1 });
+        await seedCharacterisationIdentity(ctx, sut, { userId: user.id, name: 'Concealed', assets: 1, isHidden: true });
+
+        const result = await sut.getAccessiblePeople(user.id, {
+          withHidden,
+          page: 1,
+          size: 50,
+          minimumFaceCount: 1,
+        });
+
+        // Totals are library-wide and identical either way...
+        expect(result.total).toBe(2);
+        expect(result.hidden).toBe(1);
+        // ...while the listing itself does respect withHidden.
+        expect(result.people).toHaveLength(withHidden ? 2 : 1);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    it('counts an unnamed identity only once it reaches minimumFaceCount', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+
+      try {
+        await seedCharacterisationIdentity(ctx, sut, { userId: user.id, name: '', assets: 2 });
+        await seedCharacterisationIdentity(ctx, sut, { userId: user.id, name: '', assets: 3 });
+
+        const result = await sut.getAccessiblePeople(user.id, {
+          withHidden: true,
+          page: 1,
+          size: 50,
+          minimumFaceCount: 3,
+        });
+
+        expect(result.total).toBe(1);
+        expect(result.hidden).toBe(0);
+        expect(result.people).toHaveLength(1);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    it('counts a named identity that is below minimumFaceCount', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+
+      try {
+        await seedCharacterisationIdentity(ctx, sut, { userId: user.id, name: 'Named', assets: 1 });
+
+        const result = await sut.getAccessiblePeople(user.id, {
+          withHidden: true,
+          page: 1,
+          size: 50,
+          minimumFaceCount: 5,
+        });
+
+        expect(result.total).toBe(1);
+        expect(result.people).toHaveLength(1);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    // Existing asymmetry, pinned deliberately: BTRIM in the listing, none in the totals.
+    it('treats a whitespace-only name as named for the total but unnamed for the listing', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+
+      try {
+        await seedCharacterisationIdentity(ctx, sut, { userId: user.id, name: ' '.repeat(3), assets: 1 });
+
+        const result = await sut.getAccessiblePeople(user.id, {
+          withHidden: true,
+          page: 1,
+          size: 50,
+          minimumFaceCount: 3,
+        });
+
+        expect(result.total).toBe(1);
+        expect(result.people).toHaveLength(0);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    // The fold must keep returning totals when the requested page is empty — a CROSS JOIN onto the
+    // page rows would silently produce zeros here.
+    it('still reports totals when the requested page is past the end', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+
+      try {
+        await seedCharacterisationIdentity(ctx, sut, { userId: user.id, name: 'Only', assets: 1 });
+
+        const result = await sut.getAccessiblePeople(user.id, {
+          withHidden: true,
+          page: 5,
+          size: 50,
+          minimumFaceCount: 1,
+        });
+
+        expect(result.people).toEqual([]);
+        expect(result.hasNextPage).toBe(false);
+        expect(result.total).toBe(1);
+        expect(result.hidden).toBe(0);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    it('reports zeroes for a library with no people at all', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+
+      try {
+        const result = await sut.getAccessiblePeople(user.id, {
+          withHidden: true,
+          page: 1,
+          size: 50,
+          minimumFaceCount: 1,
+        });
+
+        expect(result).toEqual({ total: 0, hidden: 0, hasNextPage: false, people: [] });
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    it('counts identities reachable only through a timeline-enabled space', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+
+      try {
+        await createAccessibleSpaceIdentity(ctx, sut, {
+          memberUserId: member.id,
+          ownerUserId: owner.id,
+          embedding: newEmbedding(),
+        });
+
+        const result = await sut.getAccessiblePeople(member.id, {
+          withHidden: true,
+          page: 1,
+          size: 50,
+          minimumFaceCount: 1,
+        });
+
+        expect(result.total).toBe(1);
+        expect(result.people).toHaveLength(1);
       } finally {
         await ctx.database.deleteFrom('user').where('id', '=', owner.id).execute();
         await ctx.database.deleteFrom('user').where('id', '=', member.id).execute();

--- a/server/test/medium/specs/repositories/face-identity.repository.spec.ts
+++ b/server/test/medium/specs/repositories/face-identity.repository.spec.ts
@@ -2312,6 +2312,326 @@ describe(FaceIdentityRepository.name, () => {
     }
   });
 
+  // `getAccessiblePeopleIdentityPage` already computes COUNT(DISTINCT assetId) per identity, and
+  // `hydrateAccessiblePeople` used to throw that away and rebuild the whole `accessible_faces` CTE
+  // to compute the identical number a second time — on a large library that recomputation was the
+  // single most expensive part of GET /api/people. Hydrate now accepts those counts. These tests
+  // pin the contract that supplying them changes NOTHING about the result.
+  describe('hydrateAccessiblePeople with precomputed asset counts', () => {
+    it('returns byte-identical rows whether or not counts are supplied', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+
+      try {
+        const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Counted' });
+        const identity = await sut.ensurePersonIdentity(person.id);
+        for (let index = 0; index < 3; index++) {
+          const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+          const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+          await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+        }
+
+        const pageRows = await sut.getAccessiblePeopleIdentityPage({
+          userId: user.id,
+          withHidden: true,
+          limit: 50,
+          offset: 0,
+          minimumFaceCount: 1,
+        });
+        const counts = new Map(pageRows.map((row) => [row.identityId, Number(row.visibleAssetCount)]));
+
+        const withoutCounts = await sut.hydrateAccessiblePeople({
+          userId: user.id,
+          identityIds: pageRows.map((row) => row.identityId),
+          withHidden: true,
+        });
+        const withCounts = await sut.hydrateAccessiblePeople({
+          userId: user.id,
+          identityIds: pageRows.map((row) => row.identityId),
+          withHidden: true,
+          assetCounts: counts,
+        });
+
+        expect(withoutCounts).toHaveLength(1);
+        expect(withoutCounts[0].numberOfAssets).toBe(3);
+        expect(withCounts).toEqual(withoutCounts);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    // The count is COUNT(DISTINCT assetId), not a face count. If the page query and hydrate ever
+    // disagreed on that, every face in the UI would show an inflated photo count.
+    it('counts distinct assets, not faces, when one asset holds several faces of the same identity', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+
+      try {
+        const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Twice' });
+        const identity = await sut.ensurePersonIdentity(person.id);
+        const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+        for (let index = 0; index < 2; index++) {
+          const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+          await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+        }
+
+        const pageRows = await sut.getAccessiblePeopleIdentityPage({
+          userId: user.id,
+          withHidden: true,
+          limit: 50,
+          offset: 0,
+          minimumFaceCount: 1,
+        });
+        expect(Number(pageRows[0].visibleAssetCount)).toBe(1);
+
+        const withCounts = await sut.hydrateAccessiblePeople({
+          userId: user.id,
+          identityIds: pageRows.map((row) => row.identityId),
+          withHidden: true,
+          assetCounts: new Map(pageRows.map((row) => [row.identityId, Number(row.visibleAssetCount)])),
+        });
+        const withoutCounts = await sut.hydrateAccessiblePeople({
+          userId: user.id,
+          identityIds: pageRows.map((row) => row.identityId),
+          withHidden: true,
+        });
+
+        expect(withCounts[0].numberOfAssets).toBe(1);
+        expect(withCounts).toEqual(withoutCounts);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    it('preserves the requested identity ordering', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+
+      try {
+        const identityIds: string[] = [];
+        for (const name of ['Anna', 'Bruno', 'Carla']) {
+          const { person } = await ctx.newPerson({ ownerId: user.id, name });
+          const identity = await sut.ensurePersonIdentity(person.id);
+          const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+          const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+          await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+          identityIds.push(identity.id);
+        }
+
+        const reversed = identityIds.toReversed();
+        const counts = new Map(reversed.map((identityId) => [identityId, 1]));
+
+        const withCounts = await sut.hydrateAccessiblePeople({
+          userId: user.id,
+          identityIds: reversed,
+          withHidden: true,
+          assetCounts: counts,
+        });
+        const withoutCounts = await sut.hydrateAccessiblePeople({
+          userId: user.id,
+          identityIds: reversed,
+          withHidden: true,
+        });
+
+        expect(withCounts.map((person) => person.name)).toEqual(['Carla', 'Bruno', 'Anna']);
+        expect(withCounts).toEqual(withoutCounts);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    // Without counts, an identity whose faces are all inaccessible is dropped by the INNER JOIN on
+    // asset_counts. The precomputed path must drop it too rather than emitting a 0-asset row.
+    it('omits an identity that has no accessible faces, matching the uncounted path', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+      const { user: stranger } = await ctx.newUser();
+
+      try {
+        const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Unreachable' });
+        const identity = await sut.ensurePersonIdentity(person.id);
+        // The only face lives on an asset owned by someone else and never shared.
+        const { asset } = await ctx.newAsset({ ownerId: stranger.id, visibility: AssetVisibility.Timeline });
+        const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+        await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+
+        const withoutCounts = await sut.hydrateAccessiblePeople({
+          userId: user.id,
+          identityIds: [identity.id],
+          withHidden: true,
+        });
+        const withCounts = await sut.hydrateAccessiblePeople({
+          userId: user.id,
+          identityIds: [identity.id],
+          withHidden: true,
+          assetCounts: new Map([[identity.id, 0]]),
+        });
+
+        expect(withoutCounts).toEqual([]);
+        expect(withCounts).toEqual([]);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+        await ctx.database.deleteFrom('user').where('id', '=', stranger.id).execute();
+      }
+    });
+
+    it('drops an identity missing from the supplied counts rather than inventing a row', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+
+      try {
+        const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Present' });
+        const identity = await sut.ensurePersonIdentity(person.id);
+        const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+        const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+        await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+
+        const withCounts = await sut.hydrateAccessiblePeople({
+          userId: user.id,
+          identityIds: [identity.id],
+          withHidden: true,
+          assetCounts: new Map(),
+        });
+
+        expect(withCounts).toEqual([]);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    it('returns an empty array for an empty identity list', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+
+      try {
+        await expect(
+          sut.hydrateAccessiblePeople({
+            userId: user.id,
+            identityIds: [],
+            withHidden: true,
+            assetCounts: new Map(),
+          }),
+        ).resolves.toEqual([]);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    it('agrees with the uncounted path for a space-visible identity', async () => {
+      const { ctx, sut } = setup();
+      const { user: owner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+
+      try {
+        const { identity } = await createAccessibleSpaceIdentity(ctx, sut, {
+          memberUserId: member.id,
+          ownerUserId: owner.id,
+          embedding: newEmbedding(),
+        });
+
+        const pageRows = await sut.getAccessiblePeopleIdentityPage({
+          userId: member.id,
+          withHidden: true,
+          limit: 50,
+          offset: 0,
+          minimumFaceCount: 1,
+        });
+        expect(pageRows.map((row) => row.identityId)).toContain(identity.id);
+
+        const withoutCounts = await sut.hydrateAccessiblePeople({
+          userId: member.id,
+          identityIds: pageRows.map((row) => row.identityId),
+          withHidden: true,
+        });
+        const withCounts = await sut.hydrateAccessiblePeople({
+          userId: member.id,
+          identityIds: pageRows.map((row) => row.identityId),
+          withHidden: true,
+          assetCounts: new Map(pageRows.map((row) => [row.identityId, Number(row.visibleAssetCount)])),
+        });
+
+        expect(withCounts).toEqual(withoutCounts);
+        expect(withCounts[0].numberOfAssets).toBe(1);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', owner.id).execute();
+        await ctx.database.deleteFrom('user').where('id', '=', member.id).execute();
+      }
+    });
+
+    // Seeds BOTH a hidden and a visible identity, so withHidden=false still yields a non-empty
+    // result. With only a hidden person, both paths return [] and the comparison proves nothing.
+    it.each([true, false])('agrees with the uncounted path for withHidden=%s', async (withHidden) => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+
+      try {
+        const seed = async (name: string, isHidden: boolean) => {
+          const { person } = await ctx.newPerson({ ownerId: user.id, name, isHidden });
+          const identity = await sut.ensurePersonIdentity(person.id);
+          const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+          const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+          await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+          return identity.id;
+        };
+        const hiddenIdentityId = await seed('Shy', true);
+        const visibleIdentityId = await seed('Open', false);
+        const identityIds = [hiddenIdentityId, visibleIdentityId];
+
+        const withoutCounts = await sut.hydrateAccessiblePeople({ userId: user.id, identityIds, withHidden });
+        const withCounts = await sut.hydrateAccessiblePeople({
+          userId: user.id,
+          identityIds,
+          withHidden,
+          assetCounts: new Map(identityIds.map((identityId) => [identityId, 1])),
+        });
+
+        // Guards the comparison itself: an empty-vs-empty result would pass either way.
+        expect(withoutCounts.length).toBe(withHidden ? 2 : 1);
+        expect(withCounts).toEqual(withoutCounts);
+        expect(withCounts.every((person) => person.numberOfAssets === 1)).toBe(true);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+
+    // The end-to-end invariant the whole optimisation rests on: the number the page query computes
+    // is the number the endpoint reports.
+    it('makes getAccessiblePeople report exactly the page query visibleAssetCount', async () => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+
+      try {
+        const { person } = await ctx.newPerson({ ownerId: user.id, name: 'Endtoend' });
+        const identity = await sut.ensurePersonIdentity(person.id);
+        for (let index = 0; index < 4; index++) {
+          const { asset } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+          const { assetFace } = await ctx.newAssetFace({ assetId: asset.id, personId: person.id });
+          await sut.linkFace({ assetFaceId: assetFace.id, identityId: identity.id, source: 'owner-person' });
+        }
+
+        const pageRows = await sut.getAccessiblePeopleIdentityPage({
+          userId: user.id,
+          withHidden: false,
+          limit: 50,
+          offset: 0,
+          minimumFaceCount: 1,
+        });
+        const result = await sut.getAccessiblePeople(user.id, {
+          withHidden: false,
+          page: 1,
+          size: 50,
+          minimumFaceCount: 1,
+        });
+
+        const expected = Number(pageRows.find((row) => row.identityId === identity.id)?.visibleAssetCount);
+        expect(expected).toBe(4);
+        expect(result.people.find((candidate) => candidate.id === person.id)?.numberOfAssets).toBe(expected);
+      } finally {
+        await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      }
+    });
+  });
+
   describe('getAccessiblePeopleStatistics', () => {
     it('counts visible and hidden identity profiles and unassigned faces in owned global scope', async () => {
       const { ctx, sut } = setup();

--- a/server/test/medium/specs/utils/accessible-timeline-asset-predicate-gate.medium.spec.ts
+++ b/server/test/medium/specs/utils/accessible-timeline-asset-predicate-gate.medium.spec.ts
@@ -1,0 +1,131 @@
+// Coverage gap probe for Fix B (PR #976).
+//
+// The equivalence tests in accessible-timeline-asset-predicate.medium.spec.ts cannot observe a space
+// arm that has lost its `timeline_spaces` gate. Every scenario they build in which a space is NOT
+// timeline-enabled is a scenario in which `hasTimelineSpaces` is false — so the predicate COLLAPSES
+// and the space arms are never emitted at all. The broken arm is masked by the very fast path the
+// tests exist to justify.
+//
+// Observing it requires a viewer who is in at least one timeline-enabled space (so the FULL predicate
+// runs) while the resource under test is linked through a DIFFERENT, non-timeline space. Then a
+// missing gate leaks the second space's assets.
+import { Kysely, sql } from 'kysely';
+import { AssetVisibility, SharedSpaceRole } from 'src/enum';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { DB } from 'src/schema';
+import { BaseService } from 'src/services/base.service';
+import { accessibleTimelineAssetPredicate } from 'src/utils/shared-space-album-scope';
+import { newMediumService } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let db: Kysely<DB>;
+
+const setup = () => {
+  const { ctx } = newMediumService(BaseService, {
+    database: db,
+    real: [],
+    mock: [LoggingRepository],
+  });
+  return { ctx };
+};
+
+const selectAccessible = async (userId: string, hasTimelineSpaces: boolean): Promise<Set<string>> => {
+  const predicate = accessibleTimelineAssetPredicate({ userId, hasTimelineSpaces });
+  const result = await sql<{ id: string }>`
+    WITH timeline_spaces AS (
+      SELECT "spaceId"
+      FROM shared_space_member
+      WHERE "userId" = ${userId}
+        AND "showInTimeline" = true
+    )
+    SELECT asset.id
+    FROM asset
+    WHERE asset."deletedAt" IS NULL
+      AND asset.visibility = ${AssetVisibility.Timeline}
+      AND (${predicate})
+  `.execute(db);
+  return new Set(result.rows.map((row) => row.id));
+};
+
+beforeAll(async () => {
+  db = await getKyselyDB();
+});
+
+describe('accessibleTimelineAssetPredicate space-arm gating', () => {
+  it('does not reach a linked library through a space the viewer has muted, while another space is live', async () => {
+    const { ctx } = setup();
+    const { user: source } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+
+    try {
+      // A live timeline space, so hasTimelineSpaces is true and the FULL predicate runs.
+      const { space: liveSpace } = await ctx.newSharedSpace({ createdById: source.id });
+      await ctx.newSharedSpaceMember({ spaceId: liveSpace.id, userId: source.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceMember({ spaceId: liveSpace.id, userId: viewer.id, role: SharedSpaceRole.Viewer });
+      const { asset: liveAsset } = await ctx.newAsset({ ownerId: source.id, visibility: AssetVisibility.Timeline });
+      await ctx.newSharedSpaceAsset({ spaceId: liveSpace.id, assetId: liveAsset.id, addedById: source.id });
+
+      // A second space the viewer has muted, carrying a linked library.
+      const { library } = await ctx.newLibrary({ ownerId: source.id });
+      const { asset: mutedAsset } = await ctx.newAsset({
+        ownerId: source.id,
+        libraryId: library.id,
+        visibility: AssetVisibility.Timeline,
+      });
+      const { space: mutedSpace } = await ctx.newSharedSpace({ createdById: source.id });
+      await ctx.newSharedSpaceMember({ spaceId: mutedSpace.id, userId: source.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceMember({ spaceId: mutedSpace.id, userId: viewer.id, role: SharedSpaceRole.Viewer });
+      await ctx.newSharedSpaceLibrary({ spaceId: mutedSpace.id, libraryId: library.id, addedById: source.id });
+      await ctx.database
+        .updateTable('shared_space_member')
+        .set({ showInTimeline: false })
+        .where('spaceId', '=', mutedSpace.id)
+        .where('userId', '=', viewer.id)
+        .execute();
+
+      const accessible = await selectAccessible(viewer.id, true);
+
+      // The live space still grants its asset...
+      expect(accessible.has(liveAsset.id)).toBe(true);
+      // ...but the muted space's linked library must not leak. Fails if the library arm loses its gate.
+      expect(accessible.has(mutedAsset.id)).toBe(false);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', 'in', [source.id, viewer.id]).execute();
+    }
+  });
+
+  it('does not reach a linked album through a space the viewer has muted, while another space is live', async () => {
+    const { ctx } = setup();
+    const { user: source } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+
+    try {
+      const { space: liveSpace } = await ctx.newSharedSpace({ createdById: source.id });
+      await ctx.newSharedSpaceMember({ spaceId: liveSpace.id, userId: source.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceMember({ spaceId: liveSpace.id, userId: viewer.id, role: SharedSpaceRole.Viewer });
+      const { asset: liveAsset } = await ctx.newAsset({ ownerId: source.id, visibility: AssetVisibility.Timeline });
+      await ctx.newSharedSpaceAsset({ spaceId: liveSpace.id, assetId: liveAsset.id, addedById: source.id });
+
+      const { asset: mutedAsset } = await ctx.newAsset({ ownerId: source.id, visibility: AssetVisibility.Timeline });
+      const { album } = await ctx.newAlbum({ ownerId: source.id });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: mutedAsset.id });
+      const { space: mutedSpace } = await ctx.newSharedSpace({ createdById: source.id });
+      await ctx.newSharedSpaceMember({ spaceId: mutedSpace.id, userId: source.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceMember({ spaceId: mutedSpace.id, userId: viewer.id, role: SharedSpaceRole.Viewer });
+      await ctx.newSharedSpaceAlbum({ spaceId: mutedSpace.id, albumId: album.id, addedById: source.id });
+      await ctx.database
+        .updateTable('shared_space_member')
+        .set({ showInTimeline: false })
+        .where('spaceId', '=', mutedSpace.id)
+        .where('userId', '=', viewer.id)
+        .execute();
+
+      const accessible = await selectAccessible(viewer.id, true);
+
+      expect(accessible.has(liveAsset.id)).toBe(true);
+      expect(accessible.has(mutedAsset.id)).toBe(false);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', 'in', [source.id, viewer.id]).execute();
+    }
+  });
+});

--- a/server/test/medium/specs/utils/accessible-timeline-asset-predicate.medium.spec.ts
+++ b/server/test/medium/specs/utils/accessible-timeline-asset-predicate.medium.spec.ts
@@ -1,0 +1,158 @@
+// Fix B — the "no timeline spaces" fast path for the People-page accessibility predicate.
+//
+// Every space arm of that predicate (direct asset, linked library, linked album x2) joins the
+// `timeline_spaces` CTE, so when a viewer belongs to no timeline-enabled space all four arms are
+// provably unsatisfiable and the predicate collapses to `asset."ownerId" = <viewer>`. Postgres
+// cannot know that at plan time — it evaluates the OR per row, which on a large library meant
+// hundreds of thousands of index probes into `asset` that discarded nothing.
+//
+// These tests prove the collapse is sound by comparing the ASSET SETS the two predicate forms
+// select over identical data, rather than by matching SQL text.
+import { Kysely, sql } from 'kysely';
+import { AssetVisibility, SharedSpaceRole } from 'src/enum';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { DB } from 'src/schema';
+import { BaseService } from 'src/services/base.service';
+import { accessibleTimelineAssetPredicate } from 'src/utils/shared-space-album-scope';
+import { newMediumService } from 'test/medium.factory';
+import { getKyselyDB } from 'test/utils';
+
+let db: Kysely<DB>;
+
+const setup = () => {
+  const { ctx } = newMediumService(BaseService, {
+    database: db,
+    real: [],
+    mock: [LoggingRepository],
+  });
+  return { ctx };
+};
+
+// Runs the predicate exactly as the repository does: inside a query that defines the
+// `timeline_spaces` CTE it correlates against.
+const selectAccessible = async (userId: string, hasTimelineSpaces: boolean): Promise<Set<string>> => {
+  const predicate = accessibleTimelineAssetPredicate({ userId, hasTimelineSpaces });
+  const result = await sql<{ id: string }>`
+    WITH timeline_spaces AS (
+      SELECT "spaceId"
+      FROM shared_space_member
+      WHERE "userId" = ${userId}
+        AND "showInTimeline" = true
+    )
+    SELECT asset.id
+    FROM asset
+    WHERE asset."deletedAt" IS NULL
+      AND asset.visibility = ${AssetVisibility.Timeline}
+      AND (${predicate})
+  `.execute(db);
+  return new Set(result.rows.map((row) => row.id));
+};
+
+beforeAll(async () => {
+  db = await getKyselyDB();
+});
+
+describe('accessibleTimelineAssetPredicate', () => {
+  it('selects the same assets either way for a viewer with no shared spaces at all', async () => {
+    const { ctx } = setup();
+    const { user } = await ctx.newUser();
+    const { user: stranger } = await ctx.newUser();
+
+    try {
+      const { asset: mine } = await ctx.newAsset({ ownerId: user.id, visibility: AssetVisibility.Timeline });
+      await ctx.newAsset({ ownerId: stranger.id, visibility: AssetVisibility.Timeline });
+
+      const full = await selectAccessible(user.id, true);
+      const short = await selectAccessible(user.id, false);
+
+      expect(full).toEqual(short);
+      expect(short.has(mine.id)).toBe(true);
+      expect(short.size).toBe(1);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', user.id).execute();
+      await ctx.database.deleteFrom('user').where('id', '=', stranger.id).execute();
+    }
+  });
+
+  it('selects the same assets either way when every membership has showInTimeline off', async () => {
+    const { ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+
+    try {
+      const { asset: ownAsset } = await ctx.newAsset({ ownerId: viewer.id, visibility: AssetVisibility.Timeline });
+      const { asset: sharedAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: SharedSpaceRole.Viewer });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: sharedAsset.id, addedById: owner.id });
+      await ctx.database
+        .updateTable('shared_space_member')
+        .set({ showInTimeline: false })
+        .where('spaceId', '=', space.id)
+        .where('userId', '=', viewer.id)
+        .execute();
+
+      const full = await selectAccessible(viewer.id, true);
+      const short = await selectAccessible(viewer.id, false);
+
+      expect(full).toEqual(short);
+      expect(short.has(ownAsset.id)).toBe(true);
+      expect(short.has(sharedAsset.id)).toBe(false);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', owner.id).execute();
+      await ctx.database.deleteFrom('user').where('id', '=', viewer.id).execute();
+    }
+  });
+
+  // Guards the two tests above from being vacuous: with a live timeline space the forms MUST differ,
+  // otherwise "they agree" would prove nothing. This is also the regression that fires if a future
+  // space arm is added that is not gated on timeline_spaces — the short form would start dropping
+  // assets the full form still returns for a no-space viewer.
+  it('differs once a timeline-enabled space actually shares an asset', async () => {
+    const { ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+
+    try {
+      const { asset: sharedAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: SharedSpaceRole.Viewer });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: sharedAsset.id, addedById: owner.id });
+
+      const full = await selectAccessible(viewer.id, true);
+      const short = await selectAccessible(viewer.id, false);
+
+      expect(full.has(sharedAsset.id)).toBe(true);
+      expect(short.has(sharedAsset.id)).toBe(false);
+      expect(full).not.toEqual(short);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', owner.id).execute();
+      await ctx.database.deleteFrom('user').where('id', '=', viewer.id).execute();
+    }
+  });
+
+  it('still returns the viewer own assets when they do belong to a timeline space', async () => {
+    const { ctx } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: viewer } = await ctx.newUser();
+
+    try {
+      const { asset: viewerAsset } = await ctx.newAsset({ ownerId: viewer.id, visibility: AssetVisibility.Timeline });
+      const { asset: sharedAsset } = await ctx.newAsset({ ownerId: owner.id, visibility: AssetVisibility.Timeline });
+      const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: SharedSpaceRole.Owner });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id, role: SharedSpaceRole.Viewer });
+      await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: sharedAsset.id, addedById: owner.id });
+
+      const full = await selectAccessible(viewer.id, true);
+
+      expect(full.has(viewerAsset.id)).toBe(true);
+      expect(full.has(sharedAsset.id)).toBe(true);
+    } finally {
+      await ctx.database.deleteFrom('user').where('id', '=', owner.id).execute();
+      await ctx.database.deleteFrom('user').where('id', '=', viewer.id).execute();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

A user reported the People page taking 10–15s cold and ~5s on return, unchanged by the `jit=off` fix (#798). Diagnostics from their instance showed `jit=off` correctly applied and JIT costing them only ~0.5s — so it was never their bottleneck.

Sampling `pg_stat_activity` during a live request showed **~13.2s of a 14.4s `GET /api/people` was database time**, split across the three queries the endpoint issues:

| Query | Live duration |
|---|---|
| page query | ~3.4s |
| **hydrate** | **~6.8s** |
| counts | ~3.0s |

Their library: 274k assets, 314k face links, 41k people, and **zero shared spaces**.

## What this changes

**A — hydrate no longer recomputes counts it was already given.** `getAccessiblePeopleIdentityPage` computes `COUNT(DISTINCT assetId)` per identity; the service discarded it and `hydrateAccessiblePeople` rebuilt the entire `accessible_faces` CTE to compute the same number again. Hydrate now takes an optional count map and, when supplied, drops both `accessible_faces` and `asset_counts`, carrying counts in through a parallel `unnest`. The two callers that page first pass it; the two single-identity getters keep the original path.

**B — the accessibility predicate collapses when the viewer has no spaces.** Every shared-space arm (direct asset, linked library, both linked-album arms) joins the `timeline_spaces` CTE, so a viewer in no timeline-enabled space cannot satisfy any of them. Postgres can't deduce that at plan time and evaluated the whole OR per row. The predicate moves into `accessibleTimelineAssetPredicate`, replacing six hand-cloned copies, and collapses to `asset."ownerId" = <viewer>` in that case. `getAccessiblePeople` resolves the flag once (one indexed lookup) and shares it; it is resolved per request, never cached.

**C — the header totals are derived from the page query.** `getAccessiblePeopleCounts` existed only to produce `total`/`hidden`, rebuilding `accessible_faces` and `accessible_profiles` to do it. Those figures now come off CTEs the page query has already materialised, and the dead method is removed so the two cannot drift.

## Measured effect

Benchmarked with the **real repository code** against a synthetic single-user library (no spaces), timing `getAccessiblePeople` three times per run:

| Library | Before | After | |
|---|---|---|---|
| 60k assets / 60k faces / 9k people | 121–132 ms | 82–90 ms | ~1.45× |
| 200k assets / 200k faces / 30k people | 412–432 ms | 301–309 ms | ~1.40× |

Identical results either way (`total=30000`, 150 rows returned).

**Please read that as ~1.4×, not the ~15× the reporter's own A/B might suggest.** That 15× compared their owner-scoped `/api/people` against the shared-spaces variant — two different queries. This work makes the shared-spaces query cheaper; it does not turn it into the owner-scoped one. On their instance ~13.5s plausibly becomes ~9–10s, which is an improvement but not a fix on its own.

The ratio also did not widen between 60k and 200k, which I had expected it to. The remaining cost is the join from faces to `asset`, which both forms must do.

## Correctness

Fix C's `total`/`hidden` are user-visible and deliberately **not** symmetric with the page. Eight characterisation tests were written against the previous behaviour **first** and pass unchanged against the folded query, pinning both existing asymmetries rather than tidying them:

- totals are library-wide and ignore `withHidden`;
- their "is this identity named" test omits the `BTRIM` the listing applies, so a whitespace-only name counts toward `total` while its person is not listed.

The page is LEFT JOINed onto the totals, so a request past the last page still returns the header numbers.

Fix A's equality tests were **mutation-tested** — forcing the counted path to return a wrong value fails 6 of 10. That exposed one test that passed vacuously (both paths returned `[]`), now reseeded with a hidden *and* a visible person plus a length assertion.

Fix B's equivalence is proven by comparing the **asset sets** the two predicate forms select over identical data, including a guard that they *must* differ once a timeline space really shares an asset — which is also the regression that fires if a future space arm is added that isn't `timeline_spaces`-gated.

Also hardens `face-identity-query-shape`: its slices silently became `''` when a delimiting method was renamed, which would have let every `not.toContain` assertion pass while inspecting nothing.

## Testing

- 25 new medium tests; `face-identity.repository.spec.ts` 114 → 135
- All people/space suites: **527 passing**
- Full unit suite: **5256 passing**, identical to base
- Full medium suite: same 5 environmental failures as base (exif ×3, `memory.service`, `workflow-core-plugin`) — all confirmed failing on the base commit too, none touching people or faces. Base actually failed *more* (33 vs 26).
- `tsc --noEmit`, `eslint --max-warnings 0`, `prettier --check` clean; generated SQL regenerated.

## Note for review

The generated `face.identity.repository.sql` shrank for the three statistics queries, which now document the collapsed predicate — `@GenerateSql` runs with a dummy user who has no spaces. The two heaviest queries pass `hasTimelineSpaces: true` so the shared-space superset stays documented. Threading the flag through the rest purely for documentation seemed worse than the loss; happy to do it if you disagree.
