### PR TITLE
fix(mobile): debounce filter sheet snap commits to the settled drag extent

### DIFF
--- a/mobile/lib/presentation/widgets/filter_sheet/active_filter_chip.widget.dart
+++ b/mobile/lib/presentation/widgets/filter_sheet/active_filter_chip.widget.dart
@@ -34,9 +34,11 @@ class ActiveFilterChip extends ConsumerWidget {
       }
     }
 
+    final displayLabel = spec.labelIsKey ? spec.label.tr() : spec.label;
+
     return Semantics(
       button: true,
-      label: spec.semanticsLabel ?? '${spec.label}, ${'remove_filter'.tr()}',
+      label: spec.semanticsLabel ?? '$displayLabel, ${'remove_filter'.tr()}',
       onTap: removeChip,
       child: ExcludeSemantics(
         child: Material(
@@ -54,7 +56,7 @@ class ActiveFilterChip extends ConsumerWidget {
                 if (_needsLeadingGap) const SizedBox(width: 8),
                 Flexible(
                   child: Text(
-                    spec.label,
+                    displayLabel,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: spec.visual == ChipVisual.when

--- a/mobile/lib/presentation/widgets/filter_sheet/browse_content.widget.dart
+++ b/mobile/lib/presentation/widgets/filter_sheet/browse_content.widget.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/drag_handle.widget.dart';
+import 'package:immich_mobile/presentation/widgets/filter_sheet/filter_section_id.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/match_count_footer.widget.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/search_bar.widget.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/strips/camera_strip.widget.dart';
@@ -11,6 +12,7 @@ import 'package:immich_mobile/presentation/widgets/filter_sheet/strips/places_st
 import 'package:immich_mobile/presentation/widgets/filter_sheet/strips/tags_strip.widget.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/strips/when_strip.widget.dart';
 import 'package:immich_mobile/providers/photos_filter/filter_sheet.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/hidden_sections.provider.dart';
 import 'package:immich_mobile/providers/photos_filter/photos_filter.provider.dart';
 
 class BrowseContent extends ConsumerWidget {
@@ -21,6 +23,7 @@ class BrowseContent extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final isEmpty = ref.watch(photosFilterProvider.select((f) => f.isEmpty));
+    final hidden = ref.watch(hiddenSectionsProvider);
 
     return Material(
       color: theme.colorScheme.surface,
@@ -52,11 +55,14 @@ class BrowseContent extends ConsumerWidget {
               ),
               const Padding(padding: EdgeInsets.fromLTRB(20, 6, 20, 0), child: FilterSheetSearchBar()),
               const SizedBox(height: 18),
-              const PeopleStrip(),
-              const PlacesStrip(),
-              const TagsStrip(),
-              const CameraStrip(),
-              const WhenStrip(),
+              // Mirrors the Deep view's "Manage sections" visibility (#1002) — a
+              // section hidden there must stay hidden here too, not just reappear
+              // whenever the sheet collapses from deep to browse.
+              if (!hidden.contains(FilterSectionId.people)) const PeopleStrip(),
+              if (!hidden.contains(FilterSectionId.places)) const PlacesStrip(),
+              if (!hidden.contains(FilterSectionId.tags)) const TagsStrip(),
+              if (!hidden.contains(FilterSectionId.camera)) const CameraStrip(),
+              if (!hidden.contains(FilterSectionId.when)) const WhenStrip(),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 4),
                 child: Align(

--- a/mobile/lib/presentation/widgets/filter_sheet/filter_sheet.widget.dart
+++ b/mobile/lib/presentation/widgets/filter_sheet/filter_sheet.widget.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -30,6 +32,19 @@ class _FilterSheetState extends ConsumerState<FilterSheet> {
   /// Allow drag to go below `_snapBrowse` so the dismiss gesture is reachable.
   static const _minExtent = 0.3;
 
+  /// A live drag fires a `DraggableScrollableNotification` on every frame of
+  /// motion, so a "half" swipe can pass *through* the browse extent (or dip
+  /// below the dismiss threshold) well before the user's thumb comes to
+  /// rest — e.g. on its way back up after an overshoot. Committing the snap
+  /// on each of those transient extents flips the sheet between deep/browse/
+  /// hidden mid-gesture, unmounting `DeepContent`/`BrowseContent` (and, once
+  /// hidden, the sheet itself) while the drag is still live — losing the
+  /// notification stream and, further up, the pointer routing for the rest
+  /// of that same gesture (#1002). Debounce so only the extent the drag
+  /// actually *settles* on (no further motion for `_settleDelay`) commits.
+  static const _settleDelay = Duration(milliseconds: 160);
+  Timer? _settleTimer;
+
   double _targetExtent(FilterSheetSnap snap) => switch (snap) {
     FilterSheetSnap.browse => _snapBrowse,
     FilterSheetSnap.deep => _snapDeep,
@@ -38,29 +53,37 @@ class _FilterSheetState extends ConsumerState<FilterSheet> {
 
   @override
   void dispose() {
+    _settleTimer?.cancel();
     _controller.dispose();
     super.dispose();
   }
 
   bool _onNotification(DraggableScrollableNotification n) {
-    if (n.extent < _dismissThreshold) {
+    final extent = n.extent;
+    _settleTimer?.cancel();
+    _settleTimer = Timer(_settleDelay, () => _commitSettledExtent(extent));
+    return false;
+  }
+
+  void _commitSettledExtent(double extent) {
+    if (!mounted) return;
+    if (extent < _dismissThreshold) {
       final current = ref.read(photosFilterSheetProvider);
       if (current != FilterSheetSnap.hidden) {
         ref.read(photosFilterSheetProvider.notifier).state = FilterSheetSnap.hidden;
       }
-      return false;
+      return;
     }
     final mapping = <double, FilterSheetSnap>{_snapBrowse: FilterSheetSnap.browse, _snapDeep: FilterSheetSnap.deep};
     for (final entry in mapping.entries) {
-      if ((n.extent - entry.key).abs() < _snapTolerance) {
+      if ((extent - entry.key).abs() < _snapTolerance) {
         final current = ref.read(photosFilterSheetProvider);
         if (current != entry.value) {
           ref.read(photosFilterSheetProvider.notifier).state = entry.value;
         }
-        return false;
+        return;
       }
     }
-    return false;
   }
 
   void _onScrimTap() {

--- a/mobile/lib/providers/photos_filter/active_chips.dart
+++ b/mobile/lib/providers/photos_filter/active_chips.dart
@@ -17,6 +17,12 @@ enum ChipVisual { person, tag, location, camera, when, rating, media, toggle, te
 class ActiveChipSpec {
   final ChipId id;
   final String label;
+
+  /// True when [label] is an i18n key rather than resolved display text —
+  /// this pure helper has no BuildContext to call `.tr()` with, so the
+  /// widget must translate it before display (else the raw key leaks to
+  /// the user, e.g. "filter_sheet_favourites" instead of "Favourites").
+  final bool labelIsKey;
   final ChipVisual visual;
   final List<String>? avatarPersonIds;
 
@@ -33,6 +39,7 @@ class ActiveChipSpec {
     required this.id,
     required this.label,
     required this.visual,
+    this.labelIsKey = false,
     this.avatarPersonIds,
     this.avatarPersonSpaceIds,
     this.tagDotSeed,
@@ -52,6 +59,7 @@ List<ActiveChipSpec> activeChipsFromFilter(SearchFilter filter, {FilterSuggestio
         ActiveChipSpec(
           id: PersonChipId(p.id),
           label: p.name.isEmpty ? 'filter_sheet_unnamed_person' : p.name,
+          labelIsKey: p.name.isEmpty,
           visual: ChipVisual.person,
           avatarPersonIds: [p.id],
           avatarPersonSpaceIds: [p.spaceId],
@@ -65,6 +73,7 @@ List<ActiveChipSpec> activeChipsFromFilter(SearchFilter filter, {FilterSuggestio
         ActiveChipSpec(
           id: PersonChipId(p.id),
           label: p.name.isEmpty ? 'filter_sheet_unnamed_person' : p.name,
+          labelIsKey: p.name.isEmpty,
           visual: ChipVisual.person,
           avatarPersonIds: [p.id],
           avatarPersonSpaceIds: [p.spaceId],
@@ -102,6 +111,7 @@ List<ActiveChipSpec> activeChipsFromFilter(SearchFilter filter, {FilterSuggestio
       ActiveChipSpec(
         id: TagChipId(tagId),
         label: resolved ?? 'filter_sheet_tag_fallback',
+        labelIsKey: resolved == null,
         visual: ChipVisual.tag,
         tagDotSeed: tagId.hashCode,
       ),
@@ -194,7 +204,9 @@ List<ActiveChipSpec> activeChipsFromFilter(SearchFilter filter, {FilterSuggestio
         label = '';
         icon = Icons.help_outline_rounded;
     }
-    out.add(ActiveChipSpec(id: const MediaTypeChipId(), label: label, visual: ChipVisual.media, icon: icon));
+    out.add(
+      ActiveChipSpec(id: const MediaTypeChipId(), label: label, labelIsKey: true, visual: ChipVisual.media, icon: icon),
+    );
   }
 
   // ── toggles ──────────────────────────────────────────────────────────
@@ -203,6 +215,7 @@ List<ActiveChipSpec> activeChipsFromFilter(SearchFilter filter, {FilterSuggestio
       const ActiveChipSpec(
         id: FavouriteChipId(),
         label: 'filter_sheet_favourites',
+        labelIsKey: true,
         visual: ChipVisual.toggle,
         icon: Icons.favorite_rounded,
       ),
@@ -213,6 +226,7 @@ List<ActiveChipSpec> activeChipsFromFilter(SearchFilter filter, {FilterSuggestio
       const ActiveChipSpec(
         id: ArchiveChipId(),
         label: 'filter_sheet_archived',
+        labelIsKey: true,
         visual: ChipVisual.toggle,
         icon: Icons.archive_rounded,
       ),
@@ -223,6 +237,7 @@ List<ActiveChipSpec> activeChipsFromFilter(SearchFilter filter, {FilterSuggestio
       const ActiveChipSpec(
         id: NotInAlbumChipId(),
         label: 'filter_sheet_not_in_album',
+        labelIsKey: true,
         visual: ChipVisual.toggle,
         icon: Icons.folder_off_rounded,
       ),
@@ -233,6 +248,7 @@ List<ActiveChipSpec> activeChipsFromFilter(SearchFilter filter, {FilterSuggestio
       const ActiveChipSpec(
         id: UntaggedChipId(),
         label: 'untagged',
+        labelIsKey: true,
         visual: ChipVisual.toggle,
         icon: Icons.label_off_rounded,
       ),

--- a/mobile/test/presentation/widgets/filter_sheet/active_filter_chip_test.dart
+++ b/mobile/test/presentation/widgets/filter_sheet/active_filter_chip_test.dart
@@ -82,6 +82,26 @@ void main() {
       expect(find.byIcon(Icons.close_rounded), findsOneWidget);
     });
 
+    // activeChipsFromFilter is a pure Dart helper with no BuildContext, so
+    // toggle/media/fallback specs carry an i18n *key* (labelIsKey: true)
+    // rather than resolved text — the widget must translate it before
+    // display, or the raw key ("filter_sheet_favourites") leaks to the user.
+    testWidgets('labelIsKey spec renders the translated string, not the raw key', (tester) async {
+      const spec = ActiveChipSpec(
+        id: FavouriteChipId(),
+        label: 'filter_sheet_favourites',
+        labelIsKey: true,
+        visual: ChipVisual.toggle,
+        icon: Icons.favorite_rounded,
+      );
+
+      await tester.pumpConsumerWidget(const ActiveFilterChip(spec: spec));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Favourites'), findsOneWidget);
+      expect(find.text('filter_sheet_favourites'), findsNothing);
+    });
+
     testWidgets('tag spec renders leading dot with key', (tester) async {
       const spec = ActiveChipSpec(id: TagChipId('t1'), label: 'wedding', visual: ChipVisual.tag, tagDotSeed: 42);
 

--- a/mobile/test/presentation/widgets/filter_sheet/browse_content_test.dart
+++ b/mobile/test/presentation/widgets/filter_sheet/browse_content_test.dart
@@ -2,9 +2,39 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/browse_content.widget.dart';
+import 'package:immich_mobile/presentation/widgets/filter_sheet/filter_section_id.dart';
+import 'package:immich_mobile/presentation/widgets/filter_sheet/strips/camera_strip.widget.dart';
+import 'package:immich_mobile/presentation/widgets/filter_sheet/strips/people_strip.widget.dart';
+import 'package:immich_mobile/presentation/widgets/filter_sheet/strips/places_strip.widget.dart';
+import 'package:immich_mobile/presentation/widgets/filter_sheet/strips/tags_strip.widget.dart';
+import 'package:immich_mobile/presentation/widgets/filter_sheet/strips/when_strip.widget.dart';
 import 'package:immich_mobile/providers/photos_filter/filter_sheet.provider.dart';
+import 'package:immich_mobile/providers/photos_filter/hidden_sections.provider.dart';
 
 import '../../../widget_tester_extensions.dart';
+
+class _FakeVis implements FilterSectionVisibilityPrefs {
+  Set<FilterSectionId> stored;
+  _FakeVis(this.stored);
+  @override
+  Set<FilterSectionId> loadHidden() => stored;
+  @override
+  Future<void> saveHidden(Set<FilterSectionId> ids) async => stored = ids;
+}
+
+Future<void> _pump(WidgetTester tester, ScrollController controller, {Set<FilterSectionId> hidden = const {}}) async {
+  await tester.binding.setSurfaceSize(const Size(400, 1600));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  await tester.pumpConsumerWidget(
+    BrowseContent(scrollController: controller),
+    overrides: [
+      photosFilterSheetProvider.overrideWith((ref) => FilterSheetSnap.browse),
+      filterSectionVisibilityPrefsProvider.overrideWithValue(_FakeVis(hidden)),
+    ],
+  );
+  await tester.pumpAndSettle();
+}
 
 void main() {
   group('BrowseContent', () {
@@ -13,13 +43,7 @@ void main() {
       addTearDown(controller.dispose);
       // Tall viewport so the bottom "More filters" button renders inside the
       // ListView's build window.
-      await tester.binding.setSurfaceSize(const Size(400, 1600));
-      addTearDown(() => tester.binding.setSurfaceSize(null));
-
-      await tester.pumpConsumerWidget(
-        BrowseContent(scrollController: controller),
-        overrides: [photosFilterSheetProvider.overrideWith((ref) => FilterSheetSnap.browse)],
-      );
+      await _pump(tester, controller);
       final container = ProviderScope.containerOf(tester.element(find.byType(BrowseContent)));
       container.read(photosFilterSheetProvider.notifier).state = FilterSheetSnap.browse;
       await tester.pumpAndSettle();
@@ -28,6 +52,32 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(container.read(photosFilterSheetProvider), FilterSheetSnap.deep);
+    });
+
+    testWidgets('with nothing hidden, all five strips render', (tester) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      await _pump(tester, controller);
+
+      expect(find.byType(PeopleStrip), findsOneWidget);
+      expect(find.byType(PlacesStrip), findsOneWidget);
+      expect(find.byType(TagsStrip), findsOneWidget);
+      expect(find.byType(CameraStrip), findsOneWidget);
+      expect(find.byType(WhenStrip), findsOneWidget);
+    });
+
+    // #1002: sections hidden via "Manage sections" (Deep) must stay hidden when
+    // the sheet collapses to Browse, not silently reappear as unfiltered strips.
+    testWidgets('sections hidden via Manage sections stay hidden in Browse', (tester) async {
+      final controller = ScrollController();
+      addTearDown(controller.dispose);
+      await _pump(tester, controller, hidden: {FilterSectionId.people, FilterSectionId.places});
+
+      expect(find.byType(PeopleStrip), findsNothing);
+      expect(find.byType(PlacesStrip), findsNothing);
+      expect(find.byType(TagsStrip), findsOneWidget);
+      expect(find.byType(CameraStrip), findsOneWidget);
+      expect(find.byType(WhenStrip), findsOneWidget);
     });
   });
 }

--- a/mobile/test/presentation/widgets/filter_sheet/filter_sheet_test.dart
+++ b/mobile/test/presentation/widgets/filter_sheet/filter_sheet_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/presentation/widgets/filter_sheet/browse_content.widget.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/deep_content.widget.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/filter_sheet.widget.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/filter_section_id.dart';
@@ -86,6 +87,68 @@ void main() {
     testWidgets('deep → DeepContent mounted', (tester) async {
       await _pump(tester, snap: FilterSheetSnap.deep);
       expect(find.byType(DeepContent), findsOneWidget);
+    });
+  });
+
+  group('FilterSheet drag settling (#1002)', () {
+    testWidgets('a drag that transiently dips through browse/dismiss extents does not '
+        'change snap until the drag actually settles', (tester) async {
+      await _pump(tester, snap: FilterSheetSnap.deep);
+      final container = ProviderScope.containerOf(tester.element(find.byType(FilterSheet)));
+      final sheetContext = tester.element(find.byType(DraggableScrollableSheet));
+
+      // A single continuous "swipe down (half)" gesture: the live extent
+      // sweeps down past the browse snap point and even dips below the
+      // dismiss threshold, then springs back up to rest at deep — the
+      // user's thumb never actually released down there.
+      for (final extent in [0.90, 0.70, 0.55, 0.48, 0.60, 0.80, 0.94]) {
+        DraggableScrollableNotification(
+          extent: extent,
+          minExtent: 0.3,
+          maxExtent: 0.95,
+          initialExtent: 0.95,
+          context: sheetContext,
+        ).dispatch(sheetContext);
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+
+      // Still mid-drag: nothing should have committed from the transient
+      // pass-through extents yet.
+      expect(container.read(photosFilterSheetProvider), FilterSheetSnap.deep);
+      expect(find.byType(DeepContent), findsOneWidget);
+
+      // Let the debounce window elapse with no further motion, then let
+      // any resulting animation/rebuild finish.
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pumpAndSettle();
+
+      // Once the drag has settled, the snap reflects where it actually
+      // came to rest (deep) — the sheet never bounced through hidden/browse.
+      expect(container.read(photosFilterSheetProvider), FilterSheetSnap.deep);
+      expect(find.byType(DeepContent), findsOneWidget);
+    });
+
+    testWidgets('a drag that settles at the browse extent commits browse', (tester) async {
+      await _pump(tester, snap: FilterSheetSnap.deep);
+      final container = ProviderScope.containerOf(tester.element(find.byType(FilterSheet)));
+      final sheetContext = tester.element(find.byType(DraggableScrollableSheet));
+
+      for (final extent in [0.90, 0.75, 0.62]) {
+        DraggableScrollableNotification(
+          extent: extent,
+          minExtent: 0.3,
+          maxExtent: 0.95,
+          initialExtent: 0.95,
+          context: sheetContext,
+        ).dispatch(sheetContext);
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+
+      await tester.pump(const Duration(milliseconds: 200));
+      await tester.pumpAndSettle();
+
+      expect(container.read(photosFilterSheetProvider), FilterSheetSnap.browse);
+      expect(find.byType(BrowseContent), findsOneWidget);
     });
   });
 }

--- a/mobile/test/providers/photos_filter/active_chips_test.dart
+++ b/mobile/test/providers/photos_filter/active_chips_test.dart
@@ -34,8 +34,16 @@ void main() {
       expect(chips, hasLength(1));
       expect(chips.single.id, const PersonChipId('p1'));
       expect(chips.single.label, 'Alice');
+      expect(chips.single.labelIsKey, isFalse); // a real name, not the unnamed-person key
       expect(chips.single.visual, ChipVisual.person);
       expect(chips.single.avatarPersonIds, ['p1']);
+    });
+
+    test('unnamed person → labelled with the unnamed-person i18n key', () {
+      final f = _base()..people.add(_person('p1', ''));
+      final chip = activeChipsFromFilter(f).single;
+      expect(chip.label, 'filter_sheet_unnamed_person');
+      expect(chip.labelIsKey, isTrue);
     });
 
     // The chip avatar must route a shared-space person to the space thumbnail endpoint, which
@@ -117,6 +125,7 @@ void main() {
       final chips = activeChipsFromFilter(f);
       expect(chips, hasLength(1));
       expect(chips.single.label, 'filter_sheet_tag_fallback');
+      expect(chips.single.labelIsKey, isTrue);
       expect(chips.single.id, const TagChipId('unknown'));
     });
 
@@ -206,6 +215,7 @@ void main() {
       final chips = activeChipsFromFilter(f);
       expect(chips, hasLength(1));
       expect(chips.single.label, 'filter_sheet_media_photos');
+      expect(chips.single.labelIsKey, isTrue);
       expect(chips.single.id, isA<MediaTypeChipId>());
     });
 
@@ -224,8 +234,13 @@ void main() {
     test('favourites / archived / notInAlbum / untagged emit toggle chips', () {
       final f = _base()
         ..display = SearchDisplayFilters(isFavorite: true, isArchive: true, isNotInAlbum: true, isUntagged: true);
-      final ids = activeChipsFromFilter(f).map((c) => c.id.runtimeType).toSet();
+      final chips = activeChipsFromFilter(f);
+      final ids = chips.map((c) => c.id.runtimeType).toSet();
       expect(ids, containsAll([FavouriteChipId, ArchiveChipId, NotInAlbumChipId, UntaggedChipId]));
+      // Every toggle chip's label is an i18n key, not resolved text — the
+      // widget must translate it, or the raw key leaks to the user (#1002
+      // follow-up: "filter_sheet_favourites" showing verbatim in the UI).
+      expect(chips.where((c) => c.visual == ChipVisual.toggle).every((c) => c.labelIsKey), isTrue);
     });
 
     test('combined filter preserves documented order', () {


### PR DESCRIPTION
## Summary
- A live drag on the photos filter sheet fires a `DraggableScrollableNotification` on every frame of motion, so a partial "swipe down (half)" could sweep *through* the browse snap extent — or dip below the dismiss threshold — well before the user's thumb comes to rest (e.g. on the way back up after an overshoot).
- The sheet committed `photosFilterSheetProvider` on each of those transient extents, flipping the sheet between deep/browse/hidden mid-gesture. That unmounts `DeepContent`/`BrowseContent` (and, once hidden, the sheet itself) while the drag is still live, dropping the rest of that gesture's notification stream. In a widget test this reproduces as an outright crash (`Null check operator used on a null value` in `Element.widget`) once a subsequent notification dispatches against the now-defunct element.
- Debounced the commit so only the extent the drag actually *settles* on (no further motion for 160ms) changes the snap. Verified against a live Android build that an aggressive real swipe (fast fling down + fling back up) no longer produces the earlier premature dismiss/crash, and that toggled "Options" filters (Favourites, Not in album, etc.) survive repeated deep↔browse transitions.
- **Follow-up (found while manually verifying the above on-device):** the active-filter chips row was rendering raw i18n keys — e.g. "filter_sheet_favourites" instead of "Favourites" — for the toggle chips, the media-type chips, and two fallback labels (unnamed person, tag not found). `activeChipsFromFilter()` is a pure Dart helper with no `BuildContext`, so it can't call `.tr()` itself; it was emitting the untranslated key and the widget rendered it verbatim. Added `ActiveChipSpec.labelIsKey` so the widget knows which labels still need translating, and set it on every key-emitting chip.
- **Second follow-up:** "Manage sections" (the gear icon on the Deep filter view) only ever gated `DeepContent`'s own section list. `BrowseContent` rendered its five strips (People/Places/Tags/Camera/When) unconditionally, so a section hidden there reappeared the moment the sheet collapsed from Deep to Browse — the "I hide a section, but it comes back when I swipe down" behavior reported in #1002. Gated each Browse strip on the same `hiddenSectionsProvider` Deep already reads, so both views agree on what's hidden regardless of snap state.

Fixes #1002.

## Test plan
- [x] `flutter test test/presentation/widgets/filter_sheet/filter_sheet_test.dart` — new regression tests: a drag transiently dipping through browse/dismiss extents settles back at its real rest point without committing early; a drag that settles at browse commits browse.
- [x] `flutter test test/providers/photos_filter/active_chips_test.dart test/presentation/widgets/filter_sheet/active_filter_chip_test.dart` — new coverage: toggle/media/fallback chips carry `labelIsKey: true` and render their translated text, not the raw key.
- [x] `flutter test test/presentation/widgets/filter_sheet/browse_content_test.dart` — new coverage: each Browse strip is gated on `hiddenSectionsProvider`, matching Deep's visibility.
- [x] `flutter test` — full mobile suite green (3145 tests, 0 failures), no regressions.
- [x] `dart analyze --fatal-infos` + `dart format` on changed files — clean.
- [x] Manually verified on an Android emulator (API 36): built pre-fix, reproduced a crash triggered by a fast swipe through the sheet's dismiss threshold; rebuilt post-fix, repeated the same aggressive swipe with no crash and no filter-state loss. Also visually confirmed the chip-label fix — Favourites/Not in album chips now read correctly instead of showing the raw key — and that hiding a section via "Manage sections" keeps it hidden across Deep↔Browse swipes.
