### PR TITLE
feat(mobile): spaces-first add-to-collection picker, real thumbnails, and the last two entry points

### DIFF
--- a/docs/superpowers/plans/2026-08-13-mobile-collection-picker-parity.md
+++ b/docs/superpowers/plans/2026-08-13-mobile-collection-picker-parity.md
@@ -1,0 +1,839 @@
+# Mobile Collection Picker Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Spaces reachable without scrolling past every album in the mobile add-to-collection
+picker, render real thumbnails for spaces and space albums, and offer the picker on the two surfaces
+that still lack it.
+
+**Architecture:** `CollectionPicker` (fork-owned) composes upstream's `AlbumSelector` with the
+fork's `SpaceCollectionSection`. One additive prop on `AlbumSelector` lets the spaces section be
+injected between the search bar and the album list, so search still covers both halves. The two
+missing entry points are wired by passing `CollectionPicker` into their existing bottom sheets.
+
+**Tech Stack:** Flutter 3.44.8, Riverpod (hooks_riverpod), `sliver_tools` (`MultiSliver`), mocktail,
+`flutter_test`.
+
+**Spec:** `docs/superpowers/specs/2026-08-13-mobile-collection-picker-parity-design.md`
+
+## Global Constraints
+
+- **Flutter 3.44.8.** The pin lives in `mobile/mise.toml`. Never call bare `flutter` — the global
+  mise pin is older and pub-solve will fail. Invoke
+  `~/.local/share/mise/installs/aqua-flutter-flutter/3.44.8/flutter/bin/{flutter,dart}` directly.
+- **One-time setup per checkout**, since `lib/generated/*.g.dart` is gitignored. From `mobile/`:
+  `flutter pub get`, then
+  `dart run easy_localization:generate -S ../i18n && dart run bin/generate_keys.dart`.
+  Drift/OpenAPI generated code is committed; `build_runner` is not needed.
+- **Two gates, both must pass:** `flutter test <path>` and `dart analyze --fatal-infos`.
+  `dart analyze` alone is not sufficient — generated-code compile errors only surface when a test
+  actually compiles.
+- **No new i18n keys.** Use the existing `albums` and `spaces` keys. Adding a key would require
+  updating nine locales in the same commit.
+- **`AlbumSelector` is upstream code.** Every change to it must be purely additive with a null
+  default, so rebases stay clean. Do not reformat or restructure anything else in that file.
+- **Red before green.** Every test step below records the _actual_ expected failure. If a test
+  passes before its production change is written, it does not discriminate — rewrite it.
+- **Do not commit iOS build churn.** `mobile/ios/Podfile.lock`,
+  `Runner.xcodeproj/project.pbxproj` and `Runner.xcworkspace/.../Package.resolved` regenerate on any
+  local build. `git checkout --` them before committing.
+
+---
+
+## File Structure
+
+| File                                                                                 | Responsibility                                       | Change                             |
+| ------------------------------------------------------------------------------------ | ---------------------------------------------------- | ---------------------------------- |
+| `mobile/lib/presentation/widgets/album/album_selector.widget.dart`                   | upstream album list + search                         | **Modify** — one additive prop     |
+| `mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart`    | the Spaces half: rows, children, thumbnails, footer  | **Modify** — thumbnails + `footer` |
+| `mobile/lib/presentation/widgets/collection/collection_picker.widget.dart`           | composes both halves, owns search state and dispatch | **Modify** — wiring                |
+| `mobile/lib/presentation/widgets/bottom_sheet/remote_album_bottom_sheet.widget.dart` | album multi-select sheet                             | **Modify** — remove one gate       |
+| `mobile/lib/presentation/widgets/spaces/space_album_bottom_sheet.widget.dart`        | space-album multi-select sheet                       | **Modify** — add the picker        |
+| `mobile/test/presentation/widgets/collection/space_collection_section_test.dart`     | section behaviour                                    | **Modify** — T1–T5                 |
+| `mobile/test/presentation/widgets/collection/collection_picker_test.dart`            | composition + layout                                 | **Modify** — L1–L6                 |
+| `mobile/test/presentation/widgets/bottom_sheet/add_to_collection_surfaces_test.dart` | which sheets offer the picker                        | **Modify** — S1–S5                 |
+
+Tasks 1–2 (thumbnails) are independent of Tasks 3–4 (layout) and can be reviewed separately. Task 3
+depends on Task 2 only through the same file, not through behaviour.
+
+---
+
+## Task 1: Space rows render a collage, not a coloured disc
+
+**Files:**
+
+- Modify: `mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart:158`
+- Test: `mobile/test/presentation/widgets/collection/space_collection_section_test.dart`
+
+**Interfaces:**
+
+- Consumes: `SpaceCollage({required List<String> recentAssetIds, required List<String> recentAssetThumbhashes, UserAvatarColor? color, required double size})` from `package:immich_mobile/widgets/spaces/space_collage.dart` — already imported in the section for `spaceGradientColors`.
+- Produces: nothing new for later tasks.
+
+- [ ] **Step 1: Give the test's `space()` helper recent assets**
+
+In `space_collection_section_test.dart`, the `space(...)` helper currently omits the recent-asset
+fields, so the DTO defaults them to `Optional.present(const [])`. Add a parameter so a test can
+supply them. Find the `SharedSpaceResponseDto space(` helper and add the parameter to its signature
+and body:
+
+```dart
+  SharedSpaceResponseDto space(
+    String id, {
+    SharedSpaceRole role = SharedSpaceRole.owner,
+    int albums = 0,
+    String? name,
+    List<String> recentAssetIds = const [],
+  }) => SharedSpaceResponseDto(
+    id: id,
+    name: name ?? 'Space $id',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    createdById: 'someone-else',
+    recentAssetIds: Optional.present(recentAssetIds),
+    recentAssetThumbhashes: Optional.present(const []),
+```
+
+Leave the rest of the helper body exactly as it is.
+
+- [ ] **Step 2: Write the failing tests (T1, T2)**
+
+Add to `space_collection_section_test.dart`, inside `void main()`:
+
+```dart
+  testWidgets('T1: a space with recent assets renders a collage, not a plain colour disc', (tester) async {
+    await pump(tester, spaces: [space('s1', recentAssetIds: ['a1', 'a2'])]);
+
+    expect(find.byType(SpaceCollage), findsOneWidget);
+    expect(find.byType(CircleAvatar), findsNothing);
+  });
+
+  testWidgets('T2: a space with no recent assets still renders the collage on its empty state', (tester) async {
+    await pump(tester, spaces: [space('s1', recentAssetIds: const [])]);
+
+    // The collage draws its own gradient fallback when the id list is empty; the row must not
+    // silently drop its leading widget in that case.
+    expect(find.byType(SpaceCollage), findsOneWidget);
+  });
+```
+
+Add the import at the top of the test file:
+
+```dart
+import 'package:immich_mobile/widgets/spaces/space_collage.dart';
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+```bash
+cd mobile && ~/.local/share/mise/installs/aqua-flutter-flutter/3.44.8/flutter/bin/flutter test \
+  test/presentation/widgets/collection/space_collection_section_test.dart --plain-name T1
+```
+
+Expected: **FAIL** — `Expected: exactly one matching candidate / Actual: _TypeWidgetFinder:<zero widgets with type "SpaceCollage">`. T2 fails the same way. If either passes here, the row already renders a collage and the test is not discriminating — stop and re-read the widget.
+
+- [ ] **Step 4: Replace the CircleAvatar**
+
+In `space_collection_section.widget.dart`, inside `_rowsFor`, replace the `leading:` line:
+
+```dart
+        leading: SpaceCollage(
+          recentAssetIds: space.recentAssetIds.orElse(null) ?? const [],
+          recentAssetThumbhashes: space.recentAssetThumbhashes.orElse(null) ?? const [],
+          color: space.color.orElse(null),
+          // Matches the `radius: 16` CircleAvatar this replaces, so row height is unchanged.
+          size: 32,
+        ),
+```
+
+Both DTO fields are `Optional<List<String>?>`, hence the double unwrap. `SpaceCollage` keeps using
+`color` for the gradient it already falls back to.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+cd mobile && ~/.local/share/mise/installs/aqua-flutter-flutter/3.44.8/flutter/bin/flutter test \
+  test/presentation/widgets/collection/space_collection_section_test.dart
+```
+
+Expected: **PASS**, including every pre-existing test in the file. A pre-existing failure here means
+the leading swap changed layout — investigate rather than adjusting the old test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart \
+        mobile/test/presentation/widgets/collection/space_collection_section_test.dart
+git commit -m "fix(mobile): render a space's collage in the collection picker"
+```
+
+---
+
+## Task 2: Space-album children render their thumbnail
+
+**Files:**
+
+- Modify: `mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart:204`
+- Test: `mobile/test/presentation/widgets/collection/space_collection_section_test.dart`
+
+**Interfaces:**
+
+- Consumes: `Thumbnail.remote({required String remoteId, required String thumbhash})` from `package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart`. `thumbhash` is **required and non-nullable**; `SpaceAlbum` has no thumbhash, so pass `''` — on this constructor the value is only a cache-busting URL parameter, never a blur placeholder (see the spec).
+- Consumes: `PresentationContext.create()` from `mobile/test/…` — see Step 1; `Thumbnail.remote` builds a `RemoteImageProvider` that reads `Store.get(StoreKey.serverEndpoint)` in its initializer, which throws in a bare widget test.
+- Produces: nothing new for later tasks.
+
+- [ ] **Step 1: Initialize the store for this test file**
+
+`Thumbnail.remote` resolves its URL eagerly, so the file needs a real `StoreService`. Add to the top
+of `void main()` in `space_collection_section_test.dart`, mirroring
+`test/presentation/widgets/spaces/space_albums_shelf_test.dart:65-68`:
+
+```dart
+  setUpAll(() async {
+    // PresentationContext.create() runs TestUtils.init() and initializes StoreService, which
+    // Thumbnail.remote's RemoteImageProvider reads when it builds its URL.
+    await PresentationContext.create();
+  });
+```
+
+Add the import. `space_collection_section_test.dart` sits at the same depth as
+`space_albums_shelf_test.dart` (`test/presentation/widgets/<dir>/`), so the relative path is
+identical:
+
+```dart
+import '../../../unit/presentation/presentation_context.dart';
+```
+
+**Caution:** `PresentationContext` is a broad harness. It is used here **only** to initialize the
+store. If any T-test starts passing before its production change, check that the harness has not
+stubbed the widget under test — a harness that mocks the layer being tested makes green meaningless.
+
+- [ ] **Step 2: Write the failing tests (T3, T4, T5)**
+
+```dart
+  testWidgets('T3: a space album with a thumbnail asset renders it', (tester) async {
+    await pump(
+      tester,
+      spaces: [space('s1', albums: 1)],
+      albums: {'s1': [album('al1', 'Hawaii', thumbnailAssetId: 'asset-1')]},
+    );
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pump();
+
+    expect(find.byType(Thumbnail), findsOneWidget);
+  });
+
+  testWidgets('T4: a space album with no thumbnail asset falls back to the icon', (tester) async {
+    await pump(
+      tester,
+      spaces: [space('s1', albums: 1)],
+      albums: {'s1': [album('al1', 'Hawaii', thumbnailAssetId: null)]},
+    );
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pump();
+
+    expect(find.byIcon(Icons.photo_album_outlined), findsOneWidget);
+    expect(find.byType(Thumbnail), findsNothing);
+  });
+
+  testWidgets('T5: the pool child keeps its action icon and never becomes a thumbnail', (tester) async {
+    await pump(
+      tester,
+      spaces: [space('s1', albums: 1)],
+      albums: {'s1': [album('al1', 'Hawaii', thumbnailAssetId: 'asset-1')]},
+    );
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pump();
+
+    expect(find.byIcon(Icons.workspaces_outline), findsOneWidget);
+  });
+```
+
+Add the import:
+
+```dart
+import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
+```
+
+The file's `album(...)` helper does not carry a thumbnail today. Replace it (currently at
+`space_collection_section_test.dart:59`) with:
+
+```dart
+  SpaceAlbum album(String id, String name, {String? thumbnailAssetId}) => SpaceAlbum(
+    id: id,
+    name: name,
+    thumbnailAssetId: thumbnailAssetId,
+    showInTimeline: true,
+    linkedAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+    createdAt: DateTime(2026, 1, 1),
+  );
+```
+
+The added parameter is optional, so every existing call site in the file keeps compiling unchanged.
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+```bash
+cd mobile && ~/.local/share/mise/installs/aqua-flutter-flutter/3.44.8/flutter/bin/flutter test \
+  test/presentation/widgets/collection/space_collection_section_test.dart --plain-name T3
+```
+
+Expected: **FAIL** — `zero widgets with type "Thumbnail"`, because the child currently always draws
+`Icon(Icons.photo_album_outlined)`. T4 and T5 **pass already** — they are the guards on the
+fallback and the pool child, and they exist to stay green through Step 4, not to go red.
+
+- [ ] **Step 4: Render the thumbnail when there is one**
+
+In `_childrenFor`, replace the album child's `leading:`:
+
+```dart
+            leading: album.thumbnailAssetId == null
+                ? const Icon(Icons.photo_album_outlined)
+                : SizedBox(
+                    width: 32,
+                    height: 32,
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(4),
+                      // SpaceAlbum carries no thumbhash; on Thumbnail.remote the value is only a
+                      // cache-busting URL param, never a blur placeholder, so '' costs nothing here.
+                      child: Thumbnail.remote(remoteId: album.thumbnailAssetId!, thumbhash: ''),
+                    ),
+                  ),
+```
+
+Add the import to the widget file:
+
+```dart
+import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
+```
+
+- [ ] **Step 5: Run the whole file to verify**
+
+```bash
+cd mobile && ~/.local/share/mise/installs/aqua-flutter-flutter/3.44.8/flutter/bin/flutter test \
+  test/presentation/widgets/collection/space_collection_section_test.dart
+```
+
+Expected: **PASS**, all tests including T4 and T5 still green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart \
+        mobile/test/presentation/widgets/collection/space_collection_section_test.dart
+git commit -m "fix(mobile): render space album thumbnails in the collection picker"
+```
+
+---
+
+## Task 3: Spaces render above albums
+
+**Files:**
+
+- Modify: `mobile/lib/presentation/widgets/album/album_selector.widget.dart:205-214`
+- Modify: `mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart` (add `footer`)
+- Modify: `mobile/lib/presentation/widgets/collection/collection_picker.widget.dart:132-163`
+- Test: `mobile/test/presentation/widgets/collection/collection_picker_test.dart`
+
+**Interfaces:**
+
+- Produces: `AlbumSelector({..., Widget? sliverAfterSearch})` — a **sliver**, rendered between the search bar and the quick-filter row.
+- Produces: `SpaceCollectionSection({..., Widget? footer})` — a box widget appended inside the section's `Column`, rendered only on the paths where the section itself renders.
+
+- [ ] **Step 1: Add the `footer` parameter to the section**
+
+In `space_collection_section.widget.dart`, add the field and constructor parameter:
+
+```dart
+  /// Rendered at the bottom of the section, and only when the section renders at all — so a caller
+  /// can attach a label for whatever follows without duplicating the section's visibility rules
+  /// (writable filter, excludeSpaceId, search query).
+  final Widget? footer;
+```
+
+Add `this.footer,` to the constructor parameter list. Then append it as the last child of the
+returned `Column`, after the `if (notice != null) … else for (…)` block:
+
+```dart
+        if (footer != null) footer!,
+```
+
+Both `SizedBox.shrink()` early returns are above this, so the footer disappears with the section.
+It **does** render on the notice path, which is intended — albums still follow it there.
+
+- [ ] **Step 2: Add the additive hook to AlbumSelector**
+
+In `album_selector.widget.dart`, add next to the existing `onSearchChanged` / `searchHint` fields:
+
+```dart
+  /// Fork hook: a sliver rendered between the search field and the album list, so a composing
+  /// picker can put another section under the shared search box. Null for every upstream call site.
+  final Widget? sliverAfterSearch;
+```
+
+Add `this.sliverAfterSearch,` to the constructor. Then in `build`, insert into the `MultiSliver`
+immediately after `_SearchBar(...)` and before `_QuickFilterButtonRow(...)`:
+
+```dart
+          if (widget.sliverAfterSearch != null) widget.sliverAfterSearch!,
+```
+
+`MultiSliver.children` is a non-nullable `List<Widget>`, so it must be spread conditionally like
+this — assigning the nullable directly will not compile. Change nothing else in this file.
+
+- [ ] **Step 3: Write the failing tests (L1–L5)**
+
+In `collection_picker_test.dart`. The existing composition test already resolves coordinates via
+`tester.getTopLeft`; reuse that approach — asserting only on presence would pass regardless of order
+and would not discriminate.
+
+```dart
+  testWidgets('L1: spaces render above albums, and both below the search field', (tester) async {
+    await pumpPicker(tester, spaces: [space('s1', 'Family')]);
+
+    final searchY = tester.getTopLeft(find.byType(SearchField)).dy;
+    final spacesY = tester.getTopLeft(find.byKey(const Key('space-collection-header'))).dy;
+    final albumsY = tester.getTopLeft(find.byKey(const Key('collection-picker-albums-header'))).dy;
+
+    expect(searchY, lessThan(spacesY));
+    expect(spacesY, lessThan(albumsY));
+  });
+
+  testWidgets('L2: both section labels render when the user has writable spaces', (tester) async {
+    await pumpPicker(tester, spaces: [space('s1', 'Family')]);
+
+    expect(find.byKey(const Key('space-collection-header')), findsOneWidget);
+    expect(find.byKey(const Key('collection-picker-albums-header')), findsOneWidget);
+  });
+
+  testWidgets('L3: neither label renders when the user has no writable spaces', (tester) async {
+    await pumpPicker(tester, spaces: const []);
+
+    expect(find.byKey(const Key('space-collection-header')), findsNothing);
+    expect(find.byKey(const Key('collection-picker-albums-header')), findsNothing);
+  });
+```
+
+`collection_picker_test.dart` has no shared pump helper — each test inlines its overrides. Add one at
+the top of `void main()`, lifting the override list from the file's first test so the L-tests can
+vary spaces and selection:
+
+```dart
+  RemoteAsset asset(String id, {String ownerId = 'user-1'}) => RemoteAsset(
+    id: id,
+    name: id,
+    ownerId: ownerId,
+    checksum: id,
+    type: AssetType.image,
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+    isEdited: false,
+  );
+
+  Future<void> pumpPicker(
+    WidgetTester tester, {
+    List<SharedSpaceResponseDto> spaces = const [],
+    List<RemoteAsset> selection = const [],
+  }) async {
+    final userService = _MockUserService();
+    final user = UserStub.user1;
+    when(() => userService.tryGetMyUser()).thenReturn(user);
+    when(() => userService.watchMyUser()).thenAnswer((_) => const Stream.empty());
+
+    await tester.pumpConsumerWidgetRaw(
+      const CustomScrollView(slivers: [CollectionPicker()]),
+      overrides: [
+        currentUserProvider.overrideWith((ref) => _StubCurrentUserNotifier(userService, user)),
+        remoteAlbumProvider.overrideWith(() => _StubRemoteAlbumNotifier()),
+        appConfigProvider.overrideWithValue(const AppConfig()),
+        sharedSpacesProvider.overrideWith((ref) async => spaces),
+        multiSelectProvider.overrideWith(
+          () => MultiSelectNotifier(
+            MultiSelectState(selectedAssets: selection.toSet(), lockedSelectionAssets: const {}),
+          ),
+        ),
+      ],
+    );
+    await tester.pump();
+  }
+```
+
+`_MockUserService`, `_StubCurrentUserNotifier` and `_StubRemoteAlbumNotifier` already exist in this
+file. The file's `space(String id, String name)` helper is reused as-is. Add
+`import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';` for `RemoteAsset` and
+`AssetType` if the file does not already import it.
+
+Leave the existing tests inlining their own overrides — rewriting them onto the helper would mix a
+refactor into a behaviour change and obscure which test caught what.
+
+- [ ] **Step 4: Run to verify they fail**
+
+```bash
+cd mobile && ~/.local/share/mise/installs/aqua-flutter-flutter/3.44.8/flutter/bin/flutter test \
+  test/presentation/widgets/collection/collection_picker_test.dart --plain-name L1
+```
+
+Expected: **FAIL** — `zero widgets with key [<'collection-picker-albums-header'>]`, since no albums
+label exists yet. L3 may pass for the wrong reason (the key does not exist at all); it only becomes
+meaningful after Step 5, which is why L2 must go green in the same step.
+
+- [ ] **Step 5: Wire the picker**
+
+In `collection_picker.widget.dart`, replace the `AlbumSelector` + trailing `SliverToBoxAdapter`
+children of the `MultiSliver` with:
+
+```dart
+        AlbumSelector(
+          onAlbumSelected: _addToAlbum,
+          onKeyboardExpanded: widget.onKeyboardExpanded,
+          onSearchChanged: (query) => setState(() => _searchQuery = query),
+          searchHint: 'search_albums_and_spaces'.t(context: context),
+          sliverAfterSearch: SliverToBoxAdapter(
+            child: SpaceCollectionSection(
+              onTargetSelected: _addToTarget,
+              excludeSpaceId: widget.excludeSpaceId,
+              isBusy: _isBusy,
+              searchQuery: _searchQuery,
+              assets: widget.assets,
+              // Rides on the section's own visibility so a user in no space never sees a lone
+              // "Albums" header over the layout they have today.
+              footer: Padding(
+                key: const Key('collection-picker-albums-header'),
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                child: Text('albums'.t(context: context), style: context.textTheme.labelLarge),
+              ),
+            ),
+          ),
+        ),
+```
+
+`SpaceCollectionSection` is a box widget, so it keeps the `SliverToBoxAdapter` it already had. The
+label reuses the existing `albums` i18n key and matches the section header's `labelLarge` style.
+
+- [ ] **Step 6: Run the whole file**
+
+```bash
+cd mobile && ~/.local/share/mise/installs/aqua-flutter-flutter/3.44.8/flutter/bin/flutter test \
+  test/presentation/widgets/collection/collection_picker_test.dart
+```
+
+Expected: **PASS**, including the pre-existing "composes the header, the album selector and the
+spaces section, in that order" test — update only its ordering expectation if it asserted the old
+albums-then-spaces order, and nothing else.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add mobile/lib/presentation/widgets/album/album_selector.widget.dart \
+        mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart \
+        mobile/lib/presentation/widgets/collection/collection_picker.widget.dart \
+        mobile/test/presentation/widgets/collection/collection_picker_test.dart
+git commit -m "feat(mobile): put spaces above albums in the add-to-collection picker"
+```
+
+---
+
+## Task 4: The search box survives becoming the spaces section's parent
+
+**Files:**
+
+- Test: `mobile/test/presentation/widgets/collection/collection_picker_test.dart`
+
+**Interfaces:**
+
+- Consumes: `AlbumSelector.sliverAfterSearch` and `SpaceCollectionSection.footer` from Task 3.
+- Produces: nothing.
+
+This task adds no production code. Task 3 turned the spaces section from `AlbumSelector`'s _sibling_
+into its _child_, so a keystroke now rebuilds the widget that owns `searchController` and
+`searchFocusNode`. These tests are **green before and after** — they earn their place by being run
+against the restructure, not by going red.
+
+- [ ] **Step 1: Write L4 and L5**
+
+```dart
+  testWidgets('L4: a query matching albums but no space collapses the section and both labels', (tester) async {
+    await pumpPicker(tester, spaces: [space('s1', 'Family')]);
+
+    await tester.enterText(find.byType(SearchField), 'zzz-no-space-matches');
+    await tester.pump();
+
+    // Intended: with only one section left, section labels are noise. Do not "fix" this.
+    expect(find.byKey(const Key('space-collection-header')), findsNothing);
+    expect(find.byKey(const Key('collection-picker-albums-header')), findsNothing);
+  });
+
+  testWidgets('L5: the notice path still renders the albums label below it', (tester) async {
+    // A selection containing a non-owned asset drives the section's notice branch: header and
+    // notice render, space rows do not — and albums still follow.
+    await pumpPicker(
+      tester,
+      spaces: [space('s1', 'Family')],
+      selection: [asset('a1', ownerId: 'someone-else')],
+    );
+
+    expect(find.byKey(const Key('space-collection-notice')), findsOneWidget);
+    expect(find.byKey(const Key('space-row-s1')), findsNothing);
+    expect(find.byKey(const Key('collection-picker-albums-header')), findsOneWidget);
+  });
+```
+
+`pumpPicker` needs a `selection` parameter that overrides `multiSelectProvider`, mirroring the
+`MultiSelectNotifier(MultiSelectState(selectedAssets: {...}, lockedSelectionAssets: {}))` override
+already used in this file's first test.
+
+- [ ] **Step 2: Write L6, the focus guard**
+
+```dart
+  testWidgets('L6: typing keeps the search field focused and narrows the spaces section', (tester) async {
+    await pumpPicker(tester, spaces: [space('s1', 'Family'), space('s2', 'Holiday')]);
+
+    await tester.tap(find.byType(SearchField));
+    await tester.pump();
+    await tester.enterText(find.byType(SearchField), 'Fam');
+    await tester.pump();
+
+    expect(find.byKey(const Key('space-row-s1')), findsOneWidget);
+    expect(find.byKey(const Key('space-row-s2')), findsNothing);
+
+    // Asserting only on the narrowed rows would pass even if every keystroke dropped focus --
+    // which is exactly what the new parent/child rebuild makes possible.
+    final editable = tester.widget<EditableText>(find.descendant(
+      of: find.byType(SearchField),
+      matching: find.byType(EditableText),
+    ));
+    expect(editable.focusNode.hasFocus, isTrue);
+  });
+```
+
+- [ ] **Step 3: Run the file**
+
+```bash
+cd mobile && ~/.local/share/mise/installs/aqua-flutter-flutter/3.44.8/flutter/bin/flutter test \
+  test/presentation/widgets/collection/collection_picker_test.dart
+```
+
+Expected: **PASS**, and critically the pre-existing "typing in the search field narrows the spaces
+section too" test passes **unmodified**. If it needs editing, the restructure broke the search wiring
+— fix the wiring, not the test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/test/presentation/widgets/collection/collection_picker_test.dart
+git commit -m "test(mobile): pin picker label collapse, notice path and search focus"
+```
+
+---
+
+## Task 5: The space-album page offers the picker
+
+**Files:**
+
+- Modify: `mobile/lib/presentation/widgets/spaces/space_album_bottom_sheet.widget.dart:55-72`
+- Test: `mobile/test/presentation/widgets/bottom_sheet/add_to_collection_surfaces_test.dart`
+
+**Interfaces:**
+
+- Consumes: `CollectionPicker({Function? onKeyboardExpanded, String? excludeSpaceId, ActionSource source, Iterable<BaseAsset>? assets, VoidCallback? onCompleted})`.
+- Produces: nothing.
+
+- [ ] **Step 1: Write the failing tests (S1, S2)**
+
+**Do not assert with `find.byType(CollectionPicker)`.** This file already documents why
+(`add_to_collection_surfaces_test.dart:118-124`): these sheets open at 0.18–0.4 of the screen, so the
+picker's sliver is below the viewport and never built. A rendered-tree assertion therefore passes or
+fails on sheet height rather than on wiring. This sheet opens at **0.18**, the smallest of them all.
+Use the file's `expectPickerMounted(tester)` helper, which reads
+`BaseBottomSheet.slivers` directly. `pumpSheet(WidgetTester, Widget)` already exists.
+
+```dart
+  testWidgets('S1: the space album sheet offers the collection picker', (tester) async {
+    await pumpSheet(tester, const SpaceAlbumBottomSheet(canEdit: true, albumId: 'al1'));
+    expectPickerMounted(tester);
+  });
+
+  testWidgets('S2: the space album sheet does not exclude its own space', (tester) async {
+    await pumpSheet(tester, const SpaceAlbumBottomSheet(canEdit: true, albumId: 'al1'));
+
+    // Assert on the wiring, not on rendered rows: the space list lives inside the picker, which is
+    // below this sheet's 0.18 viewport and never built. A null excludeSpaceId is exactly what keeps
+    // the current space reachable, so moving a photo between two albums of one space works.
+    final slivers = tester.widget<BaseBottomSheet>(find.byType(BaseBottomSheet)).slivers ?? const <Widget>[];
+    final picker = slivers.whereType<CollectionPicker>().single;
+    expect(picker.excludeSpaceId, isNull);
+  });
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+cd mobile && ~/.local/share/mise/installs/aqua-flutter-flutter/3.44.8/flutter/bin/flutter test \
+  test/presentation/widgets/bottom_sheet/add_to_collection_surfaces_test.dart --plain-name S1
+```
+
+Expected: **FAIL** — `Expected: an object with length of <1> / Actual: <0>`. The sheet passes no `slivers:`
+today.
+
+- [ ] **Step 3: Add the picker to the sheet**
+
+In `space_album_bottom_sheet.widget.dart`, add a keyboard-expand callback inside `build` above the
+`return`:
+
+```dart
+    Future<void> onKeyboardExpand() {
+      // 0.85 is this sheet's maxChildSize.
+      return sheetController.animateTo(0.85, duration: const Duration(milliseconds: 200), curve: Curves.easeInOut);
+    }
+```
+
+Then add to the `BaseBottomSheet(...)` call, after `actions:`:
+
+```dart
+      // The same picker every other multi-select surface offers. No excludeSpaceId: this sheet has
+      // no spaceId, and the current space is a legitimate target from inside one of its albums.
+      slivers: [CollectionPicker(onKeyboardExpanded: onKeyboardExpand)],
+```
+
+The sheet's actions all dispatch against `ActionSource.timeline`, so the picker takes the default
+`source` and omits `assets`, reading the timeline multiselect as the other sheets do.
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+cd mobile && ~/.local/share/mise/installs/aqua-flutter-flutter/3.44.8/flutter/bin/flutter test \
+  test/presentation/widgets/bottom_sheet/add_to_collection_surfaces_test.dart
+```
+
+Expected: **PASS**, all surfaces.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/presentation/widgets/spaces/space_album_bottom_sheet.widget.dart \
+        mobile/test/presentation/widgets/bottom_sheet/add_to_collection_surfaces_test.dart
+git commit -m "feat(mobile): offer add-to-collection on the space album page"
+```
+
+---
+
+## Task 6: An album you do not own offers the picker
+
+**Files:**
+
+- Modify: `mobile/lib/presentation/widgets/bottom_sheet/remote_album_bottom_sheet.widget.dart:98`
+- Test: `mobile/test/presentation/widgets/bottom_sheet/add_to_collection_surfaces_test.dart`
+
+**Interfaces:**
+
+- Consumes: nothing new.
+- Produces: nothing.
+
+Web gates this on view mode only (`canAddToAlbum: () => viewMode === AlbumPageViewMode.VIEW`), with
+no ownership test, so the mobile `ownsAlbum` gate on `slivers:` is stricter than web. Adding assets
+somewhere needs rights over the **destination**, which the picker and the server already enforce.
+
+- [ ] **Step 1: Write the failing tests (S3, S4, S5)**
+
+Again use `expectPickerMounted(tester)`, never `find.byType`. The file has `ownedAlbum()` but no
+non-owned equivalent; add one beside it, using the same factory:
+
+```dart
+  RemoteAlbum foreignAlbum() =>
+      RemoteAlbumFactory.create(ownerId: 'someone-else', ownerName: 'Someone Else', assetCount: 1);
+```
+
+```dart
+  testWidgets('S3: an album the user does not own still offers the picker', (tester) async {
+    await pumpSheet(tester, RemoteAlbumBottomSheet(album: foreignAlbum()));
+    expectPickerMounted(tester);
+  });
+
+  testWidgets('S5: an album the user owns still offers the picker', (tester) async {
+    await pumpSheet(tester, RemoteAlbumBottomSheet(album: ownedAlbum()));
+    expectPickerMounted(tester);
+  });
+```
+
+**S4 is deliberately not written here.** The spec asks that a non-owned album holding non-owned
+assets keep the album half usable while the spaces half self-censors behind its notice — but that
+notice lives _inside_ the picker, below this sheet's viewport, so it cannot honestly be asserted at
+the sheet level. Task 4's L5 already pins the notice path against the picker directly, which is where
+that behaviour belongs. Asserting it here would mean either a test that cannot fail or one that
+passes on sheet height. The sheet's own responsibility is only "is the picker wired up", which S3
+covers.
+
+Note the existing first test, "a selection inside an owned album offers spaces", already uses
+`ownedAlbum()` and duplicates S5. Keep both: S5 is named as the regression guard for the branch being
+deleted in Step 3, and its cost is one line.
+
+- [ ] **Step 2: Run to verify**
+
+```bash
+cd mobile && ~/.local/share/mise/installs/aqua-flutter-flutter/3.44.8/flutter/bin/flutter test \
+  test/presentation/widgets/bottom_sheet/add_to_collection_surfaces_test.dart --plain-name S3
+```
+
+Expected: S3 **FAILS** — `Expected: an object with length of <1> / Actual: <0>`, because `ownsAlbum`
+is false for a foreign album so the sheet is handed `slivers: null`. S5 **passes already**: it is the
+regression guard proving Step 3 does not change owner behaviour.
+
+- [ ] **Step 3: Remove the ownership gate**
+
+In `remote_album_bottom_sheet.widget.dart`, change the `slivers:` argument:
+
+```dart
+      // #965 follow-up: adding assets to a collection needs rights over the DESTINATION, never over
+      // the source album -- the picker and the server both enforce that. Web gates this on view mode
+      // only, with no ownership test. Every other ownsAlbum branch above is deliberately unchanged.
+      slivers: [CollectionPicker(onKeyboardExpanded: onKeyboardExpand)],
+```
+
+Do not touch any other `ownsAlbum` branch — remove-from-album, set-cover, archive, trash and the
+edit actions remain owner-only.
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+cd mobile && ~/.local/share/mise/installs/aqua-flutter-flutter/3.44.8/flutter/bin/flutter test \
+  test/presentation/widgets/bottom_sheet/add_to_collection_surfaces_test.dart
+```
+
+Expected: **PASS**, S5 still green.
+
+- [ ] **Step 5: Run the full mobile suite and both gates**
+
+```bash
+cd mobile && ~/.local/share/mise/installs/aqua-flutter-flutter/3.44.8/flutter/bin/flutter test
+cd mobile && ~/.local/share/mise/installs/aqua-flutter-flutter/3.44.8/flutter/bin/dart analyze --fatal-infos
+```
+
+Expected: all tests pass, `No issues found!`. `dart analyze` alone is not a substitute for the suite.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git checkout -- mobile/ios/Podfile.lock \
+  mobile/ios/Runner.xcodeproj/project.pbxproj \
+  mobile/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved 2>/dev/null || true
+git add mobile/lib/presentation/widgets/bottom_sheet/remote_album_bottom_sheet.widget.dart \
+        mobile/test/presentation/widgets/bottom_sheet/add_to_collection_surfaces_test.dart
+git commit -m "fix(mobile): offer add-to-collection on an album you do not own"
+```
+
+---
+
+## Manual verification
+
+Automated tests cannot see layout on a real device or a real photo library. On the iOS simulator or
+a device pointed at an instance where you own a space with linked albums:
+
+1. Timeline → select photos → add to collection. Spaces sit directly under the search box; albums
+   follow under an "Albums" label.
+2. Space rows show photo collages; expanded space albums show cover thumbnails, and an album with no
+   cover still shows the icon.
+3. Type a query matching an album but no space — both labels disappear, album results remain.
+4. Open an album you do not own → select → the picker appears.
+5. Open a space album → select → the picker appears and offers that same space.
+6. A user in no spaces sees the picker exactly as before, with no stray "Albums" label.

--- a/docs/superpowers/plans/2026-08-13-mobile-collection-picker-parity.md
+++ b/docs/superpowers/plans/2026-08-13-mobile-collection-picker-parity.md
@@ -518,9 +518,17 @@ cd mobile && ~/.local/share/mise/installs/aqua-flutter-flutter/3.44.8/flutter/bi
   test/presentation/widgets/collection/collection_picker_test.dart
 ```
 
-Expected: **PASS**, including the pre-existing "composes the header, the album selector and the
-spaces section, in that order" test — update only its ordering expectation if it asserted the old
-albums-then-spaces order, and nothing else.
+Expected: **PASS**, and the pre-existing "composes the header, the album selector and the spaces
+section, in that order" test passes **unmodified**. Do not edit it. It asserts
+`headerY < albumsY` where `albumsY` is `getTopLeft(find.byType(SearchField))` — the search field is
+still `AlbumSelector`'s first sliver after this change, so the relation holds. Its other two
+assertions (`find.byType(AlbumSelector)` and `find.byType(SpaceCollectionSection)` each finding one)
+also still hold: the section is now a descendant of `AlbumSelector` rather than its sibling, and
+`find.byType` does not care.
+
+That test's local variable is now misleadingly named — `albumsY` marks where the _search field_
+starts, and albums no longer begin there. Renaming it to `selectorY` is optional and cosmetic; if you
+do, change only the identifier, never the assertion.
 
 - [ ] **Step 7: Commit**
 
@@ -589,16 +597,17 @@ already used in this file's first test.
   testWidgets('L6: typing keeps the search field focused and narrows the spaces section', (tester) async {
     await pumpPicker(tester, spaces: [space('s1', 'Family'), space('s2', 'Holiday')]);
 
-    await tester.tap(find.byType(SearchField));
-    await tester.pump();
+    // enterText focuses the field itself (it calls showKeyboard), so no explicit tap is needed --
+    // and the focus assertion below is therefore NOT "did typing acquire focus" but "did focus
+    // SURVIVE the rebuild that the keystroke triggered". That is the regression this task guards:
+    // onSearchChanged -> setState -> AlbumSelector is handed a new child.
     await tester.enterText(find.byType(SearchField), 'Fam');
     await tester.pump();
 
     expect(find.byKey(const Key('space-row-s1')), findsOneWidget);
     expect(find.byKey(const Key('space-row-s2')), findsNothing);
 
-    // Asserting only on the narrowed rows would pass even if every keystroke dropped focus --
-    // which is exactly what the new parent/child rebuild makes possible.
+    // Asserting only on the narrowed rows would pass even if every keystroke dropped focus.
     final editable = tester.widget<EditableText>(find.descendant(
       of: find.byType(SearchField),
       matching: find.byType(EditableText),

--- a/docs/superpowers/specs/2026-08-13-mobile-collection-picker-parity-design.md
+++ b/docs/superpowers/specs/2026-08-13-mobile-collection-picker-parity-design.md
@@ -87,7 +87,14 @@ passes no `excludeSpaceId`. This closes a third row of #970's divergence table a
 
 - New optional `Widget? sliverAfterSearch`, rendered in the `MultiSliver` immediately after
   `_SearchBar` and before `_QuickFilterButtonRow`. Null by default, so upstream behaviour and every
-  other call site are untouched.
+  other call site — including `drift_album.page.dart`, which mounts `AlbumSelector` as a browser
+  rather than a picker — is untouched.
+- `MultiSliver.children` is a non-nullable `List<Widget>`, so the prop is spread conditionally
+  (`if (widget.sliverAfterSearch != null) widget.sliverAfterSearch!`) rather than dropped into the
+  list, which would not compile.
+- The prop takes a **sliver**, as its name says. `SpaceCollectionSection` is a box widget returning a
+  `Column`, so `CollectionPicker` keeps wrapping it in the `SliverToBoxAdapter` it already uses
+  today. `AlbumSelector` stays ignorant of that.
 
 ### `mobile/lib/presentation/widgets/collection/collection_picker.widget.dart`
 
@@ -99,16 +106,37 @@ passes no `excludeSpaceId`. This closes a third row of #970's divergence table a
 
 ### `mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart`
 
-- Space row `leading`: `CircleAvatar` → `SpaceCollage`, fed by the DTO's `recentAssetIds` /
-  `recentAssetThumbhashes`, with `color` for its existing empty-state gradient. `SpaceCollage` is
-  already imported in this file for `spaceGradientColors`.
-- Space-album child `leading`: `Icon(Icons.photo_album_outlined)` →
-  `Thumbnail.remote(album.thumbnailAssetId)` when non-null, falling back to the icon when null —
-  matching how `AlbumSelector` renders a personal album with no thumbnail.
+- Space row `leading`: `CircleAvatar` → `SpaceCollage`. Its `recentAssetIds` /
+  `recentAssetThumbhashes` are **required non-null `List<String>`**, while the DTO exposes
+  `Optional<List<String>?>`, so each unwraps as `space.recentAssetIds.orElse(null) ?? const []`.
+  `size` is also required and has no default: pass **32**, matching the `radius: 16` `CircleAvatar`
+  being replaced, so row height does not shift. `color` keeps feeding the existing gradient, which is
+  what `SpaceCollage` already falls back to when the id list is empty. `SpaceCollage` is already
+  imported in this file for `spaceGradientColors`.
+- Space-album child `leading`: `Icon(Icons.photo_album_outlined)` → `Thumbnail.remote(...)` when
+  `album.thumbnailAssetId` is non-null, falling back to the icon when null.
+
+  `Thumbnail.remote` requires **both** `remoteId` and a non-nullable `thumbhash`, and `SpaceAlbum`
+  carries no thumbhash. `AlbumSelector` obtains one for personal albums by wrapping the widget in a
+  `FutureBuilder` over `assetServiceProvider.getRemoteAsset(...)`. This change deliberately does
+  **not** copy that: it passes `thumbhash: ''`. The thumbhash only supplies a blur placeholder, and
+  copying the `FutureBuilder` would cost one asset fetch per space-album row on every expand — real
+  latency inside a list already gated behind an expand, in exchange for a placeholder on a 32px
+  leading. Rendering the space-album thumbnail on an equal footing with personal albums (its own
+  thumbhash on `SpaceAlbum`, via the Drift column and sync stream) is the honest fix and is out of
+  scope here.
+
 - The "Add to space" pool child keeps its icon. It is an action, not a collection.
 - New optional `Widget? footer`, appended inside the `Column` on the paths where the section renders
-  and therefore skipped by both `SizedBox.shrink()` early returns. Keeps the existing `SPACES` label
-  as-is.
+  and therefore skipped by both `SizedBox.shrink()` early returns. It **does** render on the notice
+  path (non-owned selection, locked selection, or over the asset cap), where the section draws its
+  header and notice but no space rows — albums still follow it there. Keeps the existing `SPACES`
+  label as-is.
+
+  A consequence worth naming, because it looks like a bug on first sight and must not be "fixed"
+  later: a search query matching some albums but **no** space collapses the whole section, so the
+  `ALBUMS` label disappears while the album list stays. That is intended — with one section left, a
+  section label is noise — and it is pinned by a test below.
 
 ### `mobile/lib/presentation/widgets/bottom_sheet/remote_album_bottom_sheet.widget.dart`
 
@@ -117,29 +145,78 @@ passes no `excludeSpaceId`. This closes a third row of #970's divergence table a
 
 ### `mobile/lib/presentation/widgets/spaces/space_album_bottom_sheet.widget.dart`
 
-- Pass `slivers: [CollectionPicker(onKeyboardExpanded: …)]`, with no `excludeSpaceId`. The sheet
-  already owns a `DraggableScrollableController`, so the keyboard-expand callback wires up as it
-  does on the other sheets.
+- Pass `slivers: [CollectionPicker(onKeyboardExpanded: …)]`, with no `excludeSpaceId`. The sheet's
+  constructor is `{canEdit, albumId, onRemoved}` and carries **no `spaceId` at all**, so offering the
+  current space is not merely the chosen behaviour but the one needing no new plumbing.
+- The keyboard-expand callback animates to **0.85**, this sheet's `maxChildSize`, as the other sheets
+  animate to theirs.
+- Its existing actions all dispatch against `ActionSource.timeline`, so the picker takes the default
+  `source` and omits `assets`, reading the timeline multiselect exactly as the other multi-select
+  sheets do.
 
 ## Testing
 
-Extending the existing widget tests, which already pin sheet composition and ordering:
+**Test-first, one behaviour at a time.** For each behaviour below: write the test, run it, and
+**record the actual red failure message** — not "it should fail" — then write the smallest change
+that turns it green, then move to the next. A test that passes before its production change is
+written is not evidence of anything and must be rewritten until it discriminates. #970 established
+this bar: its second commit was a set of regressions each confirmed red against the unfixed code,
+and its own review found a test that asserted `limit: 1000` and thereby locked a bug in.
 
-- `collection_picker_test.dart` — the existing ordering assertion (`headerY < albumsY`) gains a
-  spaces-above-albums case; the `ALBUMS` label renders only when a spaces section is present, and
-  neither label renders when the user has no writable spaces.
-- `space_collection_section_test.dart` — a space with recent assets renders `SpaceCollage`; a space
-  album with a `thumbnailAssetId` renders `Thumbnail`, and one without falls back to the icon.
-- `add_to_collection_surfaces_test.dart` — the space-album sheet offers the picker, and offers its
-  own space; a non-owned album sheet offers the picker.
+Two failure modes to guard against specifically, both of which have bitten this repo:
 
-Each regression test is to be confirmed red against the unfixed code before the fix lands, as #970's
-second commit did.
+- **Assertions that cannot fail.** `queryBy…` returning null passes whether or not the widget exists.
+  Assert on presence with `findsOneWidget` / `findsNothing` against a key, and for ordering assert on
+  resolved coordinates as the existing `headerY < albumsY` test does.
+- **Mocking the layer under test.** These are widget tests over real `SpaceCollectionSection` /
+  `CollectionPicker` composition; stub the providers, never the widget whose layout is the subject.
+
+### `collection_picker_test.dart` — layout
+
+| #   | Given                                  | When                                    | Then                                                                                          |
+| --- | -------------------------------------- | --------------------------------------- | --------------------------------------------------------------------------------------------- |
+| L1  | a user with writable spaces and albums | the picker builds                       | the Spaces section resolves **above** the album list, and both sit **below** the search field |
+| L2  | the same                               | the picker builds                       | `SPACES` and `ALBUMS` labels both render                                                      |
+| L3  | a user with **no** writable spaces     | the picker builds                       | neither label renders, and the album list is the only section                                 |
+| L4  | writable spaces exist                  | a query matches albums but **no** space | the section and **both** labels collapse; album results still render                          |
+| L5  | a non-owned selection (notice path)    | the picker builds                       | header, notice and the `ALBUMS` footer all render, with no space rows                         |
+
+L1 is the behaviour the change exists for; it must be red against today's ordering before the hook is
+added. L4 pins the emergent collapse described above so it is not later "fixed" into a bug.
+
+### `space_collection_section_test.dart` — thumbnails
+
+| #   | Given                                            | When                | Then                                                                                           |
+| --- | ------------------------------------------------ | ------------------- | ---------------------------------------------------------------------------------------------- |
+| T1  | a space with recent asset ids                    | the row renders     | `SpaceCollage` renders, and no bare `CircleAvatar` remains                                     |
+| T2  | a space with an **empty** recent-asset list      | the row renders     | `SpaceCollage` still renders, on its gradient empty state — the widget is present, not skipped |
+| T3  | a space album **with** `thumbnailAssetId`        | the child renders   | `Thumbnail` renders in the leading slot                                                        |
+| T4  | a space album with a **null** `thumbnailAssetId` | the child renders   | the `photo_album_outlined` icon renders and no `Thumbnail` is built                            |
+| T5  | an expanded space                                | the children render | the "Add to space" pool child still shows its icon, not a thumbnail                            |
+
+T2 and T4 are the null/empty boundaries; T5 guards the pool child from being swept into the
+thumbnail change.
+
+### `add_to_collection_surfaces_test.dart` — the two new entry points
+
+| #   | Given                                                      | When              | Then                                                                                                   |
+| --- | ---------------------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------ |
+| S1  | the space-album sheet                                      | it builds         | it offers the picker (it renders none today — this is the red test)                                    |
+| S2  | the space-album sheet for a space the user can write to    | the picker builds | that same space **is** offered as a target                                                             |
+| S3  | an album the user does **not** own                         | the sheet builds  | the picker renders                                                                                     |
+| S4  | a non-owned album whose selected assets are also non-owned | the sheet builds  | the picker renders, with the spaces section showing its non-owned notice — the album half stays usable |
+| S5  | an album the user **does** own                             | the sheet builds  | the picker still renders — the ungating changed no owner behaviour                                     |
+
+S4 is the combination the ungating newly makes reachable: it is the case most likely to be wrong and
+is invisible to S3 alone. S5 is the regression guard on the branch being removed.
 
 ## Out of scope
 
 - **Capping the spaces list.** With a handful of spaces it is unnecessary; a "show all" affordance is
   complexity to add only if it bites.
+- **A thumbhash for space albums.** Their thumbnails render without a blur placeholder because
+  `SpaceAlbum` has no thumbhash to give (see above). Carrying one would mean a Drift column plus a
+  sync-stream field, which is a data change, not a presentation one.
 - **The partner-surface rule.** Mobile's `selectionHasNonOwned` remains stricter than the server.
   Relaxing it needs mobile to learn which owners are partners, which changes every surface that rule
   governs — unchanged from #970's assessment.

--- a/docs/superpowers/specs/2026-08-13-mobile-collection-picker-parity-design.md
+++ b/docs/superpowers/specs/2026-08-13-mobile-collection-picker-parity-design.md
@@ -103,6 +103,15 @@ passes no `excludeSpaceId`. This closes a third row of #970's divergence table a
   section's visibility.
 - The label reuses the existing `albums` i18n key, as the section's header already reuses `spaces`.
   No new keys, so this change adds no nine-locale translation work.
+- **This closes a rebuild loop that did not exist before, and it is the main regression risk.**
+  `_searchQuery` lives in `CollectionPicker`: `AlbumSelector.onSearchChanged` fires → `setState` →
+  `CollectionPicker` rebuilds → it hands `AlbumSelector` a **new `sliverAfterSearch` child**. The
+  spaces section used to be `AlbumSelector`'s _sibling_, so a keystroke never fed back into the
+  widget owning the search field. `AlbumSelector` is stateful and holds `searchController` and
+  `searchFocusNode`; element identity preserves that state across the rebuild, so the field must keep
+  both its text and its focus. The existing `collection_picker_test.dart` case "typing in the search
+  field narrows the spaces section too" already covers the data flow and must stay green unmodified —
+  treat any need to edit it as evidence the restructure broke something, not as test maintenance.
 
 ### `mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart`
 
@@ -119,12 +128,23 @@ passes no `excludeSpaceId`. This closes a third row of #970's divergence table a
   `Thumbnail.remote` requires **both** `remoteId` and a non-nullable `thumbhash`, and `SpaceAlbum`
   carries no thumbhash. `AlbumSelector` obtains one for personal albums by wrapping the widget in a
   `FutureBuilder` over `assetServiceProvider.getRemoteAsset(...)`. This change deliberately does
-  **not** copy that: it passes `thumbhash: ''`. The thumbhash only supplies a blur placeholder, and
-  copying the `FutureBuilder` would cost one asset fetch per space-album row on every expand — real
-  latency inside a list already gated behind an expand, in exchange for a placeholder on a 32px
-  leading. Rendering the space-album thumbnail on an equal footing with personal albums (its own
-  thumbhash on `SpaceAlbum`, via the Drift column and sync stream) is the honest fix and is out of
-  scope here.
+  **not** copy that: it passes `thumbhash: ''`.
+
+  Note what the thumbhash actually does on this constructor, because it is not what the name
+  suggests. `Thumbnail.remote` sets `thumbhashProvider = null`
+  (`thumbnail.widget.dart:31`), so it renders **no** blur placeholder; the placeholder path belongs
+  to the other constructor, which derives it from a `RemoteAsset`. Here the value is passed straight
+  to `getThumbnailUrlForRemoteId`, which appends it as a **cache-busting query parameter**
+  (`image_url_builder.dart:16` — `'$url&c=${Uri.encodeComponent(thumbhash)}'`). An empty string is
+  non-null, so the URL simply ends in `&c=`; nothing decodes it and nothing throws.
+
+  So passing `''` costs no placeholder, because this constructor never draws one. The real cost is
+  narrow and worth stating: with a constant `c=`, the URL for a given asset id never changes, so a
+  client-cached thumbnail can survive the server regenerating that asset's thumbnail. Picking a
+  different album cover changes `thumbnailAssetId` and therefore the URL, so only re-generation of
+  the _same_ asset goes stale. That is a better trade than one asset fetch per space-album row on
+  every expand. Giving `SpaceAlbum` a real thumbhash (Drift column plus sync-stream field) is the
+  honest fix and is out of scope here.
 
 - The "Add to space" pool child keeps its icon. It is an action, not a collection.
 - New optional `Widget? footer`, appended inside the `Column` on the paths where the section renders
@@ -181,8 +201,18 @@ Two failure modes to guard against specifically, both of which have bitten this 
 | L4  | writable spaces exist                  | a query matches albums but **no** space | the section and **both** labels collapse; album results still render                          |
 | L5  | a non-owned selection (notice path)    | the picker builds                       | header, notice and the `ALBUMS` footer all render, with no space rows                         |
 
+| L6 | the picker is mounted | text is typed into the search field | the field keeps its text **and its focus**, and the spaces section narrows |
+
 L1 is the behaviour the change exists for; it must be red against today's ordering before the hook is
 added. L4 pins the emergent collapse described above so it is not later "fixed" into a bug.
+
+L6 is the regression guard on the rebuild loop, and it behaves unlike every other row here: it is
+**green before and after**, so it demonstrates nothing on its own and earns its place only by being
+run against the restructure. The pre-existing case "typing in the search field narrows the spaces
+section too" already covers the narrowing half and must stay green **unmodified**. Extend it with an
+explicit focus assertion (that the field's `EditableText` still holds focus), because asserting only
+on the narrowed rows would pass even if focus were dropped on every keystroke — which is precisely
+the failure the new loop makes possible, and which no other test here would catch.
 
 ### `space_collection_section_test.dart` — thumbnails
 

--- a/docs/superpowers/specs/2026-08-13-mobile-collection-picker-parity-design.md
+++ b/docs/superpowers/specs/2026-08-13-mobile-collection-picker-parity-design.md
@@ -1,0 +1,148 @@
+# Mobile add-to-collection picker: reachable spaces, real thumbnails, and the last two entry points
+
+Follow-up to #965 / PR #970, which made a space album reachable from every add-to-collection
+surface. Using that picker on a real library surfaced two presentation problems, and #970's own
+design note recorded two entry points it deliberately left alone. This change closes all four.
+
+## The problems
+
+**1. Spaces sit below every album.** `CollectionPicker` stacks `AlbumSelector` then
+`SpaceCollectionSection`. On a library with dozens of albums the Spaces section is several screens
+down, so the destination #970 existed to expose is effectively unreachable by scrolling.
+
+**2. Spaces and space albums render placeholder icons.** A space row draws a bare
+`CircleAvatar` filled with its gradient colour — a flat coloured disc. A space-album child draws a
+static `Icon(Icons.photo_album_outlined)`. Personal albums, one section below, draw real photo
+thumbnails, so the two halves of the same sheet look like they belong to different apps. The data
+to do better is already on the wire and unused.
+
+**3. No picker on the space-album page.** `SpaceAlbumBottomSheet` passes no `slivers:` at all.
+
+**4. No picker on an album you do not own.** `RemoteAlbumBottomSheet` gates the picker on
+`ownsAlbum`.
+
+## Decisions
+
+### Layout: keep two sections, put Spaces first
+
+Chosen over interleaving albums and spaces into one sorted list. Interleaving reads as the most
+literal "show them together", but it requires injecting fork rows into upstream's album list, and it
+lets a space sink into the middle of a long alphabetical run — reintroducing the very problem being
+fixed. Two labelled sections with Spaces on top keeps spaces above the fold unconditionally, and
+keeps the sections visually distinct, which is honest: a space row expands and carries different
+permissions, an album row does not.
+
+### The search field forces a hook, not a reorder
+
+The naive fix — swapping the two children of `CollectionPicker`'s `MultiSliver` — is wrong.
+`AlbumSelector`'s own `MultiSliver` is `[_SearchBar, _QuickFilterButtonRow, _QuickSortAndViewMode,
+…albums]`, so the search field lives **inside** the upstream widget. Reordering would put the Spaces
+section above the search box that filters it.
+
+Spaces must land _between_ `_SearchBar` and `_QuickFilterButtonRow`. Of the three ways to do that:
+
+- **Add one additive prop to `AlbumSelector`** — chosen. The fork already carries exactly this shape
+  of additive hook on this widget (`onSearchChanged`, `searchHint`), so this is a one-line insertion
+  into upstream code and stays trivially rebasable.
+- Lift `_SearchBar` into `CollectionPicker` — drags `searchController`, `searchFocusNode`,
+  `clearSearch` and `filterMode` across the fork boundary for no extra benefit.
+- Pin the Spaces section as a sticky sliver — solves the problem only while scrolled to the top, and
+  adds sliver complexity.
+
+Both labels must appear and disappear together: `SpaceCollectionSection` already collapses to
+`SizedBox.shrink()` when the user has no writable spaces, and a user in no space must not be shown a
+lone `ALBUMS` header over the layout they see today.
+
+Only `SpaceCollectionSection` knows whether it rendered — that verdict depends on the writable-space
+filter, `excludeSpaceId` and the search query, and recomputing it in `CollectionPicker` would
+duplicate logic that could then drift. So the section takes an optional `Widget? footer` and renders
+it only on the path where it renders itself; `CollectionPicker` passes the `ALBUMS` label as that
+footer. The section keeps owning the `SPACES` label it already renders, and stays ignorant of what
+the footer contains.
+
+### The album gate is removed, not widened
+
+Web's album route gates the add action on `canAddToAlbum: () => viewMode === AlbumPageViewMode.VIEW`
+(`web/src/routes/(user)/albums/[albumId=id]/…/+page.svelte:289`) — view mode only, **no ownership
+test**. Mobile's `ownsAlbum` gate is therefore stricter than web, and the parity fix is to drop it,
+not to widen it to editors.
+
+This is also correct on the merits: adding assets to a collection requires rights over the
+**destination**, never over the source album. The picker already enforces destination rights — the
+spaces section hides itself behind a notice for a non-owned selection, and the server enforces
+`Permission.AlbumAssetCreate` regardless. `ownsAlbum` continues to gate the genuinely
+ownership-bound actions in that sheet (remove-from-album, set-cover, delete); only the `slivers:`
+argument changes.
+
+### The current space is offered from inside its own album
+
+`excludeSpaceId` exists so a space is not offered as a destination for its own pool assets. On the
+space-album page the useful action is the opposite: moving a photo from one album to another inside
+the same space. Web already offers the current space for this reason, so the space-album sheet
+passes no `excludeSpaceId`. This closes a third row of #970's divergence table as a side effect.
+
+## Changes
+
+### `mobile/lib/presentation/widgets/album/album_selector.widget.dart` (upstream, additive)
+
+- New optional `Widget? sliverAfterSearch`, rendered in the `MultiSliver` immediately after
+  `_SearchBar` and before `_QuickFilterButtonRow`. Null by default, so upstream behaviour and every
+  other call site are untouched.
+
+### `mobile/lib/presentation/widgets/collection/collection_picker.widget.dart`
+
+- Stop appending `SpaceCollectionSection` after `AlbumSelector`. Pass it through the new
+  `sliverAfterSearch`, handing it the `ALBUMS` label as its `footer` so the label shares the
+  section's visibility.
+- The label reuses the existing `albums` i18n key, as the section's header already reuses `spaces`.
+  No new keys, so this change adds no nine-locale translation work.
+
+### `mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart`
+
+- Space row `leading`: `CircleAvatar` → `SpaceCollage`, fed by the DTO's `recentAssetIds` /
+  `recentAssetThumbhashes`, with `color` for its existing empty-state gradient. `SpaceCollage` is
+  already imported in this file for `spaceGradientColors`.
+- Space-album child `leading`: `Icon(Icons.photo_album_outlined)` →
+  `Thumbnail.remote(album.thumbnailAssetId)` when non-null, falling back to the icon when null —
+  matching how `AlbumSelector` renders a personal album with no thumbnail.
+- The "Add to space" pool child keeps its icon. It is an action, not a collection.
+- New optional `Widget? footer`, appended inside the `Column` on the paths where the section renders
+  and therefore skipped by both `SizedBox.shrink()` early returns. Keeps the existing `SPACES` label
+  as-is.
+
+### `mobile/lib/presentation/widgets/bottom_sheet/remote_album_bottom_sheet.widget.dart`
+
+- `slivers: ownsAlbum ? [CollectionPicker(...)] : null` → always pass the picker. Every other
+  `ownsAlbum` branch in the file is unchanged.
+
+### `mobile/lib/presentation/widgets/spaces/space_album_bottom_sheet.widget.dart`
+
+- Pass `slivers: [CollectionPicker(onKeyboardExpanded: …)]`, with no `excludeSpaceId`. The sheet
+  already owns a `DraggableScrollableController`, so the keyboard-expand callback wires up as it
+  does on the other sheets.
+
+## Testing
+
+Extending the existing widget tests, which already pin sheet composition and ordering:
+
+- `collection_picker_test.dart` — the existing ordering assertion (`headerY < albumsY`) gains a
+  spaces-above-albums case; the `ALBUMS` label renders only when a spaces section is present, and
+  neither label renders when the user has no writable spaces.
+- `space_collection_section_test.dart` — a space with recent assets renders `SpaceCollage`; a space
+  album with a `thumbnailAssetId` renders `Thumbnail`, and one without falls back to the icon.
+- `add_to_collection_surfaces_test.dart` — the space-album sheet offers the picker, and offers its
+  own space; a non-owned album sheet offers the picker.
+
+Each regression test is to be confirmed red against the unfixed code before the fix lands, as #970's
+second commit did.
+
+## Out of scope
+
+- **Capping the spaces list.** With a handful of spaces it is unnecessary; a "show all" affordance is
+  complexity to add only if it bites.
+- **The partner-surface rule.** Mobile's `selectionHasNonOwned` remains stricter than the server.
+  Relaxing it needs mobile to learn which owners are partners, which changes every surface that rule
+  governs — unchanged from #970's assessment.
+- **Child-album source and ordering.** Space-album children still come from local Drift in name
+  order, where web uses a live endpoint in `createdAt DESC`.
+- **Searching a space album by name.** Children are still not searchable, on either platform.

--- a/docs/superpowers/specs/2026-08-13-mobile-collection-picker-parity-design.md
+++ b/docs/superpowers/specs/2026-08-13-mobile-collection-picker-parity-design.md
@@ -103,15 +103,19 @@ passes no `excludeSpaceId`. This closes a third row of #970's divergence table a
   section's visibility.
 - The label reuses the existing `albums` i18n key, as the section's header already reuses `spaces`.
   No new keys, so this change adds no nine-locale translation work.
-- **This closes a rebuild loop that did not exist before, and it is the main regression risk.**
-  `_searchQuery` lives in `CollectionPicker`: `AlbumSelector.onSearchChanged` fires → `setState` →
-  `CollectionPicker` rebuilds → it hands `AlbumSelector` a **new `sliverAfterSearch` child**. The
-  spaces section used to be `AlbumSelector`'s _sibling_, so a keystroke never fed back into the
-  widget owning the search field. `AlbumSelector` is stateful and holds `searchController` and
-  `searchFocusNode`; element identity preserves that state across the rebuild, so the field must keep
-  both its text and its focus. The existing `collection_picker_test.dart` case "typing in the search
-  field narrows the spaces section too" already covers the data flow and must stay green unmodified —
-  treat any need to edit it as evidence the restructure broke something, not as test maintenance.
+- **This does not introduce a new rebuild loop — `AlbumSelector` was already reconstructed on every
+  keystroke.** `_searchQuery` lives in `CollectionPicker`; in the old `build`, `AlbumSelector(...)`
+  was already a direct, non-const child of the same `MultiSliver` as `SpaceCollectionSection`'s
+  `SliverToBoxAdapter` sibling, so `onSearchChanged` → `setState` → `CollectionPicker` rebuilds →
+  a fresh `AlbumSelector` widget → `Element.update` → `_AlbumSelectorState.build` was already
+  happening before this change, and `searchController` / `searchFocusNode` were already surviving
+  that rebuild by element identity. What actually changes here is only the **tree position** of
+  `SpaceCollectionSection`'s element: it moves from being `AlbumSelector`'s sibling to being its
+  child (passed in as `sliverAfterSearch`). That position change is still worth guarding — a
+  mistake in the new wiring could plausibly disrupt `AlbumSelector`'s element identity in a way the
+  old sibling layout could not — so the existing `collection_picker_test.dart` case "typing in the
+  search field narrows the spaces section too" must stay green unmodified: treat any need to edit
+  it as evidence the restructure broke something, not as test maintenance.
 
 ### `mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart`
 

--- a/mobile/lib/presentation/widgets/album/album_selector.widget.dart
+++ b/mobile/lib/presentation/widgets/album/album_selector.widget.dart
@@ -41,12 +41,17 @@ class AlbumSelector extends ConsumerStatefulWidget {
   /// Fork hook: replaces the "Search albums" hint when the host's search covers more than albums.
   final String? searchHint;
 
+  /// Fork hook: a sliver rendered between the search field and the album list, so a composing
+  /// picker can put another section under the shared search box. Null for every upstream call site.
+  final Widget? sliverAfterSearch;
+
   const AlbumSelector({
     super.key,
     required this.onAlbumSelected,
     this.onKeyboardExpanded,
     this.onSearchChanged,
     this.searchHint,
+    this.sliverAfterSearch,
   });
 
   @override
@@ -212,6 +217,7 @@ class _AlbumSelectorState extends ConsumerState<AlbumSelector> {
             onClearSearch: clearSearch,
             hint: widget.searchHint,
           ),
+          if (widget.sliverAfterSearch != null) widget.sliverAfterSearch!,
           _QuickFilterButtonRow(
             filterMode: filter.mode,
             onChangeFilter: changeFilter,

--- a/mobile/lib/presentation/widgets/bottom_sheet/remote_album_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/bottom_sheet/remote_album_bottom_sheet.widget.dart
@@ -95,7 +95,10 @@ class _RemoteAlbumBottomSheetState extends ConsumerState<RemoteAlbumBottomSheet>
       ],
       // #965: the same picker the main timeline offers, so a space album is reachable from
       // inside an album too — not only from the timeline.
-      slivers: ownsAlbum ? [CollectionPicker(onKeyboardExpanded: onKeyboardExpand)] : null,
+      // #965 follow-up: adding assets to a collection needs rights over the DESTINATION, never over
+      // the source album -- the picker and the server both enforce that. Web gates this on view mode
+      // only, with no ownership test. Every other ownsAlbum branch above is deliberately unchanged.
+      slivers: [CollectionPicker(onKeyboardExpanded: onKeyboardExpand)],
     );
   }
 }

--- a/mobile/lib/presentation/widgets/collection/collection_picker.widget.dart
+++ b/mobile/lib/presentation/widgets/collection/collection_picker.widget.dart
@@ -148,14 +148,21 @@ class _CollectionPickerState extends ConsumerState<CollectionPicker> {
           onKeyboardExpanded: widget.onKeyboardExpanded,
           onSearchChanged: (query) => setState(() => _searchQuery = query),
           searchHint: 'search_albums_and_spaces'.t(context: context),
-        ),
-        SliverToBoxAdapter(
-          child: SpaceCollectionSection(
-            onTargetSelected: _addToTarget,
-            excludeSpaceId: widget.excludeSpaceId,
-            isBusy: _isBusy,
-            searchQuery: _searchQuery,
-            assets: widget.assets,
+          sliverAfterSearch: SliverToBoxAdapter(
+            child: SpaceCollectionSection(
+              onTargetSelected: _addToTarget,
+              excludeSpaceId: widget.excludeSpaceId,
+              isBusy: _isBusy,
+              searchQuery: _searchQuery,
+              assets: widget.assets,
+              // Rides on the section's own visibility so a user in no space never sees a lone
+              // "Albums" header over the layout they have today.
+              footer: Padding(
+                key: const Key('collection-picker-albums-header'),
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                child: Text('albums'.t(context: context), style: context.textTheme.labelLarge),
+              ),
+            ),
           ),
         ),
       ],

--- a/mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart
+++ b/mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart
@@ -29,6 +29,7 @@ class SpaceCollectionSection extends ConsumerStatefulWidget {
     this.isBusy = false,
     this.searchQuery = '',
     this.assets,
+    this.footer,
   });
 
   final void Function(CollectionTarget target) onTargetSelected;
@@ -49,6 +50,11 @@ class SpaceCollectionSection extends ConsumerStatefulWidget {
   /// Narrows the rows to spaces whose name contains this query — supplied by the picker so
   /// its single search field covers both halves of the sheet.
   final String searchQuery;
+
+  /// Rendered at the bottom of the section, and only when the section renders at all — so a caller
+  /// can attach a label for whatever follows without duplicating the section's visibility rules
+  /// (writable filter, excludeSpaceId, search query).
+  final Widget? footer;
 
   @override
   ConsumerState<SpaceCollectionSection> createState() => _SpaceCollectionSectionState();
@@ -140,6 +146,7 @@ class _SpaceCollectionSectionState extends ConsumerState<SpaceCollectionSection>
           )
         else
           for (final space in writable) ..._rowsFor(space),
+        if (widget.footer != null) widget.footer!,
       ],
     );
   }

--- a/mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart
+++ b/mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart
@@ -5,6 +5,7 @@ import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/collection_target.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
+import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/space_album.provider.dart';
 import 'package:immich_mobile/providers/shared_space.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
@@ -207,7 +208,18 @@ class _SpaceCollectionSectionState extends ConsumerState<SpaceCollectionSection>
           ListTile(
             key: Key('space-album-child-${album.id}'),
             contentPadding: const EdgeInsets.only(left: 48, right: 16),
-            leading: const Icon(Icons.photo_album_outlined),
+            leading: album.thumbnailAssetId == null
+                ? const Icon(Icons.photo_album_outlined)
+                : SizedBox(
+                    width: 32,
+                    height: 32,
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(4),
+                      // SpaceAlbum carries no thumbhash; on Thumbnail.remote the value is only a
+                      // cache-busting URL param, never a blur placeholder, so '' costs nothing here.
+                      child: Thumbnail.remote(remoteId: album.thumbnailAssetId!, thumbhash: ''),
+                    ),
+                  ),
             title: Text(album.name, maxLines: 1, overflow: TextOverflow.ellipsis),
             enabled: !widget.isBusy,
             onTap: widget.isBusy ? null : () => _emit(SpaceAlbumTarget(spaceId: space.id, album: album)),

--- a/mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart
+++ b/mobile/lib/presentation/widgets/collection/space_collection_section.widget.dart
@@ -155,7 +155,13 @@ class _SpaceCollectionSectionState extends ConsumerState<SpaceCollectionSection>
       ListTile(
         key: Key('space-row-${space.id}'),
         enabled: !widget.isBusy,
-        leading: CircleAvatar(backgroundColor: spaceGradientColors(space.color.orElse(null)).first, radius: 16),
+        leading: SpaceCollage(
+          recentAssetIds: space.recentAssetIds.orElse(null) ?? const [],
+          recentAssetThumbhashes: space.recentAssetThumbhashes.orElse(null) ?? const [],
+          color: space.color.orElse(null),
+          // Matches the `radius: 16` CircleAvatar this replaces, so row height is unchanged.
+          size: 32,
+        ),
         title: Text(space.name, maxLines: 1, overflow: TextOverflow.ellipsis),
         trailing: expandable ? Icon(expanded ? Icons.expand_less : Icons.expand_more) : null,
         onTap: widget.isBusy

--- a/mobile/lib/presentation/widgets/spaces/space_album_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/spaces/space_album_bottom_sheet.widget.dart
@@ -18,6 +18,9 @@ import 'package:immich_mobile/presentation/widgets/collection/collection_picker.
 ///   Favorite / Archive / Trash / Lock / Set-cover / Share-link / Stack /
 ///   Unstack / Edit-date-time / Edit-location / Delete-local
 ///
+/// The sheet also mounts the shared [CollectionPicker] (#965 follow-up), with no
+/// `excludeSpaceId` — the current space is a legitimate target from inside one of its own albums.
+///
 /// Role-gating is on [canEdit] (space role), not album ownership (D3).
 ///
 /// [onRemoved] is called after a successful remove-from-album action so the

--- a/mobile/lib/presentation/widgets/spaces/space_album_bottom_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/spaces/space_album_bottom_sheet.widget.dart
@@ -5,6 +5,7 @@ import 'package:immich_mobile/presentation/widgets/action_buttons/download_actio
 import 'package:immich_mobile/presentation/widgets/action_buttons/remove_from_album_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/share_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/bottom_sheet/base_bottom_sheet.widget.dart';
+import 'package:immich_mobile/presentation/widgets/collection/collection_picker.widget.dart';
 
 /// Reduced multiselect bottom sheet for the Space Album detail page.
 ///
@@ -52,6 +53,11 @@ class _SpaceAlbumBottomSheetState extends ConsumerState<SpaceAlbumBottomSheet> {
 
   @override
   Widget build(BuildContext context) {
+    Future<void> onKeyboardExpand() {
+      // 0.85 is this sheet's maxChildSize.
+      return sheetController.animateTo(0.85, duration: const Duration(milliseconds: 200), curve: Curves.easeInOut);
+    }
+
     return BaseBottomSheet(
       controller: sheetController,
       initialChildSize: 0.18,
@@ -68,6 +74,9 @@ class _SpaceAlbumBottomSheetState extends ConsumerState<SpaceAlbumBottomSheet> {
             onComplete: widget.onRemoved,
           ),
       ],
+      // The same picker every other multi-select surface offers. No excludeSpaceId: this sheet has
+      // no spaceId, and the current space is a legitimate target from inside one of its albums.
+      slivers: [CollectionPicker(onKeyboardExpanded: onKeyboardExpand)],
     );
   }
 }

--- a/mobile/test/presentation/widgets/bottom_sheet/add_to_collection_surfaces_test.dart
+++ b/mobile/test/presentation/widgets/bottom_sheet/add_to_collection_surfaces_test.dart
@@ -121,11 +121,12 @@ void main() {
 
   /// Assert on the sliver list the sheet was handed, not on the rendered tree.
   ///
-  /// These sheets open at 0.22–0.4 of the screen. Measured: `find.byType(CollectionPicker)`
-  /// finds it in the favorites sheet (0.4) but reports nothing for the remote-album (0.22) and
-  /// archive (0.25) sheets, because the picker sits below the viewport and its sliver is never
-  /// built. That makes a rendered-tree assertion pass or fail on sheet height rather than on
-  /// wiring. What the picker renders once built is covered by the picker's own tests.
+  /// These sheets open at 0.18–0.4 of the screen. Measured: `find.byType(CollectionPicker)`
+  /// finds it in the favorites sheet (0.4) but reports nothing for the remote-album (0.22),
+  /// archive (0.25), and space-album (0.18) sheets, because the picker sits below the viewport
+  /// and its sliver is never built. That makes a rendered-tree assertion pass or fail on sheet
+  /// height rather than on wiring. What the picker renders once built is covered by the picker's
+  /// own tests.
   void expectPickerMounted(WidgetTester tester) {
     final slivers = tester.widget<BaseBottomSheet>(find.byType(BaseBottomSheet)).slivers ?? const <Widget>[];
     // Reverting a surface to `[AddToAlbumHeader(), AlbumSelector(...)]` — upstream's album-only

--- a/mobile/test/presentation/widgets/bottom_sheet/add_to_collection_surfaces_test.dart
+++ b/mobile/test/presentation/widgets/bottom_sheet/add_to_collection_surfaces_test.dart
@@ -23,6 +23,7 @@ import 'package:immich_mobile/presentation/widgets/bottom_sheet/favorite_bottom_
 import 'package:immich_mobile/presentation/widgets/bottom_sheet/local_album_bottom_sheet.widget.dart';
 import 'package:immich_mobile/presentation/widgets/bottom_sheet/remote_album_bottom_sheet.widget.dart';
 import 'package:immich_mobile/presentation/widgets/collection/collection_picker.widget.dart';
+import 'package:immich_mobile/presentation/widgets/spaces/space_album_bottom_sheet.widget.dart';
 import 'package:immich_mobile/providers/asset_viewer/asset_viewer.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/remote_album.provider.dart';
@@ -184,5 +185,21 @@ void main() {
     expect(picker.source, ActionSource.viewer);
     // The viewer has no multiselect, so it must state the asset the notices reason about.
     expect(picker.assets, [viewed]);
+  });
+
+  testWidgets('S1: the space album sheet offers the collection picker', (tester) async {
+    await pumpSheet(tester, const SpaceAlbumBottomSheet(canEdit: true, albumId: 'al1'));
+    expectPickerMounted(tester);
+  });
+
+  testWidgets('S2: the space album sheet does not exclude its own space', (tester) async {
+    await pumpSheet(tester, const SpaceAlbumBottomSheet(canEdit: true, albumId: 'al1'));
+
+    // Assert on the wiring, not on rendered rows: the space list lives inside the picker, which is
+    // below this sheet's 0.18 viewport and never built. A null excludeSpaceId is exactly what keeps
+    // the current space reachable, so moving a photo between two albums of one space works.
+    final slivers = tester.widget<BaseBottomSheet>(find.byType(BaseBottomSheet)).slivers ?? const <Widget>[];
+    final picker = slivers.whereType<CollectionPicker>().single;
+    expect(picker.excludeSpaceId, isNull);
   });
 }

--- a/mobile/test/presentation/widgets/bottom_sheet/add_to_collection_surfaces_test.dart
+++ b/mobile/test/presentation/widgets/bottom_sheet/add_to_collection_surfaces_test.dart
@@ -93,6 +93,9 @@ void main() {
 
   RemoteAlbum ownedAlbum() => RemoteAlbumFactory.create(ownerId: user.id, ownerName: user.name, assetCount: 1);
 
+  RemoteAlbum foreignAlbum() =>
+      RemoteAlbumFactory.create(ownerId: 'someone-else', ownerName: 'Someone Else', assetCount: 1);
+
   Future<void> pumpSheet(WidgetTester tester, Widget sheet) async {
     final userService = _MockUserService();
     when(() => userService.tryGetMyUser()).thenReturn(user);
@@ -201,5 +204,15 @@ void main() {
     final slivers = tester.widget<BaseBottomSheet>(find.byType(BaseBottomSheet)).slivers ?? const <Widget>[];
     final picker = slivers.whereType<CollectionPicker>().single;
     expect(picker.excludeSpaceId, isNull);
+  });
+
+  testWidgets('S3: an album the user does not own still offers the picker', (tester) async {
+    await pumpSheet(tester, RemoteAlbumBottomSheet(album: foreignAlbum()));
+    expectPickerMounted(tester);
+  });
+
+  testWidgets('S5: an album the user owns still offers the picker', (tester) async {
+    await pumpSheet(tester, RemoteAlbumBottomSheet(album: ownedAlbum()));
+    expectPickerMounted(tester);
   });
 }

--- a/mobile/test/presentation/widgets/collection/collection_picker_test.dart
+++ b/mobile/test/presentation/widgets/collection/collection_picker_test.dart
@@ -269,7 +269,7 @@ void main() {
     expect(find.byKey(const Key('collection-picker-albums-header')), findsNothing);
   });
 
-  testWidgets('L5: the notice path still renders the albums label below it', (tester) async {
+  testWidgets('L5: the notice path still renders the albums label', (tester) async {
     // A selection containing a non-owned asset drives the section's notice branch: header and
     // notice render, space rows do not — and albums still follow.
     await pumpPicker(

--- a/mobile/test/presentation/widgets/collection/collection_picker_test.dart
+++ b/mobile/test/presentation/widgets/collection/collection_picker_test.dart
@@ -149,6 +149,17 @@ void main() {
     createdAt: DateTime(2026, 1, 1),
   );
 
+  RemoteAsset asset(String id, {String ownerId = 'user-1'}) => RemoteAsset(
+    id: id,
+    name: id,
+    ownerId: ownerId,
+    checksum: id,
+    type: AssetType.image,
+    createdAt: DateTime(2026, 1, 1),
+    updatedAt: DateTime(2026, 1, 1),
+    isEdited: false,
+  );
+
   testWidgets('composes the header, the album selector and the spaces section, in that order', (tester) async {
     final userService = _MockUserService();
     final user = UserStub.user1;
@@ -245,6 +256,52 @@ void main() {
     await tester.pump();
 
     expect(find.byKey(const Key('space-row-s2')), findsOneWidget);
+  });
+
+  testWidgets('L4: a query matching albums but no space collapses the section and both labels', (tester) async {
+    await pumpPicker(tester, spaces: [space('s1', 'Family')]);
+
+    await tester.enterText(find.byType(SearchField), 'zzz-no-space-matches');
+    await tester.pump();
+
+    // Intended: with only one section left, section labels are noise. Do not "fix" this.
+    expect(find.byKey(const Key('space-collection-header')), findsNothing);
+    expect(find.byKey(const Key('collection-picker-albums-header')), findsNothing);
+  });
+
+  testWidgets('L5: the notice path still renders the albums label below it', (tester) async {
+    // A selection containing a non-owned asset drives the section's notice branch: header and
+    // notice render, space rows do not — and albums still follow.
+    await pumpPicker(
+      tester,
+      spaces: [space('s1', 'Family')],
+      selection: [asset('a1', ownerId: 'someone-else')],
+    );
+
+    expect(find.byKey(const Key('space-collection-notice')), findsOneWidget);
+    expect(find.byKey(const Key('space-row-s1')), findsNothing);
+    expect(find.byKey(const Key('collection-picker-albums-header')), findsOneWidget);
+  });
+
+  testWidgets('L6: typing keeps the search field focused and narrows the spaces section', (tester) async {
+    await pumpPicker(tester, spaces: [space('s1', 'Family'), space('s2', 'Holiday')]);
+
+    // enterText focuses the field itself (it calls showKeyboard), so no explicit tap is needed --
+    // and the focus assertion below is therefore NOT "did typing acquire focus" but "did focus
+    // SURVIVE the rebuild that the keystroke triggered". That is the regression this task guards:
+    // onSearchChanged -> setState -> AlbumSelector is handed a new child.
+    await tester.enterText(find.byType(SearchField), 'Fam');
+    await tester.pump();
+
+    expect(find.byKey(const Key('space-row-s1')), findsOneWidget);
+    expect(find.byKey(const Key('space-row-s2')), findsNothing);
+
+    // Asserting only on the narrowed rows would pass even if every keystroke dropped focus.
+    final editable = tester.widget<EditableText>(find.descendant(
+      of: find.byType(SearchField),
+      matching: find.byType(EditableText),
+    ));
+    expect(editable.focusNode.hasFocus, isTrue);
   });
 
   // #965: the same picker is now mounted from surfaces that have no timeline multiselect —

--- a/mobile/test/presentation/widgets/collection/collection_picker_test.dart
+++ b/mobile/test/presentation/widgets/collection/collection_picker_test.dart
@@ -93,6 +93,33 @@ class _RecordingActionNotifier extends ActionNotifier {
 }
 
 void main() {
+  Future<void> pumpPicker(
+    WidgetTester tester, {
+    List<SharedSpaceResponseDto> spaces = const [],
+    List<RemoteAsset> selection = const [],
+  }) async {
+    final userService = _MockUserService();
+    final user = UserStub.user1;
+    when(() => userService.tryGetMyUser()).thenReturn(user);
+    when(() => userService.watchMyUser()).thenAnswer((_) => const Stream.empty());
+
+    await tester.pumpConsumerWidgetRaw(
+      const CustomScrollView(slivers: [CollectionPicker()]),
+      overrides: [
+        currentUserProvider.overrideWith((ref) => _StubCurrentUserNotifier(userService, user)),
+        remoteAlbumProvider.overrideWith(() => _StubRemoteAlbumNotifier()),
+        appConfigProvider.overrideWithValue(const AppConfig()),
+        sharedSpacesProvider.overrideWith((ref) async => spaces),
+        multiSelectProvider.overrideWith(
+          () => MultiSelectNotifier(
+            MultiSelectState(selectedAssets: selection.toSet(), lockedSelectionAssets: const {}),
+          ),
+        ),
+      ],
+    );
+    await tester.pump();
+  }
+
   SharedSpaceMemberResponseDto member(String userId, SharedSpaceRole role) => SharedSpaceMemberResponseDto(
     userId: userId,
     name: userId,
@@ -152,6 +179,31 @@ void main() {
     final headerY = tester.getTopLeft(find.byKey(const Key('collection-picker-header'))).dy;
     final albumsY = tester.getTopLeft(find.byType(SearchField)).dy;
     expect(headerY, lessThan(albumsY));
+  });
+
+  testWidgets('L1: spaces render above albums, and both below the search field', (tester) async {
+    await pumpPicker(tester, spaces: [space('s1', 'Family')]);
+
+    final searchY = tester.getTopLeft(find.byType(SearchField)).dy;
+    final spacesY = tester.getTopLeft(find.byKey(const Key('space-collection-header'))).dy;
+    final albumsY = tester.getTopLeft(find.byKey(const Key('collection-picker-albums-header'))).dy;
+
+    expect(searchY, lessThan(spacesY));
+    expect(spacesY, lessThan(albumsY));
+  });
+
+  testWidgets('L2: both section labels render when the user has writable spaces', (tester) async {
+    await pumpPicker(tester, spaces: [space('s1', 'Family')]);
+
+    expect(find.byKey(const Key('space-collection-header')), findsOneWidget);
+    expect(find.byKey(const Key('collection-picker-albums-header')), findsOneWidget);
+  });
+
+  testWidgets('L3: neither label renders when the user has no writable spaces', (tester) async {
+    await pumpPicker(tester, spaces: const []);
+
+    expect(find.byKey(const Key('space-collection-header')), findsNothing);
+    expect(find.byKey(const Key('collection-picker-albums-header')), findsNothing);
   });
 
   testWidgets('typing in the search field narrows the spaces section too', (tester) async {

--- a/mobile/test/presentation/widgets/collection/space_collection_section_test.dart
+++ b/mobile/test/presentation/widgets/collection/space_collection_section_test.dart
@@ -11,10 +11,12 @@ import 'package:immich_mobile/providers/infrastructure/space_album.provider.dart
 import 'package:immich_mobile/providers/shared_space.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
 import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:immich_mobile/widgets/spaces/space_collage.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openapi/api.dart';
 
 import '../../../fixtures/user.stub.dart';
+import '../../../unit/presentation/presentation_context.dart';
 import '../../../widget_tester_extensions.dart';
 
 class _MockUserService extends Mock implements UserService {}
@@ -31,6 +33,12 @@ class _StubCurrentUserNotifier extends CurrentUserProvider {
 }
 
 void main() {
+  setUpAll(() async {
+    // PresentationContext.create() runs TestUtils.init() and initializes StoreService, which
+    // SpaceCollage's RemoteImageProvider reads when it builds its image URLs.
+    await PresentationContext.create();
+  });
+
   SharedSpaceMemberResponseDto member(String userId, SharedSpaceRole role) => SharedSpaceMemberResponseDto(
     userId: userId,
     name: userId,
@@ -46,12 +54,15 @@ void main() {
     SharedSpaceRole role = SharedSpaceRole.owner,
     int albums = 0,
     String? name,
+    List<String> recentAssetIds = const [],
   }) => SharedSpaceResponseDto(
     id: id,
     name: name ?? 'Space $id',
     createdAt: '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',
     createdById: 'someone-else',
+    recentAssetIds: Optional.present(recentAssetIds),
+    recentAssetThumbhashes: const Optional.present([]),
     members: Optional.present([member('user-1', role)]),
     albumCount: Optional.present(albums),
   );
@@ -427,5 +438,20 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(targets, hasLength(2), reason: 'a failed add must not leave the section permanently inert');
+  });
+
+  testWidgets('T1: a space with recent assets renders a collage, not a plain colour disc', (tester) async {
+    await pump(tester, spaces: [space('s1', recentAssetIds: ['a1', 'a2'])]);
+
+    expect(find.byType(SpaceCollage), findsOneWidget);
+    expect(find.byType(CircleAvatar), findsNothing);
+  });
+
+  testWidgets('T2: a space with no recent assets still renders the collage on its empty state', (tester) async {
+    await pump(tester, spaces: [space('s1', recentAssetIds: const [])]);
+
+    // The collage draws its own gradient fallback when the id list is empty; the row must not
+    // silently drop its leading widget in that case.
+    expect(find.byType(SpaceCollage), findsOneWidget);
   });
 }

--- a/mobile/test/presentation/widgets/collection/space_collection_section_test.dart
+++ b/mobile/test/presentation/widgets/collection/space_collection_section_test.dart
@@ -7,6 +7,7 @@ import 'package:immich_mobile/domain/models/space_album.model.dart';
 import 'package:immich_mobile/domain/models/user.model.dart';
 import 'package:immich_mobile/domain/services/user.service.dart';
 import 'package:immich_mobile/presentation/widgets/collection/space_collection_section.widget.dart';
+import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/space_album.provider.dart';
 import 'package:immich_mobile/providers/shared_space.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
@@ -67,9 +68,10 @@ void main() {
     albumCount: Optional.present(albums),
   );
 
-  SpaceAlbum album(String id, String name) => SpaceAlbum(
+  SpaceAlbum album(String id, String name, {String? thumbnailAssetId}) => SpaceAlbum(
     id: id,
     name: name,
+    thumbnailAssetId: thumbnailAssetId,
     showInTimeline: true,
     linkedAt: DateTime(2026, 1, 1),
     updatedAt: DateTime(2026, 1, 1),
@@ -453,5 +455,53 @@ void main() {
     // The collage draws its own gradient fallback when the id list is empty; the row must not
     // silently drop its leading widget in that case.
     expect(find.byType(SpaceCollage), findsOneWidget);
+  });
+
+  testWidgets('T3: a space album with a thumbnail asset renders it', (tester) async {
+    await pump(
+      tester,
+      spaces: [space('s1', albums: 1)],
+      albums: {
+        's1': [album('al1', 'Hawaii', thumbnailAssetId: 'asset-1')],
+      },
+    );
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    // A single pump only rebuilds with the album stream override still in its loading state --
+    // spaceAlbumsProvider's first value arrives via a microtask the frame doesn't wait on --
+    // so the album child never mounts under one pump. pumpAndSettle matches every other
+    // expand-then-read-children case in this file (e.g. "an album child emits a
+    // SpaceAlbumTarget...").
+    await tester.pumpAndSettle();
+
+    expect(find.byType(Thumbnail), findsOneWidget);
+  });
+
+  testWidgets('T4: a space album with no thumbnail asset falls back to the icon', (tester) async {
+    await pump(
+      tester,
+      spaces: [space('s1', albums: 1)],
+      albums: {
+        's1': [album('al1', 'Hawaii', thumbnailAssetId: null)],
+      },
+    );
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.photo_album_outlined), findsOneWidget);
+    expect(find.byType(Thumbnail), findsNothing);
+  });
+
+  testWidgets('T5: the pool child keeps its action icon and never becomes a thumbnail', (tester) async {
+    await pump(
+      tester,
+      spaces: [space('s1', albums: 1)],
+      albums: {
+        's1': [album('al1', 'Hawaii', thumbnailAssetId: 'asset-1')],
+      },
+    );
+    await tester.tap(find.byKey(const Key('space-row-s1')));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.workspaces_outline), findsOneWidget);
   });
 }

--- a/mobile/test/presentation/widgets/spaces/space_album_bottom_sheet_test.dart
+++ b/mobile/test/presentation/widgets/spaces/space_album_bottom_sheet_test.dart
@@ -2,25 +2,74 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/domain/models/album/album.model.dart';
+import 'package:immich_mobile/domain/models/config/app_config.dart';
+import 'package:immich_mobile/domain/services/user.service.dart';
+import 'package:immich_mobile/models/albums/album_search.model.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/download_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/remove_from_album_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/action_buttons/share_action_button.widget.dart';
 import 'package:immich_mobile/presentation/widgets/spaces/space_album_bottom_sheet.widget.dart';
 import 'package:immich_mobile/presentation/widgets/timeline/timeline.state.dart';
+import 'package:immich_mobile/providers/infrastructure/album.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/remote_album.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/settings.provider.dart';
+import 'package:immich_mobile/providers/shared_space.provider.dart';
 import 'package:immich_mobile/providers/timeline/multiselect.provider.dart';
+import 'package:immich_mobile/providers/user.provider.dart';
+import 'package:mocktail/mocktail.dart';
 // easy_localization initializes shared_preferences internally; tests need the mock initializer.
 // ignore: depend_on_referenced_packages
 import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../fixtures/user.stub.dart';
+
+class _MockUserService extends Mock implements UserService {}
+
+class _StubCurrentUserNotifier extends CurrentUserProvider {
+  _StubCurrentUserNotifier(super.service) {
+    state = UserStub.user1;
+  }
+}
+
+/// `AlbumSelector` fires a post-frame `refresh()` against a live `RemoteAlbumService` that
+/// this harness has no reason to stand up; the picker composes it, so stub both.
+class _StubRemoteAlbumNotifier extends RemoteAlbumNotifier {
+  @override
+  RemoteAlbumState build() => const RemoteAlbumState(albums: []);
+
+  @override
+  Future<void> refresh() async {}
+
+  @override
+  List<RemoteAlbum> searchAlbums(
+    List<RemoteAlbum> albums,
+    String query,
+    String? userId, [
+    QuickFilterMode filterMode = QuickFilterMode.all,
+  ]) => albums;
+}
 
 // ---------------------------------------------------------------------------
 // Helper
 // ---------------------------------------------------------------------------
 
 Widget _wrap(Widget widget, {List<Override> overrides = const []}) {
+  final userService = _MockUserService();
+  when(() => userService.tryGetMyUser()).thenReturn(UserStub.user1);
+  when(() => userService.watchMyUser()).thenAnswer((_) => const Stream.empty());
+
   return ProviderScope(
     overrides: [
       timelineStateProvider.overrideWith(TimelineStateNotifier.new),
       multiSelectProvider.overrideWith(MultiSelectNotifier.new),
+      // The sheet now always mounts CollectionPicker (#965 follow-up), which composes
+      // AlbumSelector + SpaceCollectionSection; both read live providers this harness has no
+      // reason to stand up.
+      currentUserProvider.overrideWith((ref) => _StubCurrentUserNotifier(userService)),
+      remoteAlbumProvider.overrideWith(() => _StubRemoteAlbumNotifier()),
+      appConfigProvider.overrideWithValue(const AppConfig()),
+      sharedSpacesProvider.overrideWith((ref) async => const []),
       ...overrides,
     ],
     child: EasyLocalization(


### PR DESCRIPTION
Follow-up to #970. Using that picker on a real library surfaced two presentation problems, and #970's own design note recorded two entry points it deliberately left alone. This closes all four.

## The problems

1. **Spaces sat below every album.** `CollectionPicker` stacked `AlbumSelector` then `SpaceCollectionSection`, so on a library with dozens of albums the Spaces section was several screens down — the destination #970 existed to expose was effectively unreachable by scrolling.
2. **Spaces and space albums rendered placeholders.** A space row drew a flat coloured disc; a space album drew a generic glyph. Personal albums one section below drew real photo thumbnails, so the two halves of the same sheet looked like different apps. The data was already on the wire and unused.
3. **No picker on the space-album page** — that sheet passed no slivers at all.
4. **No picker on an album you do not own** — gated on `ownsAlbum`.

## The fix

**A naive reorder would have been wrong.** `AlbumSelector`'s `MultiSliver` is `[_SearchBar, _QuickFilterButtonRow, _QuickSortAndViewMode, …albums]` — the search field lives *inside* the upstream widget, so swapping the picker's two children would have put Spaces above the search box that filters it. Spaces is instead injected *between* the search bar and the quick-filter row via one additive prop, `sliverAfterSearch`, on `AlbumSelector` — matching the two additive hooks the fork already carries on that widget (+6 lines to upstream code, null default, every other call site untouched).

The `ALBUMS` label rides as a `footer` on `SpaceCollectionSection`, so it shares that section's visibility rules exactly. A user in no spaces sees neither label and gets today's layout unchanged, rather than a lone `ALBUMS` header.

**Thumbnails** use widgets and data that already existed: `SpaceCollage` fed by the DTO's `recentAssetIds`/`recentAssetThumbhashes`, and `Thumbnail.remote` for space albums. `SpaceAlbum` carries no thumbhash, so `thumbhash: ''` is passed — on that constructor the value is only a cache-busting URL parameter, never a blur placeholder (`thumbhashProvider` is null there), so nothing is sacrificed. Copying `AlbumSelector`'s `FutureBuilder` would have cost one asset fetch per row per expand for no visual gain.

**The album gate is removed, not widened.** Web gates the equivalent action on `canAddToAlbum: () => viewMode === AlbumPageViewMode.VIEW` — view mode only, no ownership test — so mobile's gate was stricter than web. Adding assets needs rights over the *destination*, which the picker and the server already enforce. Only the `slivers:` argument changed; every other `ownsAlbum` branch (remove-from-album, set-cover, trash, archive, edit, lock, stack) stays owner-gated.

**From inside a space album the current space is offered**, so moving a photo between two albums of one space works. That sheet carries no `spaceId`, so this needed no new plumbing. Closes a third row of #970's divergence table.

## Tests

16 behaviours across three files, each written red-first against the unfixed code. Coverage includes the null and empty boundaries (space with no photos, album with no cover), the notice path, the permission combination the ungating newly makes reachable, and a guard on the search field keeping text *and focus* across the rebuild.

Two are deliberately labelled as regression guards that are green before and after — they earn their place by being run against the restructure, not by failing first.

Sheet-level tests assert on `BaseBottomSheet.slivers` via the existing `expectPickerMounted`, never `find.byType`: these sheets open at 0.18–0.4 of the screen, so a rendered-tree assertion would resolve on sheet height rather than wiring.

## Verification

Local: mobile 3131 tests pass, `dart analyze --fatal-infos` clean, `dart format` over `lib/` clean (0 of 807 changed). No new i18n keys — `albums` and `spaces` both already exist.

Design note: `docs/superpowers/specs/2026-08-13-mobile-collection-picker-parity-design.md`.

## Not in scope

- Capping the spaces list, and a thumbhash for space albums (a Drift column plus sync field — a data change, not a presentation one).
- Mobile's `selectionHasNonOwned` rule remains stricter than the server, unchanged from #970's assessment.
- The picker offers the album you are currently standing in; web behaves the same way, so this is parity rather than a regression.