### PR TITLE
fix(server): omit fork-only memory types from sync for non-fork-aware clients (#999)

### DIFF
--- a/server/src/services/sync.service.spec.ts
+++ b/server/src/services/sync.service.spec.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { Writable } from 'node:stream';
-import { AlbumUserRole, AssetVisibility, SyncEntityType, SyncRequestType } from 'src/enum';
+import { AlbumUserRole, AssetVisibility, MemoryType, SyncEntityType, SyncRequestType } from 'src/enum';
 import { SyncService } from 'src/services/sync.service';
 import { toAck } from 'src/utils/sync';
 import { authStub } from 'test/fixtures/auth.stub';
@@ -482,13 +482,66 @@ describe(SyncService.name, () => {
       mocks.syncCheckpoint.getAll.mockResolvedValue([]);
       mocks.syncCheckpoint.getNow.mockResolvedValue({ nowId: 'now-id' });
       syncSubs.memory.getDeletes.mockReturnValue(makeStream([{ id: deleteId, memoryId: 'm1' }]));
-      syncSubs.memory.getUpserts.mockReturnValue(makeStream([{ updateId, id: 'm1', ownerId: 'u1' }]));
+      syncSubs.memory.getUpserts.mockReturnValue(
+        makeStream([{ updateId, id: 'm1', ownerId: 'u1', type: MemoryType.OnThisDay }]),
+      );
 
       await sut.stream(authStub.user1, writable, { types: [SyncRequestType.MemoriesV1] });
 
       const messages = parseChunks(chunks);
       expect(messages.some((m: any) => m.type === SyncEntityType.MemoryDeleteV1)).toBe(true);
       expect(messages.some((m: any) => m.type === SyncEntityType.MemoryV1)).toBe(true);
+    });
+
+    it('should omit fork-only memory types from the stream for clients that do not request a gallery-fork-only sync type (upstream Immich client compatibility, #999)', async () => {
+      const { writable, chunks } = makeWritable();
+      const onThisDayId = newUuid();
+      const ruleId = newUuid();
+
+      mocks.session.isPendingSyncReset.mockResolvedValue(false);
+      mocks.syncCheckpoint.getAll.mockResolvedValue([]);
+      mocks.syncCheckpoint.getNow.mockResolvedValue({ nowId: 'now-id' });
+      syncSubs.memory.getUpserts.mockReturnValue(
+        makeStream([
+          { updateId: onThisDayId, id: 'm1', ownerId: 'u1', type: MemoryType.OnThisDay },
+          { updateId: ruleId, id: 'm2', ownerId: 'u1', type: MemoryType.Rule },
+        ]),
+      );
+
+      // No gallery-fork-only sync type (e.g. SharedSpacesV1) requested alongside MemoriesV1 —
+      // this is the request shape an unmodified upstream Immich client sends, since its
+      // generated client has no fork-only SyncRequestType values to request in the first place.
+      await sut.stream(authStub.user1, writable, { types: [SyncRequestType.MemoriesV1] });
+
+      const memoryMessages = parseChunks(chunks).filter((m: any) => m.type === SyncEntityType.MemoryV1);
+      expect(memoryMessages).toHaveLength(1);
+      expect(memoryMessages[0].data.type).toBe(MemoryType.OnThisDay);
+    });
+
+    it('should include fork-only memory types for clients that also request a gallery-fork-only sync type', async () => {
+      const { writable, chunks } = makeWritable();
+      const onThisDayId = newUuid();
+      const ruleId = newUuid();
+
+      mocks.session.isPendingSyncReset.mockResolvedValue(false);
+      mocks.syncCheckpoint.getAll.mockResolvedValue([]);
+      mocks.syncCheckpoint.getNow.mockResolvedValue({ nowId: 'now-id' });
+      syncSubs.memory.getUpserts.mockReturnValue(
+        makeStream([
+          { updateId: onThisDayId, id: 'm1', ownerId: 'u1', type: MemoryType.OnThisDay },
+          { updateId: ruleId, id: 'm2', ownerId: 'u1', type: MemoryType.Rule },
+        ]),
+      );
+
+      await sut.stream(authStub.user1, writable, {
+        types: [SyncRequestType.MemoriesV1, SyncRequestType.SharedSpacesV1],
+      });
+
+      const memoryMessages = parseChunks(chunks).filter((m: any) => m.type === SyncEntityType.MemoryV1);
+      expect(memoryMessages.map((m: any) => m.data.type)).toEqual(
+        expect.arrayContaining([MemoryType.OnThisDay, MemoryType.Rule]),
+      );
+      expect(memoryMessages).toHaveLength(2);
     });
 
     it('should handle MemoryToAssetsV1 sync type', async () => {

--- a/server/src/services/sync.service.ts
+++ b/server/src/services/sync.service.ts
@@ -13,7 +13,7 @@ import {
   SyncItem,
   SyncStreamDto,
 } from 'src/dtos/sync.dto';
-import { JobName, QueueName, SyncEntityType, SyncRequestType } from 'src/enum';
+import { JobName, MemoryType, QueueName, SyncEntityType, SyncRequestType } from 'src/enum';
 import { SyncQueryOptions } from 'src/repositories/sync.repository';
 import { SessionSyncCheckpointTable } from 'src/schema/tables/sync-checkpoint.table';
 import { BaseService } from 'src/services/base.service';
@@ -196,6 +196,16 @@ export class SyncService extends BaseService {
     const { nowId } = await this.syncCheckpointRepository.getNow();
     const options: SyncQueryOptions = { nowId, userId: auth.user.id };
 
+    // Gallery-fork-only memory types (e.g. rule-based "Smarter" memories) are sent verbatim in
+    // MemoryV1.type, but that field is a *required* enum in upstream Immich's OpenAPI spec whose
+    // only member is `on_this_day` — an unrecognized value there aborts an official Immich
+    // client's whole sync-stream parse, silently disabling background backup (#999). A
+    // gallery-fork client's generated Dart client has no such restriction, and unconditionally
+    // requests at least one gallery-fork-only sync type (SharedSpacesV1) alongside MemoriesV1, so
+    // its presence in the request reliably tells fork-aware clients apart from unmodified
+    // upstream ones, which have no way to request a type their client doesn't know exists.
+    const isForkAwareClient = dto.types.includes(SyncRequestType.SharedSpacesV1);
+
     const handlers: Record<SyncRequestType, () => Promise<void>> = {
       // deprecated handlers
       [SyncRequestType.AssetsV1]: () => this.syncAssetsV1(),
@@ -220,7 +230,7 @@ export class SyncService extends BaseService {
       [SyncRequestType.AlbumToAssetsV1]: () => this.syncAlbumToAssetsV1(options, response, checkpointMap, session.id),
       [SyncRequestType.AlbumAssetExifsV1]: () =>
         this.syncAlbumAssetExifsV1(options, response, checkpointMap, session.id),
-      [SyncRequestType.MemoriesV1]: () => this.syncMemoriesV1(options, response, checkpointMap),
+      [SyncRequestType.MemoriesV1]: () => this.syncMemoriesV1(options, response, checkpointMap, isForkAwareClient),
       [SyncRequestType.MemoryToAssetsV1]: () => this.syncMemoryAssetsV1(options, response, checkpointMap),
       [SyncRequestType.StacksV1]: () => this.syncStackV1(options, response, checkpointMap),
       [SyncRequestType.PartnerStacksV1]: () => this.syncPartnerStackV1(options, response, checkpointMap, session.id),
@@ -1576,7 +1586,12 @@ export class SyncService extends BaseService {
     }
   }
 
-  private async syncMemoriesV1(options: SyncQueryOptions, response: Writable, checkpointMap: CheckpointMap) {
+  private async syncMemoriesV1(
+    options: SyncQueryOptions,
+    response: Writable,
+    checkpointMap: CheckpointMap,
+    isForkAwareClient: boolean,
+  ) {
     const deleteType = SyncEntityType.MemoryDeleteV1;
     const deletes = this.syncRepository.memory.getDeletes({ ...options, ack: checkpointMap[deleteType] });
     for await (const { id, ...data } of deletes) {
@@ -1586,6 +1601,9 @@ export class SyncService extends BaseService {
     const upsertType = SyncEntityType.MemoryV1;
     const upserts = this.syncRepository.memory.getUpserts({ ...options, ack: checkpointMap[upsertType] });
     for await (const { updateId, ...data } of upserts) {
+      if (!isForkAwareClient && data.type !== MemoryType.OnThisDay) {
+        continue;
+      }
       send(response, { type: upsertType, ids: [updateId], data });
     }
   }


### PR DESCRIPTION
## Summary

Fixes #999 — a single Gallery-only `memory.type = 'rule'` row aborts the whole `/api/sync/stream` parse for official Immich mobile clients (upstream's `SyncMemoryV1.type` is a *required* enum with only `on_this_day` as a member), which silently disables background backup.

The straightforward fixes suggested in the issue (drop non-`on_this_day` memories from the stream entirely, or always report `type: on_this_day`) would also strip rule-based "Smarter" memories from **Gallery's own mobile app**, which sources its memory lane entirely from the local Drift DB populated by this same sync stream (`DriftMemoryService.getMemoryLane` → local-only, no separate REST fallback). Both apps hit the identical wire endpoint/schema, so a fix needs to tell them apart.

Gallery's mobile app already unconditionally requests `SharedSpacesV1` — a gallery-fork-only `SyncRequestType` — alongside `MemoriesV1` in every sync request. An unmodified upstream Immich client's generated Dart client has no such enum value and structurally cannot request it. That gives a reliable, no-new-infrastructure signal: if the incoming sync request also asks for a gallery-fork-only sync type, send memory upserts unfiltered (Gallery client); otherwise, omit non-`on_this_day` memory upserts (official Immich client) so its parse never sees a value it can't handle.

No mobile app changes needed — Gallery's client already sends the qualifying request shape.

## Test plan
- [x] Added a regression test asserting `rule` memories are omitted from `/sync/stream` when the request doesn't include a gallery-fork-only sync type (reproduces #999's crash scenario without them)
- [x] Added a test asserting both `on_this_day` and `rule` memories are still sent when the request includes `SharedSpacesV1` (Gallery's own mobile app is unaffected)
- [x] Fixed an existing `MemoriesV1` test fixture that was missing a `type` field
- [x] `pnpm test -- --run` — full server suite green (168 files, 5767 tests)
- [x] `pnpm run check` (tsc --noEmit) — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run format` — clean