### PR TITLE
docs: say what a read-only external library mount costs you

### DIFF
--- a/docs/docs/FAQ.mdx
+++ b/docs/docs/FAQ.mdx
@@ -226,6 +226,7 @@ Duplicate checking only exists for upload libraries, using the file hash. Furthe
 Images in read-write external libraries (the default) can be edited as normal.
 In read-only libraries (`:ro` in the `docker-compose.yml`), Gallery is unable to create the `.xmp` sidecar files to store edited file metadata.
 For this reason, the metadata (timestamp, location, description, star rating, etc.) cannot be edited for files in read-only external libraries.
+The edit is not rejected up front: it is applied, then reverted when the file is re-read, with no error shown.
 
 ### How are deletions of files handled in external libraries?
 

--- a/docs/docs/features/libraries.md
+++ b/docs/docs/features/libraries.md
@@ -112,8 +112,11 @@ The `immich-server` container will need access to the gallery. Modify your docke
 ```
 
 :::tip
-The `ro` flag at the end only gives read-only access to the volumes.
-This will disallow the images from being deleted in the web UI, or adding metadata to the library ([XMP sidecars](/features/xmp-sidecars)).
+The `ro` flag at the end only gives read-only access to the volumes. This protects your originals: Gallery cannot delete them from the web UI, and cannot write [XMP sidecars](/features/xmp-sidecars) next to them.
+:::
+
+:::warning
+A read-only mount also means **metadata cannot be edited** for that library. Date and time, location, description, star rating and tags are all written to the sidecar, so an edit made in the web UI is applied and then reverted shortly afterwards, with no error shown. Mount the folder read-write if you plan to edit metadata in Gallery. See the [FAQ](/FAQ#why-are-my-edits-to-files-not-being-saved-in-read-only-external-libraries) for the full trade-off.
 :::
 
 :::info

--- a/docs/docs/features/shared-spaces.md
+++ b/docs/docs/features/shared-spaces.md
@@ -436,6 +436,10 @@ Library assets disappear from the space immediately. Any photos from that librar
 
 Space members can view, download, and browse library-linked assets just like manually added ones. Editors can update metadata on library-linked assets. The library owner retains full ownership of the underlying files.
 
+:::warning
+Editing metadata on a library-linked asset requires the library's folder to be mounted **read-write**. Gallery writes these edits to an `.xmp` sidecar next to the original file, so on a read-only (`:ro`) mount the change is applied and then reverted shortly afterwards, with no error shown. This affects date and time, location, description, star rating and tags. See [Mount Docker Volumes](/features/libraries#mount-docker-volumes).
+:::
+
 ### Limitations
 
 - **One-way only** — Photos added to the space by other members are not imported back into the library.

--- a/docs/docs/features/xmp-sidecars.md
+++ b/docs/docs/features/xmp-sidecars.md
@@ -53,7 +53,7 @@ If both `.jpg.xmp` and `.xmp` are present, Gallery uses the **`.jpg.xmp`** file.
 3. **Write-back** – If Gallery has **write access** to the mount, any future metadata edits (e.g., rating or tags) are also written back to the original `.xmp` file on disk.
 
 :::danger
-If the mount is **read-only**, Gallery cannot update either the sidecar **or** the database — **metadata edits will silently fail** with no warning see issue [#10538](https://github.com/immich-app/immich/issues/10538) for more details.
+If the mount is **read-only**, Gallery cannot write the sidecar and the edit is **silently reverted**: the new value is saved to the database, then overwritten again when the file is re-read. No error is shown. See issue [#10538](https://github.com/immich-app/immich/issues/10538) for more details.
 :::
 
 ## Admin Jobs


### PR DESCRIPTION
Raised in discussion #1036: a user linked an external library into a shared space, tried to fix a photo's date, and nothing happened. They asked for a note in the docs, and whether mounting the library read-write would fix it.

It would. The trade-off just was not documented anywhere near where they were standing.

## Why the edit fails

Metadata edits are written to an `.xmp` sidecar next to the original file (`metadata.service.ts` `handleSidecarWrite`). On a `:ro` mount that write fails, and because `writeTags` logs the exiftool error instead of throwing, the job still reports success: it unlocks the edited property and chains a metadata re-extract, which reads the old value back out of the file and overwrites the new one. So the edit lands in the database, looks like it saved, and is gone moments later with nothing in the UI to say why. Affects date and time, location, description, rating and tags.

## What changed

- **`features/libraries.md`** — the mount step's `:::tip` said `:ro` disallows "adding metadata to the library (XMP sidecars)", which does not read like "you cannot change a photo's date". Split into a tip (what `:ro` protects) and a warning (what it costs), linking to the FAQ entry.
- **`features/shared-spaces.md`** — "Permissions for Library Assets" promised flatly that editors can update metadata on library-linked assets. Added the mount caveat there.
- **`features/xmp-sidecars.md`** — corrected the danger block. It claimed Gallery "cannot update either the sidecar **or** the database". The database *is* updated, then overwritten, which is the part that confuses people.
- **`FAQ.mdx`** — one sentence, so the symptom is recognisable: the edit is not rejected up front, it reverts.

Docs only, no code. The underlying behaviour is inherited from upstream (immich-app/immich issue 10538); making date edits actually work on read-only mounts is a separate change.

## Verification

- `pnpm format` clean
- `pnpm build` succeeds, no broken-link or anchor warnings
- Both new anchor targets confirmed present in the built HTML (`why-are-my-edits-...`, `mount-docker-volumes`)