### PR TITLE
fix(web): stop the collection picker listing a shared album twice (#1043)

### DIFF
--- a/web/src/lib/modals/CollectionPickerModal.spec.ts
+++ b/web/src/lib/modals/CollectionPickerModal.spec.ts
@@ -1,5 +1,5 @@
 // CollectionPickerModal.spec.ts — follows the house pattern (sdk.mock + Modal global stubs)
-import { type AlbumResponseDto, type SharedSpaceResponseDto } from '@immich/sdk';
+import { SharedSpaceRole, type AlbumResponseDto, type SharedSpaceResponseDto } from '@immich/sdk';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
 import { getAnimateMock } from '$lib/__mocks__/animate.mock';
 import { getIntersectionObserverMock } from '$lib/__mocks__/intersection-observer.mock';
@@ -45,6 +45,16 @@ const space = (id: string, name: string): SharedSpaceResponseDto =>
     assetCount: 1,
     recentAssetIds: [],
   }) as unknown as SharedSpaceResponseDto;
+/** An album owned by someone else that the caller is a member of — `getAllAlbums` returns these too. */
+const albumSharedWithMe = (id: string, name: string): AlbumResponseDto =>
+  ({ ...album(id, name), ownerId: 'someone-else', shared: true }) as unknown as AlbumResponseDto;
+/** A space created by someone else, with the caller holding `role` (or not a member at all). */
+const spaceWhereIAm = (id: string, name: string, role: SharedSpaceRole | null): SharedSpaceResponseDto =>
+  ({
+    ...space(id, name),
+    createdById: 'someone-else',
+    members: role === null ? [] : [{ userId: 'me', role }],
+  }) as unknown as SharedSpaceResponseDto;
 const withAlbum = () =>
   sdkMock.getAllAlbums.mockImplementation(({ isShared }: { isShared?: boolean }) =>
     Promise.resolve(isShared ? [] : [album('a1', 'Trip')]),
@@ -56,7 +66,7 @@ beforeEach(() => {
   Element.prototype.animate = getAnimateMock();
   vi.resetAllMocks();
   mockUser.current = { id: 'me', isAdmin: false };
-  sdkMock.getAllAlbums.mockResolvedValue([]); // both shared:false and shared:true resolve to []
+  sdkMock.getAllAlbums.mockResolvedValue([]); // no albums, whatever the picker asks for
   sdkMock.getAllSpaces.mockResolvedValue([]);
 });
 
@@ -115,6 +125,76 @@ describe('CollectionPickerModal', () => {
     await waitFor(() => expect(screen.getByTestId('spaces-hidden-notice')).toBeTruthy());
     expect(screen.queryByTestId('row-space-s1')).toBeNull();
     expect(screen.queryByTestId('new-space-row')).toBeNull();
+  });
+
+  // #1043: an album you own and have shared with someone matches every album query the picker
+  // could make — owned, shared, unfiltered — so a picker that concatenates two of them listed
+  // it twice, same thumbnail, same count. Adding an editor to an album must not clone its row.
+  it('lists an album that is both owned and shared only once', async () => {
+    sdkMock.getAllAlbums.mockImplementation(() => Promise.resolve([album('a1', 'Trip')]));
+    render(CollectionPickerModal, { assetCount: 3, onClose: vi.fn() });
+    await waitFor(() => expect(screen.getAllByTestId('row-album-a1').length).toBeGreaterThan(0));
+    // Exactly two rows: once under RECENT, once under All — never twice within a section.
+    expect(screen.getAllByTestId('row-album-a1')).toHaveLength(2);
+  });
+
+  // The fetch this replaced pulled albums the caller does *not* own in through its second,
+  // `isShared` query. The single unfiltered query has to carry them, or a member loses every
+  // album they were invited to — the exact set the two queries used to return, minus the double.
+  it('lists albums shared with the user alongside the ones they own', async () => {
+    // Server semantics: `isOwned` keeps only albums the caller owns, `isShared` only shared
+    // ones, and no filter returns both. Narrowing the query back down has to fail this test.
+    sdkMock.getAllAlbums.mockImplementation(({ isOwned, isShared }: { isOwned?: boolean; isShared?: boolean }) => {
+      const mine = album('a1', 'Trip');
+      const theirs = albumSharedWithMe('a2', 'Familie');
+      if (isOwned === true) {
+        return Promise.resolve([mine]);
+      }
+      return Promise.resolve(isShared === true ? [theirs] : [mine, theirs]);
+    });
+    render(CollectionPickerModal, { assetCount: 3, onClose: vi.fn() });
+
+    await waitFor(() => expect(screen.getAllByTestId('row-album-a1').length).toBeGreaterThan(0));
+    expect(screen.getAllByTestId('row-album-a2').length).toBeGreaterThan(0);
+  });
+
+  it('asks for albums once, unfiltered — two filtered queries is what double-listed them', async () => {
+    withAlbum();
+    render(CollectionPickerModal, { assetCount: 3, onClose: vi.fn() });
+
+    await waitFor(() => expect(screen.getAllByTestId('row-album-a1').length).toBeGreaterThan(0));
+    expect(sdkMock.getAllAlbums).toHaveBeenCalledTimes(1);
+    expect(sdkMock.getAllAlbums).toHaveBeenCalledWith({});
+  });
+
+  it('shows an owned-and-shared album once when searching, where there is no RECENT section', async () => {
+    sdkMock.getAllAlbums.mockImplementation(() => Promise.resolve([album('a1', 'Trip')]));
+    render(CollectionPickerModal, { assetCount: 3, onClose: vi.fn() });
+    await waitFor(() => expect(screen.getAllByTestId('row-album-a1').length).toBeGreaterThan(0));
+
+    await fireEvent.input(screen.getByPlaceholderText('search'), { target: { value: 'Tri' } });
+
+    // Searching drops the RECENT section, so All is the only section left: exactly one row.
+    await waitFor(() => expect(screen.getAllByTestId('row-album-a1')).toHaveLength(1));
+  });
+
+  // Space write access is decided here, not by the server's rejection after the fact: a space
+  // the caller can only view is never a destination, so it must not appear as a row at all.
+  it('offers only spaces the user owns or can edit', async () => {
+    sdkMock.getAllSpaces.mockResolvedValue([
+      space('s1', 'Mine'), // created by me
+      spaceWhereIAm('s2', 'Editing', SharedSpaceRole.Editor),
+      spaceWhereIAm('s3', 'Co-owned', SharedSpaceRole.Owner),
+      spaceWhereIAm('s4', 'Viewing', SharedSpaceRole.Viewer),
+      spaceWhereIAm('s5', 'Stranger', null),
+    ]);
+    render(CollectionPickerModal, { assetCount: 3, onClose: vi.fn() });
+
+    await waitFor(() => expect(screen.getAllByTestId('row-space-s1').length).toBeGreaterThan(0));
+    expect(screen.getAllByTestId('row-space-s2').length).toBeGreaterThan(0);
+    expect(screen.getAllByTestId('row-space-s3').length).toBeGreaterThan(0);
+    expect(screen.queryByTestId('row-space-s4')).toBeNull();
+    expect(screen.queryByTestId('row-space-s5')).toBeNull();
   });
 
   it('reports an error and still renders albums when spaces fail to load', async () => {

--- a/web/src/lib/modals/CollectionPickerModal.svelte
+++ b/web/src/lib/modals/CollectionPickerModal.svelte
@@ -118,10 +118,18 @@
     loading = false;
   });
 
+  /**
+   * Every album the user can add to: one request, no filters.
+   *
+   * This used to fetch `isOwned: true` and `isShared: true` and concatenate them, which double-
+   * listed any album the user owns *and* has shared — both queries match it (#1043). The
+   * original pair was `shared: false` + `shared: true`, a real partition; the rename to
+   * `isOwned`/`isShared` turned it into two overlapping sets. Omitting both filters returns
+   * exactly the union the picker wants — every album the user owns or is a member of — and
+   * halves the requests. Row order does not depend on it: the converter sorts by name.
+   */
   const loadAlbums = async () => {
-    const owned = await getAllAlbums({ isOwned: true });
-    owned.push(...(await getAllAlbums({ isShared: true })));
-    albums = owned;
+    albums = await getAllAlbums({});
   };
 
   // `SharedSpaceLinkedAlbumDto` is `AlbumResponseDto` minus `albumUsers` (plus link metadata),


### PR DESCRIPTION
Fixes #1043.

## The bug

An album owned by User A shows once in **Add to album or space**. Add User B as an Editor and the same album appears twice — same thumbnail, same asset count. Remove User B and it collapses back to one. Only the UI duplicates; there is one row in the database.

## Root cause

`CollectionPickerModal.loadAlbums` fetched two lists and concatenated them:

```ts
const owned = await getAllAlbums({ isOwned: true });
owned.push(...(await getAllAlbums({ isShared: true })));
```

Server-side (`album.repository.ts` `buildAlbumBaseQuery`), `isOwned: true` means *I hold the Owner role* and `isShared: true` means *this album has a non-owner member or a shared link*. Those sets overlap: an album you own and have shared satisfies both, so it was appended twice.

`git log -L` pins where the overlap came from. The original code was `{ shared: false }` + `{ shared: true }` — a genuine partition, no overlap possible. The v3 reconcile of the upstream `shared` → `isOwned`/`isShared` rename translated `shared: false` as `isOwned: true`, which is not the complement of `isShared: true`.

## Fix

One unfiltered request. With neither filter, `getAll` joins `album_user` for the caller with no role or shared predicate, so it returns exactly the union the picker wants — every album the user owns or is a member of — duplicate-free by construction, in half the round trips. Row order is unaffected: the converter sorts by name and `pickRecent` by recency, so neither depends on the order the API returned.

This covers all three surfaces, since `AssetAddToCollectionModal` and `SearchAddAllToCollectionModal` both wrap this picker.

## Tests

Written TDD, and each new test was verified to fail against the defect it guards (fix reverted / query narrowed / RBAC filter dropped):

| Test | Fails without the fix because |
| --- | --- |
| lists an album that is both owned and shared only once | 4 rows instead of 2 — the reported duplication |
| shows an owned-and-shared album once when searching | search drops the RECENT section, so All shows 2 instead of 1 |
| asks for albums once, unfiltered | two filtered queries is what double-listed them |
| lists albums shared with the user alongside the ones they own | narrowing the query to `isOwned` loses every album the caller was invited to |
| offers only spaces the user owns or can edit | a Viewer-role space (or one the caller is not in) must never be offered as a destination |

The last two are regression/RBAC guards on behaviour this change must preserve: the album set the picker shows is the same set as before minus the duplicates, and the space write-access gate still filters Viewer-role and non-member spaces out of the list.

## Verification

- `vitest run` (web): 372 files, 5969 tests passed
- `svelte-check`: 613 files, 0 errors, 0 warnings
- `tsc --noEmit`, prettier, eslint `--max-warnings 0`: clean

https://claude.ai/code/session_016ZbQgYnFr5mnTzpJUU7D9d