### PR TITLE
fix(mobile): apply the persisted album sort to the Space page shelf

### DIFF
--- a/mobile/lib/presentation/widgets/spaces/space_albums_shelf.widget.dart
+++ b/mobile/lib/presentation/widgets/spaces/space_albums_shelf.widget.dart
@@ -4,8 +4,10 @@ import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/space_album.model.dart';
 import 'package:immich_mobile/extensions/build_context_extensions.dart';
 import 'package:immich_mobile/extensions/translate_extensions.dart';
+import 'package:immich_mobile/pages/library/spaces/collection_sort.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
+import 'package:immich_mobile/providers/infrastructure/settings.provider.dart';
 import 'package:immich_mobile/providers/infrastructure/space_album.provider.dart';
 
 /// Fixed height of the Albums shelf when it is visible (at least one album
@@ -40,6 +42,12 @@ const double _kTileRadius = 16.0;
 /// Callbacks [onLinkTap] and [onAlbumTap] are **no-op stubs in B2** — B4 wires
 /// album-tap navigation and B5 wires the link picker.
 /// [onSeeAll] is wired in B3 to push [SpaceAlbumsRoute].
+///
+/// Album order comes from the same persisted [AppConfig.spaceAlbums] the "See
+/// all" page ([SpaceAlbumsPage]) writes, so the sort a user picks there is the
+/// order they see here. `spaceAlbumsProvider` emits name-ASC (the repository's
+/// `orderBy`), which is NOT the default sort — so the config has to be applied
+/// even when the user has never opened the sort menu.
 class SpaceAlbumsShelf extends ConsumerWidget {
   const SpaceAlbumsShelf({
     super.key,
@@ -62,11 +70,15 @@ class SpaceAlbumsShelf extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final albumsAsync = ref.watch(spaceAlbumsProvider(spaceId));
+    final sortConfig = ref.watch(appConfigProvider.select((config) => config.spaceAlbums));
 
     return albumsAsync.when(
       loading: () => const SizedBox.shrink(),
       error: (_, __) => const SizedBox.shrink(),
-      data: (albums) => _buildShelf(context, albums),
+      // Empty query: the shelf shows every linked album — only the See all page
+      // filters.
+      data: (albums) =>
+          _buildShelf(context, filterAndSortSpaceAlbums(albums, '', sortConfig.sortMode, sortConfig.isReverse)),
     );
   }
 

--- a/mobile/test/presentation/pages/space_detail_top_sliver_test.dart
+++ b/mobile/test/presentation/pages/space_detail_top_sliver_test.dart
@@ -6,10 +6,14 @@
 /// shelf's presence/absence logic.
 library;
 
+import 'package:drift/drift.dart' as drift;
+import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/space_album.model.dart';
+import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
+import 'package:immich_mobile/infrastructure/repositories/settings.repository.dart';
 import 'package:immich_mobile/presentation/widgets/spaces/space_top_sliver.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/space_album.provider.dart';
 import 'package:immich_mobile/providers/sync_status.provider.dart';
@@ -65,6 +69,22 @@ class _FakeSyncStatusNotifier extends SyncStatusNotifier {
 // ---------------------------------------------------------------------------
 
 void main() {
+  late Drift db;
+
+  // The shelf sorts its albums by the persisted `AppConfig.spaceAlbums`, so it
+  // reads `appConfigProvider` -> SettingsRepository.instance, which throws when
+  // uninitialized. Production initializes it in `bootstrap.dart` long before
+  // any space UI mounts; these tests need the same guarantee.
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    db = Drift(drift.DatabaseConnection(NativeDatabase.memory(), closeStreamsSynchronously: true));
+    await SettingsRepository.ensureInitialized(db);
+  });
+
+  tearDownAll(() async {
+    await db.close();
+  });
+
   testWidgets('editor + 1 album: shelf is present inside the top sliver', (tester) async {
     await tester.pumpWidget(_wrap(spaceId: 'space-1', canEdit: true, albums: [_album('a1')]));
     await tester.pump(); // stream emit

--- a/mobile/test/presentation/widgets/spaces/space_albums_shelf_test.dart
+++ b/mobile/test/presentation/widgets/spaces/space_albums_shelf_test.dart
@@ -1,9 +1,15 @@
+import 'package:drift/drift.dart' as drift;
+import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
+import 'package:immich_mobile/domain/models/settings_key.dart';
 import 'package:immich_mobile/domain/models/space_album.model.dart';
 import 'package:immich_mobile/domain/services/asset.service.dart';
+import 'package:immich_mobile/infrastructure/repositories/db.repository.dart';
+import 'package:immich_mobile/infrastructure/repositories/settings.repository.dart';
+import 'package:immich_mobile/pages/library/spaces/collection_sort.dart';
 import 'package:immich_mobile/presentation/widgets/images/thumbnail.widget.dart';
 import 'package:immich_mobile/presentation/widgets/spaces/space_albums_shelf.widget.dart';
 import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
@@ -35,16 +41,33 @@ Finder findByKeyPrefix(String prefix) => find.byWidgetPredicate(
 // Helpers
 // ---------------------------------------------------------------------------
 
-SpaceAlbum _album({required String id, String? name, String? thumbnailAssetId, bool showInTimeline = true}) =>
-    SpaceAlbum(
-      id: id,
-      name: name ?? 'Album $id',
-      thumbnailAssetId: thumbnailAssetId,
-      showInTimeline: showInTimeline,
-      linkedAt: DateTime.utc(2026, 1, 1),
-      updatedAt: DateTime.utc(2026, 1, 1),
-      createdAt: DateTime.utc(2026, 1, 1),
-    );
+SpaceAlbum _album({
+  required String id,
+  String? name,
+  String? thumbnailAssetId,
+  bool showInTimeline = true,
+  int assetCount = 0,
+  DateTime? linkedAt,
+}) => SpaceAlbum(
+  id: id,
+  name: name ?? 'Album $id',
+  thumbnailAssetId: thumbnailAssetId,
+  showInTimeline: showInTimeline,
+  assetCount: assetCount,
+  linkedAt: linkedAt ?? DateTime.utc(2026, 1, 1),
+  updatedAt: DateTime.utc(2026, 1, 1),
+  createdAt: DateTime.utc(2026, 1, 1),
+);
+
+/// The ids of the shelf's cover tiles in visual left-to-right order.
+///
+/// Read from real on-screen geometry rather than widget-tree order, so it
+/// still describes what the user sees if the strip's layout ever changes.
+List<String> _tileOrder(WidgetTester tester, List<String> ids) {
+  final positions = {for (final id in ids) id: tester.getTopLeft(find.byKey(Key('space-album-tile-$id'))).dx};
+  final sorted = ids.toList()..sort((a, b) => positions[a]!.compareTo(positions[b]!));
+  return sorted;
+}
 
 /// Overrides [spaceAlbumsProvider] with a fixed list, for use with
 /// [WidgetTester.pumpConsumerWidget]'s `overrides` param (which already
@@ -62,10 +85,26 @@ List<Override> _overrides({required String spaceId, required List<SpaceAlbum> al
 // ---------------------------------------------------------------------------
 
 void main() {
+  late Drift settingsDb;
+
   setUpAll(() async {
     // PresentationContext.create() calls TestUtils.init() + initializes
-    // StoreService (needed by Thumbnail.remote's RemoteImageProvider).
+    // StoreService (needed by Thumbnail.remote's RemoteImageProvider). It does
+    // NOT initialize SettingsRepository, which `appConfigProvider` — and hence
+    // the shelf's sort order — reads from, so wire up a real one here. Using
+    // the real repository rather than an `appConfigProvider` override keeps the
+    // persisted-choice → shelf chain under test end to end.
     await PresentationContext.create();
+    settingsDb = Drift(drift.DatabaseConnection(NativeDatabase.memory(), closeStreamsSynchronously: true));
+    await SettingsRepository.ensureInitialized(settingsDb);
+  });
+
+  setUp(() async {
+    await SettingsRepository.instance.clear(SettingsKey.values);
+  });
+
+  tearDownAll(() async {
+    await settingsDb.close();
   });
 
   const spaceId = 'space-1';
@@ -191,5 +230,59 @@ void main() {
 
     expect(find.byType(Thumbnail), findsOneWidget);
     expect(find.byIcon(Icons.photo_album_outlined), findsNothing);
+  });
+
+  // -------------------------------------------------------------------------
+  // Sort order — regression: the shelf rendered the provider's list verbatim,
+  // so a sort picked on the "See all" page never reached the Space page.
+  //
+  // `spaceAlbumsProvider` always emits name-ASC (the repository's
+  // `orderBy(meta.name)`), so every list below is fed in name-ASC order and
+  // each expectation is a DIFFERENT order — a shelf that renders the provider's
+  // list verbatim fails all three.
+  // -------------------------------------------------------------------------
+
+  testWidgets('honors a persisted sort mode picked on the See all page', (tester) async {
+    await SettingsRepository.instance.write(SettingsKey.spaceAlbumsSortMode, SpaceAlbumSortMode.photoCount);
+
+    final albums = [_album(id: 'a1', name: 'Alps', assetCount: 5), _album(id: 'a2', name: 'Beach', assetCount: 50)];
+
+    await tester.pumpConsumerWidget(
+      SpaceAlbumsShelf(spaceId: spaceId, canEdit: false, onLinkTap: () {}, onAlbumTap: (_) {}),
+      overrides: _overrides(spaceId: spaceId, albums: albums),
+    );
+
+    // photoCount defaults to desc -> Beach (50) before Alps (5).
+    expect(_tileOrder(tester, ['a1', 'a2']), ['a2', 'a1']);
+  });
+
+  testWidgets('honors the persisted reverse flag', (tester) async {
+    await SettingsRepository.instance.write(SettingsKey.spaceAlbumsSortMode, SpaceAlbumSortMode.name);
+    await SettingsRepository.instance.write(SettingsKey.spaceAlbumsIsReverse, true);
+
+    final albums = [_album(id: 'a1', name: 'Alps'), _album(id: 'a2', name: 'Beach')];
+
+    await tester.pumpConsumerWidget(
+      SpaceAlbumsShelf(spaceId: spaceId, canEdit: false, onLinkTap: () {}, onAlbumTap: (_) {}),
+      overrides: _overrides(spaceId: spaceId, albums: albums),
+    );
+
+    // name is asc by default, reversed -> desc -> Beach before Alps.
+    expect(_tileOrder(tester, ['a1', 'a2']), ['a2', 'a1']);
+  });
+
+  testWidgets('with nothing persisted, falls back to the same default as the See all page', (tester) async {
+    final albums = [
+      _album(id: 'a1', name: 'Alps', linkedAt: DateTime.utc(2026, 1, 1)),
+      _album(id: 'a2', name: 'Beach', linkedAt: DateTime.utc(2026, 6, 1)),
+    ];
+
+    await tester.pumpConsumerWidget(
+      SpaceAlbumsShelf(spaceId: spaceId, canEdit: false, onLinkTap: () {}, onAlbumTap: (_) {}),
+      overrides: _overrides(spaceId: spaceId, albums: albums),
+    );
+
+    // Default is recentlyLinked desc -> the June link before the January one.
+    expect(_tileOrder(tester, ['a1', 'a2']), ['a2', 'a1']);
   });
 }


### PR DESCRIPTION
Reported on iOS: the Space page shows shared albums in a strip at the top. Tapping **See all** opens the sort options, but changing the sort there only reorders that page — the strip on the Space page keeps its old order.

## Root cause

`SpaceAlbumsShelf` rendered `spaceAlbumsProvider`'s list verbatim. That list carries whatever the Drift query orders by — `orderBy(meta.name)` in `space_album.repository.dart:57`, so always name-ascending.

`SpaceAlbumsPage` ("See all") *did* apply the persisted choice, via `filterAndSortSpaceAlbums(...)` reading `appConfigProvider.spaceAlbums`. The sort was being written and persisted correctly; the shelf simply never read it.

This was already wrong at defaults, not only after changing the sort. The default mode is `recentlyLinked` desc, so an install where nobody ever opened the sort menu still showed name-ASC on the shelf and recently-linked-desc one tap away.

## Fix

The shelf watches the same config and runs the same sort function, with an empty query since it shows every linked album (only the See all page filters):

```dart
final sortConfig = ref.watch(appConfigProvider.select((config) => config.spaceAlbums));
...
data: (albums) => _buildShelf(context, filterAndSortSpaceAlbums(albums, '', sortConfig.sortMode, sortConfig.isReverse)),
```

## Tests

Written TDD. Three tests added to `space_albums_shelf_test.dart`, each feeding albums in name-ASC order (what the repository actually emits) and expecting a *different* order, so a shelf that renders the provider's list verbatim fails all three:

- honors a persisted sort mode picked on the See all page
- honors the persisted reverse flag
- with nothing persisted, falls back to the same default as the See all page

All three failed with `Actual: ['a1', 'a2']` before the fix; the 8 pre-existing shelf tests stayed green throughout.

The tests drive a real `SettingsRepository` rather than overriding `appConfigProvider`, so the persisted-choice → shelf chain is covered end to end instead of mocked at the layer under test. Order is read from on-screen geometry (`getTopLeft().dx`) rather than widget-tree order.

## Knock-on change

Adding the `appConfigProvider` dependency broke `space_detail_top_sliver_test` with `Bad state: SettingsRepository not initialized`. That is a test-harness gap rather than a runtime risk — production initializes it in `bootstrap.dart:56` at startup, and `SpaceAlbumsPage` already had the identical dependency. Added the same in-memory init there.

## Scope

Every other `spaceAlbumsProvider` consumer was checked and is order-independent: `space_album_detail.page.dart` and `space_detail.page.dart` do id lookups (`.where(id == albumId).firstOrNull`) and an id-set collection.

`space_collection_section.widget.dart` (the add-to-collection picker) is deliberately left alone — different surface, and applying a browsing sort preference to a destination picker is not obviously right.

## Verification

- Full mobile suite: 3144 passed, 1 skipped, exit 0
- `dart analyze --fatal-infos`: No issues found
- `dart format --set-exit-if-changed`: clean

No i18n changes — no new or edited user-facing strings.
