### PR TITLE
feat(web): run search in place on album and space album pages

### DIFF
--- a/e2e/src/specs/server/api/search-album-scope.e2e-spec.ts
+++ b/e2e/src/specs/server/api/search-album-scope.e2e-spec.ts
@@ -1,0 +1,204 @@
+import { SharedSpaceRole, type LoginResponseDto } from '@immich/sdk';
+import { createUserDto } from 'src/fixtures';
+import { app, utils } from 'src/utils';
+import request from 'supertest';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * #986 — the album scope on smart search.
+ *
+ * An album detail page runs its page-aware search scoped to the album it is showing. Server-side
+ * that made `albumIds` an ACCESS BOUNDARY on the smart path, matching what `/search/metadata` has
+ * always done: check `AlbumRead` up front, then leave the owner-scoping `userIds` unset so
+ * `albumSharedSpaceScope` re-gates the rows. Previously smart search kept `userIds`, so searching a
+ * shared album returned only your own photos beside a grid that had just shown everyone's.
+ *
+ * WHAT IS TESTABLE HERE, and why these assertions look indirect:
+ *
+ * The e2e stack sets `IMMICH_MACHINE_LEARNING_ENABLED=false`, so smart search always ends in the
+ * "Smart search is not enabled" gate and never reaches SQL. But the new `AlbumRead` check runs
+ * BEFORE that gate, so the two 400s carry different messages — and which one comes back tells us
+ * exactly whether the check ran and whether it passed:
+ *
+ *   "Not found or no album.read access"  → the check ran and REFUSED
+ *   "Smart search is not enabled"        → the check ran and PASSED (or never ran)
+ *
+ * That distinction is what makes the DTO change observable too: if `albumIds` were still stripped
+ * from `SmartSearchFacetsDto` by the zod pipe, the facets endpoint could not refuse an inaccessible
+ * album at all — it would fall through to the ML gate. So the refusal below is an end-to-end proof
+ * that the field survives validation.
+ *
+ * The row-level half (a shared album returning every member's matches) needs real embeddings and is
+ * covered by unit tests over the resolved options; it cannot be reached while ML is off.
+ */
+
+const NO_ALBUM_ACCESS = 'Not found or no album.read access';
+const ML_DISABLED = 'Smart search is not enabled';
+
+const smartSearch = async (accessToken: string, body: Record<string, unknown>) =>
+  request(app).post('/search/smart').set('Authorization', `Bearer ${accessToken}`).send(body);
+
+const smartFacets = async (accessToken: string, body: Record<string, unknown>) =>
+  request(app).post('/search/smart/facets').set('Authorization', `Bearer ${accessToken}`).send(body);
+
+describe('smart search album scope (#986)', () => {
+  let admin: LoginResponseDto;
+  let owner: LoginResponseDto;
+  let stranger: LoginResponseDto;
+  let spaceMember: LoginResponseDto;
+
+  /** Owned by `owner`, shared with nobody. */
+  let privateAlbumId: string;
+  /** Owned by `owner`, shared with `spaceMember` through a space link. */
+  let spaceLinkedAlbumId: string;
+
+  beforeAll(async () => {
+    await utils.resetDatabase();
+    admin = await utils.adminSetup({ onboarding: false });
+    owner = await utils.userSetup(admin.accessToken, createUserDto.create('album-scope-owner'));
+    stranger = await utils.userSetup(admin.accessToken, createUserDto.create('album-scope-stranger'));
+    spaceMember = await utils.userSetup(admin.accessToken, createUserDto.create('album-scope-member'));
+
+    const asset = await utils.createAsset(owner.accessToken);
+
+    const privateAlbum = await utils.createAlbum(owner.accessToken, {
+      albumName: 'Private Album',
+      assetIds: [asset.id],
+    });
+    privateAlbumId = privateAlbum.id;
+
+    // Deliberately NOT given `albumUsers`: an album-user role would grant AlbumRead on its own and
+    // the space-grant tests below would pass without the space link doing anything.
+    const spaceAlbum = await utils.createAlbum(owner.accessToken, {
+      albumName: 'Space Linked Album',
+      assetIds: [asset.id],
+    });
+    spaceLinkedAlbumId = spaceAlbum.id;
+
+    const space = await utils.createSpace(owner.accessToken, { name: 'Album Scope Space' });
+    await utils.addSpaceMember(owner.accessToken, space.id, {
+      userId: spaceMember.userId,
+      role: SharedSpaceRole.Editor,
+    });
+    await utils.linkSpaceAlbum(owner.accessToken, space.id, spaceLinkedAlbumId);
+  });
+
+  describe('POST /search/smart', () => {
+    it('refuses an album the caller cannot read', async () => {
+      const { status, body } = await smartSearch(stranger.accessToken, {
+        query: 'beach',
+        albumIds: [privateAlbumId],
+      });
+
+      expect(status).toBe(400);
+      expect(body.message).toBe(NO_ALBUM_ACCESS);
+    });
+
+    it('accepts an album the caller owns', async () => {
+      const { status, body } = await smartSearch(owner.accessToken, {
+        query: 'beach',
+        albumIds: [privateAlbumId],
+      });
+
+      // Past the access check; only the ML gate is left.
+      expect(status).toBe(400);
+      expect(body.message).toBe(ML_DISABLED);
+    });
+
+    it('accepts an album shared with the caller through a space', async () => {
+      const { status, body } = await smartSearch(spaceMember.accessToken, {
+        query: 'beach',
+        albumIds: [spaceLinkedAlbumId],
+      });
+
+      expect(status).toBe(400);
+      expect(body.message).toBe(ML_DISABLED);
+    });
+
+    it('refuses a non-existent album id rather than silently returning nothing', async () => {
+      const { status, body } = await smartSearch(owner.accessToken, {
+        query: 'beach',
+        albumIds: ['00000000-0000-4000-8000-0000000000ff'],
+      });
+
+      expect(status).toBe(400);
+      expect(body.message).toBe(NO_ALBUM_ACCESS);
+    });
+
+    it('leaves an unscoped smart search on the ML gate, with no album check in the way', async () => {
+      const { status, body } = await smartSearch(stranger.accessToken, { query: 'beach' });
+
+      expect(status).toBe(400);
+      expect(body.message).toBe(ML_DISABLED);
+    });
+
+    it('rejects a malformed album id at the DTO boundary', async () => {
+      const { status } = await smartSearch(owner.accessToken, { query: 'beach', albumIds: ['not-a-uuid'] });
+
+      expect(status).toBe(400);
+    });
+  });
+
+  describe('POST /search/smart/facets', () => {
+    // The facets schema is a `.pick()` from the base search schema and did not carry `albumIds`, so
+    // the zod pipe stripped it: the facet counts and time buckets silently described the whole
+    // library beside a result grid showing one album. A refusal here can only happen if the field
+    // now survives validation and reaches the access check.
+    it('refuses an album the caller cannot read, proving albumIds survives validation', async () => {
+      const { status, body } = await smartFacets(stranger.accessToken, {
+        query: 'beach',
+        albumIds: [privateAlbumId],
+      });
+
+      expect(status).toBe(400);
+      expect(body.message).toBe(NO_ALBUM_ACCESS);
+    });
+
+    it('accepts an album the caller owns', async () => {
+      const { status, body } = await smartFacets(owner.accessToken, {
+        query: 'beach',
+        albumIds: [privateAlbumId],
+      });
+
+      expect(status).toBe(400);
+      expect(body.message).toBe(ML_DISABLED);
+    });
+
+    it('accepts an album shared with the caller through a space', async () => {
+      const { status, body } = await smartFacets(spaceMember.accessToken, {
+        query: 'beach',
+        albumIds: [spaceLinkedAlbumId],
+      });
+
+      expect(status).toBe(400);
+      expect(body.message).toBe(ML_DISABLED);
+    });
+  });
+
+  // The reference behaviour the smart path was aligned to. Unlike smart search this one is not
+  // behind the ML gate, so it can assert on real rows: a space member searching a linked album by
+  // `albumIds` sees the OWNER's asset, not just their own.
+  describe('POST /search/metadata (the shape smart search now matches)', () => {
+    it('returns the owner’s asset to a space member searching the linked album', async () => {
+      const { status, body } = await request(app)
+        .post('/search/metadata')
+        .set('Authorization', `Bearer ${spaceMember.accessToken}`)
+        .send({ albumIds: [spaceLinkedAlbumId] });
+
+      expect(status).toBe(200);
+      const items = body.assets.items as Array<{ id: string; ownerId: string }>;
+      expect(items.length).toBeGreaterThan(0);
+      expect(items.some((item) => item.ownerId === owner.userId)).toBe(true);
+    });
+
+    it('refuses an album the caller cannot read', async () => {
+      const { status, body } = await request(app)
+        .post('/search/metadata')
+        .set('Authorization', `Bearer ${stranger.accessToken}`)
+        .send({ albumIds: [privateAlbumId] });
+
+      expect(status).toBe(400);
+      expect(body.message).toBe(NO_ALBUM_ACCESS);
+    });
+  });
+});

--- a/e2e/src/specs/web/album-search.e2e-spec.ts
+++ b/e2e/src/specs/web/album-search.e2e-spec.ts
@@ -1,0 +1,172 @@
+import type { AlbumResponseDto, LoginResponseDto, SharedSpaceResponseDto } from '@immich/sdk';
+import { expect, test, type BrowserContext, type Page } from '@playwright/test';
+import { utils } from 'src/utils';
+
+/**
+ * #986 — page-aware search on the two album detail routes.
+ *
+ * Before this, searching from inside an album navigated to `/photos` and ran the query against the
+ * caller's whole library. A space page searched its space correctly; a space album did not.
+ *
+ * SCOPE NOTE, same as photos-search.e2e-spec.ts: the e2e stack runs with
+ * `IMMICH_MACHINE_LEARNING_ENABLED=false`, so `/search/smart` always trips the "Smart search is not
+ * enabled" gate and returns no real CLIP results. That is fine here — every assertion below is
+ * about the DESTINATION and the URL/UI plumbing, which is exactly where the reported bug lived. The
+ * server-side album scoping (`albumIds` dropping the owner-scoping `userIds`, so a shared album
+ * returns every member's matches) is covered at the API layer instead; it cannot be reached through
+ * the UI while ML is off.
+ */
+
+async function submitGlobalSearch(page: Page, query: string) {
+  const mobileSearchButton = page.locator('#search-button');
+  await ((await mobileSearchButton.isVisible()) ? mobileSearchButton.click() : page.keyboard.press('Control+k'));
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  const combobox = dialog.getByRole('combobox');
+  await combobox.fill(query);
+  await combobox.press('Enter');
+  await expect(dialog).toBeHidden({ timeout: 10_000 });
+}
+
+/** SmartSearchResults settles into one of these once its (ML-disabled) call resolves. */
+async function expectSearchSurfaceSettled(page: Page) {
+  await expect(page.getByTestId('result-count').or(page.getByTestId('search-empty'))).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+test.describe('Album page-aware search', () => {
+  let admin: LoginResponseDto;
+  let album: AlbumResponseDto;
+  let space: SharedSpaceResponseDto;
+  let spaceAlbum: AlbumResponseDto;
+
+  test.beforeAll(async () => {
+    utils.initSdk();
+    await utils.resetDatabase();
+    admin = await utils.adminSetup();
+
+    const [assetOne, assetTwo] = await Promise.all([
+      utils.createAsset(admin.accessToken),
+      utils.createAsset(admin.accessToken),
+    ]);
+
+    album = await utils.createAlbum(admin.accessToken, {
+      albumName: 'Search Target Album',
+      assetIds: [assetOne.id, assetTwo.id],
+    });
+
+    space = await utils.createSpace(admin.accessToken, { name: 'Search Target Space' });
+    spaceAlbum = await utils.createAlbum(admin.accessToken, {
+      albumName: 'Search Target Space Album',
+      assetIds: [assetOne.id],
+    });
+    await utils.linkSpaceAlbum(admin.accessToken, space.id, spaceAlbum.id);
+  });
+
+  const goto = async (context: BrowserContext, page: Page, path: string) => {
+    await utils.setAuthCookies(context, admin.accessToken);
+    await page.goto(path);
+    await page.waitForSelector('[data-testid="discovery-panel"], [data-testid="collapsed-icon-strip"]');
+  };
+
+  test('searching from an album stays on that album instead of going to /photos', async ({ context, page }) => {
+    await goto(context, page, `/albums/${album.id}`);
+
+    await submitGlobalSearch(page, 'beach');
+
+    await expect(page).toHaveURL(new RegExp(String.raw`/albums/${album.id}\?q=beach`), { timeout: 10_000 });
+  });
+
+  // The reported bug: this one used to land on /photos and search the whole library.
+  test('searching from a space album stays on that space album instead of going to /photos', async ({
+    context,
+    page,
+  }) => {
+    await goto(context, page, `/spaces/${space.id}/albums/${spaceAlbum.id}`);
+
+    await submitGlobalSearch(page, 'beach');
+
+    await expect(page).toHaveURL(new RegExp(String.raw`/spaces/${space.id}/albums/${spaceAlbum.id}\?q=beach`), {
+      timeout: 10_000,
+    });
+  });
+
+  test('a query on an album replaces the browse timeline with the search surface', async ({ context, page }) => {
+    await goto(context, page, `/albums/${album.id}?q=mountain`);
+
+    await expectSearchSurfaceSettled(page);
+    await expect(page.locator('[data-testid="timeline"]')).not.toBeVisible();
+    await expect(page.getByTestId('search-chip')).toContainText('mountain');
+  });
+
+  test('a query on a space album replaces the browse timeline with the search surface', async ({ context, page }) => {
+    await goto(context, page, `/spaces/${space.id}/albums/${spaceAlbum.id}?q=mountain`);
+
+    await expectSearchSurfaceSettled(page);
+    await expect(page.getByTestId('search-chip')).toContainText('mountain');
+  });
+
+  test('clearing the search chip drops q= and restores the album timeline', async ({ context, page }) => {
+    await goto(context, page, `/albums/${album.id}?q=forest`);
+    await expectSearchSurfaceSettled(page);
+
+    // The header is absolutely positioned over the content area, so Playwright's auto-scroll lands
+    // the chip under it — dispatchEvent bypasses the intercept check. Same reason as photos-search.
+    await page.getByTestId('search-chip-close').dispatchEvent('click');
+
+    await expect(page).toHaveURL(new RegExp(String.raw`/albums/${album.id}(?!\?q=)`));
+    await expect(page.getByTestId('search-chip')).not.toBeVisible();
+  });
+
+  test('clearing the search chip on a space album drops q=', async ({ context, page }) => {
+    await goto(context, page, `/spaces/${space.id}/albums/${spaceAlbum.id}?q=forest`);
+    await expectSearchSurfaceSettled(page);
+
+    await page.getByTestId('search-chip-close').dispatchEvent('click');
+
+    await expect(page).toHaveURL(new RegExp(String.raw`/spaces/${space.id}/albums/${spaceAlbum.id}(?!\?q=)`));
+    await expect(page.getByTestId('search-chip')).not.toBeVisible();
+  });
+
+  // Regression guard for the crash class fixed alongside this feature: search mode unmounts
+  // <Timeline> and destroys its manager, and the page's Escape handler dereferenced it unguarded.
+  // On a directly-loaded ?q= URL the manager never existed, so Escape threw before doing anything.
+  test('Escape on a searched album clears the search rather than erroring', async ({ context, page }) => {
+    const pageErrors: Error[] = [];
+    page.on('pageerror', (error) => {
+      pageErrors.push(error);
+    });
+
+    await goto(context, page, `/albums/${album.id}?q=sunset`);
+    await expectSearchSurfaceSettled(page);
+
+    await page.keyboard.press('Escape');
+
+    await expect(page).toHaveURL(new RegExp(String.raw`/albums/${album.id}(?!\?q=)`), { timeout: 10_000 });
+    expect(pageErrors.map((error) => error.message)).toEqual([]);
+  });
+
+  // A query and a filter coexist on an album: the page hydrates BOTH from the URL and hands the
+  // filter to the search rather than to the (unmounted) browse timeline. Asserted by navigation
+  // rather than by clicking a control — which sections of the filter panel are expanded is
+  // persisted per user, so driving one would be brittle here. The click-through path is unit-tested
+  // on both pages.
+  test('hydrates a query and a filter together on an album', async ({ context, page }) => {
+    await goto(context, page, `/albums/${album.id}?q=sunset&rating=5`);
+
+    await expectSearchSurfaceSettled(page);
+    await expect(page.getByTestId('search-chip')).toContainText('sunset');
+    await expect(page.getByTestId('active-filters-bar')).toBeVisible();
+  });
+
+  test('an album search survives a reload as a shareable URL', async ({ context, page }) => {
+    await goto(context, page, `/albums/${album.id}?q=harbour`);
+    await expectSearchSurfaceSettled(page);
+
+    await page.reload();
+
+    await expectSearchSurfaceSettled(page);
+    await expect(page.getByTestId('search-chip')).toContainText('harbour');
+  });
+});

--- a/mobile/openapi/lib/model/smart_search_facets_dto.dart
+++ b/mobile/openapi/lib/model/smart_search_facets_dto.dart
@@ -13,6 +13,7 @@ part of openapi.api;
 class SmartSearchFacetsDto {
   /// Returns a new [SmartSearchFacetsDto] instance.
   SmartSearchFacetsDto({
+    this.albumIds = const Optional.present(const []),
     this.city = const Optional.absent(),
     this.country = const Optional.absent(),
     this.isFavorite = const Optional.absent(),
@@ -33,6 +34,9 @@ class SmartSearchFacetsDto {
     this.type = const Optional.absent(),
     this.withSharedSpaces = const Optional.absent(),
   });
+
+  /// Filter by album IDs
+  Optional<List<String>?> albumIds;
 
   /// Filter by city name
   Optional<String?> city;
@@ -161,6 +165,7 @@ class SmartSearchFacetsDto {
 
   @override
   bool operator ==(Object other) => identical(this, other) || other is SmartSearchFacetsDto &&
+    _deepEquality.equals(other.albumIds, albumIds) &&
     other.city == city &&
     other.country == country &&
     other.isFavorite == isFavorite &&
@@ -184,6 +189,7 @@ class SmartSearchFacetsDto {
   @override
   int get hashCode =>
     // ignore: unnecessary_parenthesis
+    (albumIds.hashCode) +
     (city == null ? 0 : city!.hashCode) +
     (country == null ? 0 : country!.hashCode) +
     (isFavorite == null ? 0 : isFavorite!.hashCode) +
@@ -205,10 +211,14 @@ class SmartSearchFacetsDto {
     (withSharedSpaces == null ? 0 : withSharedSpaces!.hashCode);
 
   @override
-  String toString() => 'SmartSearchFacetsDto[city=$city, country=$country, isFavorite=$isFavorite, isInAlbum=$isInAlbum, isNotInAlbum=$isNotInAlbum, language=$language, make=$make, model=$model, personIds=$personIds, query=$query, queryAssetId=$queryAssetId, rating=$rating, spaceId=$spaceId, spacePersonIds=$spacePersonIds, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, type=$type, withSharedSpaces=$withSharedSpaces]';
+  String toString() => 'SmartSearchFacetsDto[albumIds=$albumIds, city=$city, country=$country, isFavorite=$isFavorite, isInAlbum=$isInAlbum, isNotInAlbum=$isNotInAlbum, language=$language, make=$make, model=$model, personIds=$personIds, query=$query, queryAssetId=$queryAssetId, rating=$rating, spaceId=$spaceId, spacePersonIds=$spacePersonIds, tagIds=$tagIds, takenAfter=$takenAfter, takenBefore=$takenBefore, type=$type, withSharedSpaces=$withSharedSpaces]';
 
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
+    if (this.albumIds.isPresent) {
+      final value = this.albumIds.value;
+      json[r'albumIds'] = value;
+    }
     if (this.city.isPresent) {
       final value = this.city.value;
       json[r'city'] = value;
@@ -301,6 +311,9 @@ class SmartSearchFacetsDto {
       final json = value.cast<String, dynamic>();
 
       return SmartSearchFacetsDto(
+        albumIds: json.containsKey(r'albumIds') ? Optional.present(json[r'albumIds'] is Iterable
+            ? (json[r'albumIds'] as Iterable).cast<String>().toList(growable: false)
+            : const []) : const Optional.absent(),
         city: json.containsKey(r'city') ? Optional.present(mapValueOfType<String>(json, r'city')) : const Optional.absent(),
         country: json.containsKey(r'country') ? Optional.present(mapValueOfType<String>(json, r'country')) : const Optional.absent(),
         isFavorite: json.containsKey(r'isFavorite') ? Optional.present(mapValueOfType<bool>(json, r'isFavorite')) : const Optional.absent(),

--- a/open-api/immich-openapi-specs.json
+++ b/open-api/immich-openapi-specs.json
@@ -33842,6 +33842,15 @@
       },
       "SmartSearchFacetsDto": {
         "properties": {
+          "albumIds": {
+            "description": "Filter by album IDs",
+            "items": {
+              "format": "uuid",
+              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$",
+              "type": "string"
+            },
+            "type": "array"
+          },
           "city": {
             "description": "Filter by city name",
             "nullable": true,

--- a/packages/sdk/src/fetch-client.ts
+++ b/packages/sdk/src/fetch-client.ts
@@ -2337,6 +2337,8 @@ export type SmartSearchDto = {
     withSharedSpaces?: boolean;
 };
 export type SmartSearchFacetsDto = {
+    /** Filter by album IDs */
+    albumIds?: string[];
     /** Filter by city name */
     city?: string | null;
     /** Filter by country name */

--- a/server/src/dtos/search.dto.spec.ts
+++ b/server/src/dtos/search.dto.spec.ts
@@ -69,6 +69,23 @@ describe('search DTO albumless filters', () => {
     expect(result.data?.isInAlbum).toBe(true);
   });
 
+  // An album detail page runs a page-aware search scoped to its own album. Without albumIds on the
+  // facets schema the ZodValidationPipe strips it, and the facet counts / time buckets silently
+  // describe the whole library while the result grid shows one album.
+  it('should accept albumIds on smart search facet requests', () => {
+    const albumId = '00000000-0000-4000-8000-000000000009';
+    const result = SmartSearchFacetsDto.schema.safeParse({ query: 'beach', albumIds: [albumId] });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.albumIds).toEqual([albumId]);
+  });
+
+  it('should reject a non-uuid albumIds entry on smart search facet requests', () => {
+    const result = SmartSearchFacetsDto.schema.safeParse({ query: 'beach', albumIds: ['not-a-uuid'] });
+
+    expect(result.success).toBe(false);
+  });
+
   // ownerId is a narrowing contributor filter, distinct from the owner-scoping userIds resolved by
   // the service. Without a schema field for it, the ZodValidationPipe would silently strip ownerId
   // from incoming requests before the service ever sees it — the metadata-search DTO must declare it.

--- a/server/src/dtos/search.dto.ts
+++ b/server/src/dtos/search.dto.ts
@@ -129,6 +129,11 @@ const SmartSearchFacetsSchema = BaseSearchSchema.pick({
   personIds: true,
   tagIds: true,
   rating: true,
+  // An album detail page runs its page-aware search scoped to its own album, so the facets that
+  // drive that page's result count and time-bucket rail have to carry the same scope. Omitting it
+  // here does not merely lose a filter: zod strips the field, so the facets would silently describe
+  // the whole library beside a result grid showing one album.
+  albumIds: true,
   spaceId: true,
   spacePersonIds: true,
 })

--- a/server/src/repositories/search.repository.ts
+++ b/server/src/repositories/search.repository.ts
@@ -112,7 +112,18 @@ export interface SearchExifOptions {
 
 export interface SearchEmbeddingOptions {
   embedding: string;
-  userIds: string[];
+  /**
+   * Owner scoping. Optional — and left unset on purpose under an `albumIds` scope, where the
+   * caller's AlbumRead check is the access boundary and `albumSharedSpaceScope` re-gates the rows
+   * (the same shape `searchMetadata` has always used). Matches `SearchUserIdOptions.userIds`.
+   */
+  userIds?: string[];
+  /**
+   * The searching user. Deliberately SEPARATE from `userIds`, which is an owner-scoping predicate
+   * and is absent under an album scope: the facets' people list still has to resolve identity
+   * people for the viewer, so it needs the caller even when nothing is owner-scoped.
+   */
+  callerId?: string;
   maxDistance?: number;
 }
 
@@ -922,7 +933,13 @@ export class SearchRepository {
     }
 
     if (options.timelineSpaceIds?.length) {
-      return this.getFilteredIdentityPeople(filteredIds, options.userIds[0], options.timelineSpaceIds, trx);
+      // `callerId`, not `userIds[0]`: an album-scoped search has no owner scoping at all.
+      return this.getFilteredIdentityPeople(
+        filteredIds,
+        options.callerId ?? options.userIds?.[0] ?? '',
+        options.timelineSpaceIds,
+        trx,
+      );
     }
 
     const peopleRows = await trx

--- a/server/src/services/search.service.spec.ts
+++ b/server/src/services/search.service.spec.ts
@@ -851,6 +851,7 @@ describe(SearchService.name, () => {
           query: 'test',
           embedding: '[1, 2, 3]',
           userIds: [authStub.user1.user.id],
+          callerId: authStub.user1.user.id,
           maxDistance: 0,
           visibility: 'not-locked',
         },
@@ -960,6 +961,87 @@ describe(SearchService.name, () => {
       const result = await sut.searchSmart(authStub.user1, { query: 'test' });
 
       expect(result.assets.nextPage).toBeNull();
+    });
+
+    // An album detail page searches the album it is showing. Browse mode there scopes by album
+    // ACCESS (timeline.service resolves albumSpaceIds from plain membership) and shows every
+    // member's photos; query mode kept the owner-scoping `userIds`, so the same album searched
+    // returned only the caller's own assets beside a grid that had just shown everyone's.
+    // searchMetadata already resolves this the right way — access check instead of userIds, letting
+    // `albumSharedSpaceScope` re-gate — and searchSmart now matches it.
+    describe('album access (albumIds)', () => {
+      it('checks album read access when albumIds is provided', async () => {
+        const albumId = newUuid();
+        mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set());
+        mocks.access.album.checkSharedAlbumAccess.mockResolvedValue(new Set([albumId]));
+        mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([]);
+
+        await sut.searchSmart(authStub.user1, { query: 'test', albumIds: [albumId] });
+
+        expect(mocks.access.album.checkSharedAlbumAccess).toHaveBeenCalled();
+      });
+
+      it('throws when the caller cannot read the album', async () => {
+        const albumId = newUuid();
+        mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set());
+        mocks.access.album.checkSharedAlbumAccess.mockResolvedValue(new Set());
+        // Mocked so the ONLY thing that can reject here is the access check. Without it the call
+        // throws on an unstubbed repository method instead, and the assertion passes either way.
+        mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([]);
+
+        await expect(sut.searchSmart(authStub.user1, { query: 'test', albumIds: [albumId] })).rejects.toThrow(
+          BadRequestException,
+        );
+      });
+
+      it('drops the owner scope so a shared album returns every member’s matching photos', async () => {
+        const albumId = newUuid();
+        mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set());
+        mocks.access.album.checkSharedAlbumAccess.mockResolvedValue(new Set([albumId]));
+        mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([]);
+
+        await sut.searchSmart(authStub.user1, { query: 'test', albumIds: [albumId] });
+
+        const [, options] = mocks.search.searchSmart.mock.calls.at(-1)!;
+        expect(options.albumIds).toEqual([albumId]);
+        expect(options.userIds).toBeUndefined();
+      });
+
+      it('keeps the owner scope when no album scope is given', async () => {
+        await sut.searchSmart(authStub.user1, { query: 'test' });
+
+        const [, options] = mocks.search.searchSmart.mock.calls.at(-1)!;
+        expect(options.userIds).toEqual([authStub.user1.user.id]);
+      });
+
+      // The facets' people list resolves the VIEWER's identity people, and it used to read that
+      // viewer off `userIds[0]`. Under an album scope there is no `userIds`, so the caller has to
+      // be carried explicitly or the facets request dereferences undefined.
+      it('carries the caller id independently of the owner scope', async () => {
+        const albumId = newUuid();
+        mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set());
+        mocks.access.album.checkSharedAlbumAccess.mockResolvedValue(new Set([albumId]));
+        mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([]);
+
+        await sut.searchSmart(authStub.user1, { query: 'test', albumIds: [albumId] });
+
+        const [, options] = mocks.search.searchSmart.mock.calls.at(-1)!;
+        expect(options.callerId).toBe(authStub.user1.user.id);
+      });
+
+      it('applies the same album scope to the facets that annotate those results', async () => {
+        const albumId = newUuid();
+        mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set());
+        mocks.access.album.checkSharedAlbumAccess.mockResolvedValue(new Set([albumId]));
+        mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([]);
+        mocks.search.getSmartSearchFacets.mockResolvedValue({ total: 0, timeBuckets: [], people: [] } as never);
+
+        await sut.searchSmartFacets(authStub.user1, { query: 'test', albumIds: [albumId] });
+
+        const [options] = mocks.search.getSmartSearchFacets.mock.calls.at(-1)!;
+        expect(options.albumIds).toEqual([albumId]);
+        expect(options.userIds).toBeUndefined();
+      });
     });
 
     describe('shared space access (spaceId)', () => {
@@ -1159,6 +1241,8 @@ describe(SearchService.name, () => {
         const albumId = newUuid();
         const spaceId = newUuid();
         mocks.sharedSpace.getSpaceIdsForTimeline.mockResolvedValue([{ spaceId }]);
+        // An albumIds scope is now AlbumRead-checked before anything else runs.
+        mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set([albumId]));
 
         await sut.searchSmart(authStub.user1, { query: 'test', albumIds: [albumId] });
 

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -42,7 +42,10 @@ const unique = <T>(items: T[]) => [...new Set(items)];
 type ResolvedSmartSearch = {
   options: Omit<SmartSearchDto, 'page' | 'size' | 'order' | 'visibility'> & {
     embedding: string;
-    userIds: string[];
+    // Optional: an `albumIds` scope deliberately leaves this unset so the album access check is the
+    // boundary and `albumSharedSpaceScope` re-gates — see resolveSmartSearch.
+    userIds?: string[];
+    callerId?: string;
     timelineSpaceIds?: string[];
     maxDistance?: number;
     orderDirection?: SmartSearchDto['order'];
@@ -501,6 +504,23 @@ export class SearchService extends BaseService {
       throw new BadRequestException('spacePersonIds requires spaceId');
     }
 
+    /**
+     * An `albumIds` scope makes the ALBUM the access boundary, exactly as `searchMetadata` already
+     * treats it (see the matching branch there): check `AlbumRead` up front, then leave `userIds`
+     * unset so `albumSharedSpaceScope` re-gates the rows in the query builder.
+     *
+     * Keeping the owner-scoping `userIds` here instead was a filter-honesty bug. An album page
+     * BROWSES by album access — timeline.service resolves `albumSpaceIds` from plain membership —
+     * and shows every member's photos; searching that same album then returned only the caller's
+     * own, silently, beside a grid that had just shown everyone's. It also split query mode from
+     * browse mode for the same `?album=` filter everywhere else.
+     */
+    const albumIds = 'albumIds' in dto ? dto.albumIds : undefined;
+    const albumScoped = !!albumIds?.length;
+    if (albumScoped) {
+      await this.requireAccess({ auth, ids: albumIds!, permission: Permission.AlbumRead });
+    }
+
     // Cached read — the uncached path runs class-transformer + class-validator over
     // the full nested SystemConfigDto, which is ~1-3s per call on slower CPUs and
     // dominates smart-search latency. Cache invalidates on ConfigUpdate.
@@ -553,7 +573,12 @@ export class SearchService extends BaseService {
     const resolvedOptions = await this.resolveScopedPersonFilters(auth, {
       ...dto,
       timelineSpaceIds,
-      userIds: await this.getUserIdsToSearch(auth, visibility),
+      // Undefined under an album scope — the AlbumRead check above is the boundary there, and
+      // `albumSharedSpaceScope` in the query builder is what re-gates visibility and trash.
+      userIds: albumScoped ? undefined : await this.getUserIdsToSearch(auth, visibility),
+      // Always set, unlike userIds: the facets' people list needs the viewer even when nothing is
+      // owner-scoped. See SearchEmbeddingOptions.callerId.
+      callerId: auth.user.id,
       embedding,
       maxDistance: machineLearning.clip.maxDistance,
       visibility: resolvedVisibility,

--- a/web/src/lib/components/search/smart-search-results.spec.ts
+++ b/web/src/lib/components/search/smart-search-results.spec.ts
@@ -243,6 +243,21 @@ describe('SmartSearchResults', () => {
     );
   });
 
+  it('forwards the route album scope to buildSmartSearchParams', async () => {
+    render(SmartSearchResults, { props: { ...baseProps, albumIds: ['album-1'] } });
+    await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+    expect(searchSmartMock).toHaveBeenCalledWith(
+      expect.objectContaining({ smartSearchDto: expect.objectContaining({ albumIds: ['album-1'] }) }),
+    );
+  });
+
+  it('omits albumIds entirely when no album scope is given', async () => {
+    render(SmartSearchResults, { props: baseProps });
+    await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+    const dto = searchSmartMock.mock.calls[0][0].smartSearchDto as Record<string, unknown>;
+    expect(dto).not.toHaveProperty('albumIds');
+  });
+
   it('forwards route-provided exact total to the result grid', async () => {
     searchSmartMock.mockResolvedValueOnce({
       assets: {

--- a/web/src/lib/components/search/smart-search-results.spec.ts
+++ b/web/src/lib/components/search/smart-search-results.spec.ts
@@ -1,9 +1,10 @@
 import { AssetOrder } from '@immich/sdk';
-import { render } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getIntersectionObserverMock } from '$lib/__mocks__/intersection-observer.mock';
 import type { FilterState } from '$lib/components/filter-panel/filter-panel';
 import SmartSearchResults from '$lib/components/search/smart-search-results.svelte';
+import SmartSearchResultsHost from '$lib/components/search/smart-search-results.test-host.svelte';
 import { SEARCH_FILTER_DEBOUNCE_MS } from '$lib/utils/space-search';
 
 const searchSmartMock = vi.fn();
@@ -248,6 +249,36 @@ describe('SmartSearchResults', () => {
     await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
     expect(searchSmartMock).toHaveBeenCalledWith(
       expect.objectContaining({ smartSearchDto: expect.objectContaining({ albumIds: ['album-1'] }) }),
+    );
+  });
+
+  // Hosts pass `$derived([album.id])`, and Svelte's derived compares with `===`, so every unrelated
+  // `album` reassignment (a rename, the `refreshAlbum()` after a delete) mints a fresh array. Track
+  // that identity and each of those discards the loaded pages and re-runs the whole vector search.
+  //
+  // Driven through a HOST component, not `rerender`: rerender re-fires the mount effect even for
+  // literally identical props, so it cannot tell the bug from the harness.
+  it('does not re-search when the host re-derives the album scope without changing it', async () => {
+    render(SmartSearchResultsHost, { props: { album: { id: 'album-1', name: 'a' }, filters: baseFilters } });
+    await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+    expect(searchSmartMock).toHaveBeenCalledTimes(1);
+
+    await fireEvent.click(screen.getByTestId('host-rename-album'));
+    await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+
+    expect(searchSmartMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-searches when the album scope actually changes', async () => {
+    render(SmartSearchResultsHost, { props: { album: { id: 'album-1', name: 'a' }, filters: baseFilters } });
+    await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+
+    await fireEvent.click(screen.getByTestId('host-switch-album'));
+    await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+
+    expect(searchSmartMock).toHaveBeenCalledTimes(2);
+    expect(searchSmartMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ smartSearchDto: expect.objectContaining({ albumIds: ['album-2'] }) }),
     );
   });
 

--- a/web/src/lib/components/search/smart-search-results.svelte
+++ b/web/src/lib/components/search/smart-search-results.svelte
@@ -48,6 +48,17 @@
     reloadToken = 0,
   }: Props = $props();
 
+  /**
+   * Content key for the album scope. Hosts pass `$derived([album.id])`, and Svelte's derived
+   * compares with `===`, so every unrelated `album` reassignment — a rename, the `refreshAlbum()`
+   * that follows a delete — mints a fresh array. Tracking the ARRAY in the re-search effect below
+   * would discard every loaded page and re-run the whole vector search on each of those. Reading it
+   * through a `$derived` string collapses that to value equality: the effect only re-fires when the
+   * scope genuinely changes. (Calling `.join()` inside the effect would not help — reading the prop
+   * at all is what registers the dependency.)
+   */
+  const albumScopeKey = $derived(albumIds?.join(',') ?? '');
+
   let hasMoreResults = $state(false);
   let searchPage = $state(1);
   let searchAbortController: AbortController | undefined;
@@ -115,8 +126,9 @@
       searchQuery,
       reloadToken,
       // Navigating straight from one album to a sibling keeps this component mounted and only swaps
-      // the scope, so it has to re-search like any other narrowing change.
-      albumIds,
+      // the scope, so it has to re-search like any other narrowing change. Tracked by CONTENT via
+      // `albumScopeKey` — see its doc comment for why the array itself must not be read here.
+      albumScopeKey,
       filters.personIds,
       filters.city,
       filters.country,

--- a/web/src/lib/components/search/smart-search-results.svelte
+++ b/web/src/lib/components/search/smart-search-results.svelte
@@ -9,6 +9,11 @@
     searchQuery: string;
     filters: FilterState;
     spaceId?: string;
+    /**
+     * Album scope imposed by the host route — how an album detail page narrows a page-aware search
+     * to the album it is showing. Unioned with any `filters.albumId`; see `buildSmartSearchParams`.
+     */
+    albumIds?: string[];
     /** Shared-space surface + the caller's write capability on it — see `Timeline` (#889). */
     space?: { id: string; canWrite: boolean };
     withSharedSpaces?: boolean;
@@ -32,6 +37,7 @@
     searchQuery,
     filters,
     spaceId,
+    albumIds,
     space,
     withSharedSpaces,
     language,
@@ -60,7 +66,7 @@
     try {
       const { assets } = await searchSmart({
         smartSearchDto: {
-          ...buildSmartSearchParams({ query, filters, spaceId, withSharedSpaces, language }),
+          ...buildSmartSearchParams({ query, filters, spaceId, albumIds, withSharedSpaces, language }),
           page,
           size: 100,
         },
@@ -108,6 +114,9 @@
     const _ = [
       searchQuery,
       reloadToken,
+      // Navigating straight from one album to a sibling keeps this component mounted and only swaps
+      // the scope, so it has to re-search like any other narrowing change.
+      albumIds,
       filters.personIds,
       filters.city,
       filters.country,

--- a/web/src/lib/components/search/smart-search-results.test-host.svelte
+++ b/web/src/lib/components/search/smart-search-results.test-host.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import type { FilterState } from '$lib/components/filter-panel/filter-panel';
+  import SmartSearchResults from '$lib/components/search/smart-search-results.svelte';
+
+  /**
+   * Test host that reproduces how the album pages drive `SmartSearchResults`: `album` is `$state`
+   * and the scope is `$derived([album.id])`.
+   *
+   * This exists because `rerender` from @testing-library/svelte re-fires the component's mount
+   * effect even for literally identical props, so it cannot distinguish "the host re-derived the
+   * scope" from "the scope changed". Driving a real host is the only way to observe that
+   * difference.
+   */
+  interface Props {
+    album: { id: string; name: string };
+    filters: FilterState;
+  }
+
+  let { album = $bindable(), filters }: Props = $props();
+
+  const searchAlbumIds = $derived([album.id]);
+</script>
+
+<button type="button" data-testid="host-rename-album" onclick={() => (album = { ...album, name: `${album.name}!` })}>
+  rename
+</button>
+<button type="button" data-testid="host-switch-album" onclick={() => (album = { id: 'album-2', name: 'other' })}
+  >switch</button
+>
+<SmartSearchResults searchQuery="beach" {filters} albumIds={searchAlbumIds} isShared={false} language="en" />

--- a/web/src/lib/managers/global-search-manager.svelte.spec.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.spec.ts
@@ -1514,6 +1514,55 @@ describe('activate("command")', () => {
     expect(goto).toHaveBeenCalledWith('/photos?q=beach');
   });
 
+  it('activateSearch stays on a space album instead of bouncing to /photos', async () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/albums/album-1');
+    mockResolvedTypedSearch('beach');
+
+    await m.activateSearch('beach');
+
+    expect(goto).toHaveBeenCalledWith('/spaces/space-1/albums/album-1?q=beach');
+  });
+
+  it('activateSearch stays on an album detail page and drops a stale asset id', async () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/albums/album-1/photos/asset-123?view=grid');
+    mockResolvedTypedSearch('beach');
+
+    await m.activateSearch('beach');
+
+    expect(goto).toHaveBeenCalledWith('/albums/album-1/photos?view=grid&q=beach');
+  });
+
+  // The typed-search resolver emits a BARE space profile id under a space scope and a prefixed
+  // `space-person:` token otherwise. An album detail page — space album included — filters with the
+  // prefixed form, so resolving it space-scoped there yields ids that match nothing.
+  it('resolves typed search globally on a space album, not against the space', async () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/albums/album-1');
+    mockResolvedTypedSearch('beach');
+
+    await m.activateSearch('person:Alice beach');
+
+    expect(typedSearchMock.resolveTypedSearchFilters).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ spaceId: undefined }),
+    );
+  });
+
+  it('still resolves typed search against the space on a space timeline', async () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos');
+    mockResolvedTypedSearch('beach');
+
+    await m.activateSearch('person:Alice beach');
+
+    expect(typedSearchMock.resolveTypedSearchFilters).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ spaceId: 'space-1' }),
+    );
+  });
+
   describe('GlobalSearchManager typed search commit', () => {
     beforeEach(() => {
       typedSearchMock.resolveTypedSearchFilters.mockReset();
@@ -6935,18 +6984,32 @@ describe('person activation navigation', () => {
     expect(lastGoto()).toBe('/photos?people=space-person%3Aprofile-1');
   });
 
-  it('targets /photos from a space page that is not a timeline', () => {
+  // A space ALBUM is album-scoped, not space-scoped: its filter panel speaks the same prefixed
+  // person tokens /photos does, never the bare space profile id the space timeline uses. So the
+  // page-aware filter stays put but carries the PREFIXED token. Handing it the bare profile id
+  // (which is what a naive `pathname.startsWith('/spaces/')` test yields) would silently return an
+  // empty timeline — the server reads a bare id as a legacy person id the viewer does not own.
+  it('stays on a space album and uses the prefixed id for that space person', () => {
     const m = new GlobalSearchManager();
     mockPage.url = new URL('https://gallery.test/spaces/space-1/albums/album-1');
 
     m.activate('person', spacePerson('space-1'));
 
-    expect(lastGoto()).toBe('/photos?people=space-person%3Aprofile-1');
+    expect(lastGoto()).toBe('/spaces/space-1/albums/album-1?people=space-person%3Aprofile-1');
+  });
+
+  it('stays on an album detail page', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/albums/album-1');
+
+    m.activate('person', userPerson());
+
+    expect(lastGoto()).toBe('/albums/album-1?people=person%3Ap1');
   });
 
   it('targets /photos from a non-searchable page', () => {
     const m = new GlobalSearchManager();
-    mockPage.url = new URL('https://gallery.test/albums/album-1');
+    mockPage.url = new URL('https://gallery.test/albums');
 
     m.activate('person', userPerson());
 
@@ -7117,9 +7180,18 @@ describe('place activation navigation', () => {
     expect(lastGoto()).toBe('/spaces/space-1?city=Paris');
   });
 
-  it('targets /photos from a non-searchable page', () => {
+  it('stays on an album detail page', () => {
     const m = new GlobalSearchManager();
     mockPage.url = new URL('https://gallery.test/albums/album-1');
+
+    m.activate('place', paris);
+
+    expect(lastGoto()).toBe('/albums/album-1?city=Paris');
+  });
+
+  it('targets /photos from a non-searchable page', () => {
+    const m = new GlobalSearchManager();
+    mockPage.url = new URL('https://gallery.test/albums');
 
     m.activate('place', paris);
 

--- a/web/src/lib/managers/global-search-manager.svelte.ts
+++ b/web/src/lib/managers/global-search-manager.svelte.ts
@@ -167,16 +167,28 @@ function withoutEmptyLabels(names?: Map<string, string>): Map<string, string> {
 
 /**
  * The space id of the current page when that page is a space *timeline* (`/spaces/<id>` or
- * `/spaces/<id>/photos`). Deliberately not a `pathname.startsWith('/spaces/')` test:
- * `/spaces/<id>/albums/<albumId>` is a space page but not a searchable one, so no filter can be
- * applied in place there.
+ * `/spaces/<id>/photos`), and only then.
+ *
+ * Deliberately not a `pathname.startsWith('/spaces/')` test, and not a bare
+ * `getSearchablePageBasePath(...).startsWith('/spaces/')` one either: `/spaces/<id>/albums/<aid>`
+ * IS a searchable page under `/spaces/`, but it is album-scoped, not space-scoped. Its filter panel
+ * speaks the same prefixed person tokens `/photos` does (`person:` / `space-person:`), never the
+ * bare space profile id a space timeline forwards as `spacePersonIds`. Handing it a bare id yields
+ * a silently empty timeline — the server reads it as a legacy person id the viewer does not own.
+ *
+ * Hence the segment count: a space timeline base path is `/spaces/<id>` (2) or
+ * `/spaces/<id>/photos` (3); anything deeper is a sub-surface with its own scope.
  */
 function getCurrentSpaceTimelineId(pathname: string): string | undefined {
   const base = getSearchablePageBasePath(pathname);
   if (!base?.startsWith('/spaces/')) {
     return undefined;
   }
-  return base.split('/').filter(Boolean)[1];
+  const parts = base.split('/').filter(Boolean);
+  if (parts.length > 3) {
+    return undefined;
+  }
+  return parts[1];
 }
 
 // Entity-section keys dispatched by runBatch per scope. Navigation is intentionally
@@ -1856,9 +1868,10 @@ export class GlobalSearchManager {
       return;
     }
 
-    const spaceId = page.url.pathname.startsWith('/spaces/')
-      ? page.url.pathname.split('/').filter(Boolean)[1]
-      : undefined;
+    // Space-scoped resolution emits BARE space profile ids; every other surface needs the prefixed
+    // `space-person:` token. Only the space timeline forwards the bare form, so the scope has to be
+    // the timeline test, not a `/spaces/` prefix — see getCurrentSpaceTimelineId.
+    const spaceId = getCurrentSpaceTimelineId(page.url.pathname);
     const resolved = await resolveTypedSearchFilters(parsed, {
       spaceId,
       signal: this.closeSignal,

--- a/web/src/lib/utils/__tests__/searchable-page-search.spec.ts
+++ b/web/src/lib/utils/__tests__/searchable-page-search.spec.ts
@@ -286,3 +286,46 @@ describe('recently added page', () => {
     expect(buildSearchablePageUrl(new URL('https://gallery.test/photos'), 'beach')).toContain('q=beach');
   });
 });
+
+describe('album detail pages', () => {
+  it('resolves the base path for an album, its photos route and an open asset', () => {
+    expect(getSearchablePageBasePath('/albums/album-1')).toBe('/albums/album-1');
+    expect(getSearchablePageBasePath('/albums/album-1/photos')).toBe('/albums/album-1/photos');
+    expect(getSearchablePageBasePath('/albums/album-1/photos/asset-9')).toBe('/albums/album-1/photos');
+  });
+
+  it('resolves the base path for a space album, its photos route and an open asset', () => {
+    expect(getSearchablePageBasePath('/spaces/space-1/albums/album-1')).toBe('/spaces/space-1/albums/album-1');
+    expect(getSearchablePageBasePath('/spaces/space-1/albums/album-1/photos')).toBe(
+      '/spaces/space-1/albums/album-1/photos',
+    );
+    expect(getSearchablePageBasePath('/spaces/space-1/albums/album-1/photos/asset-9')).toBe(
+      '/spaces/space-1/albums/album-1/photos',
+    );
+  });
+
+  it('leaves the album list pages non-searchable', () => {
+    expect(getSearchablePageBasePath('/albums')).toBeNull();
+    expect(getSearchablePageBasePath('/spaces/space-1/albums')).toBeNull();
+  });
+
+  it('leaves the other space sub-pages non-searchable', () => {
+    expect(getSearchablePageBasePath('/spaces/space-1/members')).toBeNull();
+    expect(getSearchablePageBasePath('/spaces/space-1/people')).toBeNull();
+  });
+
+  it('builds a query URL that stays on the space album', () => {
+    expect(buildSearchablePageUrl(new URL('https://gallery.test/spaces/space-1/albums/album-1'), 'beach')).toBe(
+      '/spaces/space-1/albums/album-1?q=beach',
+    );
+  });
+
+  it('builds a filter URL for an album', () => {
+    const url = buildSearchablePageUrl(new URL('https://gallery.test/albums/album-1'), '', 'desc', {
+      ...createFilterState(),
+      rating: 5,
+    });
+
+    expect(url).toContain('rating=5');
+  });
+});

--- a/web/src/lib/utils/__tests__/space-search.spec.ts
+++ b/web/src/lib/utils/__tests__/space-search.spec.ts
@@ -323,6 +323,45 @@ describe('buildSmartSearchParams', () => {
       expect(result.albumIds).toBeUndefined();
     });
 
+    it('scopes the search to the album route it was called from', () => {
+      const result = buildSmartSearchParams({
+        query: 'beach',
+        filters: baseFilters,
+        albumIds: ['cccccccc-cccc-4ccc-cccc-cccccccccccc'],
+      });
+
+      expect(result.albumIds).toEqual(['cccccccc-cccc-4ccc-cccc-cccccccccccc']);
+    });
+
+    // An album detail page is scoped by its ROUTE, and its filter panel never offers an album
+    // control, so the two can only ever coincide via a hand-edited URL. Union rather than
+    // overwrite: the route scope must survive whatever the URL carries.
+    it('unions the route album scope with an albumId filter', () => {
+      const result = buildSmartSearchParams({
+        query: 'beach',
+        filters: { ...baseFilters, albumId: 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb' },
+        albumIds: ['cccccccc-cccc-4ccc-cccc-cccccccccccc'],
+      });
+
+      expect(result.albumIds).toEqual(['cccccccc-cccc-4ccc-cccc-cccccccccccc', 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb']);
+    });
+
+    it('does not duplicate an album that is both the route scope and the filter', () => {
+      const result = buildSmartSearchParams({
+        query: 'beach',
+        filters: { ...baseFilters, albumId: 'cccccccc-cccc-4ccc-cccc-cccccccccccc' },
+        albumIds: ['cccccccc-cccc-4ccc-cccc-cccccccccccc'],
+      });
+
+      expect(result.albumIds).toEqual(['cccccccc-cccc-4ccc-cccc-cccccccccccc']);
+    });
+
+    it('omits albumIds for an empty route scope', () => {
+      const result = buildSmartSearchParams({ query: 'beach', filters: baseFilters, albumIds: [] });
+
+      expect(result.albumIds).toBeUndefined();
+    });
+
     it('does not send description or originalFileName, which SmartSearchDto cannot express', () => {
       const result = buildSmartSearchParams({
         query: 'beach',
@@ -392,6 +431,33 @@ describe('buildSmartSearchFacetsParams', () => {
     expect(result).toMatchObject({ spaceId: 'space-1', spacePersonIds: ['space-person-1'] });
     expect(result.personIds).toBeUndefined();
     expect(result.withSharedSpaces).toBeUndefined();
+  });
+
+  // The facet counts and the time-bucket rail sit beside a result grid that IS album-scoped. If the
+  // scope did not reach the facets request they would describe the whole library instead.
+  it('carries the route album scope so the facets match the results they annotate', () => {
+    const result = buildSmartSearchFacetsParams({
+      query: 'beach',
+      filters: baseFilters,
+      albumIds: ['cccccccc-cccc-4ccc-cccc-cccccccccccc'],
+    });
+
+    expect(result.albumIds).toEqual(['cccccccc-cccc-4ccc-cccc-cccccccccccc']);
+  });
+
+  it('uses a different facet key per album scope', () => {
+    const albumOne = buildSmartSearchFacetKey({
+      query: 'beach',
+      filters: baseFilters,
+      albumIds: ['cccccccc-cccc-4ccc-cccc-cccccccccccc'],
+    });
+    const albumTwo = buildSmartSearchFacetKey({
+      query: 'beach',
+      filters: baseFilters,
+      albumIds: ['dddddddd-dddd-4ddd-dddd-dddddddddddd'],
+    });
+
+    expect(albumOne).not.toBe(albumTwo);
   });
 
   it('uses the same key for sort-only changes', () => {

--- a/web/src/lib/utils/filter-target.ts
+++ b/web/src/lib/utils/filter-target.ts
@@ -15,7 +15,9 @@ export type FilterTarget =
  * Which timeline surface is this URL on, for the purpose of contextual filtering?
  *
  * Deliberately SEPARATE from `getSearchablePageBasePath` in searchable-page-search.ts, which
- * answers a different question ("can ⌘K run a text query here?") and must not change.
+ * answers a different question ("can ⌘K run a text query here?"). The two overlap but do not
+ * coincide: a space ALBUM is a searchable page yet has no FilterTarget of its own, and /map is a
+ * FilterTarget that is not searchable. Keep them independent.
  */
 export function resolveFilterTarget(url: URL): FilterTarget | null {
   const parts = url.pathname.split('/').filter(Boolean);
@@ -220,10 +222,12 @@ export function buildContextualMapUrl(url: URL, point?: { lat: number; lng: numb
 /**
  * Write a COMPLETE FilterState into the current URL and return the URL to navigate to.
  *
- * This is the WRITE half of the hydrate → write → react loop on the surfaces that are not
- * "searchable pages" — /albums/{id} and /map. `getSearchablePageBasePath` returns null for both
- * (searchable-page-search.ts:37-56), so `buildSearchablePageUrl` returns null there and cannot be
- * reused.
+ * This is the WRITE half of the hydrate → write → react loop on /map (where
+ * `getSearchablePageBasePath` returns null, so `buildSearchablePageUrl` cannot be reused at all)
+ * and on the two album detail routes. Those two ARE searchable pages now, but they still write
+ * through here rather than through `buildSearchablePageUrl`, for the pathname reason below: their
+ * filter panel can be used with the asset viewer open, and targeting the base path would close it
+ * on every filter tweak. `q` and `sort` ride along untouched as ordinary non-filter params.
  *
  * Semantics, and how they differ from buildContextualFilterUrl:
  * - It REPLACES rather than merges. Every filter param is deleted, then re-emitted from `filters`

--- a/web/src/lib/utils/searchable-page-search.ts
+++ b/web/src/lib/utils/searchable-page-search.ts
@@ -40,8 +40,17 @@ export function getSearchablePageBasePath(pathname: string): string | null {
   }
 
   const parts = pathname.split('/').filter(Boolean);
+
+  if (parts[0] === 'albums') {
+    return albumBasePath(parts, '/albums', 1);
+  }
+
   if (parts[0] !== 'spaces' || parts[1] === undefined) {
     return null;
+  }
+
+  if (parts[2] === 'albums') {
+    return albumBasePath(parts, `/spaces/${parts[1]}/albums`, 3);
   }
 
   if (parts.length === 2) {
@@ -50,6 +59,32 @@ export function getSearchablePageBasePath(pathname: string): string | null {
 
   if (parts[2] === 'photos') {
     return `/spaces/${parts[1]}/photos`;
+  }
+
+  return null;
+}
+
+/**
+ * Shared tail of the two album detail routes — `/albums/<id>` and `/spaces/<sid>/albums/<id>` —
+ * which differ only in their prefix. `idIndex` is where the album id sits in `parts`.
+ *
+ * Mirrors the space timeline's shape above: the bare route and its `/photos` variant both resolve,
+ * and an open asset (`…/photos/<assetId>`) resolves to the `/photos` base so a search or filter
+ * change closes the viewer rather than trying to keep a now-filtered-out asset open. The album
+ * LIST pages (`/albums`, `/spaces/<sid>/albums`) have no album id and stay non-searchable.
+ */
+function albumBasePath(parts: string[], prefix: string, idIndex: number): string | null {
+  const albumId = parts[idIndex];
+  if (albumId === undefined) {
+    return null;
+  }
+
+  if (parts.length === idIndex + 1) {
+    return `${prefix}/${albumId}`;
+  }
+
+  if (parts[idIndex + 1] === 'photos') {
+    return `${prefix}/${albumId}/photos`;
   }
 
   return null;

--- a/web/src/lib/utils/space-search.ts
+++ b/web/src/lib/utils/space-search.ts
@@ -17,6 +17,13 @@ type SmartSearchParamsArgs = {
   spaceId?: string;
   withSharedSpaces?: boolean;
   language?: string;
+  /**
+   * Album scope imposed by the ROUTE, not by the filter panel — how an album detail page
+   * (`/albums/<id>` and `/spaces/<sid>/albums/<id>`) narrows a page-aware search to what it is
+   * showing. Unioned with `filters.albumId` rather than replacing it, so the route scope cannot be
+   * dropped by a hand-edited `?album=` in the URL.
+   */
+  albumIds?: string[];
 };
 
 /**
@@ -64,7 +71,7 @@ export const QUERY_MODE_FILTER_HANDLING = {
 } satisfies Record<keyof FilterState, 'sent' | 'derived' | 'unsupported'>;
 
 export function buildSmartSearchParams(args: SmartSearchParamsArgs): SmartSearchDto {
-  const { query, filters, spaceId, withSharedSpaces, language } = args;
+  const { query, filters, spaceId, withSharedSpaces, language, albumIds: scopeAlbumIds } = args;
   const params: SmartSearchDto = { query };
   if (language) {
     params.language = language;
@@ -108,12 +115,14 @@ export function buildSmartSearchParams(args: SmartSearchParamsArgs): SmartSearch
   if (filters.ocr?.trim()) {
     params.ocr = filters.ocr.trim();
   }
-  if (filters.albumId) {
-    // SmartSearchDto's albumIds is plural; wrap the single contextual filter value, matching
-    // filterStateToSearchTerms. Unlike the suggestion endpoints — where albumId is a *scope* and
-    // carries IsNotSiblingOf guards against spaceId / withSharedSpaces — here albumIds is a plain
-    // filter with no sibling guard, so it composes safely with either scope.
-    params.albumIds = [filters.albumId];
+  // SmartSearchDto's albumIds is plural; wrap the single contextual filter value, matching
+  // filterStateToSearchTerms, and union it with any route-imposed scope. Unlike the suggestion
+  // endpoints — where albumId is a *scope* and carries IsNotSiblingOf guards against spaceId /
+  // withSharedSpaces — here albumIds is a plain filter with no sibling guard, so it composes safely
+  // with either scope.
+  const albumIds = [...new Set([...(scopeAlbumIds ?? []), ...(filters.albumId ? [filters.albumId] : [])])];
+  if (albumIds.length > 0) {
+    params.albumIds = albumIds;
   }
   if (filters.tagIds.length > 0) {
     params.tagIds = filters.tagIds;

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -79,7 +79,25 @@
     getTimelineManagerTimeBuckets,
   } from '$lib/utils/timeline-zoom-navigation';
   import { getTimelineTopVisibleAnchor } from '$lib/managers/timeline-manager/timeline-anchor';
-  import { AlbumUserRole, getAlbumInfo, updateAlbumInfo, type AlbumResponseDto } from '@immich/sdk';
+  import SmartSearchResults from '$lib/components/search/smart-search-results.svelte';
+  import { globalSearchManager } from '$lib/managers/global-search-manager.svelte';
+  import { buildSearchablePageUrl, getSearchablePageState } from '$lib/utils/searchable-page-search';
+  import {
+    buildSmartSearchFacetKey,
+    buildSmartSearchFacetsParams,
+    mapSmartSearchFacetsToFilterSuggestions,
+  } from '$lib/utils/space-search';
+  import { consumeTypedSearchNamesInto } from '$lib/utils/typed-search/typed-search-name-cache';
+  import {
+    AlbumUserRole,
+    AssetOrder,
+    getAlbumInfo,
+    searchSmartFacets,
+    updateAlbumInfo,
+    type AlbumResponseDto,
+    type AssetResponseDto,
+    type SmartSearchFacetsResponseDto,
+  } from '@immich/sdk';
   import {
     ActionButton,
     CommandPaletteDefaultProvider,
@@ -130,9 +148,16 @@
     ...createFilterState(),
     ...decodeFilterParams(url),
     albumId: undefined,
+    sortOrder: getSearchablePageState(url).sortOrder,
   });
 
   let albumFilters = $state<FilterState>(hydrateAlbumFilters(page.url));
+  let committedSearchQuery = $state(getSearchablePageState(page.url).query);
+  const showSearchResults = $derived(committedSearchQuery.trim().length > 0);
+  // Loaded smart-search results. The browse Timeline (and its TimelineManager) is unmounted while
+  // these show, so the selection toolbar acts on this array instead — mirrors the space timeline.
+  let searchResults = $state<AssetResponseDto[]>([]);
+  let searchIsLoading = $state(false);
   // Token guard for the URL $effect below. Copied in spirit from photos/…/+page.svelte: without it,
   // our own goto() re-runs the effect, which re-runs goto(), forever. It is at-stripped because
   // closing the asset viewer writes `?at=<assetId>` (replaceScrollTarget), which is not a filter
@@ -307,6 +332,12 @@
 
     album = data.album;
     albumFilters = hydrateAlbumFilters(page.url);
+    committedSearchQuery = getSearchablePageState(page.url).query;
+    searchIsLoading = false;
+    smartFacetInFlight?.controller.abort();
+    smartFacets = undefined;
+    smartFacetKey = '';
+    smartFacetInFlight = undefined;
     lastHandledFilterSearch = withoutAtParam(page.url.search);
     pickerFilters = createFilterState();
     albumPersonNames.clear();
@@ -334,7 +365,10 @@
         ...createFilterState(),
         ...hydrateAlbumFilters(page.url),
       };
+      committedSearchQuery = getSearchablePageState(page.url).query;
+      searchIsLoading = false;
       lastHandledFilterSearch = nextFilterSearch;
+      consumeTypedSearchNamesInto(page.url.pathname + page.url.search, albumPersonNames, albumTagNames);
     });
   });
 
@@ -347,12 +381,88 @@
     }
   });
 
+  let smartFacets = $state<SmartSearchFacetsResponseDto>();
+  let smartFacetKey = $state('');
+  let smartFacetInFlight:
+    | { key: string; controller: AbortController; promise: Promise<SmartSearchFacetsResponseDto | undefined> }
+    | undefined;
+
+  const emptyFilterSuggestions = () => ({
+    countries: [],
+    cities: [],
+    cameraMakes: [],
+    cameraModels: [],
+    tags: [],
+    people: [],
+    ratings: [],
+    mediaTypes: [],
+    hasUnnamedPeople: false,
+  });
+
+  /**
+   * Facets for the ACTIVE search, scoped to this album — the source of the result count and of the
+   * temporal picker's buckets while a query is running. Memoised on the request shape so a filter
+   * change that cannot alter the facets (sortOrder) does not refetch.
+   */
+  async function loadAlbumSmartFacets(nextFilters: FilterState): Promise<SmartSearchFacetsResponseDto | undefined> {
+    const query = committedSearchQuery.trim();
+    if (!query) {
+      return undefined;
+    }
+
+    const args = { query, filters: nextFilters, albumIds: searchAlbumIds, language: $lang };
+    const key = buildSmartSearchFacetKey(args);
+    if (smartFacets && smartFacetKey === key) {
+      return smartFacets;
+    }
+    if (smartFacetInFlight?.key === key) {
+      return smartFacetInFlight.promise;
+    }
+
+    smartFacetInFlight?.controller.abort();
+    const controller = new AbortController();
+
+    const promise = searchSmartFacets(
+      { smartSearchFacetsDto: buildSmartSearchFacetsParams(args) },
+      { signal: controller.signal },
+    )
+      .then((result) => {
+        if (smartFacetInFlight?.key === key && !controller.signal.aborted) {
+          smartFacets = result;
+          smartFacetKey = key;
+        }
+        return result;
+      })
+      .catch((error: unknown) => {
+        if (!controller.signal.aborted) {
+          console.error('Failed to fetch smart search facets:', error);
+        }
+        return smartFacets;
+      })
+      .finally(() => {
+        if (smartFacetInFlight?.key === key) {
+          smartFacetInFlight = undefined;
+        }
+      });
+
+    smartFacetInFlight = { key, controller, promise };
+    return promise;
+  }
+
+  const searchTotal = $derived(showSearchResults ? smartFacets?.total : undefined);
+
   const albumFilterConfig = $derived.by(() => {
     const base = buildAlbumDetailFilterConfig(album.id);
     const provider = base.suggestionsProvider!;
     return {
       ...base,
+      // Browse mode asks the album's own suggestion endpoint; query mode has to ask the SEARCH, or
+      // the panel would offer facets the visible results do not contain.
       suggestionsProvider: async (filters: FilterState) => {
+        if (showSearchResults) {
+          const facets = await loadAlbumSmartFacets(filters);
+          return facets ? mapSmartSearchFacetsToFilterSuggestions(facets) : emptyFilterSuggestions();
+        }
         const result = await provider(filters);
         for (const person of result.people) {
           albumPersonNames.set(person.id, person.name);
@@ -407,17 +517,33 @@
     timelineManager?.isInitialized && !hasTimelineMonths && totalAssetCount === 0 && activeFilterCount > 0,
   );
   const timeBuckets = $derived(getTimelineManagerTimeBuckets(timelineManager));
+  // While a query is running the panel's temporal picker must bucket the MATCHES, not the album.
+  const filterTimeBuckets = $derived(showSearchResults ? (smartFacets?.timeBuckets ?? []) : timeBuckets);
   const isBrowseTimeline = $derived(viewMode === AlbumPageViewMode.VIEW);
+
+  /**
+   * The album scope handed to smart search — this album alone, matching the browse timeline's own
+   * `albumId` scope and the personal person tokens its filter panel speaks.
+   */
+  const searchAlbumIds = $derived([album.id]);
+
+  /**
+   * Browse order. An album carries its own `order`, but the navbar sort dropdown renders on every
+   * searchable page — browse mode included — so an EXPLICIT `?sort=` has to win, or the control
+   * would visibly do nothing here. Absent that param the album's own order stands.
+   */
+  const browseOrder = $derived.by(() => {
+    if (!getSearchablePageState(page.url).hasExplicitSort) {
+      return album.order ?? authManager.preferences.albums.defaultAssetOrder;
+    }
+    return albumFilters.sortOrder === 'asc' ? AssetOrder.Asc : AssetOrder.Desc;
+  });
 
   const options = $derived.by(() => {
     if (viewMode === AlbumPageViewMode.SELECT_ASSETS) {
       return buildAlbumAssetPickerOptions(album.id, pickerFilters);
     }
-    const albumOptions = buildAlbumTimelineOptions(
-      album.id,
-      album.order ?? authManager.preferences.albums.defaultAssetOrder,
-      albumFilters,
-    );
+    const albumOptions = buildAlbumTimelineOptions(album.id, browseOrder, albumFilters);
     return isBrowseTimeline ? { ...albumOptions, grouping: timelineGrouping } : albumOptions;
   });
 
@@ -490,6 +616,17 @@
     }
     void goto(nextUrl, { replaceState: true, keepFocus: true, noScroll: true });
   }
+
+  $effect(() => globalSearchManager.registerSearchablePageFilters(() => albumFilters));
+
+  const clearAlbumSearch = () => {
+    searchIsLoading = false;
+    const nextUrl = buildSearchablePageUrl(page.url, '', albumFilters.sortOrder, albumFilters);
+    if (!nextUrl) {
+      return;
+    }
+    void goto(nextUrl, { replaceState: true, keepFocus: true, noScroll: true });
+  };
 
   function clearAlbumTemporalFilter() {
     albumFilters = clearTimelineTemporalFilter(albumFilters);
@@ -591,15 +728,17 @@
                 />
               {/key}
             {:else}
-              {#key `album-${album.id}`}
+              <!-- Keyed on the search too: switching between browse and query mode swaps the whole
+                   suggestions provider, so the panel has to re-run it rather than keep browse facets. -->
+              {#key `album-${album.id}:${showSearchResults ? `search-${committedSearchQuery.trim()}:${$lang}` : 'browse'}`}
                 <FilterPanel
                   config={albumFilterConfig}
                   bind:filters={albumFilters}
                   bind:collapsed={filterCollapsed}
                   externalToggle
-                  {timeBuckets}
+                  timeBuckets={filterTimeBuckets}
                   storageKey="gallery-filter-visible-sections-album-detail"
-                  hidden={isTimelineEmpty}
+                  hidden={isTimelineEmpty && !showSearchResults}
                   onFiltersChange={syncAlbumFilterUrl}
                 />
               {/key}
@@ -626,7 +765,7 @@
               <ActiveFiltersBar
                 embedded
                 filters={albumFilters}
-                resultCount={totalAssetCount}
+                resultCount={showSearchResults ? searchTotal : totalAssetCount}
                 personNames={albumPersonNames}
                 tagNames={albumTagNames}
                 ownerNames={albumOwnerNames}
@@ -643,6 +782,8 @@
                   temporalAnchor = undefined;
                   syncAlbumFilterUrl(albumFilters);
                 }}
+                searchQuery={committedSearchQuery}
+                onClearSearch={clearAlbumSearch}
                 onAddAllToCollection={handleAddAllToCollection}
               />
             {/snippet}
@@ -650,19 +791,30 @@
               class="mb-2"
               grouping={timelineGrouping}
               onGroupingChange={handleTimelineGroupingChange}
-              showGrouping={isBrowseTimeline && !assetMultiSelectManager.selectionActive}
-              showFilters={getActiveFilterCount(albumFilters) > 0}
+              showGrouping={isBrowseTimeline && !showSearchResults && !assetMultiSelectManager.selectionActive}
+              showFilters={getActiveFilterCount(albumFilters) > 0 || showSearchResults}
               filters={albumFiltersBar}
               showFilterButton={filterCollapsed &&
                 isBrowseTimeline &&
                 !assetMultiSelectManager.selectionActive &&
-                !isTimelineEmpty}
+                (!isTimelineEmpty || showSearchResults)}
               filterActive={getActiveFilterCount(albumFilters) > 0}
               onExpandFilters={() => (filterCollapsed = false)}
             />
           {/if}
 
-          {#if showFilteredEmptyState}
+          {#if showSearchResults && viewMode !== AlbumPageViewMode.SELECT_ASSETS}
+            <SmartSearchResults
+              searchQuery={committedSearchQuery}
+              bind:isLoading={searchIsLoading}
+              bind:results={searchResults}
+              filters={albumFilters}
+              albumIds={searchAlbumIds}
+              language={$lang}
+              {isShared}
+              total={searchTotal}
+            />
+          {:else if showFilteredEmptyState}
             <div class="flex flex-1 flex-col items-center justify-center gap-2" data-testid="empty-state-message">
               <p class="text-sm text-(--fg-muted)">
                 {viewMode === AlbumPageViewMode.SELECT_ASSETS

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -67,6 +67,7 @@
   import SearchAddAllToCollectionModal from '$lib/modals/SearchAddAllToCollectionModal.svelte';
   import { resolveFilterNames } from '$lib/utils/filter-name-resolution';
   import { filterStateToSearchTerms } from '$lib/utils/filter-search-terms';
+  import type { SearchTerms } from '$lib/services/search.service';
   import { buildFilterStateUrl, isFilterStateUrlUnchanged, withoutAtParam } from '$lib/utils/filter-target';
   import { decodeFilterParams } from '$lib/utils/filter-url';
   import { lang } from '$lib/stores/preferences.store';
@@ -88,9 +89,11 @@
     mapSmartSearchFacetsToFilterSuggestions,
   } from '$lib/utils/space-search';
   import { consumeTypedSearchNamesInto } from '$lib/utils/typed-search/typed-search-name-cache';
+  import { removeSearchResults, selectAllSearchResults, updateSearchResults } from '$lib/utils/search-result-selection';
   import {
     AlbumUserRole,
     AssetOrder,
+    type AssetVisibility,
     getAlbumInfo,
     searchSmartFacets,
     updateAlbumInfo,
@@ -158,6 +161,8 @@
   // these show, so the selection toolbar acts on this array instead — mirrors the space timeline.
   let searchResults = $state<AssetResponseDto[]>([]);
   let searchIsLoading = $state(false);
+  // Bumped to force a re-run of the current search (undo-delete restores the removed assets).
+  let searchReloadToken = $state(0);
   // Token guard for the URL $effect below. Copied in spirit from photos/…/+page.svelte: without it,
   // our own goto() re-runs the effect, which re-runs goto(), forever. It is at-stripped because
   // closing the asset viewer writes `?at=<assetId>` (replaceScrollTarget), which is not a filter
@@ -212,6 +217,13 @@
   };
 
   const handleEscape = async () => {
+    // Search mode unmounts <Timeline>, so `timelineManager` is undefined here on a directly-loaded
+    // `?q=` URL — dereferencing it below would throw before anything else ran. Escape clears the
+    // search instead, matching the space timeline's handler.
+    if (showSearchResults) {
+      clearAlbumSearch();
+      return;
+    }
     timelineManager.suspendTransitions = true;
     if (viewMode === AlbumPageViewMode.SELECT_THUMBNAIL) {
       viewMode = AlbumPageViewMode.VIEW;
@@ -250,19 +262,52 @@
     await setModeToView();
   };
 
+  // While search results are showing, <Timeline> is unmounted and its manager destroyed — every
+  // bulk action has to mutate the results array instead, or it silently no-ops and the asset stays
+  // on screen (#908, the same split the space timeline makes).
   const handleSetVisibility = (assetIds: string[]) => {
-    timelineManager.removeAssets(assetIds);
+    if (showSearchResults) {
+      removeSearchResults(searchResults, assetIds);
+    } else {
+      timelineManager?.removeAssets(assetIds);
+    }
     assetMultiSelectManager.clear();
   };
 
   const handleRemoveAssets = async (assetIds: string[]) => {
-    timelineManager.removeAssets(assetIds);
+    if (showSearchResults) {
+      removeSearchResults(searchResults, assetIds);
+    } else {
+      timelineManager?.removeAssets(assetIds);
+    }
     await refreshAlbum();
   };
 
   const handleUndoRemoveAssets = async (assets: TimelineAsset[]) => {
-    timelineManager.upsertAssets(assets);
+    if (showSearchResults) {
+      // Undo hands back TimelineAssets; the results list holds full AssetResponseDtos, so
+      // re-running the search is how they come back.
+      searchReloadToken++;
+    } else {
+      timelineManager?.upsertAssets(assets);
+    }
     await refreshAlbum();
+  };
+
+  const handleBulkFavorite = (ids: string[], isFavorite: boolean) => {
+    if (showSearchResults) {
+      updateSearchResults(searchResults, ids, (asset) => (asset.isFavorite = isFavorite));
+      return;
+    }
+    timelineManager?.update(ids, (asset) => (asset.isFavorite = isFavorite));
+  };
+
+  const handleBulkArchive = (ids: string[], visibility: AssetVisibility) => {
+    if (showSearchResults) {
+      updateSearchResults(searchResults, ids, (asset) => (asset.visibility = visibility));
+      return;
+    }
+    timelineManager?.update(ids, (asset) => (asset.visibility = visibility));
   };
 
   const handleUpdateThumbnail = async (assetId: string) => {
@@ -312,17 +357,18 @@
     getAssets: () => (viewMode === AlbumPageViewMode.VIEW ? assetMultiSelectManager.assets : []),
     clearSelection: () => assetMultiSelectManager.clear(),
     canAddToAlbum: () => viewMode === AlbumPageViewMode.VIEW,
+    // `showSearchResults` joins `timelineManager` as an availability condition: in search mode the
+    // manager is gone but the handlers below are still meaningful — they act on the results array.
     getOnFavorite: () =>
-      viewMode === AlbumPageViewMode.VIEW && timelineManager
-        ? (ids, isFavorite) => timelineManager.update(ids, (asset) => (asset.isFavorite = isFavorite))
-        : undefined,
+      viewMode === AlbumPageViewMode.VIEW && (timelineManager || showSearchResults) ? handleBulkFavorite : undefined,
     getOnArchive: () =>
-      viewMode === AlbumPageViewMode.VIEW && timelineManager
-        ? (ids, visibility) => timelineManager.update(ids, (asset) => (asset.visibility = visibility))
-        : undefined,
-    getOnDelete: () => (viewMode === AlbumPageViewMode.VIEW && timelineManager ? handleRemoveAssets : undefined),
+      viewMode === AlbumPageViewMode.VIEW && (timelineManager || showSearchResults) ? handleBulkArchive : undefined,
+    getOnDelete: () =>
+      viewMode === AlbumPageViewMode.VIEW && (timelineManager || showSearchResults) ? handleRemoveAssets : undefined,
     getOnUndoDelete: () =>
-      viewMode === AlbumPageViewMode.VIEW && timelineManager ? handleUndoRemoveAssets : undefined,
+      viewMode === AlbumPageViewMode.VIEW && (timelineManager || showSearchResults)
+        ? handleUndoRemoveAssets
+        : undefined,
   });
 
   $effect(() => {
@@ -361,11 +407,22 @@
     untrack(() => {
       // Every filter — including the temporal picker's year/month — round-trips through the URL, so
       // rebuilding FilterState from the URL alone is lossless.
+      const nextQuery = getSearchablePageState(page.url).query;
+      // A NEW query invalidates the facets outright. Leaving them would let the previous query's
+      // total and time buckets annotate the new results until the fresh ones land — and a failed
+      // fetch returns the stale value, so they would never be corrected.
+      if (nextQuery !== committedSearchQuery) {
+        smartFacetInFlight?.controller.abort();
+        smartFacetInFlight = undefined;
+        smartFacets = undefined;
+        smartFacetKey = '';
+        searchResults = [];
+      }
       albumFilters = {
         ...createFilterState(),
         ...hydrateAlbumFilters(page.url),
       };
-      committedSearchQuery = getSearchablePageState(page.url).query;
+      committedSearchQuery = nextQuery;
       searchIsLoading = false;
       lastHandledFilterSearch = nextFilterSearch;
       consumeTypedSearchNamesInto(page.url.pathname + page.url.search, albumPersonNames, albumTagNames);
@@ -457,13 +514,15 @@
     return {
       ...base,
       // Browse mode asks the album's own suggestion endpoint; query mode has to ask the SEARCH, or
-      // the panel would offer facets the visible results do not contain.
+      // the panel would offer facets the visible results do not contain. BOTH branches feed the
+      // name maps — a chip picked from the facets has no other source for its label, and
+      // ActiveFiltersBar falls back to rendering the raw `person:<uuid>` token without it.
       suggestionsProvider: async (filters: FilterState) => {
-        if (showSearchResults) {
-          const facets = await loadAlbumSmartFacets(filters);
-          return facets ? mapSmartSearchFacetsToFilterSuggestions(facets) : emptyFilterSuggestions();
-        }
-        const result = await provider(filters);
+        const result = showSearchResults
+          ? await loadAlbumSmartFacets(filters).then((facets) =>
+              facets ? mapSmartSearchFacetsToFilterSuggestions(facets) : emptyFilterSuggestions(),
+            )
+          : await provider(filters);
         for (const person of result.people) {
           albumPersonNames.set(person.id, person.name);
         }
@@ -495,11 +554,19 @@
 
   const totalAssetCount = $derived(timelineManager?.assetCount ?? 0);
 
+  // The bar prints the SEARCH total in its label, so the collect call has to run the same search.
+  // Omitting the query sends `collectSearchResultAssetIds` down the metadata branch, which then
+  // collects every asset in the album — "Add all 3" quietly adding 800.
   const handleAddAllToCollection = () => {
+    const query = committedSearchQuery.trim();
+    const terms: SearchTerms = { ...filterStateToSearchTerms(albumFilters), albumIds: [album.id] };
+    if (query) {
+      terms.query = query;
+    }
     void modalManager.show(SearchAddAllToCollectionModal, {
-      terms: { ...filterStateToSearchTerms(albumFilters), albumIds: [album.id] },
-      total: totalAssetCount,
-      smartSearchEnabled: false,
+      terms,
+      total: showSearchResults ? (searchTotal ?? 0) : totalAssetCount,
+      smartSearchEnabled: !!query,
       language: $lang,
     });
   };
@@ -739,6 +806,8 @@
                   timeBuckets={filterTimeBuckets}
                   storageKey="gallery-filter-visible-sections-album-detail"
                   hidden={isTimelineEmpty && !showSearchResults}
+                  personNames={albumPersonNames}
+                  tagNames={albumTagNames}
                   onFiltersChange={syncAlbumFilterUrl}
                 />
               {/key}
@@ -808,6 +877,7 @@
               searchQuery={committedSearchQuery}
               bind:isLoading={searchIsLoading}
               bind:results={searchResults}
+              reloadToken={searchReloadToken}
               filters={albumFilters}
               albumIds={searchAlbumIds}
               language={$lang}
@@ -966,12 +1036,16 @@
         {@const Actions = getAssetBulkActions($t)}
         <CommandPaletteDefaultProvider name={$t('assets')} actions={Object.values(Actions)} />
         <CreateSharedLink />
-        <SelectAllAssets {timelineManager} assetInteraction={assetMultiSelectManager} />
+        <SelectAllAssets
+          timelineManager={showSearchResults ? undefined : timelineManager}
+          assetInteraction={assetMultiSelectManager}
+          onSelectAll={showSearchResults
+            ? () => selectAllSearchResults(searchResults, assetMultiSelectManager)
+            : undefined}
+        />
         <ActionButton action={Actions.AddToAlbum} />
         {#if assetMultiSelectManager.isAllUserOwned}
-          <FavoriteAction
-            removeFavorite={assetMultiSelectManager.isAllFavorite}
-            onFavorite={(ids, isFavorite) => timelineManager.update(ids, (asset) => (asset.isFavorite = isFavorite))}
+          <FavoriteAction removeFavorite={assetMultiSelectManager.isAllFavorite} onFavorite={handleBulkFavorite}
           ></FavoriteAction>
         {/if}
         <ButtonContextMenu icon={mdiDotsVertical} title={$t('menu')} offset={{ x: 175, y: 25 }}>
@@ -981,11 +1055,7 @@
             <ChangeDate menuItem />
             <ChangeDescription menuItem />
             <ChangeLocation menuItem />
-            <ArchiveAction
-              menuItem
-              unarchive={assetMultiSelectManager.isAllArchived}
-              onArchive={(ids, visibility) => timelineManager.update(ids, (asset) => (asset.visibility = visibility))}
-            />
+            <ArchiveAction menuItem unarchive={assetMultiSelectManager.isAllArchived} onArchive={handleBulkArchive} />
             <SetVisibilityAction menuItem onVisibilitySet={handleSetVisibility} />
           {/if}
           {#if isEditor && assetMultiSelectManager.assets.length === 1}

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -454,6 +454,9 @@
     ratings: [],
     mediaTypes: [],
     hasUnnamedPeople: false,
+    hasFavorites: false,
+    hasAssetsInAlbum: false,
+    hasAssetsNotInAlbum: false,
   });
 
   /**

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts
@@ -1,4 +1,5 @@
 import { AlbumUserRole, AssetOrder } from '@immich/sdk';
+import { modalManager } from '@immich/ui';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
@@ -781,7 +782,9 @@ describe('album detail filter panel route', () => {
     it('keeps the query in the URL when a filter changes during a search', async () => {
       mockPage.url = new URL('https://gallery.test/albums/album-1?q=beach');
       // In query mode the panel's options come from the SEARCH facets, not the album's suggestion
-      // endpoint — so this is what puts a person row on screen to click.
+      // endpoint. The id MUST differ from the browse mock's `person-view` (see getFilterSuggestions
+      // above): with the same id the row exists in both modes and the test passes even if the
+      // query-mode branch is deleted.
       sdkMock.searchSmartFacets.mockResolvedValue({
         total: 3,
         timeBuckets: [],
@@ -790,7 +793,7 @@ describe('album detail filter panel route', () => {
         cameraMakes: [],
         cameraModels: [],
         tags: [],
-        people: [{ id: 'person-view', name: 'Search Person' }],
+        people: [{ id: 'person-from-facets', name: 'Search Person' }],
         ratings: [],
         mediaTypes: [],
         hasUnnamedPeople: false,
@@ -798,13 +801,13 @@ describe('album detail filter panel route', () => {
       renderPage(album1());
       const user = userEvent.setup();
 
-      await waitFor(() => expect(screen.getByTestId('people-item-person-view')).toBeInTheDocument());
-      await user.click(screen.getByTestId('people-item-person-view'));
+      await waitFor(() => expect(screen.getByTestId('people-item-person-from-facets')).toBeInTheDocument());
+      await user.click(screen.getByTestId('people-item-person-from-facets'));
 
       await waitFor(() => {
         const [target] = gotoMock.mock.calls.at(-1) as [string];
         expect(target).toContain('q=beach');
-        expect(target).toContain('people=person-view');
+        expect(target).toContain('people=person-from-facets');
       });
     });
 
@@ -834,6 +837,99 @@ describe('album detail filter panel route', () => {
       renderPage(albumFactory.build({ id: 'album-1', assetCount: 2, order: AssetOrder.Asc }));
 
       await waitFor(() => expect(screen.getByTestId('timeline-options').textContent).toContain('"order":"asc"'));
+    });
+
+    const facetsWith = (people: Array<{ id: string; name: string }> = []) =>
+      ({
+        total: 3,
+        timeBuckets: [],
+        countries: [],
+        cities: [],
+        cameraMakes: [],
+        cameraModels: [],
+        tags: [],
+        people,
+        ratings: [],
+        mediaTypes: [],
+        hasUnnamedPeople: false,
+      }) as never;
+
+    // `vi.clearAllMocks()` in the outer beforeEach clears call history but NOT implementations, so
+    // a `mockResolvedValue` (or the never-resolving promise one test below installs) would leak
+    // into every later test in the file. Reset the facets mock per test.
+    beforeEach(() => {
+      sdkMock.searchSmartFacets.mockReset();
+      sdkMock.searchSmartFacets.mockResolvedValue(facetsWith());
+    });
+
+    // The bar's label prints the SEARCH total, so the collect call has to run the same search.
+    // Dropping the query sends it down the metadata branch, which then adds every asset in the
+    // album — "Add all 3" quietly adding 800.
+    it('carries the query into add-all-to-collection so it collects the matches, not the album', async () => {
+      mockPage.url = new URL('https://gallery.test/albums/album-1?q=beach');
+      // Spied, not rendered: the real modal mounts CollectionPickerModal, which needs album/space
+      // data this suite does not stub. The assertion is about what the page HANDS the modal.
+      const showSpy = vi.spyOn(modalManager, 'show').mockResolvedValue(undefined as never);
+      renderPage(album1());
+      const user = userEvent.setup();
+
+      await user.click(await screen.findByTestId('add-all-to-collection'));
+
+      await waitFor(() => expect(showSpy).toHaveBeenCalled());
+      const props = showSpy.mock.calls.at(-1)![1] as unknown as { terms: { query?: string } };
+      expect(props.terms.query).toBe('beach');
+      expect(props).toMatchObject({ smartSearchEnabled: true, total: 3 });
+      showSpy.mockRestore();
+    });
+
+    // Search mode unmounts <Timeline>, so `timelineManager` is undefined (direct `?q=` load) or
+    // destroyed (typed query). Every bulk handler used to dereference it unguarded: the favourite
+    // path threw, and the delete path silently no-opped while the asset stayed on screen.
+    it('offers bulk handlers in search mode that act on the results, not the unmounted timeline', async () => {
+      mockPage.url = new URL('https://gallery.test/albums/album-1?q=beach');
+      renderPage(album1());
+
+      await waitFor(() => expect(screen.getByTestId('smart-search-results')).toBeInTheDocument());
+
+      const options = registerSelectionContextMock.mock.calls.at(-1)![0];
+      const onFavorite = options.getOnFavorite();
+      const onDelete = options.getOnDelete();
+
+      expect(onFavorite).toBeTypeOf('function');
+      expect(onDelete).toBeTypeOf('function');
+      // Would throw on `undefined.update(...)` before the fix.
+      expect(() => onFavorite!(['asset-1'], true)).not.toThrow();
+    });
+
+    // The provider's query-mode branch returns early, so without name capture the chip renders the
+    // raw `person:<uuid>` token the facets emitted.
+    it('names a person chip picked from the search facets', async () => {
+      mockPage.url = new URL('https://gallery.test/albums/album-1?q=beach');
+      sdkMock.searchSmartFacets.mockResolvedValue(facetsWith([{ id: 'person-from-facets', name: 'Search Person' }]));
+      renderPage(album1());
+      const user = userEvent.setup();
+
+      await waitFor(() => expect(screen.getByTestId('people-item-person-from-facets')).toBeInTheDocument());
+      await user.click(screen.getByTestId('people-item-person-from-facets'));
+
+      await waitFor(() => expect(screen.getByTestId('active-filters-bar')).toHaveTextContent('Search Person'));
+    });
+
+    // Until the new facets land, the previous query's total keeps annotating the new results.
+    it('drops the previous query facets when the query changes', async () => {
+      mockPage.url = new URL('https://gallery.test/albums/album-1?q=beach');
+      renderPage(album1());
+
+      await waitFor(() => expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-total', '3'));
+
+      // A slow response for the new query — the stale total must not survive in the meantime.
+      sdkMock.searchSmartFacets.mockImplementation((() => new Promise(() => {})) as never);
+      mockPage.url = new URL('https://gallery.test/albums/album-1?q=mountain');
+
+      await waitFor(() =>
+        expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'mountain'),
+      );
+      expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-total', '');
     });
   });
 });

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts
@@ -1,4 +1,4 @@
-import { AlbumUserRole } from '@immich/sdk';
+import { AlbumUserRole, AssetOrder } from '@immich/sdk';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
@@ -39,6 +39,11 @@ vi.mock('$app/state', async () => {
 vi.mock('$lib/components/timeline/Timeline.svelte', async () => {
   const { default: MockTimeline } = await import('./mock-timeline.test-wrapper.svelte');
   return { default: MockTimeline };
+});
+
+vi.mock('$lib/components/search/smart-search-results.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/smart-search-results.stub.svelte');
+  return { default: MockComponent };
 });
 
 vi.mock('$lib/managers/command-context-manager.svelte', () => ({
@@ -727,6 +732,108 @@ describe('album detail filter panel route', () => {
           expect.anything(),
         ),
       );
+    });
+  });
+
+  // #986: an album is a searchable page, so a query launched from one runs against that album
+  // instead of bouncing the user to /photos and searching their whole library.
+  describe('page-aware search', () => {
+    const album1 = () => albumFactory.build({ id: 'album-1', assetCount: 2 });
+
+    it('runs the search in place instead of showing the browse timeline', async () => {
+      mockPage.url = new URL('https://gallery.test/albums/album-1?q=beach');
+
+      renderPage(album1());
+
+      await waitFor(() =>
+        expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'beach'),
+      );
+      expect(screen.queryByTestId('timeline-options')).not.toBeInTheDocument();
+    });
+
+    it('scopes the search to the album it was launched from', async () => {
+      mockPage.url = new URL('https://gallery.test/albums/album-1?q=beach');
+
+      renderPage(album1());
+
+      await waitFor(() =>
+        expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-album-ids', 'album-1'),
+      );
+    });
+
+    it('shows the browse timeline when there is no query', async () => {
+      renderPage(album1());
+
+      await waitFor(() => expect(screen.getByTestId('timeline-options')).toBeInTheDocument());
+      expect(screen.queryByTestId('smart-search-results')).not.toBeInTheDocument();
+    });
+
+    it('hydrates filters from the URL into the search', async () => {
+      mockPage.url = new URL('https://gallery.test/albums/album-1?q=beach&make=Apple');
+
+      renderPage(album1());
+
+      await waitFor(() =>
+        expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-make', 'Apple'),
+      );
+    });
+
+    it('keeps the query in the URL when a filter changes during a search', async () => {
+      mockPage.url = new URL('https://gallery.test/albums/album-1?q=beach');
+      // In query mode the panel's options come from the SEARCH facets, not the album's suggestion
+      // endpoint — so this is what puts a person row on screen to click.
+      sdkMock.searchSmartFacets.mockResolvedValue({
+        total: 3,
+        timeBuckets: [],
+        countries: [],
+        cities: [],
+        cameraMakes: [],
+        cameraModels: [],
+        tags: [],
+        people: [{ id: 'person-view', name: 'Search Person' }],
+        ratings: [],
+        mediaTypes: [],
+        hasUnnamedPeople: false,
+      } as never);
+      renderPage(album1());
+      const user = userEvent.setup();
+
+      await waitFor(() => expect(screen.getByTestId('people-item-person-view')).toBeInTheDocument());
+      await user.click(screen.getByTestId('people-item-person-view'));
+
+      await waitFor(() => {
+        const [target] = gotoMock.mock.calls.at(-1) as [string];
+        expect(target).toContain('q=beach');
+        expect(target).toContain('people=person-view');
+      });
+    });
+
+    it('re-hydrates when the URL changes under it (back/forward, shared link)', async () => {
+      renderPage(album1());
+
+      await waitFor(() => expect(screen.getByTestId('timeline-options')).toBeInTheDocument());
+
+      mockPage.url = new URL('https://gallery.test/albums/album-1?q=sunset');
+
+      await waitFor(() =>
+        expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'sunset'),
+      );
+    });
+
+    // The navbar sort dropdown renders on every searchable page, browse mode included, so an
+    // explicit ?sort= has to reach the browse query or the control visibly does nothing.
+    it('lets an explicit sort override the album order in browse mode', async () => {
+      mockPage.url = new URL('https://gallery.test/albums/album-1?sort=asc');
+
+      renderPage(albumFactory.build({ id: 'album-1', assetCount: 2, order: AssetOrder.Desc }));
+
+      await waitFor(() => expect(screen.getByTestId('timeline-options').textContent).toContain('"order":"asc"'));
+    });
+
+    it("keeps the album's own order in browse mode when the URL carries no sort", async () => {
+      renderPage(albumFactory.build({ id: 'album-1', assetCount: 2, order: AssetOrder.Asc }));
+
+      await waitFor(() => expect(screen.getByTestId('timeline-options').textContent).toContain('"order":"asc"'));
     });
   });
 });

--- a/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { goto, invalidateAll, onNavigate } from '$app/navigation';
+  import { page } from '$app/state';
   import UserPageLayout from '$lib/components/layouts/UserPageLayout.svelte';
   import AlbumTitle from '$lib/components/album-page/AlbumTitle.svelte';
   import AlbumDescription from '$lib/components/album-page/AlbumDescription.svelte';
@@ -10,6 +11,8 @@
     createFilterState,
     getActiveFilterCount,
     loadFilterCollapsed,
+    type FilterPanelConfig,
+    type FilterState,
   } from '$lib/components/filter-panel/filter-panel';
   import FilterPanel from '$lib/components/filter-panel/filter-panel.svelte';
   import FilterToggleButton from '$lib/components/filter-panel/filter-toggle-button.svelte';
@@ -34,6 +37,19 @@
   import { clearTimelineTemporalFilter } from '$lib/utils/timeline-temporal-filters';
   import { withNameCapture } from '$lib/utils/filter-name-capture';
   import { filterStateToSearchTerms } from '$lib/utils/filter-search-terms';
+  import type { SearchTerms } from '$lib/services/search.service';
+  import SmartSearchResults from '$lib/components/search/smart-search-results.svelte';
+  import { globalSearchManager } from '$lib/managers/global-search-manager.svelte';
+  import { buildFilterStateUrl, isFilterStateUrlUnchanged, withoutAtParam } from '$lib/utils/filter-target';
+  import { decodeFilterParams } from '$lib/utils/filter-url';
+  import { buildSearchablePageUrl, getSearchablePageState } from '$lib/utils/searchable-page-search';
+  import {
+    buildSmartSearchFacetKey,
+    buildSmartSearchFacetsParams,
+    mapSmartSearchFacetsToFilterSuggestions,
+  } from '$lib/utils/space-search';
+  import { consumeTypedSearchNamesInto } from '$lib/utils/typed-search/typed-search-name-cache';
+  import { untrack } from 'svelte';
   import SearchAddAllToCollectionModal from '$lib/modals/SearchAddAllToCollectionModal.svelte';
   import { lang } from '$lib/stores/preferences.store';
   import { SvelteMap } from 'svelte/reactivity';
@@ -44,12 +60,16 @@
   } from '$lib/utils/timeline-zoom-navigation';
   import {
     AlbumUserRole,
+    AssetOrder,
     getAlbumInfo,
+    searchSmartFacets,
     SharedSpaceRole,
     updateAlbumInfo,
     type AlbumResponseDto,
+    type AssetResponseDto,
     type SharedSpaceMemberResponseDto,
     type SharedSpaceResponseDto,
+    type SmartSearchFacetsResponseDto,
   } from '@immich/sdk';
   import HeaderActionButton from '$lib/components/HeaderActionButton.svelte';
   import { Icon, IconButton, modalManager, toastManager } from '@immich/ui';
@@ -80,11 +100,39 @@
   // Picker multi-select manager (mirrors global album page's timelineMultiSelectManager)
   const pickerMultiSelectManager = new AssetMultiSelectManager();
 
-  // Independent filter state per mode (mirrors the global album page).
-  let browseFilters = $state(createFilterState());
+  /**
+   * The route already scopes the timeline to this album, and the server's `albumId` is a SCALAR
+   * driving one inner join, so album ∩ album is impossible. A stray `?album=` must be IGNORED:
+   * dropping it here keeps it out of the active-filter count, out of the chip bar, and out of the
+   * next URL write. Mirrors the global album page's `hydrateAlbumFilters`.
+   */
+  const hydrateAlbumFilters = (url: URL): FilterState => ({
+    ...createFilterState(),
+    ...decodeFilterParams(url),
+    albumId: undefined,
+    sortOrder: getSearchablePageState(url).sortOrder,
+  });
+
+  // Independent filter state per mode (mirrors the global album page). Browse filters are
+  // URL-backed — the album is a searchable page, so ⌘K writes its filters here.
+  let browseFilters = $state(hydrateAlbumFilters(page.url));
+  let committedSearchQuery = $state(getSearchablePageState(page.url).query);
+  /**
+   * Token guard for the re-hydrate $effect below, so our own goto() cannot loop it. Stripped of
+   * `at` because closing the asset viewer writes `?at=<assetId>`, which is not a filter change —
+   * re-hydrating on it would rebuild an identical FilterState and needlessly re-create the timeline
+   * options object. Mirrors the global album page.
+   */
+  let lastHandledSearch = $state(withoutAtParam(page.url.search));
+  const showSearchResults = $derived(committedSearchQuery.trim().length > 0);
+  // Loaded smart-search results. The browse Timeline (and its TimelineManager) is unmounted while
+  // these show, so the selection toolbar acts on this array instead — mirrors the space timeline.
+  let searchResults = $state<AssetResponseDto[]>([]);
+  let searchIsLoading = $state(false);
   let pickerFilters = $state(createFilterState());
   const browsePersonNames = new SvelteMap<string, string>();
   const browseTagNames = new SvelteMap<string, string>();
+  consumeTypedSearchNamesInto(page.url.pathname + page.url.search, browsePersonNames, browseTagNames);
   const pickerPersonNames = new SvelteMap<string, string>();
   const pickerTagNames = new SvelteMap<string, string>();
   const currentMember = $derived(members.find((m) => m.userId === authManager.user.id));
@@ -110,9 +158,95 @@
     }
   });
 
-  const browseFilterConfig = $derived(
-    withNameCapture(buildAlbumDetailFilterConfig(album.id), browsePersonNames, browseTagNames),
-  );
+  let smartFacets = $state<SmartSearchFacetsResponseDto>();
+  let smartFacetKey = $state('');
+  let smartFacetInFlight:
+    | { key: string; controller: AbortController; promise: Promise<SmartSearchFacetsResponseDto | undefined> }
+    | undefined;
+
+  const emptyFilterSuggestions = () => ({
+    countries: [],
+    cities: [],
+    cameraMakes: [],
+    cameraModels: [],
+    tags: [],
+    people: [],
+    ratings: [],
+    mediaTypes: [],
+    hasUnnamedPeople: false,
+  });
+
+  /**
+   * Facets for the ACTIVE search, scoped to this album — the source of the result count and of the
+   * temporal picker's buckets while a query is running. Album-scoped, never space-scoped: see
+   * `searchAlbumIds`. Memoised on the request shape so a filter change that cannot alter the facets
+   * (sortOrder) does not refetch.
+   */
+  async function loadAlbumSmartFacets(nextFilters: FilterState): Promise<SmartSearchFacetsResponseDto | undefined> {
+    const query = committedSearchQuery.trim();
+    if (!query) {
+      return undefined;
+    }
+
+    const args = { query, filters: nextFilters, albumIds: searchAlbumIds, language: $lang };
+    const key = buildSmartSearchFacetKey(args);
+    if (smartFacets && smartFacetKey === key) {
+      return smartFacets;
+    }
+    if (smartFacetInFlight?.key === key) {
+      return smartFacetInFlight.promise;
+    }
+
+    smartFacetInFlight?.controller.abort();
+    const controller = new AbortController();
+
+    const promise = searchSmartFacets(
+      { smartSearchFacetsDto: buildSmartSearchFacetsParams(args) },
+      { signal: controller.signal },
+    )
+      .then((result) => {
+        if (smartFacetInFlight?.key === key && !controller.signal.aborted) {
+          smartFacets = result;
+          smartFacetKey = key;
+        }
+        return result;
+      })
+      .catch((error: unknown) => {
+        if (!controller.signal.aborted) {
+          console.error('Failed to fetch smart search facets:', error);
+        }
+        return smartFacets;
+      })
+      .finally(() => {
+        if (smartFacetInFlight?.key === key) {
+          smartFacetInFlight = undefined;
+        }
+      });
+
+    smartFacetInFlight = { key, controller, promise };
+    return promise;
+  }
+
+  const browseFilterConfig = $derived.by<FilterPanelConfig>(() => {
+    const base = buildAlbumDetailFilterConfig(album.id);
+    const browseProvider = base.suggestionsProvider!;
+    return withNameCapture(
+      {
+        ...base,
+        // Browse mode asks the album's own suggestion endpoint; query mode has to ask the SEARCH,
+        // or the panel would offer facets that the visible results do not contain.
+        suggestionsProvider: async (nextFilters: FilterState) => {
+          if (!showSearchResults) {
+            return browseProvider(nextFilters);
+          }
+          const facets = await loadAlbumSmartFacets(nextFilters);
+          return facets ? mapSmartSearchFacetsToFilterSuggestions(facets) : emptyFilterSuggestions();
+        },
+      },
+      browsePersonNames,
+      browseTagNames,
+    );
+  });
   const browseTotal = $derived(timelineManager?.assetCount ?? 0);
   const browseHasMonths = $derived((timelineManager?.months?.length ?? 0) > 0);
   const browseActive = $derived(getActiveFilterCount(browseFilters));
@@ -126,26 +260,96 @@
     timelineManager?.isInitialized && !browseHasMonths && browseTotal === 0 && browseActive > 0,
   );
   const browseTimeBuckets = $derived(getTimelineManagerTimeBuckets(timelineManager));
+  // While a query is running the panel's temporal picker must bucket the MATCHES, not the album.
+  const filterTimeBuckets = $derived(showSearchResults ? (smartFacets?.timeBuckets ?? []) : browseTimeBuckets);
+  const searchTotal = $derived(showSearchResults ? smartFacets?.total : undefined);
+
+  /**
+   * The album scope handed to smart search. Deliberately the album alone, with no `spaceId`: this
+   * page's browse timeline is album-scoped too (`buildAlbumTimelineOptions`), and its filter panel
+   * speaks the personal person tokens that go with that. Sending `spaceId` as well would also be
+   * actively wrong server-side — `albumIds` makes the service resolve `timelineSpaceIds`, and the
+   * `spaceId` predicate is skipped whenever those are set (`database.ts`), so the space scope would
+   * silently widen to every space the caller is in rather than narrowing anything.
+   */
+  const searchAlbumIds = $derived([album.id]);
+
+  /**
+   * Browse order. An album carries its own `order`, but the navbar sort dropdown is rendered on
+   * every searchable page — browse mode included — so an EXPLICIT `?sort=` has to win, or the
+   * control would visibly do nothing here. Absent that param the album's own order stands.
+   */
+  const browseOrder = $derived.by(() => {
+    if (!getSearchablePageState(page.url).hasExplicitSort) {
+      return album.order ?? authManager.preferences.albums.defaultAssetOrder;
+    }
+    return browseFilters.sortOrder === 'asc' ? AssetOrder.Asc : AssetOrder.Desc;
+  });
 
   const browseOptions = $derived({
-    ...buildAlbumTimelineOptions(
-      album.id,
-      album.order ?? authManager.preferences.albums.defaultAssetOrder,
-      browseFilters,
-    ),
+    ...buildAlbumTimelineOptions(album.id, browseOrder, browseFilters),
     // The grouping MUST live in the options object — that is what the TimelineManager reads to
     // build buckets. The top-level <Timeline grouping={...}> prop alone does not re-group.
     grouping: timelineGrouping,
+  });
+
+  $effect(() => globalSearchManager.registerSearchablePageFilters(() => browseFilters));
+
+  /** Write a filter change back to the URL — the album page's half of the hydrate → write → react
+   *  loop. `buildFilterStateUrl` (not `buildSearchablePageUrl`) because it keeps the CURRENT
+   *  pathname: the panel can be used with the asset viewer open, and targeting the base path would
+   *  close it on every filter tweak. It preserves `q` and `sort` as ordinary non-filter params. */
+  function syncFilterUrl(nextFilters: FilterState) {
+    const nextUrl = buildFilterStateUrl(page.url, nextFilters);
+    // NOT a string compare: buildFilterStateUrl re-appends the filter params last, so an unchanged
+    // state can come back re-ordered. See filter-target.ts.
+    if (isFilterStateUrlUnchanged(page.url, nextUrl)) {
+      return;
+    }
+    void goto(nextUrl, { replaceState: true, keepFocus: true, noScroll: true });
+  }
+
+  const clearSearch = () => {
+    searchIsLoading = false;
+    const nextUrl = buildSearchablePageUrl(page.url, '', browseFilters.sortOrder, browseFilters);
+    if (!nextUrl) {
+      return;
+    }
+    void goto(nextUrl, { replaceState: true, keepFocus: true, noScroll: true });
+  };
+
+  // Re-hydrate from the URL on every change we did not just make: back/forward, a shared link, a
+  // ⌘K search, and the `?at=` write from closing the asset viewer (stripped, see lastHandledSearch).
+  $effect(() => {
+    const nextSearch = withoutAtParam(page.url.search);
+    if (nextSearch === lastHandledSearch) {
+      return;
+    }
+
+    untrack(() => {
+      // Every filter — including the temporal picker's year/month — round-trips through the URL, so
+      // rebuilding FilterState from the URL alone is lossless.
+      browseFilters = hydrateAlbumFilters(page.url);
+      committedSearchQuery = getSearchablePageState(page.url).query;
+      searchIsLoading = false;
+      lastHandledSearch = nextSearch;
+      consumeTypedSearchNamesInto(page.url.pathname + page.url.search, browsePersonNames, browseTagNames);
+    });
   });
 
   // Mirror the global album page: collect every asset matching the active browse filters
   // (scoped to this album) into another album/space. ActiveFiltersBar self-gates the button
   // on there being active filters + results.
   const handleAddAllToCollection = () => {
+    const query = committedSearchQuery.trim();
+    const terms: SearchTerms = { ...filterStateToSearchTerms(browseFilters), albumIds: [album.id] };
+    if (query) {
+      terms.query = query;
+    }
     void modalManager.show(SearchAddAllToCollectionModal, {
-      terms: { ...filterStateToSearchTerms(browseFilters), albumIds: [album.id] },
-      total: browseTotal,
-      smartSearchEnabled: false,
+      terms,
+      total: showSearchResults ? (searchTotal ?? 0) : browseTotal,
+      smartSearchEnabled: !!query,
       language: $lang,
     });
   };
@@ -279,9 +483,19 @@
 
     album = data.album;
     mode = 'browse';
-    browseFilters = createFilterState();
+    // Re-seed from the URL, not from a blank slate: the sibling album's own URL carries its query
+    // and filters, and a bare reset would drop a ⌘K search the moment it navigated.
+    browseFilters = hydrateAlbumFilters(page.url);
+    committedSearchQuery = getSearchablePageState(page.url).query;
+    lastHandledSearch = withoutAtParam(page.url.search);
+    searchIsLoading = false;
+    smartFacetInFlight?.controller.abort();
+    smartFacets = undefined;
+    smartFacetKey = '';
+    smartFacetInFlight = undefined;
     browsePersonNames.clear();
     browseTagNames.clear();
+    consumeTypedSearchNamesInto(page.url.pathname + page.url.search, browsePersonNames, browseTagNames);
     assetMultiSelectManager.clear();
     resetPicker();
   });
@@ -338,15 +552,20 @@
   {#if mode === 'browse'}
     <div class="flex h-full">
       {#if !assetMultiSelectManager.selectionActive}
-        {#key `space-album-${album.id}`}
+        <!-- Keyed on the search too: switching between browse and query mode swaps the whole
+             suggestions provider, so the panel has to re-run it rather than keep browse facets. -->
+        {#key `space-album-${album.id}:${showSearchResults ? `search-${committedSearchQuery.trim()}:${$lang}` : 'browse'}`}
           <FilterPanel
             config={browseFilterConfig}
             bind:filters={browseFilters}
             bind:collapsed={filterCollapsed}
             externalToggle
-            timeBuckets={browseTimeBuckets}
+            timeBuckets={filterTimeBuckets}
             storageKey="gallery-filter-visible-sections-space-album"
-            hidden={isBrowseEmpty}
+            hidden={isBrowseEmpty && !showSearchResults}
+            personNames={browsePersonNames}
+            tagNames={browseTagNames}
+            onFiltersChange={syncFilterUrl}
           />
         {/key}
       {/if}
@@ -370,11 +589,11 @@
           </div>
         {/if}
 
-        {#if browseActive > 0}
+        {#if browseActive > 0 || showSearchResults}
           <div class="mb-4 shrink-0">
             <ActiveFiltersBar
               filters={browseFilters}
-              resultCount={browseTotal}
+              resultCount={showSearchResults ? searchTotal : browseTotal}
               personNames={browsePersonNames}
               tagNames={browseTagNames}
               onRemoveFilter={(type, id) => {
@@ -384,17 +603,33 @@
                 } else {
                   browseFilters = handlePhotosRemoveFilter(browseFilters, type, id);
                 }
+                syncFilterUrl(browseFilters);
               }}
               onClearAll={() => {
                 browseFilters = clearFilters(browseFilters);
                 temporalAnchor = undefined;
+                syncFilterUrl(browseFilters);
               }}
+              searchQuery={committedSearchQuery}
+              onClearSearch={clearSearch}
               onAddAllToCollection={handleAddAllToCollection}
             />
           </div>
         {/if}
 
-        {#if showBrowseFilteredEmpty}
+        {#if showSearchResults}
+          <SmartSearchResults
+            searchQuery={committedSearchQuery}
+            bind:isLoading={searchIsLoading}
+            bind:results={searchResults}
+            filters={browseFilters}
+            albumIds={searchAlbumIds}
+            language={$lang}
+            space={{ id: space.id, canWrite: isSpaceEditor }}
+            isShared={album.shared}
+            total={searchTotal}
+          />
+        {:else if showBrowseFilteredEmpty}
           <div class="flex flex-1 flex-col items-center justify-center gap-2" data-testid="browse-filtered-empty">
             <p class="text-sm text-gray-500 dark:text-gray-400">{$t('space_album_no_photos_match_filters')}</p>
             <button

--- a/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -49,6 +49,7 @@
     mapSmartSearchFacetsToFilterSuggestions,
   } from '$lib/utils/space-search';
   import { consumeTypedSearchNamesInto } from '$lib/utils/typed-search/typed-search-name-cache';
+  import { removeSearchResults, selectAllSearchResults, updateSearchResults } from '$lib/utils/search-result-selection';
   import { untrack } from 'svelte';
   import SearchAddAllToCollectionModal from '$lib/modals/SearchAddAllToCollectionModal.svelte';
   import { lang } from '$lib/stores/preferences.store';
@@ -61,6 +62,7 @@
   import {
     AlbumUserRole,
     AssetOrder,
+    type AssetVisibility,
     getAlbumInfo,
     searchSmartFacets,
     SharedSpaceRole,
@@ -129,6 +131,8 @@
   // these show, so the selection toolbar acts on this array instead — mirrors the space timeline.
   let searchResults = $state<AssetResponseDto[]>([]);
   let searchIsLoading = $state(false);
+  // Bumped to force a re-run of the current search (undo-delete restores the removed assets).
+  let searchReloadToken = $state(0);
   let pickerFilters = $state(createFilterState());
   const browsePersonNames = new SvelteMap<string, string>();
   const browseTagNames = new SvelteMap<string, string>();
@@ -329,8 +333,19 @@
     untrack(() => {
       // Every filter — including the temporal picker's year/month — round-trips through the URL, so
       // rebuilding FilterState from the URL alone is lossless.
+      const nextQuery = getSearchablePageState(page.url).query;
+      // A NEW query invalidates the facets outright. Leaving them would let the previous query's
+      // total and time buckets annotate the new results until the fresh ones land — and a failed
+      // fetch returns the stale value, so they would never be corrected.
+      if (nextQuery !== committedSearchQuery) {
+        smartFacetInFlight?.controller.abort();
+        smartFacetInFlight = undefined;
+        smartFacets = undefined;
+        smartFacetKey = '';
+        searchResults = [];
+      }
       browseFilters = hydrateAlbumFilters(page.url);
-      committedSearchQuery = getSearchablePageState(page.url).query;
+      committedSearchQuery = nextQuery;
       searchIsLoading = false;
       lastHandledSearch = nextSearch;
       consumeTypedSearchNamesInto(page.url.pathname + page.url.search, browsePersonNames, browseTagNames);
@@ -393,11 +408,18 @@
     album = await getAlbumInfo({ id: album.id });
   };
 
+  // While search results are showing, <Timeline> is unmounted and its manager destroyed — every
+  // bulk action has to mutate the results array instead, or it silently no-ops and the asset stays
+  // on screen (#908, same split the space timeline makes).
   const handleRemoveAssets = (assetIds: string[]) => {
     // Prune the browse timeline immediately so removed photos don't linger.
     // RemoveFromAlbumAction already re-fetches the album via bind:album and clears the
     // selection internally before firing onRemove, so we only need to defensively clear here.
-    timelineManager?.removeAssets(assetIds);
+    if (showSearchResults) {
+      removeSearchResults(searchResults, assetIds);
+    } else {
+      timelineManager?.removeAssets(assetIds);
+    }
     assetMultiSelectManager.clear();
   };
 
@@ -405,8 +427,28 @@
   // folder takes them out of this (non-locked) timeline view. It isn't an album-membership
   // change (RemoveFromAlbum is the only membership mutation this route offers), so it doesn't
   // touch album.assetCount either.
+  const handleFavorite = (ids: string[], isFavorite: boolean) => {
+    if (showSearchResults) {
+      updateSearchResults(searchResults, ids, (asset) => (asset.isFavorite = isFavorite));
+      return;
+    }
+    timelineManager?.update(ids, (asset) => (asset.isFavorite = isFavorite));
+  };
+
+  const handleArchive = (ids: string[], visibility: AssetVisibility) => {
+    if (showSearchResults) {
+      updateSearchResults(searchResults, ids, (asset) => (asset.visibility = visibility));
+      return;
+    }
+    timelineManager?.update(ids, (asset) => (asset.visibility = visibility));
+  };
+
   const handleSetVisibility = (assetIds: string[]) => {
-    timelineManager?.removeAssets(assetIds);
+    if (showSearchResults) {
+      removeSearchResults(searchResults, assetIds);
+    } else {
+      timelineManager?.removeAssets(assetIds);
+    }
     assetMultiSelectManager.clear();
   };
 
@@ -416,7 +458,11 @@
   // space-person page's identical reasoning — so force a data reload here to keep
   // album.assetCount in sync with the server.
   const handleAssetDelete = (assetIds: string[]) => {
-    timelineManager?.removeAssets(assetIds);
+    if (showSearchResults) {
+      removeSearchResults(searchResults, assetIds);
+    } else {
+      timelineManager?.removeAssets(assetIds);
+    }
     void invalidateAll();
   };
 
@@ -424,6 +470,12 @@
   // restore, so re-add the assets to the local view directly; no count refresh is needed since
   // undoing a delete doesn't change album membership either.
   const handleUndoAssetDelete = (assets: TimelineAsset[]) => {
+    if (showSearchResults) {
+      // Undo hands back TimelineAssets; the results list holds full AssetResponseDtos, so
+      // re-running the search is how they come back.
+      searchReloadToken++;
+      return;
+    }
     timelineManager?.upsertAssets(assets);
   };
 
@@ -622,6 +674,7 @@
             searchQuery={committedSearchQuery}
             bind:isLoading={searchIsLoading}
             bind:results={searchResults}
+            reloadToken={searchReloadToken}
             filters={browseFilters}
             albumIds={searchAlbumIds}
             language={$lang}
@@ -639,6 +692,9 @@
               onclick={() => {
                 browseFilters = clearFilters(browseFilters);
                 temporalAnchor = undefined;
+                // The filters are URL-backed now: without this the params survive the "clear",
+                // so a refresh or back/forward restores what the user just cleared.
+                syncFilterUrl(browseFilters);
               }}
             >
               {$t('space_album_clear_all_filters')}
@@ -729,15 +785,16 @@
      `isAllUserOwned` gates the whole metadata-edit block, matching the merged direct-space timeline. -->
 {#if mode === 'browse' && assetMultiSelectManager.selectionActive}
   <SelectionToolbar
-    {timelineManager}
+    timelineManager={showSearchResults ? undefined : timelineManager}
     assetInteraction={assetMultiSelectManager}
     {album}
     space={{ id: space.id, canWrite: isSpaceEditor }}
     downloadFilename={`${album.albumName}.zip`}
+    onSelectAll={showSearchResults ? () => selectAllSearchResults(searchResults, assetMultiSelectManager) : undefined}
     onRemove={handleRemoveAssets}
     onSetCover={handleSetAlbumCover}
-    onFavorite={(ids, isFavorite) => timelineManager.update(ids, (asset) => (asset.isFavorite = isFavorite))}
-    onArchive={(ids, visibility) => timelineManager.update(ids, (asset) => (asset.visibility = visibility))}
+    onFavorite={handleFavorite}
+    onArchive={handleArchive}
     onVisibilitySet={handleSetVisibility}
     onAssetDelete={handleAssetDelete}
     onUndoDelete={handleUndoAssetDelete}

--- a/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -178,6 +178,9 @@
     ratings: [],
     mediaTypes: [],
     hasUnnamedPeople: false,
+    hasFavorites: false,
+    hasAssetsInAlbum: false,
+    hasAssetsNotInAlbum: false,
   });
 
   /**

--- a/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/mock-active-filters-bar.test-wrapper.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/mock-active-filters-bar.test-wrapper.svelte
@@ -1,18 +1,60 @@
 <script lang="ts">
+  import type { FilterState } from '$lib/components/filter-panel/filter-panel';
+
   interface Props {
+    filters?: FilterState;
     onRemoveFilter: (type: string, id?: string) => void;
     onClearAll: () => void;
     onAddAllToCollection?: () => void;
+    // The real bar renders a search chip with a ✕ from these two, and prints `resultCount` in the
+    // add-all label. Swallowing them into `...rest` made the whole clear-search affordance — and the
+    // browse-vs-search count swap — unobservable, so a page that never wired them still passed.
+    resultCount?: number;
+    searchQuery?: string;
+    onClearSearch?: () => void;
+    personNames?: Map<string, string>;
+    tagNames?: Map<string, string>;
     [key: string]: unknown;
   }
 
-  let { onRemoveFilter, onClearAll, onAddAllToCollection, ...rest }: Props = $props();
+  let {
+    filters,
+    onRemoveFilter,
+    onClearAll,
+    onAddAllToCollection,
+    resultCount,
+    searchQuery = '',
+    onClearSearch,
+    personNames,
+    tagNames,
+    ...rest
+  }: Props = $props();
   void rest;
+
+  // Mirrors the real bar's fallback: a missing name renders the raw id, so a test can tell a named
+  // chip from an unnamed one.
+  const personLabels = $derived((filters?.personIds ?? []).map((id) => personNames?.get(id) ?? id).join(','));
+  const tagLabels = $derived((filters?.tagIds ?? []).map((id) => tagNames?.get(id) ?? id).join(','));
 </script>
 
-<div data-testid="active-filters-bar" data-has-add-all={String(!!onAddAllToCollection)}>
+<div
+  data-testid="active-filters-bar"
+  data-has-add-all={String(!!onAddAllToCollection)}
+  data-result-count={resultCount ?? ''}
+  data-search-query={searchQuery}
+  data-person-labels={personLabels}
+  data-tag-labels={tagLabels}
+>
   <button type="button" data-testid="active-filters-remove-timeline" onclick={() => onRemoveFilter('timeline')}>
     remove timeline
   </button>
   <button type="button" data-testid="active-filters-clear-all" onclick={() => onClearAll()}>clear all</button>
+  {#if searchQuery}
+    <button type="button" data-testid="active-filters-clear-search" onclick={() => onClearSearch?.()}>
+      clear search
+    </button>
+  {/if}
+  {#if onAddAllToCollection}
+    <button type="button" data-testid="active-filters-add-all" onclick={() => onAddAllToCollection()}> add all </button>
+  {/if}
 </div>

--- a/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/mock-filter-panel.test-wrapper.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/mock-filter-panel.test-wrapper.svelte
@@ -13,25 +13,34 @@
     storageKey?: string;
     personNames?: Map<string, string>;
     tagNames?: Map<string, string>;
+    onFiltersChange?: (filters: FilterState) => void;
   }
 
   // `filters` is two-way bound by the page; the buttons below let tests activate filters.
-  let { filters = $bindable(createFilterState()), hidden = false, ...rest }: Props = $props();
+  let { filters = $bindable(createFilterState()), hidden = false, onFiltersChange, ...rest }: Props = $props();
   void rest;
+
+  // The real panel funnels EVERY control through `updateFilters`, which sets the bound value and
+  // then fires `onFiltersChange` (filter-panel.svelte). Mutating the binding alone would let a page
+  // that never wires the callback — and so never writes its filters to the URL — pass.
+  function updateFilters(nextFilters: FilterState) {
+    filters = nextFilters;
+    onFiltersChange?.(nextFilters);
+  }
 </script>
 
 <div data-testid="filter-panel" data-hidden={String(hidden)}>
   <button
     type="button"
     data-testid="filter-panel-add-person"
-    onclick={() => (filters = { ...filters, personIds: ['person-1'] })}
+    onclick={() => updateFilters({ ...filters, personIds: ['person-1'] })}
   >
     add person filter
   </button>
   <button
     type="button"
     data-testid="filter-panel-add-year"
-    onclick={() => (filters = { ...filters, selectedYear: 2025 })}
+    onclick={() => updateFilters({ ...filters, selectedYear: 2025 })}
   >
     add year filter
   </button>

--- a/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/mock-filter-panel.test-wrapper.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/mock-filter-panel.test-wrapper.svelte
@@ -9,7 +9,7 @@
     config: FilterPanelConfig;
     filters?: FilterState;
     hidden?: boolean;
-    timeBuckets?: unknown;
+    timeBuckets?: Array<{ timeBucket: string; count: number }>;
     storageKey?: string;
     personNames?: Map<string, string>;
     tagNames?: Map<string, string>;
@@ -17,7 +17,14 @@
   }
 
   // `filters` is two-way bound by the page; the buttons below let tests activate filters.
-  let { filters = $bindable(createFilterState()), hidden = false, onFiltersChange, ...rest }: Props = $props();
+  let {
+    config,
+    filters = $bindable(createFilterState()),
+    hidden = false,
+    timeBuckets = [],
+    onFiltersChange,
+    ...rest
+  }: Props = $props();
   void rest;
 
   // The real panel funnels EVERY control through `updateFilters`, which sets the bound value and
@@ -27,9 +34,50 @@
     filters = nextFilters;
     onFiltersChange?.(nextFilters);
   }
+
+  /**
+   * The real panel calls `config.suggestionsProvider` on mount and on every filter change
+   * (filter-panel.svelte). Without that call here, a page's ENTIRE query-mode provider — the branch
+   * that swaps album suggestions for search facets — is never exercised, and deleting it leaves the
+   * suite green. The rendered people list below is what lets a test observe which branch ran.
+   */
+  let suggestedPeople = $state<Array<{ id: string; name: string }>>([]);
+  let suggestionError = $state('');
+
+  $effect(() => {
+    const provider = config?.suggestionsProvider;
+    const currentFilters = filters;
+    if (!provider) {
+      return;
+    }
+    let cancelled = false;
+    void provider(currentFilters)
+      .then((result) => {
+        if (cancelled) {
+          return;
+        }
+        suggestedPeople = result.people ?? [];
+        suggestionError = '';
+      })
+      .catch((error: unknown) => {
+        if (cancelled) {
+          return;
+        }
+        suggestedPeople = [];
+        suggestionError = error instanceof Error ? error.message : 'unknown error';
+      });
+    return () => {
+      cancelled = true;
+    };
+  });
 </script>
 
-<div data-testid="filter-panel" data-hidden={String(hidden)}>
+<div
+  data-testid="filter-panel"
+  data-hidden={String(hidden)}
+  data-time-buckets={timeBuckets.map((bucket) => bucket.timeBucket).join(',')}
+  data-suggestion-error={suggestionError}
+>
   <button
     type="button"
     data-testid="filter-panel-add-person"
@@ -44,4 +92,13 @@
   >
     add year filter
   </button>
+  {#each suggestedPeople as person (person.id)}
+    <button
+      type="button"
+      data-testid="filter-panel-suggested-person-{person.id}"
+      onclick={() => updateFilters({ ...filters, personIds: [person.id] })}
+    >
+      {person.name}
+    </button>
+  {/each}
 </div>

--- a/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/space-album-detail-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/space-album-detail-page.spec.ts
@@ -3,6 +3,8 @@ import {
   AssetOrder,
   SharedSpaceRole,
   getAlbumInfo,
+  getFilterSuggestions,
+  searchSmartFacets,
   type AlbumResponseDto,
   type SharedSpaceMemberResponseDto,
   type SharedSpaceResponseDto,
@@ -143,6 +145,8 @@ vi.mock('@immich/sdk', async (importOriginal) => {
   return {
     ...actual,
     getAlbumInfo: vi.fn(),
+    getFilterSuggestions: vi.fn(),
+    searchSmartFacets: vi.fn(),
   };
 });
 
@@ -1343,6 +1347,96 @@ describe('Space album detail page', () => {
       await waitFor(() =>
         expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'sunset'),
       );
+    });
+
+    const facetsWith = (people: Array<{ id: string; name: string }> = []) =>
+      ({
+        total: 7,
+        timeBuckets: [{ timeBucket: '2025-06-01', count: 7 }],
+        countries: [],
+        cities: [],
+        cameraMakes: [],
+        cameraModels: [],
+        tags: [],
+        people,
+        ratings: [],
+        mediaTypes: [],
+        hasUnnamedPeople: false,
+      }) as never;
+
+    // The panel's suggestions must come from the SEARCH in query mode, not the album's own
+    // suggestion endpoint — otherwise it offers facets the visible results do not contain.
+    it('sources the filter panel options from the search facets while a query is running', async () => {
+      mockPage.reset('https://gallery.test/spaces/space-1/albums/album-1?q=beach');
+      vi.mocked(searchSmartFacets).mockResolvedValue(facetsWith([{ id: 'facet-person', name: 'Facet Person' }]));
+
+      renderPage();
+
+      await waitFor(() => expect(screen.getByTestId('filter-panel-suggested-person-facet-person')).toBeInTheDocument());
+      expect(vi.mocked(getFilterSuggestions)).not.toHaveBeenCalled();
+    });
+
+    it('feeds the search facet time buckets to the filter panel instead of the album buckets', async () => {
+      mockPage.reset('https://gallery.test/spaces/space-1/albums/album-1?q=beach');
+      vi.mocked(searchSmartFacets).mockResolvedValue(facetsWith());
+
+      renderPage();
+
+      await waitFor(() =>
+        expect(screen.getByTestId('filter-panel')).toHaveAttribute('data-time-buckets', '2025-06-01'),
+      );
+    });
+
+    it('shows the search total rather than the browse count', async () => {
+      mockPage.reset('https://gallery.test/spaces/space-1/albums/album-1?q=beach');
+      vi.mocked(searchSmartFacets).mockResolvedValue(facetsWith());
+
+      renderPage();
+
+      await waitFor(() => expect(screen.getByTestId('active-filters-bar')).toHaveAttribute('data-result-count', '7'));
+    });
+
+    it('clears the query from the URL when the search chip is dismissed', async () => {
+      mockPage.reset('https://gallery.test/spaces/space-1/albums/album-1?q=beach');
+      vi.mocked(searchSmartFacets).mockResolvedValue(facetsWith());
+
+      renderPage();
+
+      await fireEvent.click(await screen.findByTestId('active-filters-clear-search'));
+
+      await waitFor(() => {
+        const [target] = vi.mocked(goto).mock.calls.at(-1) as [string];
+        expect(target).not.toContain('q=beach');
+      });
+    });
+
+    // The filters are URL-backed now, so removing a chip has to write the URL too — otherwise the
+    // param survives and a refresh restores the filter the user just removed.
+    it('writes temporal chip removal back to the URL', async () => {
+      mockPage.reset('https://gallery.test/spaces/space-1/albums/album-1?year=2025');
+
+      renderPage();
+
+      await fireEvent.click(await screen.findByTestId('active-filters-remove-timeline'));
+
+      await waitFor(() => {
+        const [target] = vi.mocked(goto).mock.calls.at(-1) as [string];
+        expect(target).not.toContain('year=2025');
+      });
+    });
+
+    it('writes a filtered-empty "clear all filters" back to the URL', async () => {
+      mockPage.reset('https://gallery.test/spaces/space-1/albums/album-1?city=Berlin');
+      setMockTimelineEmpty();
+
+      renderPage();
+
+      await fireEvent.click(await screen.findByTestId('browse-clear-filters'));
+
+      await waitFor(() => {
+        const [target] = vi.mocked(goto).mock.calls.at(-1) as [string];
+        expect(target).not.toContain('city=Berlin');
+      });
     });
 
     it('re-scopes the search when navigating straight to a sibling album', async () => {

--- a/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/space-album-detail-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/space-album-detail-page.spec.ts
@@ -11,12 +11,14 @@ import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
 import type { Component } from 'svelte';
 import { init, register, waitLocale } from 'svelte-i18n';
+import { goto } from '$app/navigation';
 import { getAnimateMock } from '$lib/__mocks__/animate.mock';
 import TestWrapper from '$lib/components/TestWrapper.svelte';
 import { authManager } from '$lib/managers/auth-manager.svelte';
 import { addAssetsToAlbumWithOutcome, getAlbumAssetsActions } from '$lib/services/album.service';
 import { preferencesFactory } from '@test-data/factories/preferences-factory';
 import { userAdminFactory } from '@test-data/factories/user-factory';
+import { reactivePageMock as mockPage } from '@test-data/mocks/reactive-page.mock.svelte';
 import SpaceAlbumDetailPage from './+page.svelte';
 import { mockTimelineState, resetMockTimelineState, setMockTimelineEmpty } from './mock-timeline-state';
 
@@ -62,6 +64,19 @@ vi.mock('$lib/components/filter-panel/active-filters-bar.svelte', async () => {
 });
 
 vi.mock('$app/navigation', () => ({ goto: vi.fn(), invalidateAll: vi.fn(), onNavigate: vi.fn() }));
+
+// Reactive, not a plain hoisted object: this page's filters and committed query are URL-backed, so
+// its re-hydrate $effect only re-runs when `page.url` is a real signal. A plain object would let a
+// broken re-hydrate pass. See reactive-page.mock.svelte.ts.
+vi.mock('$app/state', async () => {
+  const { reactivePageMock } = await import('@test-data/mocks/reactive-page.mock.svelte');
+  return { page: reactivePageMock };
+});
+
+vi.mock('$lib/components/search/smart-search-results.svelte', async () => {
+  const { default: MockComponent } = await import('@test-data/mocks/smart-search-results.stub.svelte');
+  return { default: MockComponent };
+});
 
 vi.mock('$lib/components/timeline/TimelineGroupingControl.svelte', async () => {
   const { default: MockComponent } = await import('./mock-grouping-control.test-wrapper.svelte');
@@ -256,6 +271,7 @@ describe('Space album detail page', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    mockPage.reset('https://gallery.test/spaces/space-1/albums/album-1');
     // The add→browse transition calls element.animate(); without a mock it returns undefined and
     // setting .onfinish on it throws an async unhandled error that fails the run (seen only in CI's
     // test ordering). Mirror the global-album route spec.
@@ -1201,6 +1217,145 @@ describe('Space album detail page', () => {
       await rerender(rerenderWith(makeAlbum({ id: 'album-2' })));
 
       expect(screen.getByTestId('space-album-timeline')).toHaveAttribute('data-mode', 'browse');
+    });
+  });
+
+  // #986: searching from inside a space album used to bounce the user to /photos and run the query
+  // against their whole library. The album is a searchable page now, so the query runs in place,
+  // scoped to the album.
+  describe('page-aware search', () => {
+    const rerenderWith = (album: AlbumResponseDto) => ({
+      component: SpaceAlbumDetailPage,
+      componentProps: { data: makePageData(album) },
+    });
+
+    it('runs the search in place instead of showing the browse timeline', () => {
+      mockPage.reset('https://gallery.test/spaces/space-1/albums/album-1?q=beach');
+
+      renderPage();
+
+      expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'beach');
+      expect(screen.queryByTestId('space-album-timeline')).not.toBeInTheDocument();
+    });
+
+    it('scopes the search to the album it was launched from', () => {
+      mockPage.reset('https://gallery.test/spaces/space-1/albums/album-1?q=beach');
+
+      renderPage({ album: makeAlbum({ id: 'album-1' }) });
+
+      expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-album-ids', 'album-1');
+    });
+
+    // A space album is scoped by its album, not by its space: sending spaceId as well would make the
+    // server drop the space gate in favour of the caller's full timeline-space set (database.ts).
+    it('does not send a space scope alongside the album scope', () => {
+      mockPage.reset('https://gallery.test/spaces/space-1/albums/album-1?q=beach');
+
+      renderPage();
+
+      expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-space-id', '');
+    });
+
+    it('shows the browse timeline when there is no query', () => {
+      renderPage();
+
+      expect(screen.getByTestId('space-album-timeline')).toBeInTheDocument();
+      expect(screen.queryByTestId('smart-search-results')).not.toBeInTheDocument();
+    });
+
+    it('hydrates filters from the URL into the search', () => {
+      mockPage.reset('https://gallery.test/spaces/space-1/albums/album-1?q=beach&city=Berlin&type=video');
+
+      renderPage();
+
+      expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-city', 'Berlin');
+      expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-filter-media-type', 'video');
+    });
+
+    it('hydrates filters from the URL into the browse timeline', () => {
+      mockPage.reset('https://gallery.test/spaces/space-1/albums/album-1?city=Berlin');
+
+      renderPage();
+
+      const options = JSON.parse(screen.getByTestId('timeline-options').textContent ?? '{}');
+      expect(options.city).toBe('Berlin');
+    });
+
+    it('carries an explicit sort into the search', () => {
+      mockPage.reset('https://gallery.test/spaces/space-1/albums/album-1?q=beach&sort=asc');
+
+      renderPage();
+
+      expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-sort-order', 'asc');
+    });
+
+    // The navbar sort dropdown appears on every searchable page, browse mode included. Ignoring the
+    // param there would leave a control that visibly does nothing.
+    it('lets an explicit sort override the album order in browse mode', () => {
+      mockPage.reset('https://gallery.test/spaces/space-1/albums/album-1?sort=asc');
+
+      renderPage({ album: makeAlbum({ order: AssetOrder.Desc }) });
+
+      expect(JSON.parse(screen.getByTestId('timeline-options').textContent ?? '{}').order).toBe(AssetOrder.Asc);
+    });
+
+    it("keeps the album's own order in browse mode when the URL carries no sort", () => {
+      renderPage({ album: makeAlbum({ order: AssetOrder.Asc }) });
+
+      expect(JSON.parse(screen.getByTestId('timeline-options').textContent ?? '{}').order).toBe(AssetOrder.Asc);
+    });
+
+    it('writes a filter change back to the URL', async () => {
+      renderPage();
+
+      await fireEvent.click(screen.getByTestId('filter-panel-add-person'));
+
+      await waitFor(() =>
+        expect(goto).toHaveBeenCalledWith(
+          '/spaces/space-1/albums/album-1?people=person-1',
+          expect.objectContaining({ replaceState: true }),
+        ),
+      );
+    });
+
+    it('keeps the query in the URL when a filter changes during a search', async () => {
+      mockPage.reset('https://gallery.test/spaces/space-1/albums/album-1?q=beach');
+
+      renderPage();
+
+      await fireEvent.click(screen.getByTestId('filter-panel-add-person'));
+
+      await waitFor(() =>
+        expect(goto).toHaveBeenCalledWith(
+          expect.stringContaining('q=beach'),
+          expect.objectContaining({ replaceState: true }),
+        ),
+      );
+    });
+
+    it('re-hydrates when the URL changes under it (back/forward, shared link)', async () => {
+      renderPage();
+
+      expect(screen.getByTestId('space-album-timeline')).toBeInTheDocument();
+
+      mockPage.url = new URL('https://gallery.test/spaces/space-1/albums/album-1?q=sunset');
+
+      await waitFor(() =>
+        expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-search-query', 'sunset'),
+      );
+    });
+
+    it('re-scopes the search when navigating straight to a sibling album', async () => {
+      mockPage.reset('https://gallery.test/spaces/space-1/albums/album-1?q=beach');
+
+      const { rerender } = renderPage({ album: makeAlbum({ id: 'album-1' }) });
+
+      expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-album-ids', 'album-1');
+
+      mockPage.url = new URL('https://gallery.test/spaces/space-1/albums/album-2?q=beach');
+      await rerender(rerenderWith(makeAlbum({ id: 'album-2' })));
+
+      expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-album-ids', 'album-2');
     });
   });
 });

--- a/web/src/test-data/mocks/smart-search-results.stub.svelte
+++ b/web/src/test-data/mocks/smart-search-results.stub.svelte
@@ -10,6 +10,12 @@
     albumIds?: string[];
     language?: string;
     total?: number;
+    // $bindable on the real component, so a host that binds it expects to be able to read loaded
+    // results back. Spreading it onto the div instead made any behaviour keyed on results — the
+    // selection toolbar acting on the search grid — unobservable.
+    results?: unknown[];
+    isShared?: boolean;
+    space?: { id: string; canWrite: boolean };
     [key: string]: unknown;
   }
 
@@ -22,6 +28,9 @@
     albumIds,
     language = '',
     total,
+    results = $bindable([]),
+    isShared,
+    space,
     ...rest
   }: Props = $props();
 </script>
@@ -49,6 +58,9 @@
   data-with-shared-spaces={String(withSharedSpaces)}
   data-space-id={spaceId ?? ''}
   data-album-ids={albumIds?.join(',') ?? ''}
+  data-result-count={results.length}
+  data-is-shared={String(isShared)}
+  data-space={JSON.stringify(space ?? null)}
   data-country={filters?.country ?? ''}
   data-language={language}
   data-total={total ?? ''}

--- a/web/src/test-data/mocks/smart-search-results.stub.svelte
+++ b/web/src/test-data/mocks/smart-search-results.stub.svelte
@@ -7,6 +7,7 @@
     filters?: FilterState;
     withSharedSpaces?: boolean;
     spaceId?: string;
+    albumIds?: string[];
     language?: string;
     total?: number;
     [key: string]: unknown;
@@ -18,6 +19,7 @@
     filters,
     withSharedSpaces,
     spaceId,
+    albumIds,
     language = '',
     total,
     ...rest
@@ -46,6 +48,7 @@
   data-filter-model={filters?.model ?? ''}
   data-with-shared-spaces={String(withSharedSpaces)}
   data-space-id={spaceId ?? ''}
+  data-album-ids={albumIds?.join(',') ?? ''}
   data-country={filters?.country ?? ''}
   data-language={language}
   data-total={total ?? ''}


### PR DESCRIPTION
## What

Searching from inside an album took you to `/photos` and ran the query against your whole library. A space page searches that space correctly; a space album did not.

Both album detail routes — `/albums/{id}` and `/spaces/{sid}/albums/{id}` — are searchable pages now. The query runs in place, scoped to the album you are looking at.

## Why it happened

`getSearchablePageBasePath` (`web/src/lib/utils/searchable-page-search.ts`) only recognised `/photos`, `/recently-added` and the space timeline, so `buildSearchDestination` fell through to its `/photos` fallback.

## How

Each album page now hydrates `q`, `sort` and its filters from the URL, registers its filters with the palette so a tag/person/place row ANDs into the album instead of leaving it, and renders `<SmartSearchResults>` scoped to `albumIds: [album.id]`.

Scope is the album alone, never `spaceId`. That matches the page's own browse timeline (`buildAlbumTimelineOptions`) and the personal person tokens its filter panel speaks. It also avoids a server interaction: an `albumIds` scope makes the service resolve `timelineSpaceIds`, and the `spaceId` predicate is skipped whenever those are set (`database.ts`), so sending both would widen the scope rather than narrow it.

Filter-panel writes keep going through `buildFilterStateUrl`, not `buildSearchablePageUrl` — the former preserves the current pathname, so using the panel with the asset viewer open no longer closes it, and `q`/`sort` ride along as ordinary non-filter params.

Making a route searchable also renders the navbar sort dropdown on it, so an explicit `?sort=` now drives the browse timeline order; absent that param the album's own `order` still stands.

## Two space-scope traps fixed in the same change

`getCurrentSpaceTimelineId` and `activateSearch`'s typed-search scope both keyed off a bare `/spaces/` prefix, which now also matches a space album.

A space album is album-scoped: its filter panel speaks the prefixed person tokens `/photos` uses (`person:` / `space-person:`), never the bare space profile id a space timeline forwards as `spacePersonIds`. Handing it the bare id yields a silently empty timeline — the server reads it as a legacy person id the viewer does not own. Both are now scoped to the space timeline by segment count.

The typed-search one was already broken on `main`: typing `person:Alice` on a space album resolved space-scoped, then navigated to `/photos` with an id matching nothing there.

## Server

- `SmartSearchFacetsSchema` picks `albumIds`, so the result count and the temporal picker's buckets describe the album being searched. Without it zod strips the field and the facets silently describe the whole library beside a one-album grid.
- **Album-scoped smart search returned only the caller's own photos.** An album page browses by album *access* — `timeline.service` resolves `albumSpaceIds` from plain membership — and shows every member's photos; searching that same album kept the owner-scoping `userIds` and returned only your own. `searchMetadata` has always handled this the other way (AlbumRead check as the boundary, `albumSharedSpaceScope` re-gating the rows in the builder); `searchSmart` now matches it. This also aligns query mode with browse mode for the same `?album=` filter elsewhere.
- The facets' people list read the viewer off `userIds[0]`, which is absent under an album scope, so the caller is carried explicitly as `callerId`.

OpenAPI spec, TS SDK and Dart client regenerated — a 9-line spec diff and one Dart model.

## Testing

Written test-first throughout; every test was watched fail before the code existed.

- `searchable-page-search.spec.ts` — the new base paths, and the list pages staying non-searchable
- `global-search-manager.svelte.spec.ts` — both space-scope narrowings, and a query staying on the album
- `space-search.spec.ts` — the route album scope, its union with an `albumId` filter, and the facet key
- `smart-search-results.spec.ts` — the scope reaching `searchSmart`
- both page specs — the search branch, URL round-trip, re-hydrate on back/forward, sibling-album navigation, sort precedence
- `search.service.spec.ts` — the access check, the dropped owner scope, and `callerId`
- `search.dto.spec.ts` — `albumIds` surviving the facets schema

web 5731 passed · server 5773 passed · `check:typescript`, `check:svelte`, eslint and prettier clean on both; e2e and CLI packages type-check against the regenerated SDK.

One test-harness fix: the space album spec's `mock-filter-panel` now fires `onFiltersChange`. The real panel funnels every control through `updateFilters`, which sets the binding *and* fires the callback, so the old mock would have let a page that never writes its filters to the URL pass.

## Not covered

- No e2e/Playwright coverage added; this is unit-tested only.
- `resolveFilterTarget` still returns null for `/spaces/{sid}/albums/{id}`, so the asset viewer's contextual "filter by this camera" inside a space album still jumps to `/photos`. Pre-existing and unchanged.
