### PR TITLE
fix(web): clear the previous search results as soon as a new search starts (#1052)

### DIFF
--- a/web/src/lib/components/search/smart-search-results-rerun.test-host.svelte
+++ b/web/src/lib/components/search/smart-search-results-rerun.test-host.svelte
@@ -21,10 +21,25 @@
   let searchQuery = $state('beach');
   let reloadToken = $state(0);
   let results = $state<AssetResponseDto[]>([]);
+  let isLoading = $state(false);
+
+  /**
+   * How the real pages commit a search from the URL: every searchable page's URL effect resets its
+   * own `isLoading` to false in the same synchronous block that assigns the new query. The component
+   * has to re-assert loading after that, or the blanked grid falls through to the "no results" empty
+   * state while the replacement is still in flight.
+   */
+  const commitSearchFromUrl = (query: string) => {
+    isLoading = false;
+    searchQuery = query;
+  };
 </script>
 
 <button type="button" data-testid="host-clear-search" onclick={() => (searchQuery = '')}>clear</button>
 <button type="button" data-testid="host-new-search" onclick={() => (searchQuery = 'mountain')}>search</button>
+<button type="button" data-testid="host-commit-url-search" onclick={() => commitSearchFromUrl('mountain')}>
+  commit
+</button>
 <button type="button" data-testid="host-add-filter" onclick={() => (filters = { ...filters, city: 'Berlin' })}>
   filter
 </button>
@@ -35,5 +50,13 @@
 <span data-testid="host-result-ids">{results.map((asset) => asset.id).join(',')}</span>
 
 {#if searchQuery}
-  <SmartSearchResults bind:results {searchQuery} {filters} {reloadToken} isShared={false} language="en" />
+  <SmartSearchResults
+    bind:results
+    bind:isLoading
+    {searchQuery}
+    {filters}
+    {reloadToken}
+    isShared={false}
+    language="en"
+  />
 {/if}

--- a/web/src/lib/components/search/smart-search-results-rerun.test-host.svelte
+++ b/web/src/lib/components/search/smart-search-results-rerun.test-host.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import type { FilterState } from '$lib/components/filter-panel/filter-panel';
+  import SmartSearchResults from '$lib/components/search/smart-search-results.svelte';
+  import type { AssetResponseDto } from '@immich/sdk';
+
+  /**
+   * Test host that reproduces how the searchable pages (`/photos`, `/recently-added`, a space
+   * timeline) drive `SmartSearchResults`: the HOST owns `results` and mounts the component only
+   * while there is a query, so the loaded assets outlive an unmount.
+   *
+   * `rerender` from @testing-library/svelte re-fires the component's mount effect, so it cannot
+   * tell "the host re-ran the search" from "the component was mounted fresh" — the difference
+   * #1052 turns on. Driving a real host is the only way to observe it.
+   */
+  interface Props {
+    filters: FilterState;
+  }
+
+  let { filters = $bindable() }: Props = $props();
+
+  let searchQuery = $state('beach');
+  let reloadToken = $state(0);
+  let results = $state<AssetResponseDto[]>([]);
+</script>
+
+<button type="button" data-testid="host-clear-search" onclick={() => (searchQuery = '')}>clear</button>
+<button type="button" data-testid="host-new-search" onclick={() => (searchQuery = 'mountain')}>search</button>
+<button type="button" data-testid="host-add-filter" onclick={() => (filters = { ...filters, city: 'Berlin' })}>
+  filter
+</button>
+<button type="button" data-testid="host-reload" onclick={() => reloadToken++}>reload</button>
+
+{#if searchQuery}
+  <SmartSearchResults bind:results {searchQuery} {filters} {reloadToken} isShared={false} language="en" />
+{/if}

--- a/web/src/lib/components/search/smart-search-results-rerun.test-host.svelte
+++ b/web/src/lib/components/search/smart-search-results-rerun.test-host.svelte
@@ -30,6 +30,10 @@
 </button>
 <button type="button" data-testid="host-reload" onclick={() => reloadToken++}>reload</button>
 
+<!-- The gallery virtualizes to zero height under happy-dom, so the loaded assets are only
+     observable through the host's own copy of them. -->
+<span data-testid="host-result-ids">{results.map((asset) => asset.id).join(',')}</span>
+
 {#if searchQuery}
   <SmartSearchResults bind:results {searchQuery} {filters} {reloadToken} isShared={false} language="en" />
 {/if}

--- a/web/src/lib/components/search/smart-search-results.spec.ts
+++ b/web/src/lib/components/search/smart-search-results.spec.ts
@@ -1,7 +1,6 @@
 import { AssetOrder } from '@immich/sdk';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { getIntersectionObserverMock } from '$lib/__mocks__/intersection-observer.mock';
 import type { FilterState } from '$lib/components/filter-panel/filter-panel';
 import SmartSearchResultsRerunHost from '$lib/components/search/smart-search-results-rerun.test-host.svelte';
 import SmartSearchResults from '$lib/components/search/smart-search-results.svelte';
@@ -31,10 +30,31 @@ const baseProps = {
 
 const mockEmptyResult = { assets: { items: [], nextPage: null } };
 
+/**
+ * The shared mock never invokes its callback, so the infinite-scroll sentinel can't be driven from a
+ * test. Capture the callbacks instead — the newest belongs to the live sentinel — so paging can be
+ * exercised alongside the search-clearing behaviour it shares state with.
+ */
+let intersectionCallbacks: IntersectionObserverCallback[] = [];
+
+const getCapturingIntersectionObserverMock = () =>
+  vi.fn(function (callback: IntersectionObserverCallback) {
+    intersectionCallbacks.push(callback);
+    return { disconnect: vi.fn(), observe: vi.fn(), takeRecords: vi.fn(), unobserve: vi.fn() };
+  });
+
+const scrollToLoadMore = async () => {
+  const callback = intersectionCallbacks.at(-1);
+  expect(callback).toBeDefined();
+  callback!([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver);
+  await vi.advanceTimersByTimeAsync(0);
+};
+
 describe('SmartSearchResults', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.stubGlobal('IntersectionObserver', getIntersectionObserverMock());
+    intersectionCallbacks = [];
+    vi.stubGlobal('IntersectionObserver', getCapturingIntersectionObserverMock());
     searchSmartMock.mockReset();
     searchSmartMock.mockResolvedValue(mockEmptyResult);
   });
@@ -182,23 +202,8 @@ describe('SmartSearchResults', () => {
     expect(lastCall![0].smartSearchDto.order).toBeUndefined();
   });
 
-  // Test 47 — loadMore (requires triggering the dumb grid's IntersectionObserver or direct invocation)
-  // The exact mechanism depends on whether onLoadMore is exposed; you may need to grab the prop
-  // off the rendered SpaceSearchResults via a test export, or simulate the IntersectionObserver
-  // entry firing. See the existing space-search-results.spec.ts for patterns.
-  it.todo('loadMore fetches the next page and appends results');
-
-  // Test 48
-  it.todo('loadMore does nothing when hasMore is false');
-
   // Test 49
   it.todo('loadMore while another loadMore is in flight: abort first, second wins');
-
-  // Test 50
-  it.todo('concurrent submit: query A in flight, query B submitted, B wins');
-
-  // Test 51
-  it.todo('submit while loadMore in flight: loadMore aborted, restart from page 1');
 
   // Test 52 — cooperative abort on unmount, NOT SDK signal propagation.
   // The wrapper uses cooperative abort (checks `controller.signal.aborted` *after*
@@ -308,13 +313,19 @@ describe('SmartSearchResults', () => {
   // query's photos stayed on screen — keeping their scroll offset — for the debounce plus the whole
   // round trip, and a host remount replayed them from scratch.
   describe('clearing previous results (#1052)', () => {
+    const asset = (id: string) => ({ id, originalFileName: `${id}.jpg` });
+    const page = (ids: string[], nextPage: string | null = null) => ({
+      assets: { items: ids.map((id) => asset(id)), nextPage },
+    });
+
+    /** The assets the host currently holds — the grid itself virtualizes to nothing under happy-dom. */
+    const resultIds = () => screen.getByTestId('host-result-ids').textContent;
+
     const renderHost = async () => {
-      searchSmartMock.mockResolvedValue({
-        assets: { items: [{ id: 'asset-1', originalFileName: 'beach.jpg' }], nextPage: null },
-      });
+      searchSmartMock.mockResolvedValue(page(['asset-1']));
       render(SmartSearchResultsRerunHost, { props: { filters: baseFilters } });
       await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
-      expect(screen.getByTestId('result-count')).toBeInTheDocument();
+      expect(resultIds()).toBe('asset-1');
     };
 
     it('blanks the previous results as soon as a new query is submitted', async () => {
@@ -323,6 +334,7 @@ describe('SmartSearchResults', () => {
       await fireEvent.click(screen.getByTestId('host-new-search'));
 
       // Deliberately no timer advance: the old results must be gone *before* the replacement lands.
+      expect(resultIds()).toBe('');
       expect(screen.getByTestId('search-loading')).toBeInTheDocument();
       expect(screen.queryByTestId('result-count')).not.toBeInTheDocument();
     });
@@ -332,6 +344,7 @@ describe('SmartSearchResults', () => {
 
       await fireEvent.click(screen.getByTestId('host-add-filter'));
 
+      expect(resultIds()).toBe('');
       expect(screen.getByTestId('search-loading')).toBeInTheDocument();
       expect(screen.queryByTestId('result-count')).not.toBeInTheDocument();
     });
@@ -343,8 +356,19 @@ describe('SmartSearchResults', () => {
       await fireEvent.click(screen.getByTestId('host-clear-search'));
       await fireEvent.click(screen.getByTestId('host-new-search'));
 
+      expect(resultIds()).toBe('');
       expect(screen.getByTestId('search-loading')).toBeInTheDocument();
       expect(screen.queryByTestId('result-count')).not.toBeInTheDocument();
+    });
+
+    it('stays blank for the whole debounce window, not just the first tick', async () => {
+      await renderHost();
+
+      await fireEvent.click(screen.getByTestId('host-new-search'));
+      await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS - 1);
+
+      expect(resultIds()).toBe('');
+      expect(searchSmartMock).toHaveBeenCalledTimes(1);
     });
 
     it('keeps the current results on screen while a reload re-runs the same search', async () => {
@@ -353,6 +377,7 @@ describe('SmartSearchResults', () => {
       await fireEvent.click(screen.getByTestId('host-reload'));
 
       // A reload restores results after an undone delete — same search, so nothing to blank.
+      expect(resultIds()).toBe('asset-1');
       expect(screen.getByTestId('result-count')).toBeInTheDocument();
       expect(screen.queryByTestId('search-loading')).not.toBeInTheDocument();
     });
@@ -360,17 +385,140 @@ describe('SmartSearchResults', () => {
     it('shows the new results once they arrive', async () => {
       await renderHost();
 
-      searchSmartMock.mockResolvedValue({
-        assets: { items: [{ id: 'asset-2', originalFileName: 'mountain.jpg' }], nextPage: null },
-      });
+      searchSmartMock.mockResolvedValue(page(['asset-2']));
       await fireEvent.click(screen.getByTestId('host-new-search'));
       await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
 
+      expect(resultIds()).toBe('asset-2');
       expect(screen.getByTestId('result-count')).toBeInTheDocument();
       expect(screen.queryByTestId('search-loading')).not.toBeInTheDocument();
       expect(searchSmartMock).toHaveBeenLastCalledWith(
         expect.objectContaining({ smartSearchDto: expect.objectContaining({ query: 'mountain' }) }),
       );
+    });
+
+    it('does not restore the previous results while the new search is in flight', async () => {
+      await renderHost();
+
+      let resolveSecond: (value: unknown) => void = () => {};
+      searchSmartMock.mockImplementationOnce(() => new Promise((resolve) => (resolveSecond = resolve)));
+
+      await fireEvent.click(screen.getByTestId('host-new-search'));
+      await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+      expect(resultIds()).toBe('');
+
+      resolveSecond(page(['asset-2']));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(resultIds()).toBe('asset-2');
+    });
+
+    it('ignores a late response from the query that was replaced', async () => {
+      let resolveFirst: (value: unknown) => void = () => {};
+      searchSmartMock.mockImplementationOnce(() => new Promise((resolve) => (resolveFirst = resolve)));
+      searchSmartMock.mockResolvedValue(page(['asset-2']));
+
+      render(SmartSearchResultsRerunHost, { props: { filters: baseFilters } });
+      await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+
+      await fireEvent.click(screen.getByTestId('host-new-search'));
+      await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+      expect(resultIds()).toBe('asset-2');
+
+      // The abandoned query answers last; it must not overwrite the search now on screen.
+      resolveFirst(page(['asset-1']));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(resultIds()).toBe('asset-2');
+    });
+
+    it('leaves the results blank when the new search fails', async () => {
+      await renderHost();
+
+      searchSmartMock.mockRejectedValueOnce(new Error('smart search is not enabled'));
+      await fireEvent.click(screen.getByTestId('host-new-search'));
+      await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+
+      expect(resultIds()).toBe('');
+      expect(screen.getByTestId('search-empty')).toBeInTheDocument();
+    });
+
+    it('restarts pagination at page 1 after a new query, discarding the loaded pages', async () => {
+      searchSmartMock.mockResolvedValueOnce(page(['asset-1'], '2'));
+      render(SmartSearchResultsRerunHost, { props: { filters: baseFilters } });
+      await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+
+      searchSmartMock.mockResolvedValueOnce(page(['asset-2'], null));
+      await scrollToLoadMore();
+      expect(resultIds()).toBe('asset-1,asset-2');
+
+      searchSmartMock.mockResolvedValue(page(['asset-9']));
+      await fireEvent.click(screen.getByTestId('host-new-search'));
+      expect(resultIds()).toBe('');
+      await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+
+      expect(resultIds()).toBe('asset-9');
+      expect(searchSmartMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({ smartSearchDto: expect.objectContaining({ page: 1, query: 'mountain' }) }),
+      );
+    });
+
+    it('appends the next page without blanking what is already loaded', async () => {
+      searchSmartMock.mockResolvedValueOnce(page(['asset-1'], '2'));
+      render(SmartSearchResultsRerunHost, { props: { filters: baseFilters } });
+      await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+
+      searchSmartMock.mockResolvedValueOnce(page(['asset-2'], null));
+      await scrollToLoadMore();
+
+      // Paging is an append, not a new search — the first page must survive it.
+      expect(resultIds()).toBe('asset-1,asset-2');
+      expect(searchSmartMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({ smartSearchDto: expect.objectContaining({ page: 2 }) }),
+      );
+    });
+
+    // Test 51 — the dangerous ordering: an append is in flight when the query changes, so its
+    // response could land on top of the freshly blanked grid and mix two searches together.
+    it('discards a page that was still loading when a new query replaced the search', async () => {
+      searchSmartMock.mockResolvedValueOnce(page(['asset-1'], '2'));
+      render(SmartSearchResultsRerunHost, { props: { filters: baseFilters } });
+      await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+
+      let resolvePage2: (value: unknown) => void = () => {};
+      searchSmartMock.mockImplementationOnce(() => new Promise((resolve) => (resolvePage2 = resolve)));
+      await scrollToLoadMore();
+      expect(resultIds()).toBe('asset-1');
+
+      searchSmartMock.mockResolvedValue(page(['asset-9']));
+      await fireEvent.click(screen.getByTestId('host-new-search'));
+      await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+
+      resolvePage2(page(['asset-2'], null));
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(resultIds()).toBe('asset-9');
+    });
+
+    it('blanks the previous album scope results when the host switches album', async () => {
+      searchSmartMock.mockResolvedValue(page(['asset-1']));
+      render(SmartSearchResultsHost, { props: { album: { id: 'album-1', name: 'a' }, filters: baseFilters } });
+      await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+      expect(screen.getByTestId('result-count')).toBeInTheDocument();
+
+      await fireEvent.click(screen.getByTestId('host-switch-album'));
+
+      expect(screen.getByTestId('search-loading')).toBeInTheDocument();
+      expect(screen.queryByTestId('result-count')).not.toBeInTheDocument();
+    });
+
+    it('does not blank when the host re-derives the album scope without changing it', async () => {
+      searchSmartMock.mockResolvedValue(page(['asset-1']));
+      render(SmartSearchResultsHost, { props: { album: { id: 'album-1', name: 'a' }, filters: baseFilters } });
+      await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+
+      await fireEvent.click(screen.getByTestId('host-rename-album'));
+
+      expect(screen.getByTestId('result-count')).toBeInTheDocument();
+      expect(screen.queryByTestId('search-loading')).not.toBeInTheDocument();
     });
   });
 

--- a/web/src/lib/components/search/smart-search-results.spec.ts
+++ b/web/src/lib/components/search/smart-search-results.spec.ts
@@ -371,6 +371,20 @@ describe('SmartSearchResults', () => {
       expect(searchSmartMock).toHaveBeenCalledTimes(1);
     });
 
+    // The blanked grid must show the spinner, not the empty state. Every searchable page resets its
+    // own `isLoading` to false in the same block that commits the new query, so the component has to
+    // re-assert loading afterwards — otherwise a new search flashes "no results" before it resolves,
+    // which reads as a worse bug than the stale results #1052 is about.
+    it('shows the loading state, not the empty state, when the host commits a search from the URL', async () => {
+      await renderHost();
+
+      await fireEvent.click(screen.getByTestId('host-commit-url-search'));
+
+      expect(resultIds()).toBe('');
+      expect(screen.getByTestId('search-loading')).toBeInTheDocument();
+      expect(screen.queryByTestId('search-empty')).not.toBeInTheDocument();
+    });
+
     it('keeps the current results on screen while a reload re-runs the same search', async () => {
       await renderHost();
 

--- a/web/src/lib/components/search/smart-search-results.spec.ts
+++ b/web/src/lib/components/search/smart-search-results.spec.ts
@@ -3,6 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getIntersectionObserverMock } from '$lib/__mocks__/intersection-observer.mock';
 import type { FilterState } from '$lib/components/filter-panel/filter-panel';
+import SmartSearchResultsRerunHost from '$lib/components/search/smart-search-results-rerun.test-host.svelte';
 import SmartSearchResults from '$lib/components/search/smart-search-results.svelte';
 import SmartSearchResultsHost from '$lib/components/search/smart-search-results.test-host.svelte';
 import { SEARCH_FILTER_DEBOUNCE_MS } from '$lib/utils/space-search';
@@ -301,6 +302,76 @@ describe('SmartSearchResults', () => {
     await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
 
     expect(getByTestId('result-count')).toHaveTextContent('spaces_search_result_count');
+  });
+
+  // #1052: a new search must blank the grid the moment it is triggered. Until it did, the previous
+  // query's photos stayed on screen — keeping their scroll offset — for the debounce plus the whole
+  // round trip, and a host remount replayed them from scratch.
+  describe('clearing previous results (#1052)', () => {
+    const renderHost = async () => {
+      searchSmartMock.mockResolvedValue({
+        assets: { items: [{ id: 'asset-1', originalFileName: 'beach.jpg' }], nextPage: null },
+      });
+      render(SmartSearchResultsRerunHost, { props: { filters: baseFilters } });
+      await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+      expect(screen.getByTestId('result-count')).toBeInTheDocument();
+    };
+
+    it('blanks the previous results as soon as a new query is submitted', async () => {
+      await renderHost();
+
+      await fireEvent.click(screen.getByTestId('host-new-search'));
+
+      // Deliberately no timer advance: the old results must be gone *before* the replacement lands.
+      expect(screen.getByTestId('search-loading')).toBeInTheDocument();
+      expect(screen.queryByTestId('result-count')).not.toBeInTheDocument();
+    });
+
+    it('blanks the previous results as soon as a filter change re-runs the search', async () => {
+      await renderHost();
+
+      await fireEvent.click(screen.getByTestId('host-add-filter'));
+
+      expect(screen.getByTestId('search-loading')).toBeInTheDocument();
+      expect(screen.queryByTestId('result-count')).not.toBeInTheDocument();
+    });
+
+    it('does not replay the previous search when the host re-mounts it for a new query', async () => {
+      await renderHost();
+
+      // Clearing the query unmounts the component, but the host keeps the loaded assets.
+      await fireEvent.click(screen.getByTestId('host-clear-search'));
+      await fireEvent.click(screen.getByTestId('host-new-search'));
+
+      expect(screen.getByTestId('search-loading')).toBeInTheDocument();
+      expect(screen.queryByTestId('result-count')).not.toBeInTheDocument();
+    });
+
+    it('keeps the current results on screen while a reload re-runs the same search', async () => {
+      await renderHost();
+
+      await fireEvent.click(screen.getByTestId('host-reload'));
+
+      // A reload restores results after an undone delete — same search, so nothing to blank.
+      expect(screen.getByTestId('result-count')).toBeInTheDocument();
+      expect(screen.queryByTestId('search-loading')).not.toBeInTheDocument();
+    });
+
+    it('shows the new results once they arrive', async () => {
+      await renderHost();
+
+      searchSmartMock.mockResolvedValue({
+        assets: { items: [{ id: 'asset-2', originalFileName: 'mountain.jpg' }], nextPage: null },
+      });
+      await fireEvent.click(screen.getByTestId('host-new-search'));
+      await vi.advanceTimersByTimeAsync(SEARCH_FILTER_DEBOUNCE_MS);
+
+      expect(screen.getByTestId('result-count')).toBeInTheDocument();
+      expect(screen.queryByTestId('search-loading')).not.toBeInTheDocument();
+      expect(searchSmartMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({ smartSearchDto: expect.objectContaining({ query: 'mountain' }) }),
+      );
+    });
   });
 
   // Test 57 — render assertion for isShared on the dumb grid

--- a/web/src/lib/components/search/smart-search-results.svelte
+++ b/web/src/lib/components/search/smart-search-results.svelte
@@ -63,6 +63,14 @@
   let searchPage = $state(1);
   let searchAbortController: AbortController | undefined;
 
+  /**
+   * Identity of the search whose assets are currently in `searchResults`, so a genuinely new search
+   * can blank them (#1052). Undefined until the first search runs, which is what makes a re-mount
+   * clear too: the HOST owns `results`, so mounting this component for a new query starts out
+   * rendering the *previous* query's assets.
+   */
+  let renderedSearchKey: string | undefined;
+
   const executeSearch = async (page: number, append: boolean) => {
     const query = searchQuery.trim();
     if (!query) {
@@ -121,10 +129,9 @@
   };
 
   $effect(() => {
-    // Track everything that should trigger a re-search
-    const _ = [
+    // Track everything that should trigger a re-search, and key the results on screen by it.
+    const searchKey = JSON.stringify([
       searchQuery,
-      reloadToken,
       // Navigating straight from one album to a sibling keeps this component mounted and only swaps
       // the scope, so it has to re-search like any other narrowing change. Tracked by CONTENT via
       // `albumScopeKey` — see its doc comment for why the array itself must not be read here.
@@ -144,10 +151,26 @@
       filters.sortOrder,
       filters.isFavorite,
       language,
-    ];
+    ]);
+
+    // Tracked so a bump re-runs the search, but deliberately kept OUT of `searchKey`: a reload
+    // re-runs the SAME search (restoring results after an undone delete) and must not blank the grid.
+    const _ = [reloadToken];
 
     if (!searchQuery.trim()) {
       return;
+    }
+
+    if (searchKey !== renderedSearchKey) {
+      renderedSearchKey = searchKey;
+      // #1052: drop the previous search's assets the moment a new one is triggered, before the
+      // debounce and the round trip. Left in place they read as results for the query just typed,
+      // and the grid keeps its old scroll offset, so the new results open part-way down the page.
+      // Clearing hands the scroll container back to the loading state, which starts at the top.
+      searchResults = [];
+      hasMoreResults = false;
+      searchPage = 1;
+      isLoading = true;
     }
 
     const timeout = setTimeout(() => {


### PR DESCRIPTION
Fixes #1052.

## The bug

Two symptoms, one cause — `smart-search-results.svelte` only ever replaced `searchResults` *after* the request resolved.

- **Same page, new search.** The previous query's photos stayed on screen, at their old scroll offset, for the 250 ms debounce plus the whole round trip. The new results then appeared part-way down the page.
- **Search → home → different search.** `results` is a `$bindable` owned by the **host** page, and every searchable page (`/photos`, `/recently-added`, space timelines, album detail) mounts the component only while there is a query. Clearing the search unmounted it but left the loaded assets on the host, so mounting it again for a new query replayed the old results from scratch.

## The fix

Key the loaded assets by the search that produced them, and blank them the moment that key changes — before the debounce, so nothing stale is ever shown against a query the user has already replaced. Emptying the grid hands the scroll container back to the loading state, which starts at the top, so the scroll position resets on its own.

`reloadToken` is deliberately kept **out** of the key: it re-runs the *same* search to restore results after an undone delete, and must not blank the grid.

The key is content-based (like the existing `albumScopeKey`), so a host re-deriving an equal `personIds`/`tagIds` array doesn't cause a gratuitous blank.

## Tests

13 tests in a new `clearing previous results (#1052)` block. **7 fail without the production change**; the other 6 are anti-regression guards against over-clearing.

Two pieces of harness make them honest:

- A test host that drives the component the way `/photos` does — host owns `results`, component mounted only while there's a query. `rerender` re-fires mount effects, so it cannot tell a re-mount from a re-run, which is exactly the distinction the second symptom turns on.
- A capturing `IntersectionObserver` mock, so the infinite-scroll sentinel can be driven and the paging state the fix resets (`searchPage`, `hasMoreResults`) is genuinely exercised — this retires the `loadMore` and concurrent-submit todos.

Covered edges: blank on new query / filter change / album-scope switch, blank survives the full debounce window, no replay on host re-mount, reload does *not* blank, append does *not* blank, pagination restarts at page 1 discarding loaded pages, a page still in flight when the query changes is discarded, a late response from the replaced query is ignored, and a failed new search leaves the grid empty rather than restoring the old results.

## Verification

- `smart-search-results.spec.ts`: 34 passed
- Full web unit suite: 5983 passed, 372 files, exit 0
- `svelte-check` 614 files / 0 errors / 0 warnings · `tsc --noEmit` · eslint · prettier — all clean

No user-facing strings changed, so no i18n updates.

## Known gaps

- No Playwright coverage: the only search e2e spec targets the legacy `/search?query=` page, not the `/photos?q=` smart-search surface. Adding one would mean building smart-search mock routes for `/photos`.
- Latent, not user-visible: if the component unmounts during the debounce, the host's bound `isLoading` stays `true`. All five hosts treat it as write-only (`= false` resets plus `bind:`) and never read it, so nothing renders on it today.

https://claude.ai/code/session_01MxGfXDLiyrfYKm3isfvP2t