### PR TITLE
docs: point revert-to-immich guide at the release asset, not main

### DIFF
--- a/docs/docs/guides/switch-back-to-immich.md
+++ b/docs/docs/guides/switch-back-to-immich.md
@@ -40,11 +40,17 @@ Leave `immich_postgres` (and `immich_redis`, if you run it) running.
 
 ## 3. Download the cleanup script
 
-The script lives at [`scripts/revert-to-immich.sql`](https://github.com/open-noodle/gallery/blob/main/scripts/revert-to-immich.sql) in the Gallery repository. Download it into your working directory:
+**Use the script attached to the release you're actually running, not the copy on the `main` branch.** The script targets the exact set of Gallery-only tables, columns, and fork migrations for its release — `main` is always ahead, so its copy can drop things your schema doesn't have (or miss things it does) if your instance is even one release behind.
+
+Find your version first: run [`immich-admin version`](/administration/server-commands#examples) in the `immich_server` container, or click the version number at the bottom of the sidebar in the Gallery web UI to open the About dialog.
+
+Then open that version's page on the [Gallery releases page](https://github.com/open-noodle/gallery/releases) — for example `https://github.com/open-noodle/gallery/releases/tag/v5.4.0` — and download the `revert-to-immich.sql` asset attached to it, either from the browser or with `curl`:
 
 ```bash
-curl -O https://raw.githubusercontent.com/open-noodle/gallery/main/scripts/revert-to-immich.sql
+curl -LO https://github.com/open-noodle/gallery/releases/download/v5.4.0/revert-to-immich.sql
 ```
+
+Replace `v5.4.0` with your own version. Every release since this asset was introduced ships one; if yours predates it, upgrade to the nearest later release first and use the script attached there.
 
 Read the script header before running it — it lists every table and column it will drop.
 


### PR DESCRIPTION
## Summary
- Every Gallery release now ships `revert-to-immich.sql` as a release asset, pinned to that release's schema (see `.github/workflows/gallery-release-server-only.yml`).
- The switch-back-to-immich guide still pointed users at the `main`-branch copy of the script, which can drift ahead of what an older instance's schema actually needs.
- Updated step 3 to have users find the version they're running (`immich-admin version`, or the sidebar version button) and download the script attached to that release's page instead.

## Test plan
- [x] `npx prettier --write` on the changed file (no formatting changes needed)
- [ ] Docs site build (CI)