### PR TITLE
fix(revert): delete Gallery's own workflow plugin so upstream Immich can boot

### DIFF
--- a/scripts/revert-to-immich.sql
+++ b/scripts/revert-to-immich.sql
@@ -287,6 +287,31 @@ DELETE FROM "migration_overrides"
  );
 
 -- -----------------------------------------------------------------------------
+-- 6b. Delete Gallery's own workflow plugin.
+--
+-- Plugins are stored IN THE DATABASE (`plugin.wasmBytes`), not just on disk, and the server loads
+-- every row from `getForLoad()` at boot. Gallery ships `gallery-core`, whose wasm imports the
+-- fork-only `gallery` host function. Upstream Immich does not register that function, so leaving
+-- the row behind makes its microservices worker die on startup with
+--
+--   cannot resolve import "extism:host/user" "gallery"
+--
+-- and the server never answers /api/server/ping. Unlike the migration_overrides cleanup above, this
+-- one is load-bearing: skip it and upstream Immich does not boot at all.
+--
+-- `plugin_method` cascades from `plugin`, and `workflow_step.pluginMethodId` cascades from
+-- `plugin_method`, so this also removes any workflow step wired to a Gallery action. Those steps
+-- could never run on upstream anyway. The parent `workflow` rows survive.
+--
+-- Upstream's own `immich-plugin-core` is deliberately left alone.
+-- -----------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF to_regclass('public.plugin') IS NOT NULL THEN
+    DELETE FROM public."plugin" WHERE "name" = 'gallery-core';
+  END IF;
+END $$;
+
 -- 7. Undo post-v3.0.1 upstream migrations that Gallery pulled in via rebase.
 --
 -- Gallery regularly rebases onto `upstream/main`, which sits ahead of the


### PR DESCRIPTION
## Why

`gallery-revert-to-immich-validation` is red on every branch cut from `main`, and has been since
#981 merged.

It is **not** schema drift — that phase reports `No schema drift detected`. The failure is the
post-phase **upstream Immich** container never answering `/api/server/ping`:

```
microservices worker error: cannot resolve import "extism:host/user" "gallery"
("extism:host/user" is a host module, but does not contain "gallery")
microservices worker exited with code 1
```

**Plugins live in the database**, not just on disk: the server loads every `plugin` row at boot and
instantiates its wasm. #981 added `gallery-core`, whose wasm imports the fork-only `gallery` host
function. Upstream Immich does not register it, so the leftover row alone stops upstream booting —
exactly what this script exists to prevent. The script had no plugin cleanup at all.

## What this does

Adds step 6b: delete the `gallery-core` plugin row.

`plugin_method` cascades from `plugin`, and `workflow_step.pluginMethodId` cascades from that, so any
workflow step wired to a Gallery action goes too. Those could never run on upstream anyway, and the
parent `workflow` rows survive. Upstream's own `immich-plugin-core` is deliberately left alone.

## Verification

Against a database migrated from this branch and seeded with both plugins, a method each, and a
workflow step on the Gallery method:

| | before | after |
| --- | --- | --- |
| `plugin` | 2 | 1 (`immich-plugin-core` retained) |
| `plugin_method` | 2 | 1 |
| `workflow_step` | 1 | 0 (cascaded) |
| `workflow` | 1 | 1 (parent kept) |

Re-running is a no-op, and the `to_regclass` guard was checked against a database with the `plugin`
table dropped.

The identical block is already on the rolling rebase branch, where CI confirmed the end-to-end
behaviour: `post: /api/server/ping OK` followed by `revert-to-immich validation PASSED`.

## Note

The gate boots the tagged upstream image for its post phase, so this only goes green once the change
is on the branch under test — this PR is what fixes it for `main` and everything cut from it.
