### PR TITLE
fix(web): nest a place link's city under its country in the filter panel (#989)

### DIFF
--- a/web/src/lib/components/filter-panel/__tests__/location-country-nesting.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/location-country-nesting.spec.ts
@@ -1,0 +1,84 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/svelte';
+import { init, register, waitLocale } from 'svelte-i18n';
+import type { FilterPanelConfig, FilterState, FilterSuggestionsResponse } from '../filter-panel';
+import { createFilterState } from '../filter-panel';
+import FilterPanel from '../filter-panel.svelte';
+
+/**
+ * #989: the Explore strip and the Places grid linked to `/photos?city=…` with no `country`, and the
+ * reporter saw the city "displayed at the same (first) level as the rest of the countries" instead
+ * of nested beneath its country.
+ *
+ * The link fix (Route.photos carrying `country`) lives in route.spec.ts / explore-page.spec.ts /
+ * places-card-group.spec.ts. This file pins the panel behaviour that fix depends on: the panel
+ * genuinely renders the two cases at DIFFERENT levels, so a change here can't silently make the
+ * country param pointless and re-open the report.
+ *
+ * The discriminator is the `ml-5` indent, which only the in-country city row carries — the
+ * country-less fallback row (location-filter.svelte, the `selectedCity && !selectedCountry` block)
+ * sits flush with the country rows by design, because it has no country block to sit inside.
+ */
+
+beforeAll(async () => {
+  register('en-US', () => import('$i18n/en.json'));
+  await init({ fallbackLocale: 'en-US' });
+  await waitLocale('en-US');
+});
+
+const suggestions = (overrides: Partial<FilterSuggestionsResponse> = {}): FilterSuggestionsResponse => ({
+  countries: [],
+  cameraMakes: [],
+  tags: [],
+  people: [],
+  ratings: [],
+  mediaTypes: [],
+  hasUnnamedPeople: false,
+  hasFavorites: false,
+  hasAssetsInAlbum: false,
+  hasAssetsNotInAlbum: false,
+  ...overrides,
+});
+
+const CITIES: Record<string, string[]> = {
+  'South Africa': ['Cape Town', 'Durban'],
+  Germany: ['Berlin'],
+};
+
+const config: FilterPanelConfig = {
+  sections: ['location'],
+  suggestionsProvider: () => Promise.resolve(suggestions({ countries: ['South Africa', 'Germany'] })),
+  providers: { cities: (country: string) => Promise.resolve(CITIES[country] ?? []) },
+};
+
+const renderPanel = (filters: Partial<FilterState>) =>
+  render(FilterPanel, {
+    props: { config, timeBuckets: [], filters: { ...createFilterState(), ...filters } },
+  });
+
+describe('a city hydrated from the URL', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('nests under its country, ticked, when the country came along', async () => {
+    renderPanel({ city: 'Cape Town', country: 'South Africa' });
+
+    // The country block auto-expands to reveal the level the selection lives on.
+    const city = await screen.findByTestId('location-city-Cape Town');
+    expect(city.className).toContain('ml-5');
+    expect(city.querySelector('.bg-immich-primary')).not.toBeNull();
+
+    // Its sibling city proves the row really is the country's expanded list, not a lone fallback.
+    expect(screen.getByTestId('location-city-Durban')).toBeInTheDocument();
+    expect(screen.getByTestId('location-country-South Africa')).toBeInTheDocument();
+  });
+
+  it('sits flat beside the countries — the reported #989 symptom — when the country is missing', async () => {
+    renderPanel({ city: 'Cape Town' });
+
+    const city = await screen.findByTestId('location-city-Cape Town');
+    expect(city.className).not.toContain('ml-5');
+
+    // No country expanded, so no sibling city is rendered anywhere.
+    expect(screen.queryByTestId('location-city-Durban')).toBeNull();
+  });
+});

--- a/web/src/lib/route.spec.ts
+++ b/web/src/lib/route.spec.ts
@@ -135,6 +135,27 @@ describe('Route', () => {
     it('should ignore an empty city', () => {
       expect(Route.photos({ city: '' })).toBe('/photos');
     });
+
+    // #989: a city alone lands in the location filter as an ORPHAN — the panel has no country to
+    // nest it under, so it renders flat beside the countries. Carrying the country makes the panel
+    // expand that country and select the city inside it.
+    it('should support a city scoped to its country', () => {
+      expect(Route.photos({ city: 'Cape Town', country: 'South Africa' })).toBe(
+        '/photos?city=Cape%20Town&country=South%20Africa',
+      );
+    });
+
+    it('should ignore an empty country', () => {
+      expect(Route.photos({ city: 'Cape Town', country: '' })).toBe('/photos?city=Cape%20Town');
+    });
+
+    // The param order is fixed by the route helper, not by the caller's object literal, so the two
+    // call sites (#989: the Explore strip and the Places grid) cannot drift apart.
+    it('should emit a stable param order regardless of the caller key order', () => {
+      expect(Route.photos({ country: 'South Africa', city: 'Cape Town' })).toBe(
+        '/photos?city=Cape%20Town&country=South%20Africa',
+      );
+    });
   });
 
   describe('viewSpaceAlbum', () => {

--- a/web/src/lib/route.ts
+++ b/web/src/lib/route.ts
@@ -132,9 +132,15 @@ export const Route = {
     `/spaces/${spaceId}/people/${personId}` + asQueryString(params),
 
   // photos
-  // `city` is a filter-panel param (SEARCHABLE_PAGE_FILTER_PARAMS) — /photos hydrates its filter
+  // `city` / `country` are filter-panel params (FILTER_URL_PARAMS) — /photos hydrates its filter
   // state from the URL, so this lands on the timeline already narrowed to that place (#867).
-  photos: (params?: { at?: string; city?: string }) => '/photos' + asQueryString(params),
+  //
+  // #989: pass BOTH halves of a place. The location filter nests cities under their country, and a
+  // `city` with no `country` has nowhere to nest — it renders flat beside the country list as an
+  // orphaned selection. The params are rebuilt here in a fixed order rather than forwarded, so the
+  // emitted URL does not depend on the caller's object-literal key order.
+  photos: (params?: { at?: string; city?: string; country?: string }) =>
+    '/photos' + asQueryString({ at: params?.at, city: params?.city, country: params?.country }),
   viewAsset: ({ id }: { id: string }) => `/photos/${id}`,
   archive: () => '/archive',
   favorites: () => '/favorites',

--- a/web/src/routes/(user)/explore/+page.svelte
+++ b/web/src/routes/(user)/explore/+page.svelte
@@ -108,7 +108,11 @@
       <SingleGridRow class="grid grid-flow-col grid-auto-fill-28 gap-x-4 md:grid-auto-fill-36">
         {#snippet children({ itemCount })}
           {#each places.slice(0, itemCount) as item (item.data.id)}
-            <a class="relative" href={Route.photos({ city: item.value })} draggable="false">
+            <a
+              class="relative"
+              href={Route.photos({ city: item.value, country: item.data.exifInfo?.country ?? undefined })}
+              draggable="false"
+            >
               <div class="flex justify-center overflow-hidden rounded-xl brightness-75 filter">
                 <img
                   src={getAssetMediaUrl({ id: item.data.id, size: AssetMediaSize.Thumbnail })}

--- a/web/src/routes/(user)/explore/explore-page.spec.ts
+++ b/web/src/routes/(user)/explore/explore-page.spec.ts
@@ -98,4 +98,48 @@ describe('Explore page', () => {
     const link = screen.getByRole('link', { name: /Cape Town/ });
     expect(link).toHaveAttribute('href', '/photos?city=Cape%20Town');
   });
+
+  // #989: the tile linked with `city` alone, so the location filter had no country to nest the
+  // city under and rendered it flat beside the country list. The country is already on the
+  // representative asset the strip renders — carry it through.
+  it('scopes a place tile to the country of its representative asset', () => {
+    renderPage(
+      [],
+      [
+        {
+          fieldName: 'exifInfo.city',
+          items: [
+            {
+              value: 'Cape Town',
+              data: assetFactory.build({ id: 'asset-1', exifInfo: { city: 'Cape Town', country: 'South Africa' } }),
+            },
+          ],
+        },
+      ],
+    );
+
+    const link = screen.getByRole('link', { name: /Cape Town/ });
+    expect(link).toHaveAttribute('href', '/photos?city=Cape%20Town&country=South%20Africa');
+  });
+
+  // Reverse geocoding can resolve a city without a country. Falling back to the city-only link
+  // keeps the tile working (as an orphaned selection) rather than emitting `country=`.
+  it('falls back to a city-only link when the asset has no country', () => {
+    renderPage(
+      [],
+      [
+        {
+          fieldName: 'exifInfo.city',
+          items: [
+            {
+              value: 'Cape Town',
+              data: assetFactory.build({ id: 'asset-1', exifInfo: { city: 'Cape Town', country: null } }),
+            },
+          ],
+        },
+      ],
+    );
+
+    expect(screen.getByRole('link', { name: /Cape Town/ })).toHaveAttribute('href', '/photos?city=Cape%20Town');
+  });
 });

--- a/web/src/routes/(user)/places/PlacesCardGroup.svelte
+++ b/web/src/routes/(user)/places/PlacesCardGroup.svelte
@@ -40,7 +40,11 @@
     <div class="flex flex-row flex-wrap gap-4">
       {#each places as item (item.id)}
         {@const city = item.exifInfo?.city}
-        <a class="relative" href={Route.photos({ city: city ?? undefined })} draggable="false">
+        <a
+          class="relative"
+          href={Route.photos({ city: city ?? undefined, country: item.exifInfo?.country ?? undefined })}
+          draggable="false"
+        >
           <div
             class="flex w-[calc((100vw-(72px+5rem))/2)] max-w-39 justify-center overflow-hidden rounded-xl brightness-75 filter"
           >

--- a/web/src/routes/(user)/places/places-card-group.spec.ts
+++ b/web/src/routes/(user)/places/places-card-group.spec.ts
@@ -5,8 +5,8 @@ import TestWrapper from '$lib/components/TestWrapper.svelte';
 import { assetFactory } from '@test-data/factories/asset-factory';
 import PlacesCardGroup from './PlacesCardGroup.svelte';
 
-function renderGroup(city: string) {
-  const props = { places: [assetFactory.build({ id: 'asset-1', exifInfo: { city } })] };
+function renderGroup(city: string, country?: string | null) {
+  const props = { places: [assetFactory.build({ id: 'asset-1', exifInfo: { city, country } })] };
 
   return render(TestWrapper as Component<{ component: typeof PlacesCardGroup; componentProps: typeof props }>, {
     component: PlacesCardGroup,
@@ -19,6 +19,24 @@ describe('PlacesCardGroup', () => {
   // filtered /photos timeline can.
   it('links a place card to the photos timeline filtered by that city', () => {
     renderGroup('Cape Town');
+
+    expect(screen.getByRole('link', { name: /Cape Town/ })).toHaveAttribute('href', '/photos?city=Cape%20Town');
+  });
+
+  // #989: the card linked with `city` alone, so the location filter rendered the city flat beside
+  // the countries instead of nested under one. /places already knows the country — it is what the
+  // enclosing group is keyed on.
+  it('scopes a place card to the country of that place', () => {
+    renderGroup('Cape Town', 'South Africa');
+
+    expect(screen.getByRole('link', { name: /Cape Town/ })).toHaveAttribute(
+      'href',
+      '/photos?city=Cape%20Town&country=South%20Africa',
+    );
+  });
+
+  it('falls back to a city-only link when the place has no country', () => {
+    renderGroup('Cape Town', null);
 
     expect(screen.getByRole('link', { name: /Cape Town/ })).toHaveAttribute('href', '/photos?city=Cape%20Town');
   });


### PR DESCRIPTION
Fixes #989.

## The report

Clicking a location on the Explore page lands on the filtered timeline, but the location filter shows the city **flat, beside the country list** instead of nested under its country.

## Cause

Both place surfaces linked with `city` and nothing else:

```svelte
href={Route.photos({ city: item.value })}
```

The location filter nests cities under their country, so a city that arrives with no country has nowhere to sit and falls back to a top-level row (`location-filter.svelte`, the `selectedCity && !selectedCountry` block) — exactly what the reporter saw. `decodeFilterParams` has always read a `country` URL param; `Route.photos` simply never offered one.

## Fix

The country was already in hand at both call sites — no extra fetch, and no server or SDK change:

- **Explore** — the tile carries the full representative asset (`search.service.ts` already dereferences `exifInfo.city` to build it), so `exifInfo.country` is right there.
- **`/places`** — `PlacesCardGroup` had the identical bug, and there the country is what the enclosing group is *keyed on* (`PlacesList` groups by `exifInfo.country` to render its headings).

`Route.photos` gains a `country` param and rebuilds its params in a fixed order rather than forwarding the caller's object literal, so the two call sites cannot emit differently ordered URLs for the same place.

Both call sites fall back to the city-only link when the country is null, so a place whose reverse geocoding resolved no country behaves exactly as it does today rather than emitting an empty `country=`.

## Known limitation (deliberate, not fixed here)

Explore tiles still group by city name alone — `getAssetIdByCity` does `distinctOn(city)` with no country in the group key — so a city name shared by two countries now narrows to the representative asset's country instead of aggregating both. Changing that means a server query change plus a `make sql` regen, and is better as its own PR. It fails safe meanwhile: the panel's cascade auto-clear drops a city its country does not contain, degrading to the country rather than to an empty timeline.

## Tests

Written first; three were genuinely red:

- `route.spec.ts` — city+country, empty country, and caller-key-order independence (this one failed: `/photos?country=…&city=…`).
- `explore-page.spec.ts` — country carried through, plus the null-country fallback.
- `places-card-group.spec.ts` — the same pair.

Note on the other two `route.spec.ts` cases: they pass *before* the fix too, because `asQueryString` forwards any object at runtime — only `tsc` rejected the extra property. `check:typescript` is their real gate, not vitest.

`location-country-nesting.spec.ts` is new and, to be straight about it, **not** red-first — the panel was already correct, it just never received a country. It pins the two states apart (the nested `ml-5` in-country row vs. the flat fallback row from the report) so a later panel change cannot silently make the `country` param pointless. Both assertions were flipped and confirmed to fail, so they discriminate rather than passing either way.

## Verification

| Gate | Result |
|---|---|
| `pnpm vitest run` (web) | 372 files, 5958 passed, 0 failed |
| `pnpm check:typescript` | clean |
| `pnpm check:svelte` | 613 files, 0 errors, 0 warnings |
| `pnpm lint` | clean |
| `prettier --check` (touched files) | clean |

No i18n keys added or changed.
