### PR TITLE
docs: forbid commit messages that autolink Immich PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,38 @@ The copy step (1) is needed because:
 - **TypeScript**: Strict mode in all packages
 - **Async**: `no-floating-promises` and `no-misused-promises` enforced everywhere
 
+## Commit Messages & PR Descriptions
+
+**Never refer to an upstream Immich PR with a form GitHub autolinks.** This repo is a **fork of
+`immich-app/immich`**, so GitHub resolves a bare `#30881` against the **parent** repo and files an
+"added a commit that referenced this pull request" event on Immich's PR. The rolling rebase branch
+replays every fork commit under a new SHA each cycle, so one such reference re-notifies that
+upstream PR on **every force-push** — it is not a one-off.
+
+| Write this                        | Never this                                                     |
+| --------------------------------- | -------------------------------------------------------------- |
+| `immich-30881`                    | `#30881` · `PR#30881` · `GH-30881` · `immich-app/immich#30881` |
+| `sveltejs/svelte 18546`           | `sveltejs/svelte#18546`                                        |
+| `xneo1/portainer_templates PR 13` | a `github.com/<other-repo>/pull/13` URL                        |
+
+**Our own `#NNN` stays** — a fork PR or issue number resolves inside this repo and is the normal,
+useful case. Only numbers above our own PR numbering, and any explicit `owner/repo#N` or foreign
+issue/PR URL, cause the problem.
+
+This applies to **commit messages, PR titles and PR descriptions** — all three create
+cross-references. Ordinary file contents do not, so `docs/upstream-reports/*.md` may cite `#30900`
+freely.
+
+To check a branch, grep its own commits — anything this prints is a reference that will notify
+another repo (5+ digits, because Immich is well past 30000 while our own PR numbers are 4-digit):
+
+```bash
+git log origin/main..HEAD --format=%B | grep -nE '(^|[^0-9A-Za-z_/-])#[0-9]{5,}|[a-z0-9._-]+/[a-z0-9._-]+#[0-9]+'
+```
+
+The rolling rebase branch also carries `make commit-autolink-check`, which covers every autolink
+form GitHub honours; it reaches `main` at the next upstream cutover.
+
 ## i18n
 
 `i18n/` at the repo root is shared by web and mobile — grep both before deleting or renaming a key.


### PR DESCRIPTION
## Why

We are spamming Immich's pull requests, and it repeats.

This repo is a **fork of `immich-app/immich`**, so GitHub resolves a bare hash-number reference in a
commit message against the **parent** repo and files an "added a commit that referenced this pull
request" event on Immich's PR. The rolling rebase branch replays every fork commit under a **new SHA
each cycle**, so a single such reference re-fires on **every force-push** — upstream saw the same
commits posted twice, hours apart.

At the point it was found: **171 fork commits referencing 154 distinct Immich PRs**, re-notified in
full, every cycle.

## What this PR does

Adds a `Commit Messages & PR Descriptions` section to `AGENTS.md`. Documentation only — no code.

`AGENTS.md` had no commit-message guidance at all, and it is the file every agent session in this
repo loads. The rolling branch already carries the history rewrite and a `make commit-autolink-check`
audit, but a rolling-branch skill only applies during a rebase cycle. Ordinary fork PRs are cut from
`main` and never see it — which is where the remaining leaks are: **4 of the last 40 merged PRs**
reference an upstream PR in their body.

## Notes

- **Our own numbers are unaffected.** They resolve inside this repo and are the normal case; only
  numbers above our own PR numbering, plus explicit `owner/repo` refs and foreign issue/PR URLs, are
  the problem.
- **File contents are fine** — only commit messages, PR titles and PR bodies create
  cross-references, so `docs/upstream-reports/*.md` may cite upstream numbers freely.
- The check one-liner it documents works on `main` today; the fuller `make commit-autolink-check`
  arrives with the next upstream cutover.
- This is documentation, so it binds agents and reviewers, not the machine. A CI job on
  `pull_request` would be the mechanical block; not included here.
- The branch passes its own rule, which is how the example in the original commit message got caught.
