### PR TITLE
fix(mobile): inset the filter sheet's Done bar only on Android (#1003)

### DIFF
--- a/mobile/lib/presentation/widgets/filter_sheet/browse_content.widget.dart
+++ b/mobile/lib/presentation/widgets/filter_sheet/browse_content.widget.dart
@@ -75,7 +75,10 @@ class BrowseContent extends ConsumerWidget {
                   ),
                 ),
               ),
-              const SizedBox(height: 88),
+              // Clears the MatchCountFooter stacked on top of this list — it grows
+              // by the system nav bar inset on Android, and the last row has to
+              // clear all of it.
+              SizedBox(height: MatchCountFooter.reservedHeightFor(context)),
             ],
           ),
           const Positioned(left: 0, right: 0, bottom: 0, child: MatchCountFooter()),

--- a/mobile/lib/presentation/widgets/filter_sheet/deep_content.widget.dart
+++ b/mobile/lib/presentation/widgets/filter_sheet/deep_content.widget.dart
@@ -89,7 +89,10 @@ class DeepContent extends ConsumerWidget {
             key: const PageStorageKey('filter-sheet-deep-scroll'),
             controller: scrollController,
             keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-            padding: const EdgeInsets.only(bottom: 88),
+            // Clears the MatchCountFooter stacked on top of this list — it grows
+            // by the system nav bar inset on Android, and the last section has
+            // to clear all of it.
+            padding: EdgeInsets.only(bottom: MatchCountFooter.reservedHeightFor(context)),
             children: [
               const KeyedSubtree(key: Key('deep-header'), child: DeepHeader()),
               const Padding(

--- a/mobile/lib/presentation/widgets/filter_sheet/match_count_footer.widget.dart
+++ b/mobile/lib/presentation/widgets/filter_sheet/match_count_footer.widget.dart
@@ -1,11 +1,68 @@
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:immich_mobile/extensions/platform_extensions.dart';
 import 'package:immich_mobile/presentation/widgets/filter_sheet/match_count_label.widget.dart';
 import 'package:immich_mobile/providers/photos_filter/filter_sheet.provider.dart';
 
 class MatchCountFooter extends ConsumerWidget {
   const MatchCountFooter({super.key});
+
+  /// Breathing room under the Done button when nothing is drawn below it.
+  static const double _basePadding = 20;
+
+  /// Height the footer occupies over the scrolling content it is stacked on
+  /// top of, so BrowseContent / DeepContent can reserve exactly that much at
+  /// the bottom of their lists. Anything less and the last filter row sits
+  /// permanently behind the Done bar, unreachable.
+  static double reservedHeightFor(BuildContext context) => 88 + systemNavBarInset(context);
+
+  /// Space the device's system navigation bar takes at the bottom of the sheet.
+  ///
+  /// Android draws that bar ON TOP of the sheet, so on devices still using the
+  /// 3-button (back / home / recents) row it covers the Done button and makes
+  /// it hard to tap (#1003). Push the button up by whatever the system
+  /// reports — 0 on a device that draws no bottom bar at all, so nothing moves
+  /// there.
+  ///
+  /// iOS reports a bottom inset too, but it is the home indicator: nothing is
+  /// drawn over the sheet, so honouring it only left dead space under the
+  /// button, and a footer that tall also hid the last filter rows behind
+  /// itself. Keep iOS on the flat padding it had before #1003.
+  ///
+  /// Read from [View], NOT from [MediaQuery] — both of MediaQuery's bottom
+  /// insets are unusable in this subtree, in opposite directions. Measured on a
+  /// 3-button device whose real inset is 48:
+  ///
+  ///  * `padding.bottom` is inflated, to 100. The sheet lives in the body of a
+  ///    `Scaffold(extendBody: true, bottomNavigationBar: GalleryBottomNav)`,
+  ///    and such a Scaffold raises the body's bottom padding to the nav bar's
+  ///    own height so extended-body content can clear it. That is what the
+  ///    original `SafeArea` fix read, so it reserved room for the nav pill —
+  ///    which `GalleryBottomNav` hides for as long as this sheet is open.
+  ///  * `viewPadding.bottom` is zeroed. Consuming that padding goes through
+  ///    `MediaQuery.removePadding`, which also drops viewPadding by the amount
+  ///    consumed, `max(0, 48 - 48)`. It reads 0 here with the keyboard down,
+  ///    and only springs back to 48 while the keyboard is up (which zeroes the
+  ///    padding being consumed).
+  ///
+  /// `View.of(context).viewPadding` is the engine's own value, ahead of any
+  /// MediaQuery rewriting, and measures a stable 48 in both states. It is in
+  /// physical pixels, hence the [FlutterView.devicePixelRatio] division.
+  @visibleForTesting
+  static double systemNavBarInset(BuildContext context) {
+    if (!CurrentPlatform.isAndroid) {
+      return 0;
+    }
+    // Subscribe to metrics changes. `View.of` does not: the view's identity is
+    // stable across a rotation or a nav-mode switch, so it notifies nobody — and
+    // both content widgets hold this footer in a `const` constructor, which a
+    // parent rebuild alone will not refresh. The value read below still has to
+    // come from the view, for the reasons above.
+    MediaQuery.maybeViewPaddingOf(context);
+    final view = View.of(context);
+    return view.viewPadding.bottom / view.devicePixelRatio;
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -13,20 +70,17 @@ class MatchCountFooter extends ConsumerWidget {
     return Material(
       color: theme.colorScheme.surface,
       elevation: 6,
-      child: SafeArea(
-        top: false,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(20, 12, 12, 20),
-          child: Row(
-            children: [
-              const Expanded(child: MatchCountLabel()),
-              FilledButton.tonal(
-                key: const Key('match-count-footer-done'),
-                onPressed: () => ref.read(photosFilterSheetProvider.notifier).state = FilterSheetSnap.hidden,
-                child: Text('filter_sheet_done'.tr()),
-              ),
-            ],
-          ),
+      child: Padding(
+        padding: EdgeInsets.fromLTRB(20, 12, 12, _basePadding + systemNavBarInset(context)),
+        child: Row(
+          children: [
+            const Expanded(child: MatchCountLabel()),
+            FilledButton.tonal(
+              key: const Key('match-count-footer-done'),
+              onPressed: () => ref.read(photosFilterSheetProvider.notifier).state = FilterSheetSnap.hidden,
+              child: Text('filter_sheet_done'.tr()),
+            ),
+          ],
         ),
       ),
     );

--- a/mobile/test/presentation/widgets/filter_sheet/match_count_footer_test.dart
+++ b/mobile/test/presentation/widgets/filter_sheet/match_count_footer_test.dart
@@ -4,26 +4,136 @@ import 'package:immich_mobile/presentation/widgets/filter_sheet/match_count_foot
 
 import '../../../widget_tester_extensions.dart';
 
+const _dpr = 3.0;
+const _screen = Size(1080, 2400);
+const _screenHeight = 800.0; // logical px
+
+/// The footer's own breathing room under the Done button.
+const _basePadding = 20.0;
+
+/// Logical px — simulates the Android 3-button (back / home / recents) nav bar,
+/// which is drawn ON TOP of the sheet.
+const _navBarInset = 48.0;
+
+/// Logical px — what iOS reports for the home indicator. Nothing is drawn over
+/// the sheet there, so the footer must not reserve it.
+const _homeIndicatorInset = 34.0;
+
+/// Logical px — the filter sheet lives in the body of a
+/// `Scaffold(extendBody: true, bottomNavigationBar: GalleryBottomNav)`, and such
+/// a Scaffold inflates the body's `MediaQuery.padding.bottom` to the nav bar's
+/// own height so extended-body content can clear it. The footer must not read
+/// that: the nav pill it accounts for is hidden while the sheet is open.
+/// Measured at 100 on the emulator against a real 48 system inset.
+const _inflatedPadding = 100.0;
+
+/// Sets the system inset ([FlutterView.viewPadding]) and, separately, the
+/// Scaffold-inflated [FlutterView.padding] the footer must ignore.
+void _fakeInsets(WidgetTester tester, {required double systemInset}) {
+  tester.view.physicalSize = _screen;
+  tester.view.devicePixelRatio = _dpr;
+  tester.view.viewPadding = FakeViewPadding(bottom: systemInset * _dpr);
+  tester.view.padding = const FakeViewPadding(bottom: _inflatedPadding * _dpr);
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+  addTearDown(tester.view.resetViewPadding);
+  addTearDown(tester.view.resetPadding);
+}
+
+/// Pins the target platform for one test. `TargetPlatformVariant` rather than a
+/// setUp/tearDown pair: the binding asserts that foundation debug vars are unset
+/// as soon as the test body returns, before any tearDown runs.
+final _android = TargetPlatformVariant.only(TargetPlatform.android);
+final _ios = TargetPlatformVariant.only(TargetPlatform.iOS);
+
+Future<void> _pumpFooter(WidgetTester tester) =>
+    tester.pumpConsumerWidget(const Align(alignment: Alignment.bottomCenter, child: MatchCountFooter()));
+
+/// Pumps the footer under a `MediaQuery.removePadding`, reproducing what the
+/// real tree does to it: consuming the bottom padding also drops
+/// `MediaQuery.viewPadding.bottom` to `max(0, systemInset - consumed)`, which is
+/// 0 once the inflated padding is consumed. Only the raw [View] still knows the
+/// true inset.
+Future<void> _pumpFooterUnderRemovedPadding(WidgetTester tester) => tester.pumpConsumerWidget(
+  Align(
+    alignment: Alignment.bottomCenter,
+    child: Builder(
+      builder: (ctx) => MediaQuery.removePadding(context: ctx, removeBottom: true, child: const MatchCountFooter()),
+    ),
+  ),
+);
+
+double _gapUnderButton(WidgetTester tester) =>
+    _screenHeight - tester.getBottomLeft(find.byKey(const Key('match-count-footer-done'))).dy;
+
+/// BrowseContent / DeepContent pad the bottom of their lists by this much to
+/// clear the footer stacked on top of them. If it were smaller than the footer,
+/// the last filter row would sit behind the Done bar, unreachable.
+void _expectReserveCoversFooter(WidgetTester tester) {
+  final reserved = MatchCountFooter.reservedHeightFor(tester.element(find.byType(MatchCountFooter)));
+  expect(tester.getSize(find.byType(MatchCountFooter)).height, lessThanOrEqualTo(reserved));
+}
+
 void main() {
-  group('MatchCountFooter', () {
-    testWidgets('keeps the Done button clear of the system bottom inset', (tester) async {
-      const dpr = 3.0;
-      const bottomInset = 48.0; // logical px — simulates the Android 3-button nav bar
-      tester.view.physicalSize = const Size(1080, 2400);
-      tester.view.devicePixelRatio = dpr;
-      tester.view.padding = const FakeViewPadding(bottom: bottomInset * dpr);
-      addTearDown(tester.view.resetPhysicalSize);
-      addTearDown(tester.view.resetDevicePixelRatio);
-      addTearDown(tester.view.resetPadding);
+  group('MatchCountFooter on Android', () {
+    testWidgets('keeps the Done button clear of the system nav bar', (tester) async {
+      _fakeInsets(tester, systemInset: _navBarInset);
 
-      await tester.pumpConsumerWidget(const Align(alignment: Alignment.bottomCenter, child: MatchCountFooter()));
+      await _pumpFooter(tester);
 
-      final screenHeight = tester.view.physicalSize.height / tester.view.devicePixelRatio;
+      // The nav bar occupies [screenHeight - inset, screenHeight]. The Done
+      // button must not extend into that zone, or it becomes unreachable (#1003).
       final buttonBottom = tester.getBottomLeft(find.byKey(const Key('match-count-footer-done'))).dy;
+      expect(buttonBottom, lessThanOrEqualTo(_screenHeight - _navBarInset));
 
-      // The system nav bar occupies [screenHeight - bottomInset, screenHeight]. The
-      // Done button must not extend into that zone, or it becomes unreachable.
-      expect(buttonBottom, lessThanOrEqualTo(screenHeight - bottomInset));
-    });
+      // ...and it clears the bar by exactly the bar, not by the Scaffold-inflated
+      // padding: the nav pill that padding accounts for is hidden here.
+      expect(_gapUnderButton(tester), closeTo(_basePadding + _navBarInset, 0.5));
+    }, variant: _android);
+
+    testWidgets('adds no inset on a device that reports no bottom bar', (tester) async {
+      _fakeInsets(tester, systemInset: 0);
+
+      await _pumpFooter(tester);
+
+      expect(_gapUnderButton(tester), closeTo(_basePadding, 0.5));
+    }, variant: _android);
+
+    testWidgets('still clears the bar when an ancestor has consumed the padding', (tester) async {
+      _fakeInsets(tester, systemInset: _navBarInset);
+
+      await _pumpFooterUnderRemovedPadding(tester);
+
+      // MediaQuery.viewPadding.bottom is 0 in this subtree; the engine's is not.
+      expect(_gapUnderButton(tester), closeTo(_basePadding + _navBarInset, 0.5));
+    }, variant: _android);
+
+    testWidgets('reserves enough room for the taller footer', (tester) async {
+      _fakeInsets(tester, systemInset: _navBarInset);
+
+      await _pumpFooter(tester);
+
+      _expectReserveCoversFooter(tester);
+    }, variant: _android);
+  });
+
+  group('MatchCountFooter on iOS', () {
+    testWidgets('does not reserve the home indicator under the Done button', (tester) async {
+      _fakeInsets(tester, systemInset: _homeIndicatorInset);
+
+      await _pumpFooter(tester);
+
+      // iOS draws nothing over the sheet, so the button keeps only the footer's
+      // own breathing room — not 20 + 34, and certainly not 20 + 90.
+      expect(_gapUnderButton(tester), closeTo(_basePadding, 0.5));
+    }, variant: _ios);
+
+    testWidgets('reserves enough room for the footer', (tester) async {
+      _fakeInsets(tester, systemInset: _homeIndicatorInset);
+
+      await _pumpFooter(tester);
+
+      _expectReserveCoversFooter(tester);
+    }, variant: _ios);
   });
 }


### PR DESCRIPTION
Follow-up to #1010, which fixed #1003.

## The problem

#1010 wrapped `MatchCountFooter` in `SafeArea(top: false)` so the Done button would clear the Android 3-button nav bar. `SafeArea` reads `MediaQuery.padding`, and the filter sheet lives in the body of a `Scaffold(extendBody: true, bottomNavigationBar: GalleryBottomNav)` — that kind of Scaffold **inflates** the body's bottom padding to the nav bar's own height. Measured on a Pixel 6 emulator: `padding.bottom = 100` where the real system inset is `48`.

So the footer was not reserving room for the *system* bar. It was reserving room for **Gallery's own nav pill**, which `GalleryBottomNav` deliberately hides for as long as the sheet is open.

On iOS that is ~86pt of dead space under the Done button (measured 110pt of gap where 20pt was intended), and it makes the footer taller than the fixed `88px` the two scroll views reserve for it — so the last rows of the filter list sat behind the Done bar permanently and could not be reached. On an iPhone 17 Pro Max that was the `Search N tags` link and the whole `CAMERA` section.

## The fix

Take the inset from `View.of(context).viewPadding`, and only on Android.

`MediaQuery` is unusable in this subtree in **both** directions. Probing from inside the running app, on a device whose real inset is 48:

| | `mq.padding` | `mq.viewPadding` | `View.viewPadding` |
|---|---|---|---|
| keyboard up | 100.0 | 48.0 | **48.0** |
| keyboard down | 100.0 | **0.0** | **48.0** |

`padding.bottom` is inflated as described. `viewPadding.bottom` is zeroed, because consuming that inflated padding goes through `MediaQuery.removePadding`, which also drops `viewPadding` by the amount consumed — `max(0, 48 - 48)`. It only springs back to 48 while the keyboard is up, which is what zeroes the padding being consumed in the first place. The engine's own value is stable in both states.

`BrowseContent` / `DeepContent` now derive their bottom reserve from the same number instead of a hardcoded `88`, so a taller footer can never cover the last row on Android either.

`systemNavBarInset` also touches `MediaQuery.maybeViewPaddingOf` purely to subscribe to metrics changes: `View.of` does not notify on rotation or a nav-mode switch, and both content widgets hold the footer in a `const` constructor, which a parent rebuild alone will not refresh.

## Verification

Both platforms driven by hand on a simulator/emulator:

- **iOS** (iPhone 17 Pro Max, iOS 26.5) — gap under the button back to 20pt, and the `Search N tags` link and `CAMERA` section are visible again.
- **Android** (Pixel 6 emulator, switched to 3-button navigation via `settings put secure navigation_mode 0`) — the Done button sits entirely clear of the back/home/recents row. Confirmed against the system's reported `navigationBars frame=[0,2256][1080,2400]`.

Gates: 202 filter-sheet widget tests pass, `dart analyze --fatal-infos` clean, `dart format` clean.

Each new test was proved to fail against the code it guards:

- the iOS case fails `Expected 20.0, Actual 110.0` against the `SafeArea` version — the same 110pt measured on the simulator;
- the `removePadding` regression case fails `Expected 68.0, Actual 20.0` against a `MediaQuery.viewPaddingOf` implementation, which is the trap this PR exists to avoid;
- the reserve case fails `Expected <= 88.0, Actual 128.0` if `reservedHeightFor` stops tracking the inset.

## Not covered

`WhenPickerFooter` and the sort / manage-sections modal sheets use the same `SafeArea(top: false)` pattern. Whether they inherit the same inflated padding depends on which Navigator they are pushed onto, and I did not verify it here.
