### PR TITLE
fix(sync): stream memories last so a memory link can't wedge mobile sync

### DIFF
--- a/mobile/lib/domain/services/sync_stream.service.dart
+++ b/mobile/lib/domain/services/sync_stream.service.dart
@@ -305,6 +305,11 @@ class SyncStreamService {
       // space-aware GC to drop remote_asset/remote_exif rows no longer reachable by
       // any path (owner/partner/classic-album/direct/space-album/space-library).
       case SyncEntityType.syncCompleteV1:
+        // Replay parked memory->asset links BEFORE the GC: every stream that can deliver an
+        // asset has now run, so a link whose asset arrived late can finally be written, and
+        // pruning afterwards keeps the existing semantics (a link to an unreachable asset is
+        // cascade-removed along with the asset).
+        await _syncStreamRepository.flushDeferredMemoryAssetsV1();
         return _syncStreamRepository.pruneAssets();
       // Request to reset the client state. Clear everything related to remote entities
       case SyncEntityType.syncResetV1:

--- a/mobile/lib/infrastructure/repositories/sync_stream.repository.dart
+++ b/mobile/lib/infrastructure/repositories/sync_stream.repository.dart
@@ -47,6 +47,11 @@ class SyncStreamRepository extends DriftDatabaseRepository {
   final Logger _logger = Logger('DriftSyncStreamRepository');
   final Drift _db;
 
+  // memory -> asset link rows whose memory or asset has not been streamed yet, held until
+  // SyncCompleteV1. Bounded by the links delivered in a single sync pass and cleared on every
+  // flush, so it never accumulates across syncs. See updateMemoryAssetsV1.
+  final Set<(String memoryId, String assetId)> _deferredMemoryAssets = {};
+
   SyncStreamRepository(super.db) : _db = db;
 
   Future<void> reset() async {
@@ -96,6 +101,7 @@ class SyncStreamRepository extends DriftDatabaseRepository {
             await _db.sharedSpaceEntity.deleteAll();
             await _db.libraryEntity.deleteAll();
           });
+          _deferredMemoryAssets.clear();
         } finally {
           // re-enable FK even if the transaction throws, otherwise the connection
           // would be left with foreign_keys = OFF, silently disabling cascades.
@@ -1081,25 +1087,130 @@ class SyncStreamRepository extends DriftDatabaseRepository {
     }
   }
 
+  // memory_asset_entity carries real foreign keys on BOTH ids, and Drift sends the batch as a
+  // single statement — so one link row whose memory or asset has not been streamed yet fails the
+  // WHOLE batch with SQLITE_CONSTRAINT_FOREIGNKEY (787). That aborts /sync/stream mid-flight and,
+  // because a failed batch is never acked, the next sync replays the same checkpoint and dies the
+  // same way: a permanently wedged client, with people, faces, spaces and libraries (all streamed
+  // later) never arriving. `onConflict: DoNothing()` does not help — it only covers PK conflicts.
+  //
+  // The server streams memories after every asset-bearing type (SYNC_TYPES_ORDER), so ordinarily
+  // both parents are present. This client must also survive an OLDER fork server that still
+  // streams them early — mobile and server release independently — so park what cannot be written
+  // yet and replay it at SyncCompleteV1 rather than dropping it or letting the constraint fire.
   Future<void> updateMemoryAssetsV1(Iterable<SyncMemoryAssetV1> data) async {
     try {
-      await _db.batch((batch) {
-        for (final asset in data) {
-          final companion = MemoryAssetEntityCompanion(memoryId: Value(asset.memoryId), assetId: Value(asset.assetId));
-
-          batch.insert(_db.memoryAssetEntity, companion, onConflict: DoNothing());
-        }
-      });
+      final deferred = await _insertMemoryAssetLinks([for (final link in data) (link.memoryId, link.assetId)]);
+      if (deferred.isNotEmpty) {
+        _deferredMemoryAssets.addAll(deferred);
+        _logger.fine('Deferred ${deferred.length} memory asset link(s) until their memory/asset arrives');
+      }
     } catch (error, stack) {
       _logger.severe('Error: updateMemoryAssetsV1', error, stack);
       rethrow;
     }
   }
 
+  // Replays the links parked by updateMemoryAssetsV1. Called on SyncCompleteV1, by which point
+  // every stream that can deliver an asset has run, so anything still unresolvable is a link this
+  // device genuinely cannot represent (e.g. a memory pointing at an asset outside its sync scope).
+  // Those are dropped with a warning instead of being carried into the next sync pass.
+  Future<void> flushDeferredMemoryAssetsV1() async {
+    if (_deferredMemoryAssets.isEmpty) {
+      return;
+    }
+
+    final pending = Set.of(_deferredMemoryAssets);
+    try {
+      final unresolved = await _insertMemoryAssetLinks(pending);
+      // Only forget the parked links once they have actually been dealt with — on failure they
+      // stay put for the next flush.
+      _deferredMemoryAssets.clear();
+
+      final replayed = pending.length - unresolved.length;
+      if (replayed > 0) {
+        _logger.info('Replayed $replayed deferred memory asset link(s)');
+      }
+      if (unresolved.isNotEmpty) {
+        final sample = unresolved.take(10).map((link) => '${link.$1}/${link.$2}').join(', ');
+        _logger.warning(
+          'Dropping ${unresolved.length} memory asset link(s) whose memory or asset never arrived: $sample',
+        );
+      }
+    } catch (error, stack) {
+      // Never rethrow: the sync itself has completed and every other batch is already acked.
+      // Failing here would abort the stream and lose the parked links for nothing.
+      _logger.severe('Error: flushDeferredMemoryAssetsV1', error, stack);
+    }
+  }
+
+  // Writes the links whose memory AND asset already exist locally, and returns the rest instead of
+  // letting the foreign keys abort the batch.
+  //
+  // Chunked because the parent lookups bind one variable per id: a single stream batch already
+  // carries up to kSyncEventBatchSize (5000) links, and a flush replays everything parked over a
+  // whole sync pass, which can be larger still. 500 keeps the `IN (...)` clauses far below any
+  // SQLITE_MAX_VARIABLE_NUMBER a bundled sqlite3 might have.
+  static const _memoryAssetLinkChunkSize = 500;
+
+  Future<Set<(String, String)>> _insertMemoryAssetLinks(Iterable<(String, String)> links) async {
+    final pending = links.toList(growable: false);
+    if (pending.isEmpty) {
+      return const {};
+    }
+
+    final deferred = <(String, String)>{};
+    for (var start = 0; start < pending.length; start += _memoryAssetLinkChunkSize) {
+      final end = start + _memoryAssetLinkChunkSize;
+      deferred.addAll(
+        await _insertMemoryAssetLinkChunk(pending.sublist(start, end > pending.length ? pending.length : end)),
+      );
+    }
+    return deferred;
+  }
+
+  Future<Set<(String, String)>> _insertMemoryAssetLinkChunk(List<(String, String)> pending) async {
+    final memoryQuery = _db.memoryEntity.selectOnly()
+      ..addColumns([_db.memoryEntity.id])
+      ..where(_db.memoryEntity.id.isIn(pending.map((link) => link.$1).toSet()));
+    final knownMemories = (await memoryQuery.map((row) => row.read(_db.memoryEntity.id)).get()).nonNulls.toSet();
+
+    final assetQuery = _db.remoteAssetEntity.selectOnly()
+      ..addColumns([_db.remoteAssetEntity.id])
+      ..where(_db.remoteAssetEntity.id.isIn(pending.map((link) => link.$2).toSet()));
+    final knownAssets = (await assetQuery.map((row) => row.read(_db.remoteAssetEntity.id)).get()).nonNulls.toSet();
+
+    final insertable = <(String, String)>[];
+    final deferred = <(String, String)>{};
+    for (final link in pending) {
+      if (knownMemories.contains(link.$1) && knownAssets.contains(link.$2)) {
+        insertable.add(link);
+      } else {
+        deferred.add(link);
+      }
+    }
+
+    if (insertable.isNotEmpty) {
+      await _db.batch((batch) {
+        for (final link in insertable) {
+          batch.insert(
+            _db.memoryAssetEntity,
+            MemoryAssetEntityCompanion(memoryId: Value(link.$1), assetId: Value(link.$2)),
+            onConflict: DoNothing(),
+          );
+        }
+      });
+    }
+
+    return deferred;
+  }
+
   Future<void> deleteMemoryAssetsV1(Iterable<SyncMemoryAssetDeleteV1> data) async {
     try {
       await _db.batch((batch) {
         for (final asset in data) {
+          // A link deleted before it could be replayed must not be resurrected by the flush.
+          _deferredMemoryAssets.remove((asset.memoryId, asset.assetId));
           batch.delete(
             _db.memoryAssetEntity,
             MemoryAssetEntityCompanion(memoryId: Value(asset.memoryId), assetId: Value(asset.assetId)),

--- a/mobile/test/domain/repositories/sync_stream_repository_test.dart
+++ b/mobile/test/domain/repositories/sync_stream_repository_test.dart
@@ -1612,6 +1612,144 @@ void main() {
     });
   });
 
+  // ---------------------------------------------------------------------------
+  // memory -> asset links (issue: SqliteException(787) wedging the whole sync)
+  // ---------------------------------------------------------------------------
+  //
+  // memory_asset_entity has real foreign keys on BOTH ids. A link row whose asset has
+  // not been streamed yet used to fail the entire Drift batch, abort /sync/stream, and —
+  // because the batch is never acked — leave the client replaying the same failing
+  // checkpoint forever. The server now streams memories last (SYNC_TYPES_ORDER), but the
+  // app must survive an older fork server too: park what it cannot write yet and replay
+  // it once every asset stream has landed.
+  group('SyncStreamRepository - memory to asset links', () {
+    SyncMemoryV1 makeMemory({String id = 'memory-1', String ownerId = 'user-1'}) => SyncMemoryV1(
+      createdAt: DateTime(2026, 4, 23),
+      data: const {'title': 'A memory'},
+      deletedAt: null,
+      hideAt: null,
+      id: id,
+      isSaved: false,
+      memoryAt: DateTime(2026, 4, 23),
+      ownerId: ownerId,
+      seenAt: null,
+      showAt: null,
+      type: MemoryType.onThisDay,
+      updatedAt: DateTime(2026, 4, 23),
+    );
+
+    setUp(() async {
+      await sut.updateUsersV1([_createUser()]);
+      await sut.updateMemoriesV1([makeMemory()]);
+    });
+
+    test('does not throw when the asset has not been streamed yet', () async {
+      await expectLater(
+        sut.updateMemoryAssetsV1([SyncMemoryAssetV1(memoryId: 'memory-1', assetId: 'not-here-yet')]),
+        completes,
+      );
+
+      expect(await db.memoryAssetEntity.select().get(), isEmpty);
+    });
+
+    test('still writes the valid links in a batch that also carries an orphan', () async {
+      await sut.updateAssetsV1([_createAsset(id: 'asset-1', checksum: 'c1', fileName: 'a.jpg')]);
+
+      await sut.updateMemoryAssetsV1([
+        SyncMemoryAssetV1(memoryId: 'memory-1', assetId: 'asset-1'),
+        SyncMemoryAssetV1(memoryId: 'memory-1', assetId: 'not-here-yet'),
+      ]);
+
+      final rows = await db.memoryAssetEntity.select().get();
+      expect(rows.map((r) => r.assetId), ['asset-1']);
+    });
+
+    test('replays a parked link once its asset arrives later in the stream', () async {
+      await sut.updateMemoryAssetsV1([SyncMemoryAssetV1(memoryId: 'memory-1', assetId: 'asset-late')]);
+      expect(await db.memoryAssetEntity.select().get(), isEmpty);
+
+      // The shared-space asset stream (or any other) delivers the asset afterwards.
+      await sut.updateSharedSpaceAssetsV1([
+        _createAsset(id: 'asset-late', checksum: 'c2', fileName: 'late.jpg', ownerId: 'user-1'),
+      ]);
+      await sut.flushDeferredMemoryAssetsV1();
+
+      final rows = await db.memoryAssetEntity.select().get();
+      expect(rows.map((r) => r.assetId), ['asset-late']);
+      expect(rows.single.memoryId, 'memory-1');
+    });
+
+    test('parks a link whose memory has not been streamed yet', () async {
+      await sut.updateAssetsV1([_createAsset(id: 'asset-1', checksum: 'c1', fileName: 'a.jpg')]);
+
+      await sut.updateMemoryAssetsV1([SyncMemoryAssetV1(memoryId: 'memory-unknown', assetId: 'asset-1')]);
+      expect(await db.memoryAssetEntity.select().get(), isEmpty);
+
+      await sut.updateMemoriesV1([makeMemory(id: 'memory-unknown')]);
+      await sut.flushDeferredMemoryAssetsV1();
+
+      expect((await db.memoryAssetEntity.select().get()).single.memoryId, 'memory-unknown');
+    });
+
+    test('drops a link that is still unresolvable at sync completion, without throwing', () async {
+      await sut.updateMemoryAssetsV1([SyncMemoryAssetV1(memoryId: 'memory-1', assetId: 'never-arrives')]);
+
+      await expectLater(sut.flushDeferredMemoryAssetsV1(), completes);
+      expect(await db.memoryAssetEntity.select().get(), isEmpty);
+
+      // The parked row is not retained across sync passes.
+      await sut.updateAssetsV1([_createAsset(id: 'never-arrives', checksum: 'c3', fileName: 'n.jpg')]);
+      await sut.flushDeferredMemoryAssetsV1();
+      expect(await db.memoryAssetEntity.select().get(), isEmpty);
+    });
+
+    test('forgets a parked link that is deleted before it can be replayed', () async {
+      await sut.updateMemoryAssetsV1([SyncMemoryAssetV1(memoryId: 'memory-1', assetId: 'asset-1')]);
+      await sut.deleteMemoryAssetsV1([SyncMemoryAssetDeleteV1(memoryId: 'memory-1', assetId: 'asset-1')]);
+
+      await sut.updateAssetsV1([_createAsset(id: 'asset-1', checksum: 'c1', fileName: 'a.jpg')]);
+      await sut.flushDeferredMemoryAssetsV1();
+
+      expect(await db.memoryAssetEntity.select().get(), isEmpty);
+    });
+
+    // The parent lookups bind one variable per id, so they are chunked. Cross the chunk boundary
+    // with a mix of resolvable and orphan links to prove the chunking keeps both sides straight.
+    test('handles a batch larger than one lookup chunk', () async {
+      const present = 600;
+      const orphans = 300;
+
+      await sut.updateAssetsV1([
+        for (var i = 0; i < present; i++) _createAsset(id: 'bulk-$i', checksum: 'bulk-c$i', fileName: 'bulk-$i.jpg'),
+      ]);
+
+      await sut.updateMemoryAssetsV1([
+        for (var i = 0; i < present; i++) SyncMemoryAssetV1(memoryId: 'memory-1', assetId: 'bulk-$i'),
+        for (var i = 0; i < orphans; i++) SyncMemoryAssetV1(memoryId: 'memory-1', assetId: 'missing-$i'),
+      ]);
+
+      expect(await db.memoryAssetEntity.select().get(), hasLength(present));
+
+      // The orphans were parked, not written and not lost.
+      await sut.updateAssetsV1([
+        for (var i = 0; i < orphans; i++) _createAsset(id: 'missing-$i', checksum: 'late-c$i', fileName: 'late-$i.jpg'),
+      ]);
+      await sut.flushDeferredMemoryAssetsV1();
+
+      expect(await db.memoryAssetEntity.select().get(), hasLength(present + orphans));
+    });
+
+    test('writes links normally when both parents are already present', () async {
+      await sut.updateAssetsV1([_createAsset(id: 'asset-1', checksum: 'c1', fileName: 'a.jpg')]);
+
+      await sut.updateMemoryAssetsV1([SyncMemoryAssetV1(memoryId: 'memory-1', assetId: 'asset-1')]);
+      // Re-delivery of the same link must stay a no-op (composite PK).
+      await sut.updateMemoryAssetsV1([SyncMemoryAssetV1(memoryId: 'memory-1', assetId: 'asset-1')]);
+
+      expect(await db.memoryAssetEntity.select().get(), hasLength(1));
+    });
+  });
+
   test('stores rule memories from sync without requiring year data', () async {
     await sut.updateUsersV1([_createUser()]);
 

--- a/mobile/test/domain/services/sync_stream_service_test.dart
+++ b/mobile/test/domain/services/sync_stream_service_test.dart
@@ -291,12 +291,33 @@ void main() {
 
     test("syncCompleteV1 triggers pruneAssets (mobile-3)", () async {
       when(() => mockSyncStreamRepo.pruneAssets()).thenAnswer((_) async {});
+      when(() => mockSyncStreamRepo.flushDeferredMemoryAssetsV1()).thenAnswer((_) async {});
 
       await simulateEvents([
         const SyncEvent(type: SyncEntityType.syncCompleteV1, data: 'complete', ack: 'ack-complete'),
       ]);
 
       verify(() => mockSyncStreamRepo.pruneAssets()).called(1);
+    });
+
+    // Memory -> asset links parked because their asset had not been streamed yet are replayed
+    // once the stream is done. It has to happen BEFORE the GC: pruneAssets drops assets that are
+    // no longer reachable and cascades the links away with them, so flushing afterwards would
+    // re-add links for assets the GC just decided to remove.
+    test("syncCompleteV1 replays deferred memory asset links before pruning", () async {
+      final calls = <String>[];
+      when(() => mockSyncStreamRepo.flushDeferredMemoryAssetsV1()).thenAnswer((_) async {
+        calls.add('flush');
+      });
+      when(() => mockSyncStreamRepo.pruneAssets()).thenAnswer((_) async {
+        calls.add('prune');
+      });
+
+      await simulateEvents([
+        const SyncEvent(type: SyncEntityType.syncCompleteV1, data: 'complete', ack: 'ack-complete'),
+      ]);
+
+      expect(calls, ['flush', 'prune']);
     });
 
     test("aborts and stops processing if cancelled during iteration", () async {

--- a/server/src/services/sync.service.spec.ts
+++ b/server/src/services/sync.service.spec.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { Writable } from 'node:stream';
 import { AlbumUserRole, AssetVisibility, MemoryType, SyncEntityType, SyncRequestType } from 'src/enum';
-import { SyncService } from 'src/services/sync.service';
+import { SYNC_TYPES_ORDER, SyncService } from 'src/services/sync.service';
 import { toAck } from 'src/utils/sync';
 import { authStub } from 'test/fixtures/auth.stub';
 import { newUuid } from 'test/small.factory';
@@ -1123,6 +1123,53 @@ describe(SyncService.name, () => {
         expect.objectContaining({ afterUpdateId: partialExtraId }),
         partnerId,
       );
+    });
+  });
+
+  // gallery-fork: mobile's `memory_asset_entity` carries real foreign keys — `assetId` →
+  // `remote_asset_entity.id` and `memoryId` → `memory_entity.id`. Drift inserts the whole
+  // MemoryToAssetV1 batch in one statement, so a single link row whose asset has not been
+  // streamed yet fails with SQLITE_CONSTRAINT_FOREIGNKEY (787), aborts the batch, and — because
+  // the batch is then never acked — leaves the sync stuck on the same checkpoint forever.
+  //
+  // Upstream keeps this safe by construction: every stream that carries an asset row
+  // (AssetsV*, PartnerAssetsV*, AlbumAssetsV*) is ordered before MemoryToAssetsV1, and a memory
+  // upstream can only ever reference the owner's own assets. The fork breaks that assumption in
+  // two ways: shared spaces, libraries and space albums deliver assets belonging to *other*
+  // owners, and a memory may legitimately reference them (MemoryRepository.search gates memory
+  // assets on visibility, not ownership). Those fork streams must therefore land before the
+  // memory link rows, exactly like AlbumAssetsV2 lands before AlbumToAssetsV1.
+  describe('SYNC_TYPES_ORDER', () => {
+    // Every request type whose mobile handler writes into `remote_asset_entity`.
+    const assetBearingTypes = [
+      SyncRequestType.AssetsV1,
+      SyncRequestType.AssetsV2,
+      SyncRequestType.PartnerAssetsV1,
+      SyncRequestType.PartnerAssetsV2,
+      SyncRequestType.AlbumAssetsV1,
+      SyncRequestType.AlbumAssetsV2,
+      SyncRequestType.SharedSpaceAssetsV1,
+      SyncRequestType.LibraryAssetsV1,
+      SyncRequestType.SharedSpaceAlbumAssetsV1,
+    ];
+
+    it('should stream every asset-bearing type before MemoryToAssetsV1', () => {
+      const linkIndex = SYNC_TYPES_ORDER.indexOf(SyncRequestType.MemoryToAssetsV1);
+      expect(linkIndex).toBeGreaterThan(-1);
+
+      const streamedAfter = assetBearingTypes.filter((type) => SYNC_TYPES_ORDER.indexOf(type) > linkIndex);
+      expect(streamedAfter).toEqual([]);
+    });
+
+    it('should stream MemoriesV1 before MemoryToAssetsV1', () => {
+      expect(SYNC_TYPES_ORDER.indexOf(SyncRequestType.MemoriesV1)).toBeLessThan(
+        SYNC_TYPES_ORDER.indexOf(SyncRequestType.MemoryToAssetsV1),
+      );
+    });
+
+    it('should order every asset-bearing type it names', () => {
+      const missing = assetBearingTypes.filter((type) => !SYNC_TYPES_ORDER.includes(type));
+      expect(missing).toEqual([]);
     });
   });
 

--- a/server/src/services/sync.service.ts
+++ b/server/src/services/sync.service.ts
@@ -81,8 +81,8 @@ export const SYNC_TYPES_ORDER = [
   SyncRequestType.AlbumAssetExifsV1,
   SyncRequestType.AssetOcrV1,
   SyncRequestType.PartnerAssetExifsV1,
-  SyncRequestType.MemoriesV1,
-  SyncRequestType.MemoryToAssetsV1,
+  // MemoriesV1 / MemoryToAssetsV1 used to sit here, upstream's position. They now stream LAST —
+  // see the note above the fork block at the end of this array.
   SyncRequestType.PeopleV1,
   SyncRequestType.AssetFacesV1,
   SyncRequestType.AssetFacesV2,
@@ -116,6 +116,24 @@ export const SYNC_TYPES_ORDER = [
   SyncRequestType.SharedSpaceAlbumToAssetsV1,
   SyncRequestType.SharedSpaceAlbumAssetsV1,
   SyncRequestType.SharedSpaceAlbumAssetExifsV1,
+  // Memories stream LAST, after every type that can deliver an asset row.
+  //
+  // Mobile's `memory_asset_entity` has real foreign keys (`assetId` → `remote_asset_entity.id`,
+  // `memoryId` → `memory_entity.id`) and inserts a MemoryToAssetV1 batch as one Drift statement.
+  // A link row whose asset has not arrived yet fails the batch with
+  // SQLITE_CONSTRAINT_FOREIGNKEY (787), which aborts the whole /sync/stream request; since the
+  // batch is never acked, the next sync replays the same checkpoint and fails identically —
+  // a permanently wedged client, not a transient error.
+  //
+  // Upstream is safe by construction: a memory can only reference its owner's own assets, and
+  // AssetsV*/PartnerAssetsV*/AlbumAssetsV* all precede MemoryToAssetsV1 (the same ordering that
+  // protects AlbumToAssetsV1). The fork breaks both halves of that assumption — shared spaces,
+  // libraries and space albums deliver assets owned by *other* users, and memory assets are
+  // gated on visibility rather than ownership (MemoryRepository.search), so a memory may
+  // legitimately point at one of them. Keeping the memory types after the fork's asset-bearing
+  // streams restores the invariant. `sync.service.spec.ts` guards it.
+  SyncRequestType.MemoriesV1,
+  SyncRequestType.MemoryToAssetsV1,
 ];
 
 const throwSessionRequired = () => {

--- a/server/test/medium/specs/sync/sync-memory-asset.spec.ts
+++ b/server/test/medium/specs/sync/sync-memory-asset.spec.ts
@@ -1,5 +1,5 @@
 import { Kysely } from 'kysely';
-import { SyncEntityType, SyncRequestType } from 'src/enum';
+import { SharedSpaceRole, SyncEntityType, SyncRequestType } from 'src/enum';
 import { MemoryRepository } from 'src/repositories/memory.repository';
 import { DB } from 'src/schema';
 import { SyncTestContext } from 'test/medium.factory';
@@ -87,5 +87,52 @@ describe(SyncEntityType.MemoryToAssetV1, () => {
       expect.objectContaining({ type: SyncEntityType.SyncCompleteV1 }),
     ]);
     await ctx.assertSyncIsComplete(auth, [SyncRequestType.MemoryToAssetsV1]);
+  });
+  // gallery-fork regression: a memory may legitimately reference an asset owned by someone else
+  // and reached through a shared space — MemoryRepository.search gates memory assets on
+  // visibility, not ownership, and the seeded demo memories rely on exactly that. Mobile's
+  // memory_asset_entity FKs assetId → remote_asset_entity, so if the MemoryToAssetV1 link row
+  // streams before the SharedSpaceAsset* row that creates the asset locally, the Drift batch dies
+  // with SQLITE_CONSTRAINT_FOREIGNKEY (787), the stream aborts, the batch is never acked, and the
+  // client re-runs the same failing checkpoint forever. Asset rows must land first.
+  it('should stream a space-shared asset before the memory link that references it', async () => {
+    const { auth, ctx } = await setup();
+    const { user: peer } = await ctx.newUser();
+
+    const { space } = await ctx.newSharedSpace({ createdById: peer.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: peer.id, role: SharedSpaceRole.Owner });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: auth.user.id, role: SharedSpaceRole.Viewer });
+
+    // Owned by the peer, reachable by the syncing user only through the space.
+    const { asset } = await ctx.newAsset({ ownerId: peer.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: asset.id });
+
+    // ...but referenced by a memory the syncing user owns.
+    const { memory } = await ctx.newMemory({ ownerId: auth.user.id });
+    await ctx.newMemoryAsset({ memoryId: memory.id, assetId: asset.id });
+
+    const response = await ctx.syncStream(auth, [
+      SyncRequestType.MemoriesV1,
+      SyncRequestType.MemoryToAssetsV1,
+      SyncRequestType.SharedSpacesV1,
+      SyncRequestType.SharedSpaceMembersV1,
+      SyncRequestType.SharedSpaceAssetsV1,
+    ]);
+
+    const types = (response as { type: string }[]).map((event) => event.type);
+    const assetIndex = types.findIndex((type) =>
+      [
+        SyncEntityType.SharedSpaceAssetCreateV1,
+        SyncEntityType.SharedSpaceAssetUpdateV1,
+        SyncEntityType.SharedSpaceAssetBackfillV1,
+      ].includes(type as SyncEntityType),
+    );
+    const memoryIndex = types.indexOf(SyncEntityType.MemoryV1);
+    const linkIndex = types.indexOf(SyncEntityType.MemoryToAssetV1);
+
+    expect(assetIndex).toBeGreaterThan(-1);
+    expect(linkIndex).toBeGreaterThan(-1);
+    expect(assetIndex).toBeLessThan(linkIndex);
+    expect(memoryIndex).toBeLessThan(linkIndex);
   });
 });


### PR DESCRIPTION
## The report

Opening the mobile app on the demo account killed the sync stream:

```
SqliteException(787): FOREIGN KEY constraint failed (code 787)
  INSERT INTO "memory_asset_entity" ("asset_id", "memory_id") VALUES (?, ?)
    ON CONFLICT("asset_id", "memory_id") DO NOTHING,
  parameters: ce27ec3e-79db-4ca3-bd7d-5b19b3ab7e96, b1d2f398-9af6-4484-9ac6-cdf4cc864317
Error: updateMemoryAssetsV1
```

## Which parent was missing, and why

Queried the demo DB rather than guessing:

| id | owner |
|---|---|
| memory `b1d2f398…` | `demo@gallery.app` (a `seed=demo` memory) |
| asset `ce27ec3e…` | `pierremarais67@gmail.com` — **not** the demo user |

So the **asset** is the missing parent. It reaches the demo user only through the `Family & Friends` Space, where they are a `viewer`. This is not a one-off: **135 of the demo user's 157 memory links point at assets someone else owns**, and all 139 distinct link assets are reachable — 22 owned, 131 via a Space, **0 unreachable**. Memory assets are gated on visibility, not ownership (`MemoryRepository.search`), which the seeded demo memories deliberately rely on.

## Root cause: a broken ordering invariant

Upstream is safe by construction — a memory can only reference its owner's own assets, and every asset-bearing stream precedes `MemoryToAssetsV1`. That is the same ordering that protects the structurally identical `AlbumToAssetsV1` (`AlbumAssetsV2` streams at index 10, the link rows at 14).

The fork appended its asset-bearing streams **after** the memory types:

```
… MemoriesV1(19) → MemoryToAssetsV1(20) → … → SharedSpaceAssetsV1(30) → LibraryAssetsV1 → SharedSpaceAlbumAssetsV1
```

So link rows for Space-shared assets arrive before the assets exist locally. `memory_asset_entity` has real foreign keys and Drift writes the batch as one statement, so a single early row fails the **whole** batch. `onConflict: DoNothing()` does not help — it only covers primary-key conflicts.

**It does not self-heal.** A failed batch is never acked (`_processBatch` acks only after the handler returns), and `streamChanges` turns the throw into `Future.error`, so the request aborts and the next sync replays the same checkpoint and dies identically. Everything ordered after memories — people, faces, spaces, libraries, space albums — never arrives at all.

> Answering the third question in the brief: `updateAlbumToAssetsV1` has the identical shape but is protected by ordering. The fork's own `SharedSpaceAlbumAssetEntity` dodges the same hazard a third way — it deliberately carries no FKs (*"loose refs; ordering between streams not guaranteed"*).

## The fix

**Server (root cause).** `MemoriesV1` / `MemoryToAssetsV1` move to the end of `SYNC_TYPES_ORDER`, restoring the invariant. Deployable on its own: a wedged client recovers by itself, because the failed batch was never acked and replays once the assets land.

**Mobile (defense in depth).** Mobile and server release independently, so a current app will meet broken-order servers for a while. `updateMemoryAssetsV1` now writes the links whose parents exist and parks the rest, replaying them at `SyncCompleteV1` — by which point every asset-bearing stream has run:

```
updateMemoryAssetsV1(links)
  ├─ insert rows whose memory + asset exist
  └─ park the rest ─────────────┐
                                │
SyncCompleteV1                  │
  ├─ flushDeferredMemoryLinks() ┘   (all asset streams done)
  ├─ warn only if STILL unresolvable
  └─ pruneAssets()
```

Nothing is dropped on the ordinary path. A link still unresolvable at completion is dropped with a warning rather than taking the whole sync down. Parked links are cleared on `SyncResetV1` and forgotten if deleted before replay; parent lookups are chunked at 500, since a flush can replay more links than one 5000-event batch.

Worth noting: since #998 the memory lane reads `GET /memories`, not the local table — so this wedge was pure collateral damage from a table that is no longer even the primary read path.

## Tests (all written to fail first)

- `sync.service.spec.ts` — pins the invariant. Red before the fix, naming exactly `SharedSpaceAssetsV1`, `LibraryAssetsV1`, `SharedSpaceAlbumAssetsV1`.
- `sync-memory-asset.spec.ts` (medium) — reproduces the demo case end to end: peer-owned asset in a Space, memory owned by the syncing user. Verified red on the old order: `expected 6 to be less than 1`.
- `sync_stream_repository_test.dart` — 8 cases (park, replay, mixed batch, missing memory, drop-at-completion, delete-before-replay, chunk boundary, plain path). Verified genuine: disabling the filter turns 6 of 8 red.
- `sync_stream_service_test.dart` — asserts flush runs **before** `pruneAssets`.

## Verification

| Gate | Result |
|---|---|
| Server unit (`sync.service.spec.ts`) | 60 passed |
| Server medium (all 64 sync specs) | 490 passed |
| Mobile full suite | 3232 passed, 1 skipped |
| `tsc --noEmit` / eslint / prettier | clean |
| `dart analyze --fatal-infos` / `dart format` | clean |
