### PR TITLE
ci(release): attach revert-to-immich.sql to every release

### DIFF
--- a/.github/workflows/gallery-prerelease-server.yml
+++ b/.github/workflows/gallery-prerelease-server.yml
@@ -91,6 +91,15 @@ jobs:
             fi
           fi
 
+          # Every release ships the revert-to-immich escape hatch as an asset,
+          # pinned to the release commit. Check the blob at $sha (not the
+          # working tree — the `commit` input can pin an older ancestor) so a
+          # missing script fails here rather than after the image builds.
+          if ! git cat-file -e "${sha}:scripts/revert-to-immich.sql" 2>/dev/null; then
+            echo "::error::scripts/revert-to-immich.sql is missing at ${sha} — every release must ship the revert script"
+            exit 1
+          fi
+
           echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "Pre-releasing $INPUT_VERSION from $sha"
@@ -523,7 +532,8 @@ jobs:
               --repo "$REPO" \
               --clobber \
               docker/docker-compose.yml \
-              docker/example.env
+              docker/example.env \
+              scripts/revert-to-immich.sql
           else
             gh release create "$VERSION" \
               --repo "$REPO" \
@@ -532,7 +542,8 @@ jobs:
               --prerelease \
               --notes-file /tmp/prerelease-notes.md \
               docker/docker-compose.yml \
-              docker/example.env
+              docker/example.env \
+              scripts/revert-to-immich.sql
           fi
 
           echo "Pre-released $VERSION from $SHA"

--- a/.github/workflows/gallery-release-server-only.yml
+++ b/.github/workflows/gallery-release-server-only.yml
@@ -99,6 +99,16 @@ jobs:
             fi
           fi
 
+          # Every release ships the revert-to-immich escape hatch as an asset,
+          # pinned to the release commit. Check the blob at $sha (not the
+          # working tree — the `commit` input can pin an older ancestor) so a
+          # missing script fails here rather than after the image builds and
+          # the force-pushed tag.
+          if ! git cat-file -e "${sha}:scripts/revert-to-immich.sql" 2>/dev/null; then
+            echo "::error::scripts/revert-to-immich.sql is missing at ${sha} — every release must ship the revert script"
+            exit 1
+          fi
+
           major=$(echo "$INPUT_VERSION" | sed 's/^v//' | cut -d. -f1)
           echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
           echo "major=v${major}" >> "$GITHUB_OUTPUT"
@@ -619,7 +629,8 @@ jobs:
             --latest \
             --notes "$notes" \
             docker/docker-compose.yml \
-            docker/example.env
+            docker/example.env \
+            scripts/revert-to-immich.sql
 
           echo "Released $VERSION from $SHA"
 


### PR DESCRIPTION
## Why

Releases shipped only `docker-compose.yml` and `example.env`. The revert-to-immich escape hatch was reachable only by browsing the repo at the right tag — and the file changes every few releases (521 lines on `main` vs 478 at v5.3.1), so grabbing it from `main` gives you the wrong set of migrations to undo.

## What

Attach `scripts/revert-to-immich.sql` alongside the existing two assets, at all three call sites:

- `gallery-release-server-only.yml` — `gh release create`
- `gallery-prerelease-server.yml` — `gh release upload --clobber` (re-run path)
- `gallery-prerelease-server.yml` — `gh release create` (first-run path)

Both tag jobs already check out at `ref: ${{ needs.version.outputs.sha }}`, so the uploaded copy is the script as it stood at that release's commit — no git plumbing needed.

Plus a preflight in each `version` job. It lands there rather than at upload time because the git tag is force-pushed and all images are built *before* `gh release create` runs — a missing script would otherwise fail ~an hour in, with a tag already published and no release. The check reads the blob at `$sha` rather than `test -f` on the working tree, because the `commit:` input can pin an older ancestor than the checked-out ref.

## Verification

- **Preflight exercised against real commits, both branches:** v5.3.1's SHA passes; v4.49.1's SHA (a real commit predating the script) fails with the expected error. Confirms the guard isn't vacuous.
- **actionlint 1.7.12, base vs branch:** 12 findings → 12 findings. The one apparent delta is the pre-existing SC2129 shifting from script line 25 → 35 due to the inserted lines. No new findings.
- `bash -n` on both edited `run:` blocks, and YAML parse on both files.

## Related

The 35 existing releases that contain the script (v4.50.0 → v5.3.1, prereleases included) were backfilled separately, each with the version from its own tag — verified by downloading each asset back and matching `git hash-object` against the tag's blob SHA (35/35). v4.49.1 and older predate the script, so the cut is clean.