### PR TITLE
fix(mobile): keep the filter sheet's Done button clear of the system nav bar

### DIFF
--- a/mobile/lib/presentation/widgets/filter_sheet/match_count_footer.widget.dart
+++ b/mobile/lib/presentation/widgets/filter_sheet/match_count_footer.widget.dart
@@ -13,16 +13,20 @@ class MatchCountFooter extends ConsumerWidget {
     return Material(
       color: theme.colorScheme.surface,
       elevation: 6,
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(20, 12, 12, 20),
-        child: Row(
-          children: [
-            const Expanded(child: MatchCountLabel()),
-            FilledButton.tonal(
-              onPressed: () => ref.read(photosFilterSheetProvider.notifier).state = FilterSheetSnap.hidden,
-              child: Text('filter_sheet_done'.tr()),
-            ),
-          ],
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(20, 12, 12, 20),
+          child: Row(
+            children: [
+              const Expanded(child: MatchCountLabel()),
+              FilledButton.tonal(
+                key: const Key('match-count-footer-done'),
+                onPressed: () => ref.read(photosFilterSheetProvider.notifier).state = FilterSheetSnap.hidden,
+                child: Text('filter_sheet_done'.tr()),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/mobile/test/presentation/widgets/filter_sheet/match_count_footer_test.dart
+++ b/mobile/test/presentation/widgets/filter_sheet/match_count_footer_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/presentation/widgets/filter_sheet/match_count_footer.widget.dart';
+
+import '../../../widget_tester_extensions.dart';
+
+void main() {
+  group('MatchCountFooter', () {
+    testWidgets('keeps the Done button clear of the system bottom inset', (tester) async {
+      const dpr = 3.0;
+      const bottomInset = 48.0; // logical px — simulates the Android 3-button nav bar
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = dpr;
+      tester.view.padding = const FakeViewPadding(bottom: bottomInset * dpr);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      addTearDown(tester.view.resetPadding);
+
+      await tester.pumpConsumerWidget(const Align(alignment: Alignment.bottomCenter, child: MatchCountFooter()));
+
+      final screenHeight = tester.view.physicalSize.height / tester.view.devicePixelRatio;
+      final buttonBottom = tester.getBottomLeft(find.byKey(const Key('match-count-footer-done'))).dy;
+
+      // The system nav bar occupies [screenHeight - bottomInset, screenHeight]. The
+      // Done button must not extend into that zone, or it becomes unreachable.
+      expect(buttonBottom, lessThanOrEqualTo(screenHeight - bottomInset));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- `MatchCountFooter` (the sticky Done bar on the Filters/Search sheet's Browse and Deep views) padded its Done button with a fixed 20px bottom inset regardless of the device's system navigation bar.
- On phones where that bar is taller than 20px (e.g. gesture nav or 3-button nav on some Android devices), the button sits under/behind the system bar and is very hard or impossible to tap.
- Fixes #1003.

## Fix
Wrap the footer's content in `SafeArea(top: false, ...)`, matching the pattern already used by the sibling `WhenPickerFooter` (the Done bar on the When picker page). This adds the device's actual bottom inset on top of the existing 20px padding, so the button always clears the system nav bar.

## Test plan
- [x] Added a widget test (`match_count_footer_test.dart`) that simulates a 48px system nav bar inset and asserts the Done button's bottom edge stays clear of it.
- [x] Verified the test fails without the fix (both missing the key, and with the key but without `SafeArea` — confirms the assertion catches the actual geometry regression, not just widget presence).
- [x] `flutter test test/presentation/widgets/filter_sheet/` — 184/184 passing.
- [x] `dart analyze` and `dart format` clean on changed files.