### PR TITLE
fix(mobile): show original folder in asset details

### DIFF
--- a/docs/plans/2026-08-22-mobile-asset-folder-info-design.md
+++ b/docs/plans/2026-08-22-mobile-asset-folder-info-design.md
@@ -1,0 +1,57 @@
+# Mobile Asset Folder Information
+
+## Summary
+
+Show the server-side original asset path in the mobile asset-info panel, matching the web asset viewer.
+
+## Motivation
+
+The mobile API model already receives `originalPath`, but the mobile cached asset model drops it and the asset-info UI only renders the filename, size, and resolution. Users therefore cannot identify the source folder from iOS or Android even though the web viewer exposes the same information.
+
+## Scope
+
+- Fetch the original path when the remote asset-info panel is opened.
+- Show the path in the Technical Details section under a localized `Folder` row.
+- Omit the row when the asset has no remote ID, the request returns no path, or the path is empty.
+- Do not add the path to the cached Drift asset schema.
+- Do not change server APIs, folder navigation, or local-only asset behavior.
+
+## UX
+
+When a remote asset has an original path, Technical Details shows:
+
+- Existing filename, file size, and resolution row.
+- A `Folder` row with the original path as its subtitle.
+
+The path remains copyable through the existing `SheetTile` long-press behavior. If path retrieval fails, the existing asset details remain available and the new row is omitted.
+
+## Architecture and Data Flow
+
+1. `AssetDetails` watches `assetOriginalPathProvider` for the displayed asset.
+2. The provider resolves the remote ID and calls `AssetApiRepository.getOriginalPath`.
+3. The repository requests `GET /assets/{id}` and returns `AssetResponseDto.originalPath`.
+4. `AssetDetails` passes the value to `TechnicalDetails`.
+5. `TechnicalDetails` renders the row only for a non-empty path.
+
+The value is fetched on demand rather than persisted because the mobile Drift asset schema does not currently carry server filesystem paths.
+
+## Error Handling
+
+The provider returns `null` for local-only assets or a missing API response. `AssetDetails` uses the resolved value only, so loading and error states preserve the existing details UI without adding a failure surface.
+
+## Testing
+
+- Provider test verifies the remote ID is sent to the API repository and the original path is returned.
+- Widget test verifies a non-empty path is rendered in Technical Details.
+- Existing asset-viewer widget tests remain green.
+
+## Files Changed
+
+| File | Change |
+| --- | --- |
+| `mobile/lib/repositories/asset_api.repository.dart` | Fetch `originalPath` from the asset-info endpoint. |
+| `mobile/lib/providers/infrastructure/asset_viewer/asset.provider.dart` | Provide the path on demand for the current asset. |
+| `mobile/lib/presentation/widgets/asset_viewer/asset_details.widget.dart` | Pass the resolved path to Technical Details. |
+| `mobile/lib/presentation/widgets/asset_viewer/asset_details/technical_details.widget.dart` | Render the Folder row. |
+| `mobile/test/providers/asset_viewer/asset_original_path_provider_test.dart` | Cover path retrieval. |
+| `mobile/test/presentation/widgets/asset_viewer/technical_details_widget_test.dart` | Cover path rendering. |

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_details.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_details.widget.dart
@@ -20,6 +20,7 @@ class AssetDetails extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final exifInfo = ref.watch(assetExifProvider(asset)).valueOrNull;
+    final originalPath = ref.watch(assetOriginalPathProvider(asset)).valueOrNull;
 
     return Container(
       constraints: BoxConstraints(minHeight: minHeight),
@@ -44,7 +45,7 @@ class AssetDetails extends ConsumerWidget {
             DateTimeDetails(asset: asset, exifInfo: exifInfo),
             PeopleDetails(asset: asset),
             LocationDetails(asset: asset, exifInfo: exifInfo),
-            TechnicalDetails(asset: asset, exifInfo: exifInfo),
+            TechnicalDetails(asset: asset, exifInfo: exifInfo, originalPath: originalPath),
             RatingDetails(exifInfo: exifInfo),
             AppearsInDetails(asset: asset),
             SizedBox(height: context.padding.bottom + 48),

--- a/mobile/lib/presentation/widgets/asset_viewer/asset_details/technical_details.widget.dart
+++ b/mobile/lib/presentation/widgets/asset_viewer/asset_details/technical_details.widget.dart
@@ -14,8 +14,9 @@ const _kSeparator = '  •  ';
 class TechnicalDetails extends ConsumerWidget {
   final BaseAsset asset;
   final ExifInfo? exifInfo;
+  final String? originalPath;
 
-  const TechnicalDetails({super.key, required this.asset, this.exifInfo});
+  const TechnicalDetails({super.key, required this.asset, this.exifInfo, this.originalPath});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -30,7 +31,7 @@ class TechnicalDetails extends ConsumerWidget {
           title: 'details'.t(context: context),
           titleStyle: context.textTheme.labelLarge?.copyWith(color: context.colorScheme.onSurfaceSecondary),
         ),
-        _buildFileInfoTile(context, ref, asset, exifInfo),
+        _buildFileInfoTile(context, ref, asset, exifInfo, originalPath),
         if (cameraTitle != null) ...[
           const SizedBox(height: 16),
           SheetTile(
@@ -62,7 +63,13 @@ class TechnicalDetails extends ConsumerWidget {
     );
   }
 
-  Widget _buildFileInfoTile(BuildContext context, WidgetRef ref, BaseAsset asset, ExifInfo? exifInfo) {
+  Widget _buildFileInfoTile(
+    BuildContext context,
+    WidgetRef ref,
+    BaseAsset asset,
+    ExifInfo? exifInfo,
+    String? originalPath,
+  ) {
     final icon = Icon(
       asset.isImage ? Icons.image_outlined : Icons.videocam_outlined,
       size: 24,
@@ -71,29 +78,39 @@ class TechnicalDetails extends ConsumerWidget {
     final subtitle = _getFileInfo(asset, exifInfo);
     final subtitleStyle = context.textTheme.bodyMedium?.copyWith(color: context.colorScheme.onSurfaceSecondary);
 
-    if (asset is LocalAsset) {
-      final assetMediaRepository = ref.watch(assetMediaRepositoryProvider);
-      return FutureBuilder<String?>(
-        future: assetMediaRepository.getOriginalFilename(asset.id),
-        builder: (context, snapshot) {
-          return SheetTile(
-            title: snapshot.data ?? asset.name,
+    Widget buildFileInfo(String title) {
+      return Column(
+        children: [
+          SheetTile(
+            title: title,
             titleStyle: context.textTheme.labelLarge,
             leading: icon,
             subtitle: subtitle,
             subtitleStyle: subtitleStyle,
-          );
-        },
+          ),
+          if (originalPath != null && originalPath.isNotEmpty) ...[
+            const SizedBox(height: 16),
+            SheetTile(
+              title: 'folder'.t(context: context),
+              titleStyle: context.textTheme.labelLarge,
+              leading: Icon(Icons.folder_outlined, size: 24, color: context.textTheme.labelLarge?.color),
+              subtitle: originalPath,
+              subtitleStyle: subtitleStyle,
+            ),
+          ],
+        ],
       );
     }
 
-    return SheetTile(
-      title: asset.name,
-      titleStyle: context.textTheme.labelLarge,
-      leading: icon,
-      subtitle: subtitle,
-      subtitleStyle: subtitleStyle,
-    );
+    if (asset is LocalAsset) {
+      final assetMediaRepository = ref.watch(assetMediaRepositoryProvider);
+      return FutureBuilder<String?>(
+        future: assetMediaRepository.getOriginalFilename(asset.id),
+        builder: (context, snapshot) => buildFileInfo(snapshot.data ?? asset.name),
+      );
+    }
+
+    return buildFileInfo(asset.name);
   }
 
   static String _getFileInfo(BaseAsset asset, ExifInfo? exifInfo) {

--- a/mobile/lib/providers/infrastructure/asset_viewer/asset.provider.dart
+++ b/mobile/lib/providers/infrastructure/asset_viewer/asset.provider.dart
@@ -2,7 +2,17 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/domain/models/asset/base_asset.model.dart';
 import 'package:immich_mobile/domain/models/exif.model.dart';
 import 'package:immich_mobile/providers/infrastructure/asset.provider.dart';
+import 'package:immich_mobile/repositories/asset_api.repository.dart';
 
 final assetExifProvider = FutureProvider.autoDispose.family<ExifInfo?, BaseAsset>((ref, asset) {
   return ref.watch(assetServiceProvider).getExif(asset);
+});
+
+final assetOriginalPathProvider = FutureProvider.autoDispose.family<String?, BaseAsset>((ref, asset) async {
+  final assetId = asset.remoteId;
+  if (assetId == null) {
+    return null;
+  }
+
+  return ref.watch(assetApiRepositoryProvider).getOriginalPath(assetId);
 });

--- a/mobile/lib/repositories/asset_api.repository.dart
+++ b/mobile/lib/repositories/asset_api.repository.dart
@@ -73,6 +73,11 @@ class AssetApiRepository extends ApiRepository {
     return response.originalMimeType.orElse(null);
   }
 
+  Future<String?> getOriginalPath(String assetId) async {
+    final response = await _api.getAssetInfo(assetId);
+    return response?.originalPath;
+  }
+
   Future<void> updateDescription(String assetId, String description) {
     return _api.updateAsset(assetId, UpdateAssetDto(description: Optional.present(description)));
   }

--- a/mobile/test/presentation/widgets/asset_viewer/technical_details_widget_test.dart
+++ b/mobile/test/presentation/widgets/asset_viewer/technical_details_widget_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/presentation/widgets/asset_viewer/asset_details/technical_details.widget.dart';
+
+import '../../../test_utils.dart';
+import '../../../widget_tester_extensions.dart';
+
+void main() {
+  testWidgets('shows the original asset path in technical details', (tester) async {
+    const originalPath = '/data/library/2025/holiday/photo.jpg';
+    final asset = TestUtils.createRemoteAsset(id: 'asset-1');
+
+    await tester.pumpConsumerWidget(TechnicalDetails(asset: asset, originalPath: originalPath));
+    await tester.pumpAndSettle();
+
+    expect(find.text(originalPath), findsOneWidget);
+  });
+}

--- a/mobile/test/providers/asset_viewer/asset_original_path_provider_test.dart
+++ b/mobile/test/providers/asset_viewer/asset_original_path_provider_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/providers/infrastructure/asset_viewer/asset.provider.dart';
+import 'package:immich_mobile/repositories/asset_api.repository.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../test_utils.dart';
+
+class _MockAssetApiRepository extends Mock implements AssetApiRepository {}
+
+void main() {
+  test('loads the original path for a remote asset', () async {
+    final apiRepository = _MockAssetApiRepository();
+    when(() => apiRepository.getOriginalPath('asset-1')).thenAnswer((_) async => '/data/library/photo.jpg');
+    final container = ProviderContainer(overrides: [assetApiRepositoryProvider.overrideWithValue(apiRepository)]);
+    addTearDown(container.dispose);
+
+    final asset = TestUtils.createRemoteAsset(id: 'asset-1');
+
+    expect(await container.read(assetOriginalPathProvider(asset).future), '/data/library/photo.jpg');
+    verify(() => apiRepository.getOriginalPath('asset-1')).called(1);
+  });
+}


### PR DESCRIPTION
## Summary
- fetch the server-provided original path when opening mobile asset details
- show the folder path beneath the filename in the technical details section
- add provider and widget coverage for the path flow

## Design spec
- [Mobile Asset Folder Information](https://github.com/open-noodle/gallery/blob/fix/mobile-info-folder-path/docs/plans/2026-08-22-mobile-asset-folder-info-design.md)

## Scope note
This is a read-only mobile metadata parity fix. It does not change server behavior, external-library scanning, storage paths, or folder navigation.

## Verification
- `flutter test` — full mobile unit-test suite passed
- `flutter test test/presentation/widgets/asset_viewer`
- `flutter test test/presentation/widgets/asset_viewer/technical_details_widget_test.dart test/providers/asset_viewer/asset_original_path_provider_test.dart`
- `dart format --set-exit-if-changed ...`
- `dart analyze --fatal-infos` on changed Dart files
- mobile code generation check completed with no generated-file changes

Uses the pinned Flutter 3.44.8 toolchain.