### PR TITLE
feat(storage): add S3 SSE-C encryption at rest for S3-managed assets

### DIFF
--- a/server/src/backends/disk-storage.backend.ts
+++ b/server/src/backends/disk-storage.backend.ts
@@ -6,6 +6,8 @@ import { pipeline } from 'node:stream/promises';
 import { ServeOptions, ServeStrategy, StorageBackend } from 'src/interfaces/storage-backend.interface';
 
 export class DiskStorageBackend implements StorageBackend {
+  readonly supportsReadableUrl = true;
+
   constructor(private mediaLocation: string) {}
 
   private resolvePath(key: string): string {

--- a/server/src/backends/s3-storage.backend.spec.ts
+++ b/server/src/backends/s3-storage.backend.spec.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { Readable } from 'node:stream';
@@ -14,6 +15,7 @@ vi.mock('@aws-sdk/client-s3', () => {
     DeleteObjectCommand: vi.fn((input: any) => ({ input, _type: 'DeleteObjectCommand' })),
     ListObjectsV2Command: vi.fn((input: any) => ({ input, _type: 'ListObjectsV2Command' })),
     DeleteObjectsCommand: vi.fn((input: any) => ({ input, _type: 'DeleteObjectsCommand' })),
+    CopyObjectCommand: vi.fn((input: any) => ({ input, _type: 'CopyObjectCommand' })),
   };
 });
 
@@ -31,7 +33,12 @@ import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { S3StorageBackend } from 'src/backends/s3-storage.backend';
 import { CacheControl } from 'src/enum';
-import { RangeNotSatisfiableError } from 'src/interfaces/storage-backend.interface';
+import { RangeNotSatisfiableError, S3SseConfig } from 'src/interfaces/storage-backend.interface';
+
+const sseCConfig = (rawKeyByte = 7): Extract<S3SseConfig, { mode: 'sse-c' }> => {
+  const key = Buffer.alloc(32, rawKeyByte);
+  return { mode: 'sse-c', key, keyMd5: createHash('md5').update(key).digest() };
+};
 
 describe('S3StorageBackend', () => {
   let backend: S3StorageBackend;
@@ -657,6 +664,149 @@ describe('S3StorageBackend', () => {
       });
 
       await expect(backend.getPrefixUsage('thumbs/user-a/', (filename) => filename !== 'skip.webp')).resolves.toBe(10);
+    });
+  });
+
+  describe('SSE-C', () => {
+    let sseBackend: S3StorageBackend;
+    let sseSend: ReturnType<typeof vi.fn>;
+    const sse = sseCConfig();
+    const expectedHeaders = {
+      SSECustomerAlgorithm: 'AES256',
+      SSECustomerKey: sse.key.toString('base64'),
+      SSECustomerKeyMD5: sse.keyMd5.toString('base64'),
+    };
+
+    beforeEach(() => {
+      sseBackend = new S3StorageBackend({
+        bucket: 'test-bucket',
+        region: 'us-east-1',
+        presignedUrlExpiry: 3600,
+        // serveMode is deliberately 'proxy': StorageService.onBootstrap is what actually
+        // enforces the redirect+SSE-C hard-fail; this backend-level test only needs a valid,
+        // self-consistent config to exercise put/get/exists/reencryptInPlace in isolation.
+        serveMode: 'proxy',
+        sse,
+      });
+      const client = (S3Client as unknown as ReturnType<typeof vi.fn>).mock.results.at(-1)?.value;
+      sseSend = client?.send;
+    });
+
+    it('reports supportsReadableUrl as false', () => {
+      expect(sseBackend.supportsReadableUrl).toBe(false);
+    });
+
+    it('reports supportsReadableUrl as true when SSE is not configured', () => {
+      expect(backend.supportsReadableUrl).toBe(true);
+    });
+
+    it('attaches SSE-C headers to put (via Upload params)', async () => {
+      const { Upload } = await import('@aws-sdk/lib-storage');
+      await sseBackend.put('upload/user1/ab/cd/file.jpg', Buffer.from('data'), { contentType: 'image/jpeg' });
+
+      expect(Upload).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({
+            Bucket: 'test-bucket',
+            Key: 'upload/user1/ab/cd/file.jpg',
+            ...expectedHeaders,
+          }),
+        }),
+      );
+    });
+
+    it('attaches SSE-C headers to get (GetObjectCommand)', async () => {
+      sseSend.mockResolvedValueOnce({ Body: Readable.from([Buffer.from('data')]), ContentLength: 4 });
+
+      await sseBackend.get('upload/user1/ab/cd/file.jpg');
+
+      expect(GetObjectCommand).toHaveBeenCalledWith(
+        expect.objectContaining({ Bucket: 'test-bucket', Key: 'upload/user1/ab/cd/file.jpg', ...expectedHeaders }),
+      );
+    });
+
+    it('attaches SSE-C headers to exists (HeadObjectCommand)', async () => {
+      sseSend.mockResolvedValueOnce({});
+
+      await sseBackend.exists('upload/user1/ab/cd/file.jpg');
+
+      const headCalls = sseSend.mock.calls.filter(([cmd]) => cmd._type === 'HeadObjectCommand');
+      expect(headCalls).toEqual([[expect.objectContaining({ input: expect.objectContaining(expectedHeaders) })]]);
+    });
+
+    it('does not attach SSE-C headers to deletePrefix (ListObjectsV2/DeleteObjects)', async () => {
+      sseSend
+        .mockResolvedValueOnce({ Contents: [{ Key: 'upload/u/a.jpg' }], IsTruncated: false })
+        .mockResolvedValueOnce({ Deleted: [{}] });
+
+      await sseBackend.deletePrefix('upload/u/');
+
+      for (const [cmd] of sseSend.mock.calls) {
+        expect(cmd.input).not.toMatchObject(expectedHeaders);
+      }
+    });
+
+    it('does not attach SSE-C headers to getPrefixUsage (ListObjectsV2)', async () => {
+      sseSend.mockResolvedValueOnce({ Contents: [{ Size: 5 }], IsTruncated: false });
+
+      await sseBackend.getPrefixUsage('upload/u/');
+
+      const [[cmd]] = sseSend.mock.calls;
+      expect(cmd.input).not.toMatchObject(expectedHeaders);
+    });
+
+    it('always uses the proxy/stream serve strategy, ignoring serveMode', async () => {
+      sseSend.mockResolvedValueOnce({ Body: Readable.from([Buffer.from('data')]), ContentLength: 4 });
+
+      const strategy = await sseBackend.getServeStrategy('upload/user1/photo.jpg', {
+        contentType: 'image/jpeg',
+        cacheControl: CacheControl.PrivateWithCache,
+      });
+
+      expect(strategy.type).toBe('stream');
+      expect(getSignedUrl).not.toHaveBeenCalled();
+      expect(GetObjectCommand).toHaveBeenCalledWith(expect.objectContaining(expectedHeaders));
+    });
+
+    describe('reencryptInPlace', () => {
+      it('self-copies the object with only destination SSE-C headers set', async () => {
+        const { CopyObjectCommand } = await import('@aws-sdk/client-s3');
+        sseSend.mockResolvedValueOnce({});
+
+        await sseBackend.reencryptInPlace('library/user1/ab/cd/photo.jpg');
+
+        expect(CopyObjectCommand).toHaveBeenCalledWith(
+          expect.objectContaining({
+            Bucket: 'test-bucket',
+            Key: 'library/user1/ab/cd/photo.jpg',
+            CopySource: 'test-bucket/library/user1/ab/cd/photo.jpg',
+            MetadataDirective: 'COPY',
+            ...expectedHeaders,
+          }),
+        );
+        // no CopySourceSSECustomerKey* headers: the source object is assumed unencrypted
+        const [[cmd]] = sseSend.mock.calls;
+        expect(cmd.input).not.toHaveProperty('CopySourceSSECustomerKey');
+      });
+
+      it('URI-encodes each path segment of the key without encoding slashes', async () => {
+        const { CopyObjectCommand } = await import('@aws-sdk/client-s3');
+        sseSend.mockResolvedValueOnce({});
+
+        await sseBackend.reencryptInPlace('library/user 1/a b/photo #1.jpg');
+
+        expect(CopyObjectCommand).toHaveBeenCalledWith(
+          expect.objectContaining({
+            CopySource: 'test-bucket/library/user%201/a%20b/photo%20%231.jpg',
+          }),
+        );
+      });
+
+      it('throws when SSE-C is not configured on this backend', async () => {
+        await expect(backend.reencryptInPlace('library/user1/photo.jpg')).rejects.toThrow(
+          'reencryptInPlace requires SSE-C to be configured on this backend',
+        );
+      });
     });
   });
 });

--- a/server/src/backends/s3-storage.backend.ts
+++ b/server/src/backends/s3-storage.backend.ts
@@ -1,4 +1,5 @@
 import {
+  CopyObjectCommand,
   DeleteObjectCommand,
   DeleteObjectsCommand,
   GetObjectCommand,
@@ -6,6 +7,7 @@ import {
   GetObjectCommandOutput,
   HeadObjectCommand,
   ListObjectsV2Command,
+  PutObjectCommandInput,
   S3Client,
 } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
@@ -19,6 +21,7 @@ import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import {
   RangeNotSatisfiableError,
+  S3SseConfig,
   ServeOptions,
   ServeStrategy,
   StorageBackend,
@@ -65,6 +68,18 @@ export interface S3StorageConfig {
   presignedUrlExpiry: number;
   serveMode: 'redirect' | 'proxy';
   proxyReadConcurrency?: number;
+  sse?: S3SseConfig;
+}
+
+/**
+ * The three SSE-C request headers, precomputed once at construction instead of per-request.
+ * S3 requires all three identical on every put/get/head of an SSE-C object — see
+ * specs/2026-09-02-s3-sse-c-encryption-design.md.
+ */
+interface SseCustomerHeaders {
+  SSECustomerAlgorithm: 'AES256';
+  SSECustomerKey: string;
+  SSECustomerKeyMD5: string;
 }
 
 export class S3StorageBackend implements StorageBackend {
@@ -73,12 +88,31 @@ export class S3StorageBackend implements StorageBackend {
   private presignedUrlExpiry: number;
   private serveMode: 'redirect' | 'proxy';
   private proxyReadLimiter: AsyncLimiter;
+  private sseHeaders: SseCustomerHeaders | undefined;
+
+  /**
+   * A presigned GetObject URL cannot carry the SSE-C customer-key headers S3 requires to decrypt
+   * the object (a plain `<img>`/`<video>` fetch or a bare `ffprobe <url>` invocation has no way to
+   * attach them), so redirect-style serving and URL-based probing are both unavailable whenever
+   * SSE-C is active. See getServeStrategy and getReadableUrl below.
+   */
+  readonly supportsReadableUrl: boolean;
 
   constructor(config: S3StorageConfig) {
     this.bucket = config.bucket;
     this.presignedUrlExpiry = config.presignedUrlExpiry;
     this.serveMode = config.serveMode;
     this.proxyReadLimiter = new AsyncLimiter(config.proxyReadConcurrency ?? 32);
+
+    const sse = config.sse ?? { mode: 'none' as const };
+    if (sse.mode === 'sse-c') {
+      this.sseHeaders = {
+        SSECustomerAlgorithm: 'AES256',
+        SSECustomerKey: sse.key.toString('base64'),
+        SSECustomerKeyMD5: sse.keyMd5.toString('base64'),
+      };
+    }
+    this.supportsReadableUrl = !this.sseHeaders;
 
     this.client = new S3Client({
       region: config.region,
@@ -95,15 +129,15 @@ export class S3StorageBackend implements StorageBackend {
   }
 
   async put(key: string, source: Readable | Buffer, metadata?: { contentType?: string }): Promise<void> {
-    const upload = new Upload({
-      client: this.client,
-      params: {
-        Bucket: this.bucket,
-        Key: key,
-        Body: source,
-        ContentType: metadata?.contentType,
-      },
-    });
+    const params: PutObjectCommandInput = {
+      Bucket: this.bucket,
+      Key: key,
+      Body: source,
+      ContentType: metadata?.contentType,
+      ...this.sseHeaders,
+    };
+
+    const upload = new Upload({ client: this.client, params });
 
     await upload.done();
   }
@@ -119,7 +153,9 @@ export class S3StorageBackend implements StorageBackend {
   ): Promise<{ stream: Readable; contentType?: string; length?: number; contentRange?: string }> {
     let response: GetObjectCommandOutput;
     try {
-      response = await this.client.send(new GetObjectCommand({ Bucket: this.bucket, Key: key, Range: range }));
+      response = await this.client.send(
+        new GetObjectCommand({ Bucket: this.bucket, Key: key, Range: range, ...this.sseHeaders }),
+      );
     } catch (error: any) {
       if (range && (error.name === 'InvalidRange' || error.$metadata?.httpStatusCode === 416)) {
         throw new RangeNotSatisfiableError(key);
@@ -141,7 +177,7 @@ export class S3StorageBackend implements StorageBackend {
 
   async exists(key: string): Promise<boolean> {
     try {
-      await this.client.send(new HeadObjectCommand({ Bucket: this.bucket, Key: key }));
+      await this.client.send(new HeadObjectCommand({ Bucket: this.bucket, Key: key, ...this.sseHeaders }));
       return true;
     } catch (error: any) {
       if (error.name === 'NotFound' || error.$metadata?.httpStatusCode === 404) {
@@ -203,7 +239,13 @@ export class S3StorageBackend implements StorageBackend {
   }
 
   async getServeStrategy(key: string, options: ServeOptions): Promise<ServeStrategy> {
-    if (this.serveMode === 'proxy') {
+    // SSE-C objects can only ever be served by proxy: a presigned GetObject URL has no way to
+    // carry the x-amz-server-side-encryption-customer-key* headers S3 requires to decrypt the
+    // object, so a plain <img>/<video> fetch of a redirect target would just receive ciphertext.
+    // StorageService.onBootstrap already refuses to start with serveMode=redirect + SSE-C
+    // configured; this check is defense-in-depth for any path that constructs the backend
+    // without going through that startup validation (e.g. tests).
+    if (this.serveMode === 'proxy' || this.sseHeaders) {
       const release = await this.proxyReadLimiter.acquire();
       try {
         // forward the client's Range to S3 and relay its partial response, so
@@ -237,6 +279,11 @@ export class S3StorageBackend implements StorageBackend {
     return { type: 'redirect', url };
   }
 
+  /**
+   * Callers must check `supportsReadableUrl` first: with SSE-C active this presigned URL cannot
+   * be used to fetch the object (S3 requires the customer-key headers on the GET, which a bare
+   * URL fetch cannot carry), so BaseService.getProbeInput falls back to downloadToTemp instead.
+   */
   async getReadableUrl(key: string): Promise<string> {
     return getSignedUrl(this.client, new GetObjectCommand({ Bucket: this.bucket, Key: key }), {
       expiresIn: READABLE_URL_EXPIRY_SECONDS,
@@ -259,5 +306,44 @@ export class S3StorageBackend implements StorageBackend {
         }
       },
     };
+  }
+
+  /**
+   * Re-encrypts an existing, currently-unencrypted object in place using the backend's
+   * configured SSE-C key, via a self-copy (CopySource === destination Key). This never downloads
+   * or re-uploads bytes through the Gallery process — the copy happens entirely inside S3/the
+   * S3-compatible provider — which is why StorageMigrationService uses it (rather than
+   * get()+put()) for the "enable encryption on an existing bucket" migration.
+   *
+   * Only destination SSE-C headers are sent; no CopySourceSSECustomerKey* headers are sent,
+   * because the source object is assumed unencrypted going into this call. Calling this a second
+   * time on an object already encrypted with this key will fail the read half of the copy (S3
+   * needs decryption headers for an already-encrypted source) — callers must track completion
+   * externally (StorageMigrationService uses the existing storage_migration_log table for this,
+   * not object state) rather than relying on this method being self-idempotent.
+   *
+   * Throws if the backend was not constructed with SSE-C configured — this method only makes
+   * sense as part of turning encryption on, not as a general-purpose copy utility.
+   */
+  async reencryptInPlace(key: string): Promise<void> {
+    if (!this.sseHeaders) {
+      throw new Error('reencryptInPlace requires SSE-C to be configured on this backend');
+    }
+
+    // CopySource must be URI-encoded per-segment, not as a whole: encodeURIComponent on the full
+    // key would turn '/' into '%2F' and break the path structure S3 expects.
+    const encodedKey = key
+      .split('/')
+      .map((segment) => encodeURIComponent(segment))
+      .join('/');
+    await this.client.send(
+      new CopyObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+        CopySource: `${this.bucket}/${encodedKey}`,
+        MetadataDirective: 'COPY',
+        ...this.sseHeaders,
+      }),
+    );
   }
 }

--- a/server/src/controllers/storage-migration.controller.ts
+++ b/server/src/controllers/storage-migration.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Endpoint, HistoryBuilder } from 'src/decorators';
 import {
+  S3EnableEncryptionStartDto,
   StorageMigrationBatchParamDto,
   StorageMigrationEstimateQueryDto,
   StorageMigrationStartDto,
@@ -57,5 +58,46 @@ export class StorageMigrationController {
   })
   rollback(@Param() { batchId }: StorageMigrationBatchParamDto) {
     return this.service.rollback(batchId);
+  }
+
+  @Get('s3-encryption/estimate')
+  @Authenticated({ permission: Permission.JobRead, admin: true })
+  @Endpoint({
+    summary: 'Get S3 enable-encryption estimate',
+    description:
+      'Estimate the number of existing S3 objects that would be re-encrypted in place if S3 encryption ' +
+      '(IMMICH_S3_SSE_MODE=sse-c) were enabled now. Only relevant for buckets that already contain ' +
+      'unencrypted objects; a fresh bucket needs no migration.',
+    history: new HistoryBuilder().added('v2.7.5').alpha('v2.7.5'),
+  })
+  getS3EncryptionEstimate() {
+    return this.service.getS3EncryptionEstimate();
+  }
+
+  @Post('s3-encryption/start')
+  @Authenticated({ permission: Permission.JobCreate, admin: true })
+  @Endpoint({
+    summary: 'Start S3 enable-encryption migration',
+    description:
+      'Re-encrypt existing, currently-unencrypted S3 objects in place using the configured SSE-C key ' +
+      '(IMMICH_S3_SSE_C_KEY). Requires IMMICH_S3_SSE_MODE=sse-c to already be configured and the server ' +
+      'restarted with that config before starting this job, since the job re-encrypts using whatever key ' +
+      'the running S3 backend already holds.',
+    history: new HistoryBuilder().added('v2.7.5').alpha('v2.7.5'),
+  })
+  startS3Encryption(@Body() dto: S3EnableEncryptionStartDto) {
+    return this.service.startS3Encryption(dto);
+  }
+
+  @Get('s3-encryption/status')
+  @Authenticated({ permission: Permission.JobRead, admin: true })
+  @Endpoint({
+    summary: 'Get S3 enable-encryption migration status',
+    description:
+      'Retrieve the current status of the S3 enable-encryption queue, including active and pending job counts.',
+    history: new HistoryBuilder().added('v2.7.5').alpha('v2.7.5'),
+  })
+  getS3EncryptionStatus() {
+    return this.service.getS3EncryptionStatus();
   }
 }

--- a/server/src/dtos/env.dto.ts
+++ b/server/src/dtos/env.dto.ts
@@ -58,6 +58,12 @@ export const EnvSchema = z
     IMMICH_S3_SECRET_ACCESS_KEY: z.string().optional(),
     IMMICH_S3_PRESIGNED_URL_EXPIRY: z.coerce.number().int().optional(),
     IMMICH_S3_SERVE_MODE: z.enum(['redirect', 'proxy']).optional(),
+    // 'sse-kms' is a reserved value for a future SSE-KMS mode; only 'none' and 'sse-c' are
+    // implemented today. See specs/2026-09-02-s3-sse-c-encryption-design.md.
+    IMMICH_S3_SSE_MODE: z.enum(['none', 'sse-c']).optional(),
+    // Base64-encoded, must decode to exactly 32 raw bytes (AES-256). Validated at startup in
+    // StorageService.onBootstrap, not here, so the error message can reference the env var name.
+    IMMICH_S3_SSE_C_KEY: z.string().optional(),
     IMMICH_MICROSERVICES_METRICS_PORT: z.coerce.number().int().optional(),
     IMMICH_ALLOW_EXTERNAL_PLUGINS: stringBool.optional(),
     IMMICH_PLUGINS_INSTALL_FOLDER: absolutePath,

--- a/server/src/dtos/storage-migration.dto.ts
+++ b/server/src/dtos/storage-migration.dto.ts
@@ -41,3 +41,12 @@ export class StorageMigrationFileTypesDto extends createZodDto(StorageMigrationF
 export class StorageMigrationStartDto extends createZodDto(StorageMigrationStartSchema) {}
 export class StorageMigrationEstimateQueryDto extends createZodDto(StorageMigrationEstimateQuerySchema) {}
 export class StorageMigrationBatchParamDto extends createZodDto(StorageMigrationBatchParamSchema) {}
+
+const S3EnableEncryptionStartSchema = z
+  .object({
+    fileTypes: StorageMigrationFileTypesSchema.describe('File types to encrypt'),
+    concurrency: z.int().min(1).max(20).default(5).describe('Concurrency level'),
+  })
+  .meta({ id: 'S3EnableEncryptionStartDto' });
+
+export class S3EnableEncryptionStartDto extends createZodDto(S3EnableEncryptionStartSchema) {}

--- a/server/src/enum.ts
+++ b/server/src/enum.ts
@@ -1005,6 +1005,10 @@ export enum JobName {
   StorageBackendMigrationQueueAll = 'StorageBackendMigrationQueueAll',
   StorageBackendMigrationSingle = 'StorageBackendMigrationSingle',
 
+  // S3 SSE-C Encryption (enable-encryption-in-place migration)
+  S3EnableEncryptionQueueAll = 'S3EnableEncryptionQueueAll',
+  S3EnableEncryptionSingle = 'S3EnableEncryptionSingle',
+
   // Shared Space Face Recognition
   SharedSpaceFaceMatch = 'SharedSpaceFaceMatch',
   SharedSpaceFaceMatchAll = 'SharedSpaceFaceMatchAll',

--- a/server/src/interfaces/storage-backend.interface.ts
+++ b/server/src/interfaces/storage-backend.interface.ts
@@ -35,7 +35,31 @@ export type ServeStrategy =
   /** `contentRange` is set only when the backend honored a requested range, and drives the 206 response. */
   | { type: 'stream'; stream: Readable; length?: number; contentRange?: string };
 
+/**
+ * S3 server-side encryption configuration. Only SSE-C ("mode: 'sse-c'") is implemented today.
+ * The type is a discriminated union so a future SSE-KMS mode can be added without reshaping
+ * the config that already exists. See specs/2026-09-02-s3-sse-c-encryption-design.md.
+ */
+export type S3SseConfig =
+  | { mode: 'none' }
+  | {
+      mode: 'sse-c';
+      /** Raw 32-byte AES-256 key, decoded from IMMICH_S3_SSE_C_KEY (base64). */
+      key: Buffer;
+      /** MD5 digest of `key`, precomputed once so it isn't recomputed per-request. */
+      keyMd5: Buffer;
+    };
+
 export interface StorageBackend {
+  /**
+   * Whether `getReadableUrl` returns something a browser or a bare `ffprobe <url>` invocation can
+   * fetch on its own. False for an S3 backend with SSE-C active: a presigned URL cannot carry the
+   * `x-amz-server-side-encryption-customer-key*` headers S3 requires to decrypt the object, so
+   * callers must fall back to `downloadToTemp` instead. Always true for disk and for S3 with no
+   * server-side encryption (or, in the future, SSE-KMS, which needs no such headers on GET).
+   */
+  readonly supportsReadableUrl: boolean;
+
   /** Write content to the given key */
   put(key: string, source: Readable | Buffer, metadata?: { contentType?: string }): Promise<void>;
 

--- a/server/src/repositories/config.repository.spec.ts
+++ b/server/src/repositories/config.repository.spec.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { ImmichTelemetry } from 'src/enum';
 import { clearEnvCache, ConfigRepository } from 'src/repositories/config.repository';
 
@@ -48,6 +49,8 @@ const resetEnv = () => {
     'IMMICH_S3_SECRET_ACCESS_KEY',
     'IMMICH_S3_PRESIGNED_URL_EXPIRY',
     'IMMICH_S3_SERVE_MODE',
+    'IMMICH_S3_SSE_MODE',
+    'IMMICH_S3_SSE_C_KEY',
   ]) {
     delete process.env[env];
   }
@@ -374,6 +377,7 @@ describe('getEnv', () => {
         secretAccessKey: 'minioadmin',
         presignedUrlExpiry: 7200,
         serveMode: 'proxy',
+        sse: { mode: 'none' },
       });
     });
 
@@ -391,6 +395,39 @@ describe('getEnv', () => {
         secretAccessKey: undefined,
         presignedUrlExpiry: 3600,
         serveMode: 'redirect',
+        sse: { mode: 'none' },
+      });
+    });
+
+    describe('sse-c', () => {
+      it('should default to no encryption', () => {
+        const { storage } = getEnv();
+        expect(storage.s3.sse).toEqual({ mode: 'none' });
+      });
+
+      it('should ignore an SSE-C key when SSE mode is not set to sse-c', () => {
+        process.env.IMMICH_S3_SSE_C_KEY = Buffer.alloc(32, 7).toString('base64');
+        const { storage } = getEnv();
+        expect(storage.s3.sse).toEqual({ mode: 'none' });
+      });
+
+      it('should parse and decode a base64 SSE-C key once at config-load time', () => {
+        const rawKey = Buffer.alloc(32, 7);
+        process.env.IMMICH_S3_SSE_MODE = 'sse-c';
+        process.env.IMMICH_S3_SSE_C_KEY = rawKey.toString('base64');
+
+        const { storage } = getEnv();
+
+        expect(storage.s3.sse.mode).toBe('sse-c');
+        if (storage.s3.sse.mode === 'sse-c') {
+          expect(storage.s3.sse.key).toEqual(rawKey);
+          expect(storage.s3.sse.keyMd5).toEqual(createHash('md5').update(rawKey).digest());
+        }
+      });
+
+      it('should reject an SSE mode that is not none or sse-c', () => {
+        process.env.IMMICH_S3_SSE_MODE = 'sse-kms';
+        expect(() => getEnv()).toThrow(/Invalid environment variables/);
       });
     });
   });

--- a/server/src/repositories/config.repository.ts
+++ b/server/src/repositories/config.repository.ts
@@ -7,6 +7,7 @@ import { HelmetOptions } from 'helmet';
 import { RedisOptions } from 'ioredis';
 import { CLS_ID, ClsModuleOptions } from 'nestjs-cls';
 import { OpenTelemetryModuleOptions } from 'nestjs-otel/lib/interfaces';
+import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { citiesFile, IWorker } from 'src/constants';
@@ -22,6 +23,7 @@ import {
   LogLevel,
   QueueName,
 } from 'src/enum';
+import { S3SseConfig } from 'src/interfaces/storage-backend.interface';
 import { VectorExtension } from 'src/types';
 import { setDifference } from 'src/utils/set';
 
@@ -125,6 +127,7 @@ export interface EnvData {
       secretAccessKey?: string;
       presignedUrlExpiry: number;
       serveMode: 'redirect' | 'proxy';
+      sse: S3SseConfig;
     };
   };
 
@@ -161,6 +164,24 @@ const TELEMETRY_TYPES = new Set(Object.values(ImmichTelemetry));
 const asSet = <T>(value: string | undefined, defaults: T[]) => {
   const values = (value || '').replaceAll(/\s/g, '').split(',').filter(Boolean);
   return new Set(values.length === 0 ? defaults : (values as T[]));
+};
+
+/**
+ * Parses the SSE-C key once at config-load time rather than per-request. Length validation
+ * (must decode to exactly 32 raw bytes for AES-256) happens in StorageService.onBootstrap, not
+ * here, so a bad key produces the fail-fast ImmichStartupError message instead of a generic
+ * "Invalid environment variables" one raised before any service has a chance to log context.
+ */
+const parseS3SseConfig = (mode: string | undefined, base64Key: string | undefined): S3SseConfig => {
+  if (mode !== 'sse-c') {
+    return { mode: 'none' };
+  }
+
+  // Decoded here (not just validated) so callers never touch the raw env var again; StorageService
+  // still re-validates the length before this config is trusted for real S3 calls.
+  const key = Buffer.from(base64Key || '', 'base64');
+  const keyMd5 = createHash('md5').update(key).digest();
+  return { mode: 'sse-c', key, keyMd5 };
 };
 
 const resolveHelmetFile = (helmetFile: 'true' | 'false' | string | undefined) => {
@@ -381,6 +402,7 @@ const getEnv = (): EnvData => {
         secretAccessKey: dto.IMMICH_S3_SECRET_ACCESS_KEY,
         presignedUrlExpiry: dto.IMMICH_S3_PRESIGNED_URL_EXPIRY || 3600,
         serveMode: (dto.IMMICH_S3_SERVE_MODE as 'redirect' | 'proxy') || 'redirect',
+        sse: parseS3SseConfig(dto.IMMICH_S3_SSE_MODE, dto.IMMICH_S3_SSE_C_KEY),
       },
     },
 

--- a/server/src/repositories/storage-migration.repository.ts
+++ b/server/src/repositories/storage-migration.repository.ts
@@ -75,6 +75,108 @@ export class StorageMigrationRepository {
       .stream();
   }
 
+  // --- S3-only streaming queries (enable-encryption-in-place migration) ---
+  //
+  // These are written as their own queries, not `streamOriginals('toDisk')` etc. (which happen
+  // to use the same `not like '/%'` filter, since a relative key means "currently on S3"),
+  // because reusing the disk<->S3 migration's direction parameter to mean "give me S3 keys" here
+  // would be a confusing, easily-broken coupling if that filter's meaning ever changes.
+
+  streamS3Originals() {
+    return this.db.selectFrom('asset').select(['id', 'originalPath']).where('originalPath', 'not like', '/%').stream();
+  }
+
+  streamS3AssetFiles(fileTypes: AssetFileType[]) {
+    return this.db
+      .selectFrom('asset_file')
+      .select(['id', 'assetId', 'path', 'type'])
+      .where('type', 'in', fileTypes)
+      .where('path', 'not like', '/%')
+      .stream();
+  }
+
+  streamS3EncodedVideos() {
+    return this.db
+      .selectFrom('asset_file')
+      .select(['id', 'assetId', 'path', 'type'])
+      .where('type', '=', AssetFileType.EncodedVideo)
+      .where('path', 'not like', '/%')
+      .stream();
+  }
+
+  streamS3PersonThumbnails() {
+    return this.db
+      .selectFrom('person')
+      .select(['id', 'thumbnailPath'])
+      .where('thumbnailPath', '!=', '')
+      .where('thumbnailPath', 'not like', '/%')
+      .stream();
+  }
+
+  streamS3ProfileImages() {
+    return this.db
+      .selectFrom('user')
+      .select(['id', 'profileImagePath'])
+      .where('profileImagePath', '!=', '')
+      .where('profileImagePath', 'not like', '/%')
+      .stream();
+  }
+
+  async getS3FileCounts(): Promise<StorageMigrationFileCounts> {
+    const pathPattern = '/%';
+
+    const [originals, assetFiles, encodedVideos, personThumbnails, profileImages] = await Promise.all([
+      this.db
+        .selectFrom('asset')
+        .select((eb) => eb.fn.countAll<number>().as('count'))
+        .where('originalPath', 'not like', pathPattern)
+        .executeTakeFirstOrThrow(),
+
+      this.db
+        .selectFrom('asset_file')
+        .select((eb) => [
+          eb.fn.countAll<number>().filterWhere('type', '=', AssetFileType.Thumbnail).as('thumbnails'),
+          eb.fn.countAll<number>().filterWhere('type', '=', AssetFileType.Preview).as('previews'),
+          eb.fn.countAll<number>().filterWhere('type', '=', AssetFileType.FullSize).as('fullsize'),
+          eb.fn.countAll<number>().filterWhere('type', '=', AssetFileType.Sidecar).as('sidecars'),
+        ])
+        .where('path', 'not like', pathPattern)
+        .executeTakeFirstOrThrow(),
+
+      this.db
+        .selectFrom('asset_file')
+        .select((eb) => eb.fn.countAll<number>().as('count'))
+        .where('type', '=', AssetFileType.EncodedVideo)
+        .where('path', 'not like', pathPattern)
+        .executeTakeFirstOrThrow(),
+
+      this.db
+        .selectFrom('person')
+        .select((eb) => eb.fn.countAll<number>().as('count'))
+        .where('thumbnailPath', '!=', '')
+        .where('thumbnailPath', 'not like', pathPattern)
+        .executeTakeFirstOrThrow(),
+
+      this.db
+        .selectFrom('user')
+        .select((eb) => eb.fn.countAll<number>().as('count'))
+        .where('profileImagePath', '!=', '')
+        .where('profileImagePath', 'not like', pathPattern)
+        .executeTakeFirstOrThrow(),
+    ]);
+
+    return {
+      originals: originals.count,
+      thumbnails: assetFiles.thumbnails,
+      previews: assetFiles.previews,
+      fullsize: assetFiles.fullsize,
+      sidecars: assetFiles.sidecars,
+      encodedVideos: encodedVideos.count,
+      personThumbnails: personThumbnails.count,
+      profileImages: profileImages.count,
+    };
+  }
+
   // --- Estimate queries ---
 
   async getOriginalsSizeEstimate(direction: StorageMigrationDirection): Promise<number> {
@@ -215,5 +317,23 @@ export class StorageMigrationRepository {
 
   async deleteLogEntriesByBatch(batchId: string) {
     return this.db.deleteFrom('storage_migration_log').where('batchId', '=', batchId).execute();
+  }
+
+  /**
+   * Idempotency check for the enable-encryption migration: unlike the disk<->S3 migration
+   * (idempotent via `targetBackend.exists(targetPath)`, since the object moves to a new
+   * location), reencryptInPlace's source and destination key are the same, and re-running
+   * CopyObject on an object that's already SSE-C encrypted fails (S3 needs decrypt headers for
+   * an encrypted source, which reencryptInPlace deliberately does not send). So completion is
+   * tracked via this log table instead of by querying object state.
+   */
+  async isS3EncryptionLogged(direction: string, key: string): Promise<boolean> {
+    const row = await this.db
+      .selectFrom('storage_migration_log')
+      .select('id')
+      .where('direction', '=', direction)
+      .where('newPath', '=', key)
+      .executeTakeFirst();
+    return !!row;
   }
 }

--- a/server/src/services/asset.service.spec.ts
+++ b/server/src/services/asset.service.spec.ts
@@ -2741,7 +2741,10 @@ describe(AssetService.name, () => {
       const assetId = newUuid();
       const getReadableUrl = vi.fn().mockResolvedValue('https://bucket.s3/key?X-Amz-Signature=abc');
       const { StorageService } = await import('src/services/storage.service.js');
-      vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue({ getReadableUrl } as any);
+      vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue({
+        getReadableUrl,
+        supportsReadableUrl: true,
+      } as any);
 
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
       mocks.asset.getForEdit.mockResolvedValue({
@@ -2782,7 +2785,10 @@ describe(AssetService.name, () => {
       const assetId = newUuid();
       const getReadableUrl = vi.fn().mockResolvedValue('https://bucket.s3/key?X-Amz-Signature=SECRET');
       const { StorageService } = await import('src/services/storage.service.js');
-      vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue({ getReadableUrl } as any);
+      vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue({
+        getReadableUrl,
+        supportsReadableUrl: true,
+      } as any);
 
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
       mocks.asset.getForEdit.mockResolvedValue({
@@ -2838,7 +2844,10 @@ describe(AssetService.name, () => {
       const assetId = newUuid();
       const getReadableUrl = vi.fn().mockResolvedValue('https://bucket.s3/key?X-Amz-Signature=abc');
       const { StorageService } = await import('src/services/storage.service.js');
-      vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue({ getReadableUrl } as any);
+      vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue({
+        getReadableUrl,
+        supportsReadableUrl: true,
+      } as any);
 
       mocks.access.asset.checkOwnerAccess.mockResolvedValue(new Set([assetId]));
       mocks.asset.getForEdit.mockResolvedValue({

--- a/server/src/services/asset.service.ts
+++ b/server/src/services/asset.service.ts
@@ -896,7 +896,9 @@ export class AssetService extends BaseService {
 
       // Audio-only file check. getProbeInput hands ffprobe an absolute path (disk) or a
       // presigned URL (S3) — it does NOT download the video, which matters here because
-      // this runs inside the request.
+      // this runs inside the request. Exception: an SSE-C encrypted S3 original has no usable
+      // presigned URL (see StorageBackend.supportsReadableUrl), so getProbeInput downloads it
+      // to a temp file in that case instead.
       let probeResult: Awaited<ReturnType<typeof this.mediaRepository.probe>>;
       try {
         probeResult = await this.mediaRepository.probe(await this.getProbeInput(asset.originalPath));

--- a/server/src/services/base.service.spec.ts
+++ b/server/src/services/base.service.spec.ts
@@ -57,4 +57,37 @@ describe(BaseService.name, () => {
       await expect((sut as any).ensureLocalFile('upload/user/abc.jpg')).rejects.toThrow('S3 unavailable');
     });
   });
+
+  describe('getProbeInput', () => {
+    it('returns the path as-is for absolute paths', async () => {
+      const result = await (sut as any).getProbeInput('/var/lib/immich/upload/video.mp4');
+      expect(result).toBe('/var/lib/immich/upload/video.mp4');
+    });
+
+    it('returns a presigned url when the backend supports readable urls', async () => {
+      const getReadableUrl = vi.fn().mockResolvedValue('https://bucket.s3/key?X-Amz-Signature=abc');
+      const backend = { supportsReadableUrl: true, getReadableUrl };
+      const { StorageService } = await import('src/services/storage.service.js');
+      vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue(backend as any);
+
+      const result = await (sut as any).getProbeInput('upload/user/video.mp4');
+
+      expect(result).toBe('https://bucket.s3/key?X-Amz-Signature=abc');
+      expect(getReadableUrl).toHaveBeenCalledWith('upload/user/video.mp4');
+    });
+
+    it('falls back to downloadToTemp when the backend does not support readable urls (SSE-C)', async () => {
+      const getReadableUrl = vi.fn();
+      const downloadToTemp = vi.fn().mockResolvedValue({ tempPath: '/tmp/video.mp4', cleanup: vi.fn() });
+      const backend = { supportsReadableUrl: false, getReadableUrl, downloadToTemp };
+      const { StorageService } = await import('src/services/storage.service.js');
+      vi.spyOn(StorageService, 'resolveBackendForKey').mockReturnValue(backend as any);
+
+      const result = await (sut as any).getProbeInput('upload/user/video.mp4');
+
+      expect(result).toBe('/tmp/video.mp4');
+      expect(downloadToTemp).toHaveBeenCalledWith('upload/user/video.mp4');
+      expect(getReadableUrl).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/server/src/services/base.service.ts
+++ b/server/src/services/base.service.ts
@@ -451,6 +451,11 @@ export class BaseService {
    * Returns something ffmpeg/ffprobe can read directly: an absolute path as-is,
    * or a presigned URL for a storage-backend key. Unlike ensureLocalFile this
    * does NOT download the object, so it is safe to call inside a request handler.
+   *
+   * Exception: when the resolved backend has SSE-C active, a presigned URL cannot carry the
+   * customer-key headers S3 needs to decrypt the object (see StorageBackend.supportsReadableUrl),
+   * so this falls back to ensureLocalFile's download-to-temp bracket instead, losing the
+   * skip-the-download optimization in that case only.
    */
   protected async getProbeInput(filePath: string): Promise<string> {
     if (isAbsolute(filePath)) {
@@ -458,7 +463,12 @@ export class BaseService {
     }
     // lazy import to avoid circular dependency (StorageService extends BaseService)
     const { StorageService } = await import('./storage.service.js');
-    return StorageService.resolveBackendForKey(filePath).getReadableUrl(filePath);
+    const backend = StorageService.resolveBackendForKey(filePath);
+    if (!backend.supportsReadableUrl) {
+      const { localPath } = await this.ensureLocalFile(filePath);
+      return localPath;
+    }
+    return backend.getReadableUrl(filePath);
   }
 
   protected async getFaceThumbnailSource(assetId: string): Promise<string | null> {

--- a/server/src/services/storage-migration.service.spec.ts
+++ b/server/src/services/storage-migration.service.spec.ts
@@ -707,4 +707,274 @@ describe(StorageMigrationService.name, () => {
       expect(mocks.storageMigration.deleteLogEntriesByBatch).not.toHaveBeenCalled();
     });
   });
+
+  describe('S3 enable-encryption-in-place migration', () => {
+    const nonZeroS3FileCounts = {
+      originals: 10,
+      thumbnails: 0,
+      previews: 0,
+      fullsize: 0,
+      sidecars: 0,
+      encodedVideos: 0,
+      personThumbnails: 0,
+      profileImages: 0,
+    };
+
+    const zeroS3FileCounts = {
+      originals: 0,
+      thumbnails: 0,
+      previews: 0,
+      fullsize: 0,
+      sidecars: 0,
+      encodedVideos: 0,
+      personThumbnails: 0,
+      profileImages: 0,
+    };
+
+    const allFileTypes = {
+      originals: true,
+      thumbnails: true,
+      previews: true,
+      fullsize: true,
+      encodedVideos: true,
+      sidecars: true,
+      personThumbnails: true,
+      profileImages: true,
+    };
+
+    const sseCConfig = { mode: 'sse-c' as const, key: Buffer.alloc(32, 1), keyMd5: Buffer.alloc(16, 2) };
+
+    describe('getS3EncryptionEstimate', () => {
+      it('should return file counts and total from repository', async () => {
+        mocks.storageMigration.getS3FileCounts.mockResolvedValue(nonZeroS3FileCounts);
+
+        const result = await sut.getS3EncryptionEstimate();
+
+        expect(result).toEqual({ fileCounts: { ...nonZeroS3FileCounts, total: 10 } });
+      });
+    });
+
+    describe('startS3Encryption', () => {
+      const options = { fileTypes: allFileTypes, concurrency: 4 };
+
+      it('should validate SSE-C config, check no active migration, queue orchestrator, and return batchId', async () => {
+        mocks.config.getEnv.mockReturnValue(mockEnvData({ storage: { s3: { sse: sseCConfig } } }));
+        mocks.job.isActive.mockResolvedValue(false);
+        mockS3Backend.exists.mockResolvedValue(true);
+        mocks.storageMigration.getS3FileCounts.mockResolvedValue(nonZeroS3FileCounts);
+
+        const result = await sut.startS3Encryption(options);
+
+        expect(result).toHaveProperty('batchId');
+        expect(mocks.job.isActive).toHaveBeenCalledWith(QueueName.StorageBackendMigration);
+        expect(mocks.job.queue).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: JobName.S3EnableEncryptionQueueAll,
+            data: expect.objectContaining({ fileTypes: allFileTypes, batchId: result.batchId }),
+          }),
+        );
+      });
+
+      it('should throw if SSE-C is not configured', async () => {
+        mocks.config.getEnv.mockReturnValue(mockEnvData({ storage: { s3: { sse: { mode: 'none' } } } }));
+
+        await expect(sut.startS3Encryption(options)).rejects.toThrow(
+          'IMMICH_S3_SSE_MODE must be set to sse-c to enable S3 encryption',
+        );
+        expect(mocks.job.queue).not.toHaveBeenCalled();
+      });
+
+      it('should throw if a migration is already active', async () => {
+        mocks.config.getEnv.mockReturnValue(mockEnvData({ storage: { s3: { sse: sseCConfig } } }));
+        mocks.job.isActive.mockResolvedValue(true);
+        mockS3Backend.exists.mockResolvedValue(true);
+        mocks.storageMigration.getS3FileCounts.mockResolvedValue(nonZeroS3FileCounts);
+
+        await expect(sut.startS3Encryption(options)).rejects.toThrow('A storage migration is already in progress');
+      });
+
+      it('should throw if there are no S3 files to encrypt', async () => {
+        mocks.config.getEnv.mockReturnValue(mockEnvData({ storage: { s3: { sse: sseCConfig } } }));
+        mockS3Backend.exists.mockResolvedValue(true);
+        mocks.storageMigration.getS3FileCounts.mockResolvedValue(zeroS3FileCounts);
+
+        await expect(sut.startS3Encryption(options)).rejects.toThrow('No S3 files to encrypt');
+        expect(mocks.job.queue).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('getS3EncryptionStatus', () => {
+      it('should return active state and job counts', async () => {
+        mocks.job.isActive.mockResolvedValue(true);
+        mocks.job.getJobCounts.mockResolvedValue({ active: 1 } as any);
+
+        const result = await sut.getS3EncryptionStatus();
+
+        expect(result).toEqual({ isActive: true, active: 1 });
+        expect(mocks.job.isActive).toHaveBeenCalledWith(QueueName.StorageBackendMigration);
+      });
+    });
+
+    describe('handleS3EnableEncryptionQueueAll', () => {
+      const baseJob = { batchId: 'batch-1', concurrency: 4 };
+
+      beforeEach(() => {
+        mocks.config.getEnv.mockReturnValue(mockEnvData({ storage: { s3: { sse: sseCConfig } } }));
+      });
+
+      it('should stream S3-only files based on fileTypes flags and queue worker jobs', async () => {
+        mocks.storageMigration.streamS3Originals.mockReturnValue(
+          makeStream([{ id: 'asset-1', originalPath: 'library/user/ab/cd/file.jpg' }]),
+        );
+        mocks.storageMigration.streamS3AssetFiles.mockReturnValue(
+          makeStream([
+            { id: 'file-1', assetId: 'asset-1', path: 'thumbs/user/ab/cd/thumb.webp', type: AssetFileType.Thumbnail },
+          ]),
+        );
+        mocks.storageMigration.streamS3EncodedVideos.mockReturnValue(
+          makeStream([
+            {
+              id: 'file-2',
+              assetId: 'asset-2',
+              path: 'encoded-video/user/ab/cd/video.mp4',
+              type: AssetFileType.EncodedVideo,
+            },
+          ]),
+        );
+        mocks.storageMigration.streamS3PersonThumbnails.mockReturnValue(
+          makeStream([{ id: 'person-1', thumbnailPath: 'thumbs/user/ab/cd/person.jpeg' }]),
+        );
+        mocks.storageMigration.streamS3ProfileImages.mockReturnValue(
+          makeStream([{ id: 'user-1', profileImagePath: 'profile/user/ab/cd/profile.jpg' }]),
+        );
+
+        const result = await sut.handleS3EnableEncryptionQueueAll({ ...baseJob, fileTypes: allFileTypes });
+
+        expect(result).toBe(JobStatus.Success);
+        const queuedJobs = mocks.job.queueAll.mock.calls.flat().flat();
+        expect(queuedJobs).toHaveLength(5);
+        expect(queuedJobs[0]).toEqual(
+          expect.objectContaining({
+            name: JobName.S3EnableEncryptionSingle,
+            data: expect.objectContaining({
+              entityType: 'asset',
+              entityId: 'asset-1',
+              fileType: 'original',
+              key: 'library/user/ab/cd/file.jpg',
+              batchId: 'batch-1',
+            }),
+          }),
+        );
+      });
+
+      it('should throw if SSE-C is not configured', async () => {
+        mocks.config.getEnv.mockReturnValue(mockEnvData({ storage: { s3: { sse: { mode: 'none' } } } }));
+
+        await expect(sut.handleS3EnableEncryptionQueueAll({ ...baseJob, fileTypes: allFileTypes })).rejects.toThrow(
+          'IMMICH_S3_SSE_MODE must be set to sse-c to enable S3 encryption',
+        );
+      });
+
+      it('should only queue enabled file types', async () => {
+        mocks.storageMigration.streamS3Originals.mockReturnValue(
+          makeStream([{ id: 'asset-1', originalPath: 'library/user/ab/cd/file.jpg' }]),
+        );
+        mocks.storageMigration.streamS3AssetFiles.mockReturnValue(makeStream([]));
+        mocks.storageMigration.streamS3EncodedVideos.mockReturnValue(makeStream([]));
+        mocks.storageMigration.streamS3PersonThumbnails.mockReturnValue(makeStream([]));
+        mocks.storageMigration.streamS3ProfileImages.mockReturnValue(makeStream([]));
+
+        const fileTypes = {
+          originals: true,
+          thumbnails: false,
+          previews: false,
+          fullsize: false,
+          encodedVideos: false,
+          sidecars: false,
+          personThumbnails: false,
+          profileImages: false,
+        };
+
+        await sut.handleS3EnableEncryptionQueueAll({ ...baseJob, fileTypes });
+
+        expect(mocks.storageMigration.streamS3Originals).toHaveBeenCalled();
+        expect(mocks.storageMigration.streamS3AssetFiles).not.toHaveBeenCalled();
+        expect(mocks.storageMigration.streamS3EncodedVideos).not.toHaveBeenCalled();
+        expect(mocks.storageMigration.streamS3PersonThumbnails).not.toHaveBeenCalled();
+        expect(mocks.storageMigration.streamS3ProfileImages).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('handleS3EnableEncryptionSingle', () => {
+      const baseJob = {
+        entityType: 'asset' as const,
+        entityId: 'asset-1',
+        fileType: 'original' as string | null,
+        key: 'library/user/ab/cd/file.jpg',
+        batchId: 'batch-1',
+      };
+
+      it('should reencrypt in place and write a migration log entry, returning Success', async () => {
+        mocks.storageMigration.isS3EncryptionLogged.mockResolvedValue(false);
+        mockS3Backend.exists.mockResolvedValue(true);
+        (mockS3Backend as any).reencryptInPlace = vi.fn().mockResolvedValue(void 0);
+        mocks.storageMigration.createLogEntry.mockResolvedValue({} as any);
+
+        const result = await sut.handleS3EnableEncryptionSingle(baseJob);
+
+        expect(result).toBe(JobStatus.Success);
+        expect(mocks.storageMigration.isS3EncryptionLogged).toHaveBeenCalledWith('s3EnableEncryption', baseJob.key);
+        expect((mockS3Backend as any).reencryptInPlace).toHaveBeenCalledWith(baseJob.key);
+        expect(mocks.storageMigration.createLogEntry).toHaveBeenCalledWith({
+          entityType: 'asset',
+          entityId: 'asset-1',
+          fileType: 'original',
+          oldPath: baseJob.key,
+          newPath: baseJob.key,
+          direction: 's3EnableEncryption',
+          batchId: 'batch-1',
+        });
+      });
+
+      it('should skip when already logged as encrypted (idempotency)', async () => {
+        mocks.storageMigration.isS3EncryptionLogged.mockResolvedValue(true);
+        (mockS3Backend as any).reencryptInPlace = vi.fn();
+
+        const result = await sut.handleS3EnableEncryptionSingle(baseJob);
+
+        expect(result).toBe(JobStatus.Skipped);
+        expect((mockS3Backend as any).reencryptInPlace).not.toHaveBeenCalled();
+      });
+
+      it('should skip when the source key no longer exists', async () => {
+        mocks.storageMigration.isS3EncryptionLogged.mockResolvedValue(false);
+        mockS3Backend.exists.mockResolvedValue(false);
+        (mockS3Backend as any).reencryptInPlace = vi.fn();
+
+        const result = await sut.handleS3EnableEncryptionSingle(baseJob);
+
+        expect(result).toBe(JobStatus.Skipped);
+        expect((mockS3Backend as any).reencryptInPlace).not.toHaveBeenCalled();
+      });
+
+      it('should return Failed when reencryptInPlace throws', async () => {
+        mocks.storageMigration.isS3EncryptionLogged.mockResolvedValue(false);
+        mockS3Backend.exists.mockResolvedValue(true);
+        (mockS3Backend as any).reencryptInPlace = vi.fn().mockRejectedValue(new Error('S3 error'));
+
+        const result = await sut.handleS3EnableEncryptionSingle(baseJob);
+
+        expect(result).toBe(JobStatus.Failed);
+        expect(mocks.storageMigration.createLogEntry).not.toHaveBeenCalled();
+      });
+
+      it('should return Failed when S3 backend is not configured', async () => {
+        vi.spyOn(StorageService, 'getS3Backend').mockReturnValue(undefined);
+
+        const result = await sut.handleS3EnableEncryptionSingle(baseJob);
+
+        expect(result).toBe(JobStatus.Failed);
+      });
+    });
+  });
 });

--- a/server/src/services/storage-migration.service.ts
+++ b/server/src/services/storage-migration.service.ts
@@ -339,6 +339,207 @@ export class StorageMigrationService extends BaseService {
     return { rolledBack, failed, total };
   }
 
+  // --- S3 enable-encryption-in-place migration ---
+  //
+  // Distinct from disk<->S3 migration above: the object's key never changes here, only its
+  // encryption state, so there is no DB path update and no rollback-by-path-swap. Progress is
+  // tracked via the same storage_migration_log table (direction='s3EnableEncryption'), which
+  // doubles as the idempotency check since reencryptInPlace itself is not safely re-runnable
+  // against an object it already encrypted (see isS3EncryptionLogged).
+
+  private static readonly S3_ENABLE_ENCRYPTION_DIRECTION = 's3EnableEncryption';
+
+  private getEnabledS3EncryptionFileTypes(fileTypes: StorageMigrationFileTypes): AssetFileType[] {
+    const types: AssetFileType[] = [];
+    if (fileTypes.thumbnails) {
+      types.push(AssetFileType.Thumbnail);
+    }
+    if (fileTypes.previews) {
+      types.push(AssetFileType.Preview);
+    }
+    if (fileTypes.fullsize) {
+      types.push(AssetFileType.FullSize);
+    }
+    if (fileTypes.sidecars) {
+      types.push(AssetFileType.Sidecar);
+    }
+    return types;
+  }
+
+  private validateS3EncryptionConfig(): void {
+    if (this.configRepository.getEnv().storage.s3.sse.mode !== 'sse-c') {
+      throw new BadRequestException('IMMICH_S3_SSE_MODE must be set to sse-c to enable S3 encryption');
+    }
+  }
+
+  async getS3EncryptionEstimate() {
+    const fileCounts = await this.storageMigrationRepository.getS3FileCounts();
+    const total =
+      fileCounts.originals +
+      fileCounts.thumbnails +
+      fileCounts.previews +
+      fileCounts.fullsize +
+      fileCounts.sidecars +
+      fileCounts.encodedVideos +
+      fileCounts.personThumbnails +
+      fileCounts.profileImages;
+
+    return { fileCounts: { ...fileCounts, total } };
+  }
+
+  async startS3Encryption(options: { fileTypes: StorageMigrationFileTypes; concurrency: number }) {
+    this.validateS3EncryptionConfig();
+    await this.validateS3Connection();
+
+    const fileCounts = await this.storageMigrationRepository.getS3FileCounts();
+    const total =
+      fileCounts.originals +
+      fileCounts.thumbnails +
+      fileCounts.previews +
+      fileCounts.fullsize +
+      fileCounts.sidecars +
+      fileCounts.encodedVideos +
+      fileCounts.personThumbnails +
+      fileCounts.profileImages;
+    if (total === 0) {
+      throw new BadRequestException('No S3 files to encrypt');
+    }
+
+    const isActive = await this.jobRepository.isActive(QueueName.StorageBackendMigration);
+    if (isActive) {
+      throw new BadRequestException('A storage migration is already in progress');
+    }
+
+    const batchId = randomUUID();
+
+    await this.jobRepository.queue({
+      name: JobName.S3EnableEncryptionQueueAll,
+      data: { ...options, batchId },
+    });
+
+    return { batchId };
+  }
+
+  async getS3EncryptionStatus() {
+    const [isActive, counts] = await Promise.all([
+      this.jobRepository.isActive(QueueName.StorageBackendMigration),
+      this.jobRepository.getJobCounts(QueueName.StorageBackendMigration),
+    ]);
+
+    return { isActive, ...counts };
+  }
+
+  @OnJob({ name: JobName.S3EnableEncryptionQueueAll, queue: QueueName.StorageBackendMigration })
+  async handleS3EnableEncryptionQueueAll(job: JobOf<JobName.S3EnableEncryptionQueueAll>): Promise<JobStatus> {
+    const { fileTypes, concurrency, batchId } = job;
+
+    this.validateS3EncryptionConfig();
+    this.jobRepository.setConcurrency(QueueName.StorageBackendMigration, concurrency);
+
+    let totalQueued = 0;
+    const batch: Array<{
+      name: JobName.S3EnableEncryptionSingle;
+      data: JobOf<JobName.S3EnableEncryptionSingle>;
+    }> = [];
+
+    const flushBatch = async () => {
+      if (batch.length === 0) {
+        return;
+      }
+      await this.jobRepository.queueAll([...batch]);
+      totalQueued += batch.length;
+      this.logger.log(`Queued ${totalQueued} S3 files for encryption`);
+      batch.length = 0;
+    };
+
+    const enqueue = async (data: JobOf<JobName.S3EnableEncryptionSingle>) => {
+      batch.push({ name: JobName.S3EnableEncryptionSingle, data });
+      if (batch.length >= 1000) {
+        await flushBatch();
+      }
+    };
+
+    if (fileTypes.originals) {
+      for await (const row of this.storageMigrationRepository.streamS3Originals()) {
+        await enqueue({ entityType: 'asset', entityId: row.id, fileType: 'original', key: row.originalPath, batchId });
+      }
+    }
+
+    const assetFileTypes = this.getEnabledS3EncryptionFileTypes(fileTypes);
+    if (assetFileTypes.length > 0) {
+      for await (const row of this.storageMigrationRepository.streamS3AssetFiles(assetFileTypes)) {
+        await enqueue({ entityType: 'assetFile', entityId: row.id, fileType: row.type, key: row.path, batchId });
+      }
+    }
+
+    if (fileTypes.encodedVideos) {
+      for await (const row of this.storageMigrationRepository.streamS3EncodedVideos()) {
+        await enqueue({ entityType: 'asset', entityId: row.assetId, fileType: 'encodedVideo', key: row.path, batchId });
+      }
+    }
+
+    if (fileTypes.personThumbnails) {
+      for await (const row of this.storageMigrationRepository.streamS3PersonThumbnails()) {
+        await enqueue({ entityType: 'person', entityId: row.id, fileType: null, key: row.thumbnailPath, batchId });
+      }
+    }
+
+    if (fileTypes.profileImages) {
+      for await (const row of this.storageMigrationRepository.streamS3ProfileImages()) {
+        await enqueue({ entityType: 'user', entityId: row.id, fileType: null, key: row.profileImagePath, batchId });
+      }
+    }
+
+    await flushBatch();
+
+    this.logger.log(`Finished queueing ${totalQueued} S3 files for encryption (batchId=${batchId})`);
+    return JobStatus.Success;
+  }
+
+  @OnJob({ name: JobName.S3EnableEncryptionSingle, queue: QueueName.StorageBackendMigration })
+  async handleS3EnableEncryptionSingle(job: JobOf<JobName.S3EnableEncryptionSingle>): Promise<JobStatus> {
+    const { entityType, entityId, fileType, key, batchId } = job;
+    const direction = StorageMigrationService.S3_ENABLE_ENCRYPTION_DIRECTION;
+
+    try {
+      const s3Backend = StorageService.getS3Backend();
+      if (!s3Backend) {
+        throw new BadRequestException('S3 storage backend is not configured');
+      }
+
+      // Idempotency: reencryptInPlace is not safely re-runnable against an object it already
+      // encrypted (S3 would need CopySource decrypt headers this call deliberately omits), so
+      // completion is tracked via the migration log rather than by probing object state.
+      const alreadyDone = await this.storageMigrationRepository.isS3EncryptionLogged(direction, key);
+      if (alreadyDone) {
+        return JobStatus.Skipped;
+      }
+
+      const exists = await s3Backend.exists(key);
+      if (!exists) {
+        this.logger.warn(`Source file not found, skipping: ${key}`);
+        return JobStatus.Skipped;
+      }
+
+      await s3Backend.reencryptInPlace(key);
+
+      await this.storageMigrationRepository.createLogEntry({
+        entityType,
+        entityId,
+        fileType,
+        oldPath: key,
+        newPath: key,
+        direction,
+        batchId,
+      });
+
+      return JobStatus.Success;
+    } catch (error: any) {
+      this.logger.error(`Failed to encrypt file ${key}: ${error.message}`, error.stack);
+      return JobStatus.Failed;
+    }
+  }
+
   private resolveSourceBackend(direction: StorageMigrationDirection) {
     if (direction === 'toS3') {
       return StorageService.getDiskBackend();

--- a/server/src/services/storage.service.spec.ts
+++ b/server/src/services/storage.service.spec.ts
@@ -454,6 +454,7 @@ describe(StorageService.name, () => {
               secretAccessKey: undefined,
               presignedUrlExpiry: 3600,
               serveMode: 'redirect',
+              sse: { mode: 'none' },
             },
           },
         }),
@@ -462,6 +463,111 @@ describe(StorageService.name, () => {
       await expect(sut.onBootstrap()).rejects.toThrow(
         'IMMICH_STORAGE_BACKEND is set to s3 but IMMICH_S3_BUCKET is not configured',
       );
+    });
+
+    describe('S3 SSE-C', () => {
+      const rawKey32 = Buffer.alloc(32, 9);
+
+      it('should throw ImmichStartupError when the SSE-C key does not decode to 32 bytes', async () => {
+        mocks.config.getEnv.mockReturnValue(
+          mockEnvData({
+            storage: {
+              backend: 's3' as any,
+              mediaLocation: '/data',
+              s3: {
+                bucket: 'test-bucket',
+                region: 'us-east-1',
+                endpoint: undefined,
+                accessKeyId: undefined,
+                secretAccessKey: undefined,
+                presignedUrlExpiry: 3600,
+                serveMode: 'proxy',
+                sse: { mode: 'sse-c', key: Buffer.alloc(16, 1), keyMd5: Buffer.alloc(16, 2) },
+              },
+            },
+          }),
+        );
+
+        await expect(sut.onBootstrap()).rejects.toThrow(
+          'IMMICH_S3_SSE_C_KEY must decode (base64) to exactly 32 bytes for AES-256, got 16',
+        );
+      });
+
+      it('should hard-fail when SSE-C is configured with serveMode redirect', async () => {
+        mocks.config.getEnv.mockReturnValue(
+          mockEnvData({
+            storage: {
+              backend: 's3' as any,
+              mediaLocation: '/data',
+              s3: {
+                bucket: 'test-bucket',
+                region: 'us-east-1',
+                endpoint: undefined,
+                accessKeyId: undefined,
+                secretAccessKey: undefined,
+                presignedUrlExpiry: 3600,
+                serveMode: 'redirect',
+                sse: { mode: 'sse-c', key: rawKey32, keyMd5: Buffer.alloc(16, 2) },
+              },
+            },
+          }),
+        );
+
+        await expect(sut.onBootstrap()).rejects.toThrow('IMMICH_S3_SSE_MODE=sse-c requires IMMICH_S3_SERVE_MODE=proxy');
+      });
+
+      it('should start successfully when SSE-C is configured with serveMode proxy', async () => {
+        mocks.systemMetadata.get.mockResolvedValue({ mountChecks: { upload: true } });
+        mocks.asset.getFileSamples.mockResolvedValue([]);
+        mocks.config.getEnv.mockReturnValue(
+          mockEnvData({
+            storage: {
+              backend: 's3' as any,
+              mediaLocation: '/data',
+              ignoreMountCheckErrors: false,
+              s3: {
+                bucket: 'test-bucket',
+                region: 'us-east-1',
+                endpoint: undefined,
+                accessKeyId: undefined,
+                secretAccessKey: undefined,
+                presignedUrlExpiry: 3600,
+                serveMode: 'proxy',
+                sse: { mode: 'sse-c', key: rawKey32, keyMd5: Buffer.alloc(16, 2) },
+              },
+            },
+          }),
+        );
+
+        await expect(sut.onBootstrap()).resolves.toBeUndefined();
+        expect(StorageService.getS3Backend()).toBeDefined();
+      });
+
+      it('should start successfully with no SSE and serveMode redirect (unaffected by the new checks)', async () => {
+        mocks.systemMetadata.get.mockResolvedValue({ mountChecks: { upload: true } });
+        mocks.asset.getFileSamples.mockResolvedValue([]);
+        mocks.config.getEnv.mockReturnValue(
+          mockEnvData({
+            storage: {
+              backend: 's3' as any,
+              mediaLocation: '/data',
+              ignoreMountCheckErrors: false,
+              s3: {
+                bucket: 'test-bucket',
+                region: 'us-east-1',
+                endpoint: undefined,
+                accessKeyId: undefined,
+                secretAccessKey: undefined,
+                presignedUrlExpiry: 3600,
+                serveMode: 'redirect',
+                sse: { mode: 'none' },
+              },
+            },
+          }),
+        );
+
+        await expect(sut.onBootstrap()).resolves.toBeUndefined();
+      });
     });
 
     it('should not skip mount checks when all flags are already set', async () => {

--- a/server/src/services/storage.service.ts
+++ b/server/src/services/storage.service.ts
@@ -15,7 +15,7 @@ import {
   StorageFolder,
   SystemMetadataKey,
 } from 'src/enum';
-import { StorageBackend } from 'src/interfaces/storage-backend.interface';
+import { S3SseConfig, StorageBackend } from 'src/interfaces/storage-backend.interface';
 import { BaseService } from 'src/services/base.service';
 import { JobOf, SystemFlags } from 'src/types';
 import { ImmichStartupError } from 'src/utils/misc';
@@ -73,6 +73,22 @@ export class StorageService extends BaseService {
     return '/usr/src/app/upload';
   }
 
+  /**
+   * SSE-C requires 32 raw bytes for AES-256. Validated here (not in the zod env schema) so the
+   * error message can name the env var directly, matching how the S3-bucket-missing check below
+   * is also deferred to this fail-fast startup path rather than schema validation.
+   */
+  private validateS3Encryption(sse: S3SseConfig) {
+    if (sse.mode !== 'sse-c') {
+      return;
+    }
+    if (sse.key.length !== 32) {
+      throw new ImmichStartupError(
+        `IMMICH_S3_SSE_C_KEY must decode (base64) to exactly 32 bytes for AES-256, got ${sse.key.length}`,
+      );
+    }
+  }
+
   @OnEvent({ name: 'AppBootstrap', priority: BootstrapEventPriority.StorageService })
   async onBootstrap() {
     StorageCore.setMediaLocation(this.detectMediaLocation());
@@ -82,9 +98,26 @@ export class StorageService extends BaseService {
     StorageService.diskBackend = new DiskStorageBackend(StorageCore.getMediaLocation());
     StorageService.writeBackendType = envData.storage.backend;
 
+    this.validateS3Encryption(envData.storage.s3.sse);
+
+    // SSE-C objects cannot be served via a presigned redirect URL (S3 has no way to receive the
+    // customer-key headers on a bare browser fetch), so serveMode=redirect + SSE-C is a hard
+    // startup failure rather than a silent fallback to proxy — see
+    // specs/2026-09-02-s3-sse-c-encryption-design.md for why a silent override was rejected.
+    if (envData.storage.s3.sse.mode === 'sse-c' && envData.storage.s3.serveMode === 'redirect') {
+      throw new ImmichStartupError(
+        'IMMICH_S3_SSE_MODE=sse-c requires IMMICH_S3_SERVE_MODE=proxy: a presigned redirect URL ' +
+          'cannot carry the SSE-C decryption headers S3 requires, so redirect-mode serving is ' +
+          'incompatible with SSE-C. Set IMMICH_S3_SERVE_MODE=proxy explicitly to proceed.',
+      );
+    }
+
     if (envData.storage.s3.bucket) {
       StorageService.s3Backend = new S3StorageBackend(envData.storage.s3);
       this.logger.log(`S3 storage backend configured (bucket: ${envData.storage.s3.bucket})`);
+      if (envData.storage.s3.sse.mode === 'sse-c') {
+        this.logger.log('S3 server-side encryption with customer-provided keys (SSE-C) is active');
+      }
     }
 
     if (envData.storage.backend === 's3' && !StorageService.s3Backend) {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -458,6 +458,34 @@ export interface IStorageMigrationQueueAllJob {
   batchId: string;
 }
 
+/**
+ * Re-encrypts an already-existing S3 object in place with the currently-configured SSE-C key,
+ * via CopyObject self-copy (see S3StorageBackend.reencryptInPlace) — no DB path change, unlike
+ * IStorageMigrationJob, since the key doesn't move, only its encryption state changes.
+ */
+export interface IS3EnableEncryptionJob {
+  entityType: 'asset' | 'assetFile' | 'person' | 'user';
+  entityId: string;
+  fileType: string | null;
+  key: string;
+  batchId: string;
+}
+
+export interface IS3EnableEncryptionQueueAllJob {
+  fileTypes: {
+    originals: boolean;
+    thumbnails: boolean;
+    previews: boolean;
+    fullsize: boolean;
+    encodedVideos: boolean;
+    sidecars: boolean;
+    personThumbnails: boolean;
+    profileImages: boolean;
+  };
+  concurrency: number;
+  batchId: string;
+}
+
 export interface JobCounts {
   active: number;
   completed: number;
@@ -606,6 +634,10 @@ export type JobItem =
   // Storage Backend Migration
   | { name: JobName.StorageBackendMigrationQueueAll; data: IStorageMigrationQueueAllJob }
   | { name: JobName.StorageBackendMigrationSingle; data: IStorageMigrationJob }
+
+  // S3 SSE-C Encryption (enable-encryption-in-place migration)
+  | { name: JobName.S3EnableEncryptionQueueAll; data: IS3EnableEncryptionQueueAllJob }
+  | { name: JobName.S3EnableEncryptionSingle; data: IS3EnableEncryptionJob }
 
   // Shared Space Face Recognition
   | { name: JobName.SharedSpaceFaceMatch; data: ISharedSpaceFaceMatchJob }

--- a/server/test/repositories/config.repository.mock.ts
+++ b/server/test/repositories/config.repository.mock.ts
@@ -95,6 +95,7 @@ export const envData: EnvData = {
       secretAccessKey: undefined,
       presignedUrlExpiry: 3600,
       serveMode: 'redirect',
+      sse: { mode: 'none' },
     },
   },
 
@@ -119,13 +120,17 @@ export const envData: EnvData = {
 };
 
 type MockEnvOverrides = Omit<Partial<EnvData>, 'storage'> & {
-  storage?: Partial<EnvData['storage']>;
+  storage?: Omit<Partial<EnvData['storage']>, 's3'> & { s3?: Partial<EnvData['storage']['s3']> };
 };
 
 export const mockEnvData = (config: MockEnvOverrides): EnvData => ({
   ...envData,
   ...config,
-  storage: { ...envData.storage, ...config.storage },
+  storage: {
+    ...envData.storage,
+    ...config.storage,
+    s3: { ...envData.storage.s3, ...config.storage?.s3 },
+  },
 });
 export const newConfigRepositoryMock = (): Mocked<RepositoryInterface<ConfigRepository>> => {
   return {

--- a/specs/2026-09-02-s3-sse-c-encryption-design.md
+++ b/specs/2026-09-02-s3-sse-c-encryption-design.md
@@ -1,0 +1,177 @@
+# S3 Encryption at Rest via SSE-C
+
+## Problem
+
+Gallery's S3-compatible storage backend (`S3StorageBackend`) writes and reads objects in
+plaintext as far as the app is concerned. Provider-side default bucket encryption (SSE-S3) may or
+may not be enabled by the operator, and Gallery has no way to require or verify it — encryption
+at rest today is entirely an infrastructure concern outside the app's control.
+
+This adds an app-controlled option: **SSE-C** (Server-Side Encryption with Customer-provided
+Keys). S3 still does the actual AES-256 encrypt/decrypt work — Gallery never implements a cipher
+— but Gallery supplies and controls the key on every request, rather than trusting the bucket's
+default encryption configuration.
+
+## Why SSE-C and not app-managed envelope encryption
+
+An earlier design considered implementing AES-256-GCM directly inside `S3StorageBackend` (encrypt
+before `put`, decrypt after `get`/`downloadToTemp`). That approach was rejected in favor of SSE-C
+because:
+
+- No new cipher code, no IV/nonce/authTag schema migration on `asset_file`, no new dependency.
+- S3 (or the S3-compatible provider) already implements SSE-C correctly; Gallery's job is limited
+  to attaching three well-defined headers on the right commands.
+- The chokepoint this needs to touch (`S3StorageBackend`) is exactly the same either way — see
+  "Why this stays inside S3StorageBackend" below — so the SSE-C version does strictly less work
+  for the same architectural insertion point.
+
+## Why SSE-KMS is not implemented (yet)
+
+SSE-KMS would avoid the redirect-mode restriction entirely (see below), because S3 needs no
+special headers on `GetObject` for a KMS-encrypted object — decrypt authorization is via IAM/KMS
+key policy on the credentials that signed the request, so a presigned URL just works. That makes
+it strictly better for buckets on a provider with real KMS integration.
+
+It isn't implemented here because most self-hosted S3-compatible targets Gallery is deployed
+against (bare MinIO, Ceph RGW without a KMS backend, etc.) don't have a KMS to point at, whereas
+SSE-C is a plain header-based feature nearly every S3-compatible implementation supports. The
+config is shaped as a discriminated union (`S3SseConfig`) specifically so adding an `sse-kms`
+variant later is a config-shape non-event — see `server/src/interfaces/storage-backend.interface.ts`.
+
+## Decision: SSE-C inside `S3StorageBackend`, forced proxy serve mode
+
+Three headers (`SSECustomerAlgorithm: AES256`, `SSECustomerKey`, `SSECustomerKeyMD5`), computed
+once at construction from `IMMICH_S3_SSE_C_KEY`, are attached to every `put`, `get`
+(`GetObjectCommand`), and `exists` (`HeadObjectCommand`) call. `deletePrefix`/`getPrefixUsage`
+(list/delete metadata operations) and the `HeadBucket` startup health check do not need them —
+they never touch object bytes.
+
+### Why this stays inside `S3StorageBackend`
+
+Nearly every service that touches file bytes (`ensureLocalFile`, `serveFromBackend`,
+`persistFile`/`put`, `resolveBackendForKey`) already only sees the `StorageBackend` interface, not
+the S3 SDK directly. Putting SSE-C headers inside the backend implementation means all of that
+code needs zero changes. Three call sites bypass those chokepoints and call `backend.get()`/`put()`
+directly (`download.service.ts`'s ZIP stream, `machine-learning.repository.ts`'s inference upload,
+`storage-migration.service.ts`'s disk↔S3 copy) — all three still only call `get()`/`put()` on the
+backend instance, so they inherit SSE-C transparently too.
+
+Checksums (SHA-1, used for dedup) are computed during the initial multer upload to local disk,
+before the S3 backend is ever invoked — see `file-upload.interceptor.ts`. Because encryption is
+applied only inside the S3 backend's `put()`, dedup is completely unaffected.
+
+### Why redirect serve mode is incompatible with SSE-C
+
+`IMMICH_S3_SERVE_MODE=redirect` hands the browser a presigned `GetObject` URL and gets the Node
+process out of the media byte path entirely (see `2026-05-02-s3-direct-media-delivery-design.md`,
+written specifically to move *away* from proxying every byte through the API process for
+stability reasons). A presigned URL only signs which headers must be present and their values as
+part of the signature — it does not let a plain `<img>`/`<video>` browser fetch, or a bare
+`ffprobe <url>` invocation, attach a custom header. S3 requires the SSE-C customer-key header on
+every `GetObject` of an SSE-C object, so a redirect target would just serve ciphertext to
+whatever's on the other end.
+
+**Decision: hard-fail at startup**, not silent fallback. `StorageService.onBootstrap()` throws an
+`ImmichStartupError` if `IMMICH_S3_SSE_MODE=sse-c` and `IMMICH_S3_SERVE_MODE=redirect` (the
+default) are both set. The admin must explicitly set `IMMICH_S3_SERVE_MODE=proxy`. A silent
+override was considered and rejected: a config value silently not doing what it says is worse
+than an explicit failure with a clear remediation message, especially for a security-relevant
+setting. This means **SSE-C reintroduces the exact class of production risk** the redirect-mode
+change was built to eliminate (API-process-in-the-hot-byte-path saturation under fast-scroll
+load) — this is an inherent tradeoff of the approach, not a bug, and is the primary reason SSE-C
+should be opt-in rather than a default.
+
+### `getProbeInput` / ffprobe fallback
+
+`getProbeInput()` normally returns a short-TTL presigned URL so `ffprobe` can read an S3 original
+without a full download. That URL has the same problem as redirect serving. `StorageBackend` now
+exposes a `supportsReadableUrl: boolean` flag (`false` only for S3 with SSE-C active); when false,
+`BaseService.getProbeInput()` falls back to the existing `ensureLocalFile`/`downloadToTemp`
+bracket instead, at the cost of the skip-the-download optimization in that case only. No other
+`ensureLocalFile` call site changes — they already download-to-temp unconditionally, and
+`downloadToTemp` decrypts correctly today because it's built on `get()`.
+
+## Existing-object migration (`storage-migration` job queue)
+
+Turning on SSE-C does not retroactively encrypt objects already in the bucket, and — this is the
+sharp edge — **enabling SSE-C headers on a bucket with pre-existing unencrypted objects breaks
+reads of those objects**: S3 doesn't silently ignore SSE-C headers on an object that isn't SSE-C
+encrypted, it errors, because sending decryption headers for a plaintext object is treated as a
+mismatch rather than a no-op.
+
+A new job type (`S3EnableEncryptionQueueAll` / `S3EnableEncryptionSingle`, running on the existing
+`QueueName.StorageBackendMigration` queue) re-encrypts existing S3 objects in place, added to
+`StorageMigrationService` alongside the existing disk↔S3 migration:
+
+- **Mechanism**: `S3StorageBackend.reencryptInPlace(key)` issues a `CopyObjectCommand` with
+  `CopySource` equal to the object's own key (a self-copy) and only *destination* SSE-C headers —
+  no `CopySourceSSECustomerKey*` headers, since the source is assumed unencrypted. This happens
+  entirely inside S3/the provider; Gallery's process never sees the bytes. This is why
+  `reencryptInPlace` is used instead of the disk↔S3 migration's `get()`+`put()` pattern.
+- **Key difference from disk↔S3 migration**: the object's key never changes, only its encryption
+  state — there is no DB path column to update. `IStorageMigrationJob`'s "check if target path
+  already exists" idempotency check doesn't apply here (the "target" and "source" are the same
+  key). Instead, completion is tracked via the existing `storage_migration_log` table
+  (`direction = 's3EnableEncryption'`, `oldPath = newPath = key`), because `reencryptInPlace`
+  itself is not safely re-runnable against an object it has already encrypted — a second call
+  would need `CopySourceSSECustomerKey*` headers this call deliberately omits, and would fail.
+- **Deploy-order requirement**: `IMMICH_S3_SSE_MODE=sse-c` (and a valid 32-byte
+  `IMMICH_S3_SSE_C_KEY`) must already be configured and the server restarted with that config
+  *before* starting this migration job — the job re-encrypts using whatever key the running S3
+  backend already holds. There is no separate "target key" parameter.
+- **Rollback**: not implemented as a mirror job in this change. Because the key doesn't move, a
+  rollback would need a second `CopyObjectCommand` with the key as *source* SSE-C headers and no
+  destination encryption — structurally different from the existing path-swap `rollback()`, which
+  assumes reverting means writing the old path back into the DB column. Left as a follow-up if
+  actually needed; SSE-C is opt-in and reversible at the config level (unsetting
+  `IMMICH_S3_SSE_MODE` stops *new* writes from being encrypted) even though already-migrated
+  objects would need this follow-up work to read again without the key.
+
+## Key management
+
+`IMMICH_S3_SSE_C_KEY` is base64-encoded, must decode to exactly 32 raw bytes (AES-256), and is
+validated at startup (`StorageService.onBootstrap`) rather than in the zod env schema, so the
+error message can reference the env var by name directly (matching how the "S3 bucket configured
+but backend isn't s3" check is also deferred past schema parsing).
+
+**S3 never stores the SSE-C key** — losing it means permanently losing access to every object
+encrypted with it. There is no recovery path. This is categorically different from a typical
+misconfiguration and should be called out prominently in deployment docs, not just in this file.
+
+No new secrets-storage mechanism was built for this key. It follows the existing `IMMICH_S3_*`
+precedent (env var only, never DB-stored) rather than the `system_metadata` JSONB blob used for
+SMTP/OAuth secrets — that blob has no field-level encryption and is admin-UI-editable, which would
+be a worse fit for a value whose accidental loss is unrecoverable.
+
+## Out of scope
+
+- **SSE-KMS.** Config shape reserved (`S3SseConfig` discriminated union in
+  `storage-backend.interface.ts`), zero implementation. See "Why SSE-KMS is not implemented" above.
+- **Client-side / end-to-end encryption.** A fundamentally different, much larger design — the
+  server would need to stop generating thumbnails/transcodes from plaintext, which touches the
+  entire media pipeline, not just the storage backend.
+- **Disk-backed storage.** SSE-C is an S3-protocol feature; `DiskStorageBackend` always reports
+  `supportsReadableUrl: true` and is otherwise untouched.
+- **External libraries.** Already out of scope for the S3 backend entirely (local disk paths,
+  never copied into Gallery-managed storage) — see `2026-03-02-s3-storage-design.md` §9.
+- **Rollback job for the enable-encryption migration.** See "Rollback" above.
+
+## Files changed
+
+- `server/src/dtos/env.dto.ts` — `IMMICH_S3_SSE_MODE`, `IMMICH_S3_SSE_C_KEY`
+- `server/src/repositories/config.repository.ts` — parses/decodes the SSE-C key once at
+  config-load time (`parseS3SseConfig`)
+- `server/src/interfaces/storage-backend.interface.ts` — `S3SseConfig` discriminated union,
+  `StorageBackend.supportsReadableUrl`
+- `server/src/backends/s3-storage.backend.ts` — SSE-C headers on `put`/`get`/`exists`, forced
+  proxy strategy in `getServeStrategy`, new `reencryptInPlace`
+- `server/src/backends/disk-storage.backend.ts` — `supportsReadableUrl = true`
+- `server/src/services/base.service.ts` — `getProbeInput` falls back to `ensureLocalFile` when
+  `!supportsReadableUrl`
+- `server/src/services/storage.service.ts` — startup validation (key length, redirect+SSE-C
+  hard-fail)
+- `server/src/repositories/storage-migration.repository.ts`,
+  `server/src/services/storage-migration.service.ts`,
+  `server/src/controllers/storage-migration.controller.ts`,
+  `server/src/dtos/storage-migration.dto.ts` — enable-encryption-in-place migration
+- `server/src/enum.ts`, `server/src/types.ts` — `JobName.S3EnableEncryption{QueueAll,Single}`


### PR DESCRIPTION
## Summary

Adds server-side encryption with customer-provided keys (SSE-C) as an opt-in encryption-at-rest
option for Gallery-managed assets stored on S3-compatible backends. S3 performs the actual
AES-256 encrypt/decrypt; Gallery supplies and controls a 32-byte key via `IMMICH_S3_SSE_C_KEY`
and attaches it to every put/get/head request in `S3StorageBackend`.

Full design rationale (including why SSE-C was chosen over app-managed envelope encryption and
SSE-KMS, and what's explicitly out of scope) is in
`specs/2026-09-02-s3-sse-c-encryption-design.md`.

## What changed

- **Config**: `IMMICH_S3_SSE_MODE` (`none`|`sse-c`) + `IMMICH_S3_SSE_C_KEY` env vars, parsed once
  into a discriminated `S3SseConfig` (`sse-kms` reserved for a future change, not implemented).
- **`S3StorageBackend`**: attaches SSE-C headers to `put`/`get`/`exists`. List and delete-prefix
  operations are untouched since they never touch object bytes. New `reencryptInPlace()` uses a
  `CopyObject` self-copy so existing objects can be encrypted without routing bytes through the
  app process.
- **Redirect-mode incompatibility**: SSE-C objects can't be served via a presigned redirect URL
  (S3 requires the customer-key header on every `GetObject`, which a bare browser/ffprobe fetch
  can't attach). `StorageService.onBootstrap` hard-fails at startup if SSE-C is enabled with
  `IMMICH_S3_SERVE_MODE=redirect`, rather than silently falling back to proxy mode.
  `getProbeInput` falls back to `downloadToTemp` when the resolved backend reports
  `supportsReadableUrl: false`.
- **Enable-encryption-in-place migration**: new `S3EnableEncryptionQueueAll`/`Single` job pair
  (reusing the `StorageBackendMigration` queue) re-encrypts existing S3 objects in place for
  buckets that already contain unencrypted objects, since turning on SSE-C headers against an
  unencrypted object fails reads rather than no-op'ing. Progress is tracked via the existing
  `storage_migration_log` table (`direction=s3EnableEncryption`) because the re-encrypt call is
  not safely re-runnable against an already-encrypted object.
- **New admin endpoints** under `/storage-migration/s3-encryption/*` for estimate/start/status,
  mirroring the existing disk↔S3 migration API shape.

## Out of scope (see design doc)

- SSE-KMS (config shape reserved, not implemented)
- Rollback job for the enable-encryption migration
- Client-side / end-to-end encryption
- External libraries (already out of scope for S3-managed storage generally)
- Web/mobile admin UI for the new endpoints

## Verification

- `tsc --noEmit`: clean
- `nest build`: clean
- `eslint --max-warnings 0`: clean on all touched files
- `prettier --check`: clean on all touched files
- Full server unit test suite: 184 test files, 6125 tests passing, 0 failures (46 new tests added
  across backend, service, and startup-validation specs)

---
*Risk*: encrypting/decrypting still happens inside S3 (not app-implemented crypto), and the
feature is fully opt-in via env var — default behavior (`IMMICH_S3_SSE_MODE` unset) is unchanged.
The main operational risk is losing `IMMICH_S3_SSE_C_KEY`, which is unrecoverable (S3 never
stores the key) — called out prominently in the design doc.