### PR TITLE
fix(mobile): brand the Android task-switcher title

### DIFF
--- a/mobile/lib/constants/constants.dart
+++ b/mobile/lib/constants/constants.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 const String kMobileMetadataKey = "mobile-app";
 
+const String kAppTitle = 'Noodle Gallery';
+
 // Number of log entries to retain on app start
 const int kLogTruncateLimit = 2000;
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -261,7 +261,7 @@ class ImmichAppState extends ConsumerState<ImmichApp> with WidgetsBindingObserve
     return ProviderScope(
       overrides: [localeProvider.overrideWithValue(context.locale)],
       child: MaterialApp.router(
-        title: 'Immich',
+        title: kAppTitle,
         debugShowCheckedModeBanner: true,
         scaffoldMessengerKey: scaffoldMessengerKey,
         localizationsDelegates: context.localizationDelegates,

--- a/mobile/lib/pages/common/splash_screen.page.dart
+++ b/mobile/lib/pages/common/splash_screen.page.dart
@@ -5,6 +5,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/constants/constants.dart';
 import 'package:immich_mobile/constants/locales.dart';
 import 'package:immich_mobile/domain/models/config/app_config.dart';
 import 'package:immich_mobile/domain/models/store.model.dart';
@@ -45,7 +46,7 @@ class BootstrapErrorWidget extends StatelessWidget {
       assetLoader: const CodegenLoader(),
       child: Builder(
         builder: (lCtx) => MaterialApp(
-          title: 'Immich',
+          title: kAppTitle,
           debugShowCheckedModeBanner: true,
           localizationsDelegates: lCtx.localizationDelegates,
           supportedLocales: lCtx.supportedLocales,

--- a/mobile/test/policy/app_title_branding_test.dart
+++ b/mobile/test/policy/app_title_branding_test.dart
@@ -1,0 +1,20 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:immich_mobile/constants/constants.dart';
+
+void main() {
+  test('every MaterialApp title in source is the branded kAppTitle, not the upstream Immich name', () {
+    const sources = ['lib/main.dart', 'lib/pages/common/splash_screen.page.dart'];
+
+    for (final path in sources) {
+      final content = File(path).readAsStringSync();
+      expect(content, isNot(contains("title: 'Immich'")), reason: path);
+      expect(content, contains('title: kAppTitle'), reason: path);
+    }
+  });
+
+  test('kAppTitle carries the fork brand name', () {
+    expect(kAppTitle, 'Noodle Gallery');
+  });
+}


### PR DESCRIPTION
## Summary
- Fixes #1001 — the Android Recent Apps / Overview screen showed "Immich" instead of the fork's brand name.
- `MaterialApp`'s `title` (used by Android for the task-switcher label, overriding the already-branded `android:label` in the manifest) was hardcoded to `'Immich'` in both `main.dart` and the bootstrap-error splash screen.
- Introduced a `kAppTitle` constant (`'Noodle Gallery'`) in `constants.dart` and pointed both `MaterialApp` titles at it.

## Test plan
- [x] TDD: added `mobile/test/policy/app_title_branding_test.dart`, confirmed it failed before the fix (missing `kAppTitle`) and passes after
- [x] `dart analyze --fatal-infos` — no issues
- [x] `dart format --output=none --set-exit-if-changed` — no changes needed
- [x] Full `flutter test` suite — 3143 passed, 0 failed
