### PR TITLE
fix(web): give search results inside a Space the screen height they need on mobile (#1028)

### DIFF
--- a/web/src/lib/components/filter-panel/active-filters-bar.svelte
+++ b/web/src/lib/components/filter-panel/active-filters-bar.svelte
@@ -213,86 +213,106 @@
 </script>
 
 <div
-  class="flex flex-wrap items-center gap-2 {embedded
+  class="flex flex-col gap-1.5 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2 {embedded
     ? ''
     : 'border-b border-gray-200/60 px-4 py-2.5 dark:border-white/10'}"
   data-testid="active-filters-bar"
 >
-  {#if resultCount !== undefined}
-    <span class="text-xs font-medium text-gray-500 dark:text-gray-400" data-testid="result-count">
-      {$t('filter_result_count', { values: { count: resultCount } })}
-    </span>
-  {/if}
+  <!--
+    Below `sm` the chips are one horizontally-scrollable row with the actions underneath, so the bar
+    is a fixed two rows however many filters are on. It used to wrap to roughly a row per chip, and
+    on a phone that ate the screen the search results were supposed to be using (#1028): four rows
+    for a single search chip, six once a few filters were added.
 
-  {#if showCountSeparator}
-    <span class="size-1 rounded-full bg-gray-400/60 dark:bg-gray-500/60" aria-hidden="true"></span>
-  {/if}
+    `sm:contents` dissolves this wrapper from `sm` up, leaving every desktop viewport with exactly
+    the single wrapping row it has always had.
+  -->
+  <div class="flex scrollbar-hidden items-center gap-2 overflow-x-auto pe-1 sm:contents">
+    {#if resultCount !== undefined}
+      <span class="shrink-0 text-xs font-medium text-gray-500 dark:text-gray-400" data-testid="result-count">
+        {$t('filter_result_count', { values: { count: resultCount } })}
+      </span>
+    {/if}
 
-  {#if searchQuery.trim()}
-    <span
-      class="inline-flex items-center gap-1.5 rounded-full border border-immich-primary/30 bg-immich-primary/10 py-1 pr-1 pl-2.5 text-xs font-medium text-immich-primary dark:border-immich-dark-primary/30 dark:bg-immich-dark-primary/10 dark:text-immich-dark-primary"
-      data-testid="search-chip"
-    >
-      <Icon icon={mdiMagnify} size="14" />
-      <span>{searchQuery}</span>
-      <button
-        type="button"
-        class="flex size-[18px] items-center justify-center rounded-full text-immich-primary/60 transition-colors hover:bg-immich-primary/15 hover:text-immich-primary dark:text-immich-dark-primary/60 dark:hover:bg-immich-dark-primary/20 dark:hover:text-immich-dark-primary"
-        onclick={() => onClearSearch?.()}
-        aria-label={$t('filter_sheet_picker_clear_search')}
-        data-testid="search-chip-close"
+    {#if showCountSeparator}
+      <span class="size-1 shrink-0 rounded-full bg-gray-400/60 dark:bg-gray-500/60" aria-hidden="true"></span>
+    {/if}
+
+    {#if searchQuery.trim()}
+      <span
+        class="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-immich-primary/30 bg-immich-primary/10 py-1 pr-1 pl-2.5 text-xs font-medium text-immich-primary dark:border-immich-dark-primary/30 dark:bg-immich-dark-primary/10 dark:text-immich-dark-primary"
+        data-testid="search-chip"
       >
-        <Icon icon={mdiClose} size="12" />
-      </button>
-    </span>
-  {/if}
+        <Icon icon={mdiMagnify} size="14" />
+        <span>{searchQuery}</span>
+        <button
+          type="button"
+          class="flex size-[18px] items-center justify-center rounded-full text-immich-primary/60 transition-colors hover:bg-immich-primary/15 hover:text-immich-primary dark:text-immich-dark-primary/60 dark:hover:bg-immich-dark-primary/20 dark:hover:text-immich-dark-primary"
+          onclick={() => onClearSearch?.()}
+          aria-label={$t('filter_sheet_picker_clear_search')}
+          data-testid="search-chip-close"
+        >
+          <Icon icon={mdiClose} size="12" />
+        </button>
+      </span>
+    {/if}
 
-  {#each chips as chip (`${chip.type}-${chip.id ?? chip.labelKey ?? chip.label}`)}
-    {@const chipLabel = chip.labelKey ? $t(chip.labelKey, { values: chip.labelValues }) : (chip.label ?? '')}
-    <span
-      class="inline-flex items-center gap-1.5 rounded-full border border-gray-200/70 bg-gray-100 py-1 pr-1 pl-2.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-200 dark:border-white/10 dark:bg-white/6 dark:text-gray-200 dark:hover:bg-white/10"
-      data-testid="active-chip"
-    >
-      <Icon icon={chip.icon} size="14" class="text-gray-500 dark:text-gray-400" />
-      <span>{chipLabel}</span>
-      <button
-        type="button"
-        class="flex size-[18px] items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-gray-300/70 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-white/10 dark:hover:text-gray-200"
-        onclick={() => onRemoveFilter(chip.type, chip.id)}
-        aria-label={$t('filter_remove_chip', { values: { label: chipLabel } })}
-        data-testid="chip-close"
+    {#each chips as chip (`${chip.type}-${chip.id ?? chip.labelKey ?? chip.label}`)}
+      {@const chipLabel = chip.labelKey ? $t(chip.labelKey, { values: chip.labelValues }) : (chip.label ?? '')}
+      <span
+        class="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-gray-200/70 bg-gray-100 py-1 pr-1 pl-2.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-200 dark:border-white/10 dark:bg-white/6 dark:text-gray-200 dark:hover:bg-white/10"
+        data-testid="active-chip"
       >
-        <Icon icon={mdiClose} size="12" />
-      </button>
-    </span>
-  {/each}
+        <Icon icon={chip.icon} size="14" class="text-gray-500 dark:text-gray-400" />
+        <span>{chipLabel}</span>
+        <button
+          type="button"
+          class="flex size-[18px] items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-gray-300/70 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-white/10 dark:hover:text-gray-200"
+          onclick={() => onRemoveFilter(chip.type, chip.id)}
+          aria-label={$t('filter_remove_chip', { values: { label: chipLabel } })}
+          data-testid="chip-close"
+        >
+          <Icon icon={mdiClose} size="12" />
+        </button>
+      </span>
+    {/each}
+  </div>
 
-  {#if showAddAll}
-    <button
-      type="button"
-      class="ml-auto inline-flex items-center gap-1.5 rounded-full bg-immich-primary/10 py-1 ps-2.5 pe-3.5 text-xs font-semibold text-immich-primary transition-colors hover:bg-immich-primary/16 dark:bg-immich-dark-primary/10 dark:text-immich-dark-primary dark:hover:bg-immich-dark-primary/20"
-      onclick={() => onAddAllToCollection?.()}
-      data-testid="add-all-to-collection"
-    >
-      <Icon icon={mdiPlus} size="15" />
-      <span>{$t('add_all_search_results', { values: { count: resultCount ?? 0 } })}</span>
-    </button>
-  {/if}
+  {#if showAddAll || hasActiveFilters}
+    <!-- `sm:ms-auto` reproduces the `ml-auto` these two buttons used to carry individually: from
+         `sm` up the chips are siblings again, so pushing the group right right-aligns the actions
+         exactly as before. -->
+    <div class="flex items-center gap-2 sm:ms-auto">
+      {#if showAddAll}
+        <button
+          type="button"
+          class="inline-flex min-w-0 items-center gap-1.5 rounded-full bg-immich-primary/10 py-1 ps-2.5 pe-3.5 text-xs font-semibold text-immich-primary transition-colors hover:bg-immich-primary/16 dark:bg-immich-dark-primary/10 dark:text-immich-dark-primary dark:hover:bg-immich-dark-primary/20"
+          onclick={() => onAddAllToCollection?.()}
+          data-testid="add-all-to-collection"
+        >
+          <Icon icon={mdiPlus} size="15" class="shrink-0" />
+          <!-- Truncated rather than swapped for a shorter string: the accessible name then stays
+               the full label at every width, so what a screen reader announces still matches what
+               is on screen (WCAG 2.5.3). -->
+          <span class="truncate">{$t('add_all_search_results', { values: { count: resultCount ?? 0 } })}</span>
+        </button>
+      {/if}
 
-  {#if hasActiveFilters}
-    <button
-      type="button"
-      class="rounded-full px-2.5 py-1 text-xs font-semibold text-immich-primary transition-colors hover:bg-immich-primary/10 dark:text-immich-dark-primary dark:hover:bg-immich-dark-primary/10"
-      class:ml-auto={!showAddAll}
-      onclick={() => {
-        onClearAll();
-        if (searchQuery) {
-          onClearSearch?.();
-        }
-      }}
-      data-testid="clear-all-btn"
-    >
-      {$t('clear_all')}
-    </button>
+      {#if hasActiveFilters}
+        <button
+          type="button"
+          class="shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold text-immich-primary transition-colors hover:bg-immich-primary/10 dark:text-immich-dark-primary dark:hover:bg-immich-dark-primary/10"
+          onclick={() => {
+            onClearAll();
+            if (searchQuery) {
+              onClearSearch?.();
+            }
+          }}
+          data-testid="clear-all-btn"
+        >
+          {$t('clear_all')}
+        </button>
+      {/if}
+    </div>
   {/if}
 </div>

--- a/web/src/lib/components/search/smart-search-results.spec.ts
+++ b/web/src/lib/components/search/smart-search-results.spec.ts
@@ -289,6 +289,20 @@ describe('SmartSearchResults', () => {
     expect(dto).not.toHaveProperty('albumIds');
   });
 
+  // #1028: the space shell collapses its cover as the reader scrolls the results, and the only
+  // scrolling element lives inside the grid this component wraps.
+  it('forwards scroll reports from the result grid to the host', async () => {
+    const onScroll = vi.fn();
+    const { getByTestId } = render(SmartSearchResults, { props: { ...baseProps, onScroll } });
+    await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+
+    const scroller = getByTestId('search-results-scroller');
+    Object.defineProperty(scroller, 'scrollTop', { value: 180, configurable: true });
+    await fireEvent.scroll(scroller);
+
+    expect(onScroll).toHaveBeenCalledWith(180);
+  });
+
   it('forwards route-provided exact total to the result grid', async () => {
     searchSmartMock.mockResolvedValueOnce({
       assets: {

--- a/web/src/lib/components/search/smart-search-results.svelte
+++ b/web/src/lib/components/search/smart-search-results.svelte
@@ -31,6 +31,8 @@
      * undone delete, since undo hands back TimelineAssets rather than full AssetResponseDtos.
      */
     reloadToken?: number;
+    /** Reports the results grid's scroll offset — see `SpaceSearchResults` (#1028). */
+    onScroll?: (scrollTop: number) => void;
   }
 
   let {
@@ -46,6 +48,7 @@
     total,
     results: searchResults = $bindable([]),
     reloadToken = 0,
+    onScroll,
   }: Props = $props();
 
   /**
@@ -174,4 +177,5 @@
   {isShared}
   sortMode={filters.sortOrder}
   {total}
+  {onScroll}
 />

--- a/web/src/lib/components/spaces/space-search-results.spec.ts
+++ b/web/src/lib/components/spaces/space-search-results.spec.ts
@@ -97,6 +97,30 @@ describe('SpaceSearchResults', () => {
     expect(screen.getByTestId('gallery-viewer')).toHaveAttribute('data-has-scroll-element', 'true');
   });
 
+  // #1028: the results grid owns the only scrolling element on the surface, so a host that wants
+  // to shrink its chrome as the reader scrolls (the space shell collapsing its cover) can only
+  // learn about it from here.
+  it('should report its scroll position so the host can collapse the chrome around it', async () => {
+    const onScroll = vi.fn();
+    render(SpaceSearchResults, {
+      props: {
+        results: mockAssets,
+        isLoading: false,
+        hasMore: false,
+        totalLoaded: 3,
+        onLoadMore: vi.fn(),
+        sortMode: 'relevance',
+        onScroll,
+      },
+    });
+
+    const scroller = screen.getByTestId('search-results-scroller');
+    Object.defineProperty(scroller, 'scrollTop', { value: 240, configurable: true });
+    await fireEvent.scroll(scroller);
+
+    expect(onScroll).toHaveBeenCalledWith(240);
+  });
+
   it('should keep ownership of the asset viewer so space context is preserved', () => {
     render(SpaceSearchResults, {
       props: {

--- a/web/src/lib/components/spaces/space-search-results.svelte
+++ b/web/src/lib/components/spaces/space-search-results.svelte
@@ -27,6 +27,12 @@
     total?: number;
     /** Re-runs the current search — used to restore results after an undone delete. */
     onReload?: () => void;
+    /**
+     * Reports the scroll offset of the results grid. This section is the only scrolling element on
+     * the surface, so a host that shrinks its chrome as the reader scrolls — the space shell
+     * collapsing its cover — has no other way to hear about it (#1028). Mirrors `Timeline`'s prop.
+     */
+    onScroll?: (scrollTop: number) => void;
   }
 
   let {
@@ -41,6 +47,7 @@
     sortMode,
     total,
     onReload,
+    onScroll,
   }: Props = $props();
 
   let isViewerOpen = $state(false);
@@ -120,6 +127,8 @@
   bind:this={scrollContainer}
   bind:clientHeight={viewport.height}
   class="flex-1 immich-scrollbar overflow-y-auto p-4"
+  data-testid="search-results-scroller"
+  onscroll={() => onScroll?.(scrollContainer?.scrollTop ?? 0)}
 >
   {#if isLoading && results.length === 0}
     <div class="flex justify-center py-8" data-testid="search-loading">

--- a/web/src/routes/(user)/spaces/[spaceId]/+layout.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/+layout.svelte
@@ -11,6 +11,7 @@
   import SpaceEditModal from '$lib/modals/SpaceEditModal.svelte';
   import { Route } from '$lib/route';
   import { handleError } from '$lib/utils/handle-error';
+  import { getSearchablePageState } from '$lib/utils/searchable-page-search';
   import {
     bulkAddAssets,
     removeMember,
@@ -71,6 +72,12 @@
   // The cover (SpaceHero) is tall + scroll-collapsible on the Photos route, compact on other tabs.
   let repositioning = $state(false);
   const onPhotosTab = $derived(page.url.pathname === base || page.url.pathname.startsWith(`${base}/photos`));
+
+  // It is compact on the Photos route too while a search is showing results — a results view leads
+  // with the results. A phone leaves the space ~520 CSS px of page height, and a tall cover stacked
+  // with the app bar, tabs and search header left the grid a sliver of it (#1028). The query is read
+  // from the URL (`?q=`), the same source the Photos page commits it from.
+  const searchActive = $derived(onPhotosTab && getSearchablePageState(page.url).query.length > 0);
 
   // No-cover spaces fall back to a per-space colored gradient derived from space.color.
   const gradientClasses: Record<string, string> = {
@@ -305,7 +312,7 @@
           {repositioning}
           onSavePosition={handleSavePosition}
           onCancelReposition={() => (repositioning = false)}
-          compact={!onPhotosTab}
+          compact={!onPhotosTab || searchActive}
           collapsed={onPhotosTab && spaceUiManager.coverCollapsed}
         />
         <SpaceTabs

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -662,6 +662,14 @@
   const smartFacetBuckets = $derived(showSearchResults ? (smartFacets?.timeBuckets ?? []) : timelineBuckets);
   const smartFacetTotal = $derived(showSearchResults ? smartFacets?.total : undefined);
 
+  // Collapse the shell's cover once the reader scrolls past it. Both surfaces this tab can show —
+  // the browse timeline and the search results grid — scroll independently, so both report here;
+  // wiring only the timeline left the cover pinned open over search results, which on a phone is
+  // most of the screen (#1028).
+  const COVER_COLLAPSE_SCROLL_THRESHOLD = 64;
+  const handleSurfaceScroll = (scrollTop: number) =>
+    spaceUiManager.setCoverCollapsed(scrollTop > COVER_COLLAPSE_SCROLL_THRESHOLD);
+
   const clearSearch = () => {
     isLoading = false;
     const nextUrl = buildSearchablePageUrl(page.url, '', filters.sortOrder, filters);
@@ -761,6 +769,10 @@
         smartFacets = undefined;
         smartFacetKey = '';
         smartFacetInFlight = undefined;
+        // Committing or clearing the query swaps the timeline for the results grid and back, and
+        // the incoming surface mounts at the top — so a collapse inherited from the outgoing one
+        // would hide the cover with nothing scrolled under it.
+        spaceUiManager.setCoverCollapsed(false);
       }
       lastHandledSearchState = nextToken;
     });
@@ -880,6 +892,7 @@
         space={{ id: space.id, canWrite: isEditor }}
         isShared={true}
         total={smartFacetTotal}
+        onScroll={handleSurfaceScroll}
       />
     {/if}
 
@@ -907,7 +920,7 @@
           onTemporalAnchorResolved={() => (temporalAnchor = undefined)}
           grouping={timelineGrouping}
           onGroupingChange={handleTimelineGroupingChange}
-          onScroll={(scrollTop) => spaceUiManager.setCoverCollapsed(scrollTop > 64)}
+          onScroll={handleSurfaceScroll}
         >
           {#if viewMode === 'view'}
             {#if isOwner}

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -297,6 +297,45 @@ describe('Spaces page search URL state', () => {
     expect(screen.getByTestId('smart-search-results')).toHaveAttribute('data-sort-order', 'relevance');
   });
 
+  // #1028: on a phone the cover + tabs left search results a sliver of the screen, because only
+  // the browse timeline reported its scroll offset — the results grid never did, so the shell's
+  // collapse-on-scroll never fired while a search was on screen.
+  it('collapses the space cover once the search results are scrolled', async () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach');
+
+    renderPage();
+    expect(spaceUiManager.coverCollapsed).toBe(false);
+
+    await fireEvent.click(screen.getByTestId('search-results-scroll-down'));
+
+    expect(spaceUiManager.coverCollapsed).toBe(true);
+  });
+
+  it('restores the space cover when the search results are scrolled back to the top', async () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach');
+
+    renderPage();
+    await fireEvent.click(screen.getByTestId('search-results-scroll-down'));
+
+    await fireEvent.click(screen.getByTestId('search-results-scroll-top'));
+
+    expect(spaceUiManager.coverCollapsed).toBe(false);
+  });
+
+  // Committing or clearing a search swaps the timeline for the results grid and back. The
+  // incoming surface always mounts scrolled to the top, so a collapse left over from the outgoing
+  // one hides the cover with nothing scrolled under it.
+  it('shows the cover again when clearing the search swaps back to the timeline', async () => {
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach');
+    renderPage();
+    await fireEvent.click(screen.getByTestId('search-results-scroll-down'));
+    expect(spaceUiManager.coverCollapsed).toBe(true);
+
+    mockPage.url = new URL('https://gallery.test/spaces/space-1/photos');
+
+    await waitFor(() => expect(spaceUiManager.coverCollapsed).toBe(false));
+  });
+
   it('hydrates an explicit search sort from the URL', () => {
     mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=beach&sort=asc');
 

--- a/web/src/routes/(user)/spaces/[spaceId]/space-layout.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/space-layout.spec.ts
@@ -342,6 +342,23 @@ describe('space [spaceId] +layout.svelte', () => {
     expect(screen.getByTestId('hero-title')).toHaveTextContent('Trip');
   });
 
+  // #1028: a phone gives the space roughly 520 CSS px of page height. The tall cover alone eats
+  // 220 of them, which — stacked with the app bar, tabs and the search header — left the results
+  // grid a sliver. A search is a results view, so the cover steps down to its compact size the
+  // moment results are on screen, before the reader scrolls at all.
+  it('shrinks the cover to compact while the photos tab is showing search results', () => {
+    mockPage.url = new URL('https://gallery.test/spaces/s1/photos?q=beach');
+    renderLayout(SharedSpaceRole.Owner);
+    expect(screen.getByTestId('space-hero').style.height).toBe('96px');
+  });
+
+  // The counterpart: browsing the space is a cover-first view, and must stay that way.
+  it('keeps the cover tall on the photos tab when no search is running', () => {
+    mockPage.url = new URL('https://gallery.test/spaces/s1/photos');
+    renderLayout(SharedSpaceRole.Owner);
+    expect(screen.getByTestId('space-hero').style.height).toBe('220px');
+  });
+
   it('passes a per-space colored gradient to the cover derived from space.color', () => {
     renderLayout(SharedSpaceRole.Owner, { space: space({ color: UserAvatarColor.Pink }) });
     expect(screen.getByTestId('hero-gradient')).toHaveClass('from-pink-300', 'to-pink-500');

--- a/web/src/test-data/mocks/smart-search-results.stub.svelte
+++ b/web/src/test-data/mocks/smart-search-results.stub.svelte
@@ -16,6 +16,7 @@
     results?: unknown[];
     isShared?: boolean;
     space?: { id: string; canWrite: boolean };
+    onScroll?: (scrollTop: number) => void;
     [key: string]: unknown;
   }
 
@@ -31,6 +32,7 @@
     results = $bindable([]),
     isShared,
     space,
+    onScroll,
     ...rest
   }: Props = $props();
 </script>
@@ -64,4 +66,9 @@
   data-country={filters?.country ?? ''}
   data-language={language}
   data-total={total ?? ''}
-></div>
+>
+  <!-- The real grid scrolls its own container; hosts learn about it only through `onScroll`.
+       These stand in for scrolling past / back above the collapse threshold. -->
+  <button type="button" data-testid="search-results-scroll-down" onclick={() => onScroll?.(240)}> scroll down </button>
+  <button type="button" data-testid="search-results-scroll-top" onclick={() => onScroll?.(0)}> scroll to top </button>
+</div>


### PR DESCRIPTION
Fixes #1028.

## The defect

The space shell has had a collapse-on-scroll cover since #752 — `SpaceHero` renders at 220px tall, 96px compact, 0px collapsed, driven by `spaceUiManager.coverCollapsed`. But the only thing that ever called `setCoverCollapsed()` was the browse `Timeline`:

```svelte
<Timeline onScroll={(scrollTop) => spaceUiManager.setCoverCollapsed(scrollTop > 64)} />
```

A search unmounts that timeline and mounts `SmartSearchResults`, which scrolls in **its own** container and reported nothing. So on the search surface the collapse was dead code and the cover stayed pinned open — on an iPhone, over most of the screen.

A second, independent problem: `ActiveFiltersBar` wrapped to roughly a row per chip. In German, one search chip produced **four** rows; a few filters made it six.

## Changes

| File | Change |
|---|---|
| `space-search-results.svelte` | New optional `onScroll?: (scrollTop: number) => void`, fired from the results scroll container — mirrors `Timeline`'s prop |
| `smart-search-results.svelte` | Forwards it through |
| space photos `+page.svelte` | Both surfaces share `handleSurfaceScroll`; the collapse resets when the query changes, since the incoming surface always mounts at the top |
| `+layout.svelte` | `compact={!onPhotosTab \|\| searchActive}` — the cover is 96px, not 220px, as soon as results are on screen |
| `active-filters-bar.svelte` | Below `sm`: chips in one horizontally-scrollable row, actions underneath. `sm:contents` dissolves the wrapper above `sm` |

## Effect

Reported screen (~523 CSS px of page height on an iPhone 17 Pro):

| | Before | After |
|---|---|---|
| Results at rest | ~138px (**15%**) | ~193px (**37%**) |
| Results scrolled | ~138px (**15%**) | ~289px (**55%**) |

Filters bar, measured from the real component:

| | Before | After |
|---|---|---|
| One search chip | 132px (4 rows) | **74px (2 rows)** |
| Search + 3 filters | 168px (6 rows) | **74px (2 rows)** |
| Desktop, either | 52px / 76px | **identical** |

## Verification

- TDD throughout, red→green each cycle. 7 new tests. Two were checked against a false green by flipping the threshold to `true` and confirming they go red.
- Full web unit suite: **5971 passed**, 0 failures (373 files). `tsc --noEmit` clean. `svelte-check` 613 files, 0 errors / 0 warnings. Prettier and eslint clean.
- happy-dom resolves no stylesheets, so the layout itself was proven in a real browser: the app's actual Tailwind + `@immich/ui` theme compiled into a static page, the **real component's** rendered markup dropped in, measured in WebKit at 402px and 1100px. Desktop came back byte-identical.

## Two notes for review

1. **The compact cover applies on desktop too**, deliberately — `searchActive` is not breakpoint-gated, so a 1080p screen also drops 220px → 96px during a search. It matches how the non-photos tabs already render. Easy to gate to mobile if you'd rather keep it tall.
2. **The tabs still don't collapse on scroll**, though the issue names them. They're the space's primary navigation and the browse path keeps them, so hiding them read as a design change rather than a bug fix. Happy to add it.

No i18n changes — no new or reworded strings. `add_all_search_results` is CSS-truncated rather than swapped for a shorter key, so its accessible name stays the full label at every width (WCAG 2.5.3).
