### PR TITLE
fix(memory): localize the recent-trip memory card title and subtitle

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -2600,6 +2600,8 @@
   "reassing_hint": "Markierte Dateien einer vorhandenen Person zuweisen",
   "recent": "Neueste",
   "recent_searches": "Letzte Suchen",
+  "recent_trip_subtitle": "{assetCount, plural, one {# Foto} other {# Fotos}} aus {dayCount, plural, one {einem Tag} other {# Tagen}}",
+  "recent_trip_title": "Kürzliche Reise nach {location}",
   "recently_added": "Kürzlich hinzugefügt",
   "recently_added_body": "Öffne direkt deine neusten Änderungen direkt auf einer Seite.",
   "recently_added_description": "Durchsuche deine Medien nachdem Sie auf Immich hochgeladen wurden",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2642,6 +2642,8 @@
   "reassing_hint": "Assign selected assets to an existing person",
   "recent": "Recent",
   "recent_searches": "Recent searches",
+  "recent_trip_subtitle": "{assetCount, plural, one {# photo} other {# photos}} over {dayCount, plural, one {# day} other {# days}}",
+  "recent_trip_title": "Recent trip to {location}",
   "recently_added": "Recently added",
   "recently_added_body": "Jump straight to everything you've added lately on a dedicated page.",
   "recently_added_description": "Browse your assets sorted by when they were uploaded to Immich",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -2600,6 +2600,8 @@
   "reassing_hint": "Asignar recursos seleccionados a una persona existente",
   "recent": "Reciente",
   "recent_searches": "Búsquedas recientes",
+  "recent_trip_subtitle": "{assetCount, plural, one {# foto} other {# fotos}} en {dayCount, plural, one {# día} other {# días}}",
+  "recent_trip_title": "Viaje reciente a {location}",
   "recently_added": "Añadidos recientemente",
   "recently_added_body": "Acceda directamente a todo lo que ha añadido recientemente en una página dedicada.",
   "recently_added_description": "Explora tus archivos ordenados por fecha de subida a Immich",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -2600,6 +2600,8 @@
   "reassing_hint": "Attribuer ces médias à une personne existante",
   "recent": "Récent",
   "recent_searches": "Recherches récentes",
+  "recent_trip_subtitle": "{assetCount, plural, one {# photo} other {# photos}} en {dayCount, plural, one {# jour} other {# jours}}",
+  "recent_trip_title": "Voyage récent à {location}",
   "recently_added": "Récemment ajouté",
   "recently_added_body": "Allez directement à ce que vous avez ajouté récemment dans une page dédiée.",
   "recently_added_description": "Naviguez dans vos médias, triés par date d'envoi dans Immich",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -2600,6 +2600,8 @@
   "reassing_hint": "Assegna le risorse selezionate ad una persona esistente",
   "recent": "Recenti",
   "recent_searches": "Ricerche recenti",
+  "recent_trip_subtitle": "{assetCount, plural, one {# foto} other {# foto}} in {dayCount, plural, one {# giorno} other {# giorni}}",
+  "recent_trip_title": "Viaggio recente a {location}",
   "recently_added": "Aggiunti recentemente",
   "recently_added_body": "Vai direttamente a tutto ciò che hai aggiunto di recente su una pagina dedicata.",
   "recently_added_description": "Sfoglia le tue risorse ordinate in base alla data di caricamento su Immich",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -2600,6 +2600,8 @@
   "reassing_hint": "Geselecteerde items toewijzen aan een bestaand persoon",
   "recent": "Recent",
   "recent_searches": "Recente zoekopdrachten",
+  "recent_trip_subtitle": "{assetCount, plural, one {# foto} other {# foto's}} over {dayCount, plural, one {# dag} other {# dagen}}",
+  "recent_trip_title": "Recente reis naar {location}",
   "recently_added": "Onlangs toegevoegd",
   "recently_added_body": "Ga direct naar een aparte pagina met al je recent toegevoegde items.",
   "recently_added_description": "Blader door je items, op volgorde van wanneer ze zijn toegevoegd aan Immich",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -2618,6 +2618,8 @@
   "reassing_hint": "Przypisz wybrane zasoby do istniejącej osoby",
   "recent": "Ostatnie",
   "recent_searches": "Ostatnie wyszukiwania",
+  "recent_trip_subtitle": "{assetCount, plural, one {# zdjęcie} few {# zdjęcia} many {# zdjęć} other {# zdjęć}} z {dayCount, plural, one {# dnia} few {# dni} many {# dni} other {# dni}}",
+  "recent_trip_title": "Ostatnia podróż do {location}",
   "recently_added": "Ostatnio dodane",
   "recently_added_body": "Przejdź od razu do wszystkich elementów, które ostatnio dodałeś, na specjalnej stronie.",
   "recently_added_description": "Przeglądaj swoje zasoby posortowane według daty przesłania ich do Immich",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -2602,6 +2602,8 @@
   "reassing_hint": "Назначить выбранные объекты указанному человеку",
   "recent": "Недавние",
   "recent_searches": "Недавние поисковые запросы",
+  "recent_trip_subtitle": "{assetCount, plural, one {# фото} few {# фото} many {# фото} other {# фото}} за {dayCount, plural, one {# день} few {# дня} many {# дней} other {# дня}}",
+  "recent_trip_title": "Недавняя поездка в {location}",
   "recently_added": "Недавно добавленные",
   "recently_added_body": "Переход к отдельной странице с недавно добавленными объектами.",
   "recently_added_description": "Просмотр объектов, отсортированных по дате их загрузки в Immich",

--- a/i18n/zh_Hans.json
+++ b/i18n/zh_Hans.json
@@ -2600,6 +2600,8 @@
   "reassing_hint": "指派选择的项目到已存在的人物",
   "recent": "最近",
   "recent_searches": "最近搜索",
+  "recent_trip_subtitle": "{assetCount, plural, one {# 张照片} other {# 张照片}}，跨越{dayCount, plural, one {# 天} other {# 天}}",
+  "recent_trip_title": "近期{location}之旅",
   "recently_added": "近期添加",
   "recently_added_body": "在专属页面上，直接查看您近期添加的所有内容。",
   "recently_added_description": "浏览您的媒体，并按上传到 Immich 的时间排序。",

--- a/i18n/zh_Hant.json
+++ b/i18n/zh_Hant.json
@@ -2600,6 +2600,8 @@
   "reassing_hint": "將選取的項目指派給現有人物",
   "recent": "最近",
   "recent_searches": "最近搜尋項目",
+  "recent_trip_subtitle": "{assetCount, plural, one {# 張相片} other {# 張相片}}，跨越{dayCount, plural, other {# 天}}",
+  "recent_trip_title": "近期{location}之旅",
   "recently_added": "最近新增",
   "recently_added_body": "前往專屬頁面，直接查看您最近新增的所有內容。",
   "recently_added_description": "瀏覽您的項目，並按上傳到 Immich 的時間排序",

--- a/server/src/services/memory-rules/memory-rule.interface.ts
+++ b/server/src/services/memory-rules/memory-rule.interface.ts
@@ -3,7 +3,7 @@ import { DateTime } from 'luxon';
 export interface MemoryRuleCandidate {
   ruleId: string;
   dedupeKey: string;
-  title: string;
+  title?: string;
   subtitle?: string;
   score: number;
   assetIds: string[];

--- a/server/src/services/memory-rules/on-this-day-place.rule.spec.ts
+++ b/server/src/services/memory-rules/on-this-day-place.rule.spec.ts
@@ -125,7 +125,10 @@ describe(OnThisDayPlaceMemoryRule.name, () => {
   it('emits one candidate per qualifying year', async () => {
     const { rule } = ruleWith([...cityAssets(2023, 'Lisbon', 6), ...cityAssets(2022, 'Rome', 5, 'Italy')]);
     const result = await rule.evaluate({ ownerId: 'user-1', target });
-    expect(result.map((c) => c.title).toSorted()).toEqual(['On this day in Lisbon', 'On this day in Rome']);
+    expect(result.map((c) => c.title).toSorted((a, b) => (a ?? '').localeCompare(b ?? ''))).toEqual([
+      'On this day in Lisbon',
+      'On this day in Rome',
+    ]);
   });
 
   it('caps at the top 3 years by score', async () => {

--- a/server/src/services/memory-rules/people-together.rule.spec.ts
+++ b/server/src/services/memory-rules/people-together.rule.spec.ts
@@ -138,7 +138,10 @@ describe(PeopleTogetherMemoryRule.name, () => {
     const { rule } = ruleWith(rows);
     const result = await rule.evaluate({ ownerId: 'user-1', target });
     expect(result).toHaveLength(2);
-    expect(result.map((c) => c.title).toSorted()).toEqual(['Anna & Rex', 'Rex & Whiskers']);
+    expect(result.map((c) => c.title).toSorted((a, b) => (a ?? '').localeCompare(b ?? ''))).toEqual([
+      'Anna & Rex',
+      'Rex & Whiskers',
+    ]);
   });
 
   it('given more than 8 co-occurring photos, then assetIds is capped at 8', async () => {

--- a/server/src/services/memory-rules/recent-trip.rule.spec.ts
+++ b/server/src/services/memory-rules/recent-trip.rule.spec.ts
@@ -93,11 +93,18 @@ describe(RecentTripMemoryRule.name, () => {
     expect(candidate).toMatchObject({
       ruleId: 'recent_trip',
       dedupeKey: 'recent_trip:france:paris:2026-04-23',
-      title: 'Recent trip to Paris, France',
-      subtitle: '9 photos over 3 days',
       assetIds: ['asset-1', 'asset-2', 'asset-3', 'asset-4', 'asset-5', 'asset-6', 'asset-7'],
       visibleForDays: 3,
+      context: {
+        placeLabel: 'Paris, France',
+        country: 'France',
+        city: 'Paris',
+        assetCount: 9,
+        dayCount: 3,
+      },
     });
+    expect(candidate?.title).toBeUndefined();
+    expect(candidate?.subtitle).toBeUndefined();
   });
 
   it('scales the visibility window with trip length, clamped to 3–7 days', async () => {
@@ -202,9 +209,16 @@ describe(RecentTripMemoryRule.name, () => {
 
     expect(candidate).toMatchObject({
       ruleId: 'recent_trip',
-      title: 'Recent trip to France',
-      subtitle: '8 photos over 2 days',
+      context: {
+        placeLabel: 'France',
+        country: 'France',
+        city: null,
+        assetCount: 8,
+        dayCount: 2,
+      },
     });
+    expect(candidate?.title).toBeUndefined();
+    expect(candidate?.subtitle).toBeUndefined();
   });
 
   it('skips same-country clusters when city metadata is missing or not trustworthy', async () => {
@@ -339,10 +353,15 @@ describe(RecentTripMemoryRule.name, () => {
     });
 
     expect(candidate).toMatchObject({
-      title: 'Recent trip to Paris, France',
-      subtitle: '12 photos over 3 days',
+      context: {
+        placeLabel: 'Paris, France',
+        assetCount: 12,
+        dayCount: 3,
+      },
       assetIds: ['a-1', 'a-3', 'a-5', 'a-6', 'a-9', 'a-11', 'a-12'],
     });
+    expect(candidate?.title).toBeUndefined();
+    expect(candidate?.subtitle).toBeUndefined();
   });
 
   it('collapses adjacent assets inside the two-minute burst window', async () => {

--- a/server/src/services/memory-rules/recent-trip.rule.ts
+++ b/server/src/services/memory-rules/recent-trip.rule.ts
@@ -79,8 +79,6 @@ export class RecentTripMemoryRule implements MemoryRule {
       {
         ruleId: this.id,
         dedupeKey: `recent_trip:${placeKey}:${dedupeDay}`,
-        title: `Recent trip to ${placeLabel}`,
-        subtitle: `${candidate.assetCount} photos over ${candidate.dayCount} days`,
         score: 50 + candidate.dayCount * 5 + Math.min(candidate.assetCount, 20),
         assetIds,
         memoryAt: target,

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -707,7 +707,7 @@ export type OnThisDayData = { year: number };
 export type RuleMemoryData = {
   ruleId: string;
   dedupeKey: string;
-  title: string;
+  title?: string;
   subtitle?: string;
   score?: number;
   context?: Record<string, unknown>;

--- a/server/test/medium/specs/services/memory.service.spec.ts
+++ b/server/test/medium/specs/services/memory.service.spec.ts
@@ -514,7 +514,7 @@ describe(MemoryService.name, () => {
             type: MemoryType.Rule,
             data: expect.objectContaining({
               ruleId: 'recent_trip',
-              title: 'Recent trip to Paris, France',
+              context: expect.objectContaining({ placeLabel: 'Paris, France' }),
             }),
           }),
         ]),
@@ -667,7 +667,7 @@ describe(MemoryService.name, () => {
       const [memory] = await memoryRepo.search(user.id, { type: MemoryType.Rule, for: now.toJSDate() });
       expect(memory?.data).toMatchObject({
         ruleId: 'recent_trip',
-        title: 'Recent trip to Paris, France',
+        context: { placeLabel: 'Paris, France' },
       });
       expect(memory?.assets).toHaveLength(7);
       expect(memory?.assets.map(({ id }) => id)).toEqual([

--- a/web/src/lib/utils.spec.ts
+++ b/web/src/lib/utils.spec.ts
@@ -1,5 +1,5 @@
 import { AssetMediaSize, AssetTypeEnum, MemoryType, type MemoryResponseDto } from '@immich/sdk';
-import { getAssetMediaUrl, getAssetUrl, getMemoryTitle, semverToName } from '$lib/utils';
+import { getAssetMediaUrl, getAssetUrl, getMemorySubtitle, getMemoryTitle, semverToName } from '$lib/utils';
 import { assetFactory } from '@test-data/factories/asset-factory';
 import { sharedLinkFactory } from '@test-data/factories/shared-link-factory';
 
@@ -199,27 +199,36 @@ describe('utils', () => {
     });
   });
 
+  const memoryTranslate = ((key: string, payload?: { values?: Record<string, number | string> }) => {
+    if (key === 'years_ago') {
+      return `${payload?.values?.years} years ago`;
+    }
+
+    if (key === 'recent_trip_title') {
+      return `Recent trip to ${payload?.values?.location}`;
+    }
+
+    if (key === 'recent_trip_subtitle') {
+      return `${payload?.values?.assetCount} photos over ${payload?.values?.dayCount} days`;
+    }
+
+    return key;
+  }) as unknown as Parameters<typeof getMemoryTitle>[1];
+
+  const memory = (overrides: Partial<MemoryResponseDto>): MemoryResponseDto => ({
+    assets: [],
+    createdAt: '2026-04-23T00:00:00Z',
+    data: {},
+    id: 'memory-id',
+    isSaved: false,
+    memoryAt: '2026-04-23T00:00:00Z',
+    ownerId: 'owner-id',
+    type: MemoryType.Rule,
+    updatedAt: '2026-04-23T00:00:00Z',
+    ...overrides,
+  });
+
   describe(getMemoryTitle.name, () => {
-    const translate = ((key: string, payload?: { values?: Record<string, number> }) => {
-      if (key === 'years_ago') {
-        return `${payload?.values?.years} years ago`;
-      }
-
-      return key;
-    }) as unknown as Parameters<typeof getMemoryTitle>[1];
-    const memory = (overrides: Partial<MemoryResponseDto>): MemoryResponseDto => ({
-      assets: [],
-      createdAt: '2026-04-23T00:00:00Z',
-      data: {},
-      id: 'memory-id',
-      isSaved: false,
-      memoryAt: '2026-04-23T00:00:00Z',
-      ownerId: 'owner-id',
-      type: MemoryType.Rule,
-      updatedAt: '2026-04-23T00:00:00Z',
-      ...overrides,
-    });
-
     it('prefers a server-supplied title when present', () => {
       expect(
         getMemoryTitle(
@@ -228,7 +237,7 @@ describe('utils', () => {
             title: 'Happy birthday, Alice',
             data: { title: 'Happy birthday, Alice' },
           }),
-          translate,
+          memoryTranslate,
           new Date('2026-04-23T00:00:00Z'),
         ),
       ).toBe('Happy birthday, Alice');
@@ -241,10 +250,47 @@ describe('utils', () => {
             type: MemoryType.OnThisDay,
             data: { year: 2024 },
           }),
-          translate,
+          memoryTranslate,
           new Date('2026-04-23T00:00:00Z'),
         ),
       ).toBe('2 years ago');
+    });
+
+    it('builds a localized title for a recent-trip memory from its structured context', () => {
+      expect(
+        getMemoryTitle(
+          memory({
+            type: MemoryType.Rule,
+            data: { ruleId: 'recent_trip', context: { placeLabel: 'Paris, France' } },
+          }),
+          memoryTranslate,
+          new Date('2026-04-23T00:00:00Z'),
+        ),
+      ).toBe('Recent trip to Paris, France');
+    });
+  });
+
+  describe(getMemorySubtitle.name, () => {
+    it('prefers a server-supplied subtitle when present', () => {
+      expect(getMemorySubtitle(memory({ type: MemoryType.Rule, subtitle: 'Coastal weekend' }), memoryTranslate)).toBe(
+        'Coastal weekend',
+      );
+    });
+
+    it('builds a localized subtitle for a recent-trip memory from its structured context', () => {
+      expect(
+        getMemorySubtitle(
+          memory({
+            type: MemoryType.Rule,
+            data: { ruleId: 'recent_trip', context: { assetCount: 9, dayCount: 3 } },
+          }),
+          memoryTranslate,
+        ),
+      ).toBe('9 photos over 3 days');
+    });
+
+    it('falls back to an empty string when no subtitle can be built', () => {
+      expect(getMemorySubtitle(memory({ type: MemoryType.OnThisDay, data: { year: 2024 } }), memoryTranslate)).toBe('');
     });
   });
 });

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -377,6 +377,16 @@ export const handlePromiseError = <T>(promise: Promise<T>): void => {
   promise.catch((error) => console.error(`[utils.ts]:handlePromiseError ${error}`, error));
 };
 
+const getRuleContextValue = (memory: MemoryResponseDto, ruleId: string, key: string) => {
+  const data = memory.data as Record<string, unknown>;
+  if (memory.type !== MemoryType.Rule || data.ruleId !== ruleId) {
+    return undefined;
+  }
+
+  const context = data.context as Record<string, unknown> | undefined;
+  return context?.[key];
+};
+
 export const getMemoryTitle = (memory: MemoryResponseDto, translate: MessageFormatter, now = new Date()) => {
   if (memory.title) {
     return memory.title;
@@ -391,7 +401,26 @@ export const getMemoryTitle = (memory: MemoryResponseDto, translate: MessageForm
     }
   }
 
+  const location = getRuleContextValue(memory, 'recent_trip', 'placeLabel');
+  if (typeof location === 'string') {
+    return translate('recent_trip_title', { values: { location } });
+  }
+
   return translate('unknown');
+};
+
+export const getMemorySubtitle = (memory: MemoryResponseDto, translate: MessageFormatter) => {
+  if (memory.subtitle) {
+    return memory.subtitle;
+  }
+
+  const assetCount = getRuleContextValue(memory, 'recent_trip', 'assetCount');
+  const dayCount = getRuleContextValue(memory, 'recent_trip', 'dayCount');
+  if (typeof assetCount === 'number' && typeof dayCount === 'number') {
+    return translate('recent_trip_subtitle', { values: { assetCount, dayCount } });
+  }
+
+  return '';
 };
 
 export const memoryLaneTitle = derived(t, ($t) => {

--- a/web/src/routes/(user)/memories/memory-index-utils.spec.ts
+++ b/web/src/routes/(user)/memories/memory-index-utils.spec.ts
@@ -2,13 +2,21 @@ import { MemoryType, type MemoryResponseDto } from '@immich/sdk';
 import type { MessageFormatter } from 'svelte-i18n';
 import { buildMemoryIndexItems, filterMemoryIndexItems, groupMemoryIndexItems } from './memory-index-utils';
 
-const translate = ((key: string, payload?: { values?: Record<string, number> }) => {
+const translate = ((key: string, payload?: { values?: Record<string, number | string> }) => {
   if (key === 'years_ago') {
     return `${payload?.values?.years} years ago`;
   }
 
   if (key === 'memory_type_on_this_day') {
     return 'On this day';
+  }
+
+  if (key === 'recent_trip_title') {
+    return `Recent trip to ${payload?.values?.location}`;
+  }
+
+  if (key === 'recent_trip_subtitle') {
+    return `${payload?.values?.assetCount} photos over ${payload?.values?.dayCount} days`;
   }
 
   return key;
@@ -168,5 +176,22 @@ describe('memory index utilities', () => {
     expect(filterMemoryIndexItems(items, { query: MemoryType.OnThisDay }).map((item) => item.memory.id)).toEqual([
       'type-match',
     ]);
+  });
+
+  it('builds a localized title and subtitle for a recent-trip memory with no server-supplied text', () => {
+    const items = buildMemoryIndexItems(
+      [
+        memory({
+          id: 'recent-trip',
+          data: { ruleId: 'recent_trip', context: { placeLabel: 'Paris, France', assetCount: 9, dayCount: 3 } },
+        }),
+      ],
+      options,
+    );
+
+    expect(items[0]).toMatchObject({
+      title: 'Recent trip to Paris, France',
+      subtitle: '9 photos over 3 days',
+    });
   });
 });

--- a/web/src/routes/(user)/memories/memory-index-utils.ts
+++ b/web/src/routes/(user)/memories/memory-index-utils.ts
@@ -1,6 +1,6 @@
 import { MemoryType, type MemoryResponseDto } from '@immich/sdk';
 import type { MessageFormatter } from 'svelte-i18n';
-import { getMemoryTitle } from '$lib/utils';
+import { getMemorySubtitle, getMemoryTitle } from '$lib/utils';
 
 export type MemoryIndexFilter = 'all' | 'saved';
 
@@ -59,7 +59,7 @@ export const buildMemoryIndexItems = (
     .map((memory): MemoryIndexItem => {
       const shownAt = new Date(memory.showAt ?? memory.createdAt);
       const title = getMemoryTitle(memory, translate, now);
-      const subtitle = memory.subtitle ?? '';
+      const subtitle = getMemorySubtitle(memory, translate);
       const dateLabel = dateFormatter.format(shownAt);
       const typeLabel = getTypeLabel(memory, translate);
       const memoryYear = getMemoryYear(memory);


### PR DESCRIPTION
## Summary
- The `RecentTripMemoryRule` baked English prose ("Recent trip to X", "N photos over M days") directly into the stored memory data, so it displayed in English regardless of the configured app language.
- The rule already computed structured place/count data in `context` (city, country, assetCount, dayCount), so the fix stops emitting the hardcoded strings and has the web client build a localized title/subtitle from that context — the same pattern already used for the "on this day" memory title.
- Added `recent_trip_title` / `recent_trip_subtitle` translation keys to all locales maintained in this repo (en + the 9 fully-translated locales: de, fr, it, nl, pl, es, ru, zh_Hans, zh_Hant).

Fixes #1006

## Test plan
- [x] `RecentTripMemoryRule` unit tests updated to assert no baked title/subtitle and structured `context` data (`server/src/services/memory-rules/recent-trip.rule.spec.ts`)
- [x] New unit tests for `getMemoryTitle` / `getMemorySubtitle` localizing recent-trip memories from context (`web/src/lib/utils.spec.ts`)
- [x] New unit test for `buildMemoryIndexItems` producing a localized title/subtitle for recent-trip memories (`web/src/routes/(user)/memories/memory-index-utils.spec.ts`)
- [x] Medium (DB-backed) `memory.service.spec.ts` recent-trip assertions updated and passing in isolation (15/15)
- [x] `tsc --noEmit` clean on both server and web
- [x] `eslint --max-warnings 0` clean on all changed files
- [x] `prettier --check` clean on all changed files, including all 10 touched `i18n/*.json`