### PR TITLE
fix(server): download a Space album's contributions, not just the owner's photos (#1048)

### DIFF
--- a/server/src/repositories/download.repository.ts
+++ b/server/src/repositories/download.repository.ts
@@ -25,17 +25,36 @@ export class DownloadRepository {
     return builder(this.db).select(['asset.originalPath']).where('asset.id', '=', anyUuid(ids)).stream();
   }
 
-  downloadAlbumId(albumId: string) {
-    return (
-      builder(this.db)
-        .innerJoin('album_asset', 'asset.id', 'album_asset.assetId')
-        .where('album_asset.albumId', '=', albumId)
-        // rbac-8 (no functional change): flat visibility gate — NO owner exception — so an album-archive
-        // export omits Hidden/Locked rows for everyone, matching the album grid (withDefaultVisibility) and
-        // map-markers. An `own OR` here would let the owner download Hidden while the grid hides it.
-        .where((eb) => spaceVisibilityGate(eb))
-        .stream()
-    );
+  /**
+   * #1048: `albumSpaceIds` are the live member-spaces the SERVICE resolved for this caller
+   * (`getAlbumSpaceIds`) — the viewer's spaces linking the album, or the single tethered space of a
+   * share link. When set, the archive unions the cross-owner `album_space_asset` contributions
+   * (#764) the album grid already shows; a personal album, an `album_user` share and a spaceless
+   * link all resolve none and read `album_asset` alone, exactly as before. Same contract as
+   * `AssetRepository`'s album arm, so browse and download can't disagree.
+   */
+  downloadAlbumId(albumId: string, albumSpaceIds?: string[]) {
+    const ownerRows = builder(this.db)
+      .innerJoin('album_asset', 'asset.id', 'album_asset.assetId')
+      .where('album_asset.albumId', '=', albumId)
+      // rbac-8 (no functional change): flat visibility gate — NO owner exception — so an album-archive
+      // export omits Hidden/Locked rows for everyone, matching the album grid (withDefaultVisibility) and
+      // map-markers. An `own OR` here would let the owner download Hidden while the grid hides it.
+      .where((eb) => spaceVisibilityGate(eb));
+
+    if (!albumSpaceIds?.length) {
+      return ownerRows.stream();
+    }
+
+    const contributed = builder(this.db)
+      .innerJoin('album_space_asset', 'asset.id', 'album_space_asset.assetId')
+      .where('album_space_asset.albumId', '=', albumId)
+      .where('album_space_asset.spaceId', '=', anyUuid(albumSpaceIds))
+      .where((eb) => spaceVisibilityGate(eb));
+
+    // UNION (not ALL) dedupes the P1-6 coexistence window, where the same asset carries both an
+    // `album_asset` and an `album_space_asset` row — the archive must list it once.
+    return ownerRows.union(contributed).stream();
   }
 
   downloadUserId(userId: string) {
@@ -66,6 +85,23 @@ export class DownloadRepository {
       .where('shared_space_album.spaceId', '=', spaceId)
       .where((eb) => spaceVisibilityGate(eb));
 
-    return direct.union(library).union(album).stream();
+    // #1048: the linked album's cross-owner contributions (#764) — the fourth path a space shows.
+    // Correlated on BOTH albumId and spaceId so a contribution is only ever reachable through the
+    // one space it was made to, and requires a live `shared_space_album` link, so a retained
+    // contribution row of an unlinked album stays inert.
+    const contributed = builder(this.db)
+      .innerJoin('album_space_asset', 'asset.id', 'album_space_asset.assetId')
+      .innerJoin('shared_space_album', (join) =>
+        join
+          .onRef('shared_space_album.albumId', '=', 'album_space_asset.albumId')
+          .onRef('shared_space_album.spaceId', '=', 'album_space_asset.spaceId'),
+      )
+      .innerJoin('album', (join) =>
+        join.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
+      )
+      .where('shared_space_album.spaceId', '=', spaceId)
+      .where((eb) => spaceVisibilityGate(eb));
+
+    return direct.union(library).union(album).union(contributed).stream();
   }
 }

--- a/server/src/repositories/download.repository.ts
+++ b/server/src/repositories/download.repository.ts
@@ -40,7 +40,13 @@ export class DownloadRepository {
       // rbac-8 (no functional change): flat visibility gate — NO owner exception — so an album-archive
       // export omits Hidden/Locked rows for everyone, matching the album grid (withDefaultVisibility) and
       // map-markers. An `own OR` here would let the owner download Hidden while the grid hides it.
-      .where((eb) => spaceVisibilityGate(eb));
+      .where((eb) => spaceVisibilityGate(eb))
+      // #1048: both album arms mirror `AccessRepository.asset.checkSpaceAccess`, whose album and
+      // contributed arms BOTH require `isOffline = false`. The manifest this builds is re-checked
+      // asset-by-asset under `AssetDownload` before the zip is streamed, and `requireAccess` is
+      // all-or-nothing — so a single offline row here does not merely go missing from the archive,
+      // it 400s the entire download for anyone whose only route to it is the space.
+      .where('asset.isOffline', '=', false);
 
     if (!albumSpaceIds?.length) {
       return ownerRows.stream();
@@ -50,7 +56,8 @@ export class DownloadRepository {
       .innerJoin('album_space_asset', 'asset.id', 'album_space_asset.assetId')
       .where('album_space_asset.albumId', '=', albumId)
       .where('album_space_asset.spaceId', '=', anyUuid(albumSpaceIds))
-      .where((eb) => spaceVisibilityGate(eb));
+      .where((eb) => spaceVisibilityGate(eb))
+      .where('asset.isOffline', '=', false);
 
     // UNION (not ALL) dedupes the P1-6 coexistence window, where the same asset carries both an
     // `album_asset` and an `album_space_asset` row — the archive must list it once.
@@ -65,6 +72,9 @@ export class DownloadRepository {
   }
 
   downloadSpaceId(spaceId: string) {
+    // Per-arm `isOffline` handling below deliberately mirrors `checkSpaceAccess` arm for arm: the
+    // directly-added arm has NO offline gate there, the library / album / contributed arms all do.
+    // Keep them aligned — an arm the manifest includes but the gate rejects 400s the whole download.
     const direct = builder(this.db)
       .innerJoin('shared_space_asset', 'asset.id', 'shared_space_asset.assetId')
       .where('shared_space_asset.spaceId', '=', spaceId)
@@ -83,7 +93,8 @@ export class DownloadRepository {
         join.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
       )
       .where('shared_space_album.spaceId', '=', spaceId)
-      .where((eb) => spaceVisibilityGate(eb));
+      .where((eb) => spaceVisibilityGate(eb))
+      .where('asset.isOffline', '=', false);
 
     // #1048: the linked album's cross-owner contributions (#764) — the fourth path a space shows.
     // Correlated on BOTH albumId and spaceId so a contribution is only ever reachable through the
@@ -100,7 +111,8 @@ export class DownloadRepository {
         join.onRef('album.id', '=', 'shared_space_album.albumId').on('album.deletedAt', 'is', null),
       )
       .where('shared_space_album.spaceId', '=', spaceId)
-      .where((eb) => spaceVisibilityGate(eb));
+      .where((eb) => spaceVisibilityGate(eb))
+      .where('asset.isOffline', '=', false);
 
     return direct.union(library).union(album).union(contributed).stream();
   }

--- a/server/src/services/download.service.spec.ts
+++ b/server/src/services/download.service.spec.ts
@@ -1,7 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
 import { Readable } from 'node:stream';
 import { DownloadResponseDto } from 'src/dtos/download.dto';
-import { AssetType } from 'src/enum';
+import { AssetType, SharedSpaceRole } from 'src/enum';
 import { DownloadService } from 'src/services/download.service';
 import { StorageService } from 'src/services/storage.service';
 import { AssetFactory } from 'test/factories/asset.factory';
@@ -19,6 +19,17 @@ const downloadResponse: DownloadResponseDto = {
     },
   ],
 };
+
+const albumStream = () =>
+  makeStream([
+    { id: 'asset-1', livePhotoVideoId: null, size: 100_000 },
+    { id: 'asset-2', livePhotoVideoId: null, size: 5000 },
+  ]);
+
+const albumLinkAuth = (spaceId: string | null) => ({
+  user: authStub.admin.user,
+  sharedLink: { ...authStub.adminSharedLink.sharedLink, albumId: 'album-1', spaceId },
+});
 
 describe(DownloadService.name, () => {
   let sut: DownloadService;
@@ -562,6 +573,7 @@ describe(DownloadService.name, () => {
     it('should return a list of archives (albumId)', async () => {
       mocks.user.getMetadata.mockResolvedValue([]);
       mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set(['album-1']));
+      mocks.sharedSpace.getMemberSpaceIdsLinkingAlbum.mockResolvedValue([]);
       mocks.downloadRepository.downloadAlbumId.mockReturnValue(
         makeStream([
           { id: 'asset-1', livePhotoVideoId: null, size: 100_000 },
@@ -572,7 +584,68 @@ describe(DownloadService.name, () => {
       await expect(sut.getDownloadInfo(authStub.admin, { albumId: 'album-1' })).resolves.toEqual(downloadResponse);
 
       expect(mocks.access.album.checkOwnerAccess).toHaveBeenCalledWith(authStub.admin.user.id, new Set(['album-1']));
-      expect(mocks.downloadRepository.downloadAlbumId).toHaveBeenCalledWith('album-1');
+      expect(mocks.downloadRepository.downloadAlbumId).toHaveBeenCalledWith('album-1', undefined);
+    });
+
+    // #1048: a space-linked album shows cross-owner contributions (#764) in the grid and through a
+    // share link created from the space (#1018). The archive is scoped by the SAME space ids the
+    // album browse resolves, so "download all" ships what the page showed.
+    describe('albumId — cross-owner contributions', () => {
+      beforeEach(() => {
+        mocks.user.getMetadata.mockResolvedValue([]);
+        mocks.access.album.checkOwnerAccess.mockResolvedValue(new Set(['album-1']));
+        mocks.access.album.checkSharedLinkAccess.mockResolvedValue(new Set(['album-1']));
+        mocks.downloadRepository.downloadAlbumId.mockReturnValue(albumStream());
+      });
+
+      it("scopes an authenticated download to the viewer's live member-spaces linking the album", async () => {
+        mocks.sharedSpace.getMemberSpaceIdsLinkingAlbum.mockResolvedValue(['space-1', 'space-2']);
+
+        await expect(sut.getDownloadInfo(authStub.admin, { albumId: 'album-1' })).resolves.toEqual(downloadResponse);
+
+        expect(mocks.sharedSpace.getMemberSpaceIdsLinkingAlbum).toHaveBeenCalledWith('album-1', authStub.admin.user.id);
+        expect(mocks.downloadRepository.downloadAlbumId).toHaveBeenCalledWith('album-1', ['space-1', 'space-2']);
+      });
+
+      it('resolves no space scope when the album is not linked to any space the viewer belongs to', async () => {
+        mocks.sharedSpace.getMemberSpaceIdsLinkingAlbum.mockResolvedValue([]);
+
+        await expect(sut.getDownloadInfo(authStub.admin, { albumId: 'album-1' })).resolves.toEqual(downloadResponse);
+
+        expect(mocks.downloadRepository.downloadAlbumId).toHaveBeenCalledWith('album-1', undefined);
+      });
+
+      it("scopes a shared link to the ONE space it was created from, never the creator's other spaces", async () => {
+        mocks.sharedSpace.getMemberSpaceIdsLinkingAlbum.mockResolvedValue(['space-1', 'space-2']);
+
+        await expect(sut.getDownloadInfo(albumLinkAuth('space-1'), { albumId: 'album-1' })).resolves.toEqual(
+          downloadResponse,
+        );
+
+        expect(mocks.sharedSpace.getMemberSpaceIdsLinkingAlbum).toHaveBeenCalledWith('album-1', '42', {
+          roles: [SharedSpaceRole.Owner, SharedSpaceRole.Editor],
+        });
+        expect(mocks.downloadRepository.downloadAlbumId).toHaveBeenCalledWith('album-1', ['space-1']);
+      });
+
+      it('resolves no space scope for a shared link whose creator no longer holds a publisher role', async () => {
+        mocks.sharedSpace.getMemberSpaceIdsLinkingAlbum.mockResolvedValue([]);
+
+        await expect(sut.getDownloadInfo(albumLinkAuth('space-1'), { albumId: 'album-1' })).resolves.toEqual(
+          downloadResponse,
+        );
+
+        expect(mocks.downloadRepository.downloadAlbumId).toHaveBeenCalledWith('album-1', undefined);
+      });
+
+      it('resolves no space scope for a link with no space (every pre-#1018 link)', async () => {
+        await expect(sut.getDownloadInfo(albumLinkAuth(null), { albumId: 'album-1' })).resolves.toEqual(
+          downloadResponse,
+        );
+
+        expect(mocks.sharedSpace.getMemberSpaceIdsLinkingAlbum).not.toHaveBeenCalled();
+        expect(mocks.downloadRepository.downloadAlbumId).toHaveBeenCalledWith('album-1', undefined);
+      });
     });
 
     it('should return a list of archives (userId)', async () => {

--- a/server/src/services/download.service.ts
+++ b/server/src/services/download.service.ts
@@ -9,6 +9,7 @@ import { Permission } from 'src/enum';
 import { StorageBackend } from 'src/interfaces/storage-backend.interface';
 import { BaseService } from 'src/services/base.service';
 import { StorageService } from 'src/services/storage.service';
+import { getAlbumSpaceIds } from 'src/utils/album-space-ids';
 import { HumanReadableSize } from 'src/utils/bytes';
 import { getPreferences } from 'src/utils/preferences';
 
@@ -78,7 +79,11 @@ export class DownloadService extends BaseService {
     } else if (dto.albumId) {
       const albumId = dto.albumId;
       await this.requireAccess({ auth, permission: Permission.AlbumDownload, ids: [albumId] });
-      assets = this.downloadRepository.downloadAlbumId(albumId);
+      // #1048: a space-linked album shows cross-owner contributions (#764) — in the grid, and
+      // through a link created from the space (#1018). Scope the archive by the SAME space ids the
+      // album browse resolves, or "download all" silently ships only the album owner's own photos.
+      const albumSpaceIds = await getAlbumSpaceIds({ auth, albumId, repository: this.sharedSpaceRepository });
+      assets = this.downloadRepository.downloadAlbumId(albumId, albumSpaceIds);
     } else if (dto.userId) {
       const userId = dto.userId;
       await this.requireAccess({ auth, permission: Permission.TimelineDownload, ids: [userId] });

--- a/server/src/services/timeline.service.ts
+++ b/server/src/services/timeline.service.ts
@@ -11,8 +11,8 @@ import { AssetVisibility, Permission, TimeBucketSize } from 'src/enum';
 import { TimeBucketOptions } from 'src/repositories/asset.repository';
 import { BaseService } from 'src/services/base.service';
 import { requireElevatedPermission } from 'src/utils/access';
+import { getAlbumSpaceIds } from 'src/utils/album-space-ids';
 import { getMyPartnerIds } from 'src/utils/asset.util';
-import { sharedLinkPublisherRoles } from 'src/utils/shared-link-space-tether';
 import { normalizeTimeBucketForBucketSize } from 'src/utils/timeline-bucket';
 
 @Injectable()
@@ -87,37 +87,12 @@ export class TimelineService extends BaseService {
       }
     }
 
-    let albumSpaceIds: string[] | undefined;
     // #752 P0-2: album browse — resolve the viewer's live member-spaces linking this album so the
-    // repository unions member-gated contributions.
-    if (dto.albumId) {
-      if (auth.sharedLink) {
-        // #1018: a shared link resolves at most the ONE space it was created from, never the link
-        // creator's full membership — that would leak a contribution from any OTHER space they
-        // happen to share the album into. Both halves of the tether are re-checked here: the album
-        // must still be linked to that space, and the creator must still be a member of it (which
-        // is exactly what getMemberSpaceIdsLinkingAlbum returns). A link with no space — every
-        // pre-#1018 link, and every album_user share — resolves none, as before.
-        const linkSpaceId = auth.sharedLink.spaceId;
-        if (linkSpaceId) {
-          // Role-gated for the same reason the access tether is: a creator demoted to Viewer no
-          // longer holds the authority that published the contributions.
-          const ids = await this.sharedSpaceRepository.getMemberSpaceIdsLinkingAlbum(
-            dto.albumId,
-            auth.sharedLink.userId,
-            { roles: sharedLinkPublisherRoles },
-          );
-          if (ids.includes(linkSpaceId)) {
-            albumSpaceIds = [linkSpaceId];
-          }
-        }
-      } else {
-        const ids = await this.sharedSpaceRepository.getMemberSpaceIdsLinkingAlbum(dto.albumId, auth.user.id);
-        if (ids.length > 0) {
-          albumSpaceIds = ids;
-        }
-      }
-    }
+    // repository unions member-gated contributions. Shared with the album archive (#1048) so the
+    // grid and "download all" can never disagree about what the album contains.
+    const albumSpaceIds = dto.albumId
+      ? await getAlbumSpaceIds({ auth, albumId: dto.albumId, repository: this.sharedSpaceRepository })
+      : undefined;
 
     const scopedOptions = await this.resolveScopedPersonFilters(auth, { ...options, timelineSpaceIds });
 

--- a/server/src/utils/album-space-ids.ts
+++ b/server/src/utils/album-space-ids.ts
@@ -1,0 +1,53 @@
+// Fork-owned resolver for the "which spaces does this album browse read contributions from?"
+// question — the service-side counterpart to the SQL arms in `shared-space-album-scope.ts`.
+//
+// A space-linked album's contents are the album owner's own `album_asset` rows UNION the cross-owner
+// `album_space_asset` contributions (#764). The contributed half is never granted blindly: every
+// read re-derives it from live space state, scoped to the space ids resolved HERE. Two callers need
+// the same answer — the album time-bucket browse (`timeline.service`) and the album archive
+// (`download.service`, #1048) — and they must agree, or "download all" ships something other than
+// what the grid just showed.
+import { AuthDto } from 'src/dtos/auth.dto';
+import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
+import { sharedLinkPublisherRoles } from 'src/utils/shared-link-space-tether';
+
+/**
+ * The live member-spaces whose contributions `albumId` may surface for this caller, or `undefined`
+ * when there are none (a personal album, an `album_user` share, a pre-#1018 spaceless link) — in
+ * which case the caller falls back to `album_asset` alone, exactly as before #764.
+ *
+ * - **Shared link**: at most the ONE space the link was created from, never the creator's full
+ *   membership — that would leak a contribution from any OTHER space they happen to share the album
+ *   into. Role-gated for the same reason the access tether is (#1018): a creator demoted to Viewer no
+ *   longer holds the authority that published the contributions.
+ * - **Authenticated**: every space the viewer is a live member of that currently links the album,
+ *   any role. Not preference-filtered — a member who hid the space from their home timeline still
+ *   sees the album's contributions on the album itself.
+ *
+ * Both branches go through `getMemberSpaceIdsLinkingAlbum`, which enforces the live album↔space
+ * link, live membership, and A1 (album not soft-deleted).
+ */
+export const getAlbumSpaceIds = async ({
+  auth,
+  albumId,
+  repository,
+}: {
+  auth: AuthDto;
+  albumId: string;
+  repository: SharedSpaceRepository;
+}): Promise<string[] | undefined> => {
+  if (auth.sharedLink) {
+    const linkSpaceId = auth.sharedLink.spaceId;
+    if (!linkSpaceId) {
+      return undefined;
+    }
+
+    const spaceIds = await repository.getMemberSpaceIdsLinkingAlbum(albumId, auth.sharedLink.userId, {
+      roles: sharedLinkPublisherRoles,
+    });
+    return spaceIds.includes(linkSpaceId) ? [linkSpaceId] : undefined;
+  }
+
+  const spaceIds = await repository.getMemberSpaceIdsLinkingAlbum(albumId, auth.user.id);
+  return spaceIds.length > 0 ? spaceIds : undefined;
+};

--- a/server/test/medium/specs/repositories/download.repository.spec.ts
+++ b/server/test/medium/specs/repositories/download.repository.spec.ts
@@ -304,3 +304,161 @@ describe('DownloadRepository.downloadAlbumId', () => {
     // Locked cannot be placed in albums (see service-layer invariant above).
   });
 });
+
+// ---------------------------------------------------------------------------
+// #1048: cross-owner contributions (#764) inside a space-linked album. The album
+// grid — and an album share link created from the space (#1018) — both show the
+// other members' photos, so the album archive must contain them too. Before this
+// the album arm read `album_asset` alone and silently shipped only the album
+// owner's own photos.
+//
+// The contributed arm is gated on the space ids the SERVICE resolved (live
+// member-spaces linking the album, or the single tethered space of a link), the
+// same contract `AssetRepository`'s album arm uses — so a plain album_user share
+// or a spaceless link resolves none and nothing widens.
+// ---------------------------------------------------------------------------
+const seedContributedAlbum = async () => {
+  const { ctx, sut, spaceRepo } = setup();
+  const { user: owner } = await ctx.newUser();
+  const { user: contributor } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: contributor.id, role: 'editor' });
+
+  const { asset: ownAsset } = await ctx.newAsset({ ownerId: owner.id });
+  await ctx.newExif({ assetId: ownAsset.id, fileSizeInByte: 1024 });
+  const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Space album' }, [ownAsset.id]);
+  await spaceRepo.addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+
+  const { asset: contributed } = await ctx.newAsset({ ownerId: contributor.id });
+  await ctx.newExif({ assetId: contributed.id, fileSizeInByte: 2048 });
+  await ctx.newAlbumSpaceAsset({
+    albumId: album.id,
+    assetId: contributed.id,
+    spaceId: space.id,
+    addedById: contributor.id,
+  });
+
+  return { ctx, sut, spaceRepo, owner, contributor, space, album, ownAsset, contributed };
+};
+
+describe('DownloadRepository.downloadAlbumId — cross-owner contributions', () => {
+  it("includes another member's contribution when the album's space is in scope", async () => {
+    const { sut, album, space, ownAsset, contributed } = await seedContributedAlbum();
+
+    const ids = await collectIds(sut.downloadAlbumId(album.id, [space.id]));
+
+    expect(ids.has(ownAsset.id)).toBe(true);
+    expect(ids.has(contributed.id)).toBe(true);
+  });
+
+  it('omits contributions when no space scope is resolved (plain album share)', async () => {
+    const { sut, album, ownAsset, contributed } = await seedContributedAlbum();
+
+    const ids = await collectIds(sut.downloadAlbumId(album.id));
+
+    expect(ids.has(ownAsset.id)).toBe(true);
+    expect(ids.has(contributed.id)).toBe(false);
+  });
+
+  it('omits a contribution tethered to a different space', async () => {
+    const { ctx, sut, owner, album, ownAsset, contributed } = await seedContributedAlbum();
+    const { space: otherSpace } = await ctx.newSharedSpace({ createdById: owner.id });
+
+    const ids = await collectIds(sut.downloadAlbumId(album.id, [otherSpace.id]));
+
+    expect(ids.has(ownAsset.id)).toBe(true);
+    expect(ids.has(contributed.id)).toBe(false);
+  });
+
+  it('excludes a Hidden contribution, includes an Archive one', async () => {
+    const { ctx, sut, contributor, space, album, contributed } = await seedContributedAlbum();
+
+    const { asset: archived } = await ctx.newAsset({ ownerId: contributor.id, visibility: AssetVisibility.Archive });
+    await ctx.newExif({ assetId: archived.id, fileSizeInByte: 2048 });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: archived.id, spaceId: space.id });
+
+    await ctx.database
+      .updateTable('asset')
+      .set({ visibility: AssetVisibility.Hidden })
+      .where('id', '=', contributed.id)
+      .execute();
+
+    const ids = await collectIds(sut.downloadAlbumId(album.id, [space.id]));
+
+    expect(ids.has(archived.id)).toBe(true);
+    expect(ids.has(contributed.id)).toBe(false);
+  });
+
+  it('excludes a soft-deleted contribution', async () => {
+    const { ctx, sut, space, album, contributed } = await seedContributedAlbum();
+    await ctx.softDeleteAsset(contributed.id);
+
+    const ids = await collectIds(sut.downloadAlbumId(album.id, [space.id]));
+
+    expect(ids.has(contributed.id)).toBe(false);
+  });
+
+  it('yields an asset once when it is both an album member and a contribution', async () => {
+    const { ctx, sut, space, album, ownAsset } = await seedContributedAlbum();
+    // P1-6 coexistence window: the same asset carries an album_asset AND an
+    // album_space_asset row. The archive must not list it twice.
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: ownAsset.id, spaceId: space.id });
+
+    const rows: string[] = [];
+    for await (const row of sut.downloadAlbumId(album.id, [space.id])) {
+      rows.push(row.id);
+    }
+
+    expect(rows.filter((id) => id === ownAsset.id)).toHaveLength(1);
+  });
+});
+
+describe('DownloadRepository.downloadSpaceId — cross-owner contributions', () => {
+  it("includes another member's contribution to a linked album", async () => {
+    const { ctx, sut, spaceRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: contributor } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: owner.id, role: 'owner' });
+    await ctx.newSharedSpaceMember({ spaceId: space.id, userId: contributor.id, role: 'editor' });
+
+    const { asset: ownAsset } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newExif({ assetId: ownAsset.id, fileSizeInByte: 1024 });
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Space album' }, [ownAsset.id]);
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+
+    const { asset: contributed } = await ctx.newAsset({ ownerId: contributor.id });
+    await ctx.newExif({ assetId: contributed.id, fileSizeInByte: 2048 });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: contributed.id, spaceId: space.id });
+
+    const ids = await collectIds(sut.downloadSpaceId(space.id));
+
+    expect(ids.has(ownAsset.id)).toBe(true);
+    expect(ids.has(contributed.id)).toBe(true);
+  });
+
+  it('excludes a contribution whose album has been unlinked from the space', async () => {
+    const { ctx, sut, spaceRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: contributor } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+
+    const { asset: ownAsset } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newExif({ assetId: ownAsset.id, fileSizeInByte: 1024 });
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Unlinked' }, [ownAsset.id]);
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+
+    const { asset: contributed } = await ctx.newAsset({ ownerId: contributor.id });
+    await ctx.newExif({ assetId: contributed.id, fileSizeInByte: 2048 });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: contributed.id, spaceId: space.id });
+
+    // Unlinking drops shared_space_album; the album_space_asset row is retained but inert.
+    await spaceRepo.removeAlbum(space.id, album.id);
+
+    const ids = await collectIds(sut.downloadSpaceId(space.id));
+
+    expect(ids.has(ownAsset.id)).toBe(false);
+    expect(ids.has(contributed.id)).toBe(false);
+  });
+});

--- a/server/test/medium/specs/repositories/download.repository.spec.ts
+++ b/server/test/medium/specs/repositories/download.repository.spec.ts
@@ -461,4 +461,89 @@ describe('DownloadRepository.downloadSpaceId — cross-owner contributions', () 
     expect(ids.has(ownAsset.id)).toBe(false);
     expect(ids.has(contributed.id)).toBe(false);
   });
+
+  it('excludes an OFFLINE contribution and an OFFLINE album asset, but keeps a directly-added one', async () => {
+    // Deliberate asymmetry, mirrored from `checkSpaceAccess`: its album and contributed arms gate
+    // `isOffline = false`, its directly-added arm does not. The download manifest must match the
+    // gate arm for arm — a row the gate rejects 400s the whole download, not just that row.
+    const { ctx, sut, spaceRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: contributor } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+    const { library } = await ctx.newLibrary({ ownerId: owner.id });
+
+    const seedOffline = async (ownerId: string) => {
+      const { asset } = await ctx.newAsset({ ownerId, libraryId: library.id, isOffline: true });
+      await ctx.newExif({ assetId: asset.id, fileSizeInByte: 1024 });
+      return asset;
+    };
+
+    const offlineDirect = await seedOffline(owner.id);
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: offlineDirect.id });
+
+    const offlineAlbumAsset = await seedOffline(owner.id);
+    const offlineContribution = await seedOffline(contributor.id);
+    const { asset: online } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newExif({ assetId: online.id, fileSizeInByte: 1024 });
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Offline mix' }, [
+      online.id,
+      offlineAlbumAsset.id,
+    ]);
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: offlineContribution.id, spaceId: space.id });
+
+    const ids = await collectIds(sut.downloadSpaceId(space.id));
+
+    expect(ids.has(online.id)).toBe(true);
+    expect(ids.has(offlineDirect.id)).toBe(true);
+    expect(ids.has(offlineAlbumAsset.id)).toBe(false);
+    expect(ids.has(offlineContribution.id)).toBe(false);
+  });
+
+  it('excludes a contribution to a linked album that has since been trashed', async () => {
+    const { ctx, sut, spaceRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: contributor } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+
+    const { asset: ownAsset } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newExif({ assetId: ownAsset.id, fileSizeInByte: 1024 });
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Trashed' }, [ownAsset.id]);
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+
+    const { asset: contributed } = await ctx.newAsset({ ownerId: contributor.id });
+    await ctx.newExif({ assetId: contributed.id, fileSizeInByte: 2048 });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: contributed.id, spaceId: space.id });
+
+    await ctx.softDeleteAlbum(album.id);
+
+    const ids = await collectIds(sut.downloadSpaceId(space.id));
+
+    expect(ids.has(ownAsset.id)).toBe(false);
+    expect(ids.has(contributed.id)).toBe(false);
+  });
+
+  it('yields an asset once when it is reachable both directly and as a contribution', async () => {
+    const { ctx, sut, spaceRepo } = setup();
+    const { user: owner } = await ctx.newUser();
+    const { user: contributor } = await ctx.newUser();
+    const { space } = await ctx.newSharedSpace({ createdById: owner.id });
+
+    const { asset: ownAsset } = await ctx.newAsset({ ownerId: owner.id });
+    await ctx.newExif({ assetId: ownAsset.id, fileSizeInByte: 1024 });
+    const { result: album } = await ctx.newAlbum({ ownerId: owner.id, albumName: 'Both paths' }, [ownAsset.id]);
+    await spaceRepo.addAlbum({ spaceId: space.id, albumId: album.id, addedById: owner.id });
+
+    const { asset: contributed } = await ctx.newAsset({ ownerId: contributor.id });
+    await ctx.newExif({ assetId: contributed.id, fileSizeInByte: 2048 });
+    await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: contributed.id, spaceId: space.id });
+    await ctx.newSharedSpaceAsset({ spaceId: space.id, assetId: contributed.id });
+
+    const rows: string[] = [];
+    for await (const row of sut.downloadSpaceId(space.id)) {
+      rows.push(row.id);
+    }
+
+    expect(rows.filter((id) => id === contributed.id)).toHaveLength(1);
+  });
 });

--- a/server/test/medium/specs/services/download.service.spec.ts
+++ b/server/test/medium/specs/services/download.service.spec.ts
@@ -11,6 +11,7 @@
  * two are asserted together.
  */
 import { Kysely } from 'kysely';
+import { StorageCore } from 'src/cores/storage.core';
 import { SharedLinkType, SharedSpaceRole } from 'src/enum';
 import { AccessRepository } from 'src/repositories/access.repository';
 import { AlbumRepository } from 'src/repositories/album.repository';
@@ -42,6 +43,8 @@ const setup = () =>
   });
 
 beforeAll(async () => {
+  // getDownloadInfo's live-photo branch reads StorageCore.isAndroidMotionPath.
+  StorageCore.setMediaLocation('/tmp/test-immich-media');
   defaultDatabase = await getKyselyDB();
 });
 
@@ -72,6 +75,36 @@ const seedSpaceAlbum = async () => {
   });
 
   return { sut, ctx, sharer, contributor, space, album, ownAsset, contributed };
+};
+
+const seedOfflineContribution = async () => {
+  const seeded = await seedSpaceAlbum();
+  const { ctx, contributor, space, album } = seeded;
+  const { library } = await ctx.newLibrary({ ownerId: contributor.id });
+  const { asset: offline } = await ctx.newAsset({
+    ownerId: contributor.id,
+    libraryId: library.id,
+    isOffline: true,
+  });
+  await ctx.newExif({ assetId: offline.id, fileSizeInByte: 2048 });
+  await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: offline.id, spaceId: space.id });
+  return { ...seeded, offline };
+};
+
+const seedTwoSpaces = async () => {
+  const seeded = await seedSpaceAlbum();
+  const { ctx, sharer, album } = seeded;
+  const { user: outsider } = await ctx.newUser();
+  const { space: otherSpace } = await ctx.newSharedSpace({ createdById: sharer.id });
+  await ctx.newSharedSpaceMember({ spaceId: otherSpace.id, userId: sharer.id, role: SharedSpaceRole.Owner });
+  await ctx.newSharedSpaceMember({ spaceId: otherSpace.id, userId: outsider.id, role: SharedSpaceRole.Editor });
+  await ctx.get(SharedSpaceRepository).addAlbum({ spaceId: otherSpace.id, albumId: album.id, addedById: sharer.id });
+
+  const { asset: otherContribution } = await ctx.newAsset({ ownerId: outsider.id });
+  await ctx.newExif({ assetId: otherContribution.id, fileSizeInByte: 4096 });
+  await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: otherContribution.id, spaceId: otherSpace.id });
+
+  return { ...seeded, otherSpace, otherContribution };
 };
 
 const manifestIds = (response: { archives: { assetIds: string[] }[] }) =>
@@ -165,5 +198,120 @@ describe(`${DownloadService.name} — space-linked album (#1048)`, () => {
     const ids = manifestIds(await sut.getDownloadInfo(auth, { albumId: album.id }));
 
     expect(ids).toEqual(new Set([ownAsset.id]));
+  });
+
+  // -------------------------------------------------------------------------
+  // The manifest and the gate must agree. `downloadArchive` re-checks every id
+  // under `AssetDownload` and `requireAccess` is all-or-nothing, so one row the
+  // gate rejects does not go quietly missing — it 400s the whole download.
+  // -------------------------------------------------------------------------
+  describe('manifest never outruns the AssetDownload gate', () => {
+    it('omits an OFFLINE contribution rather than 400-ing the member download', async () => {
+      const { sut, ctx, contributor, ownAsset, contributed, album, offline } = await seedOfflineContribution();
+      const auth = factory.auth({ user: contributor });
+
+      const ids = manifestIds(await sut.getDownloadInfo(auth, { albumId: album.id }));
+
+      expect(ids).toEqual(new Set([ownAsset.id, contributed.id]));
+      expect(ids.has(offline.id)).toBe(false);
+      await expect(ctx.get(AccessRepository).asset.checkSpaceAccess(contributor.id, ids)).resolves.toEqual(ids);
+    });
+
+    it('omits an OFFLINE asset the album OWNER contributed to the space', async () => {
+      const { sut, ctx, sharer, space, album, ownAsset, contributed } = await seedSpaceAlbum();
+      const { user: member } = await ctx.newUser();
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id, role: SharedSpaceRole.Viewer });
+
+      const { library } = await ctx.newLibrary({ ownerId: sharer.id });
+      const { asset: offline } = await ctx.newAsset({ ownerId: sharer.id, libraryId: library.id, isOffline: true });
+      await ctx.newExif({ assetId: offline.id, fileSizeInByte: 2048 });
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: offline.id });
+
+      const ids = manifestIds(await sut.getDownloadInfo(factory.auth({ user: member }), { albumId: album.id }));
+
+      expect(ids).toEqual(new Set([ownAsset.id, contributed.id]));
+      await expect(ctx.get(AccessRepository).asset.checkSpaceAccess(member.id, ids)).resolves.toEqual(ids);
+    });
+
+    it("carries a contributed live photo's motion part, and the gate grants it on both paths", async () => {
+      const { sut, ctx, sharer, contributor, space, album, ownAsset, contributed } = await seedSpaceAlbum();
+
+      const { asset: motion } = await ctx.newAsset({ ownerId: contributor.id });
+      await ctx.newExif({ assetId: motion.id, fileSizeInByte: 500 });
+      const { asset: still } = await ctx.newAsset({ ownerId: contributor.id, livePhotoVideoId: motion.id });
+      await ctx.newExif({ assetId: still.id, fileSizeInByte: 2048 });
+      await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: still.id, spaceId: space.id });
+
+      const expected = new Set([ownAsset.id, contributed.id, still.id, motion.id]);
+
+      const memberIds = manifestIds(
+        await sut.getDownloadInfo(factory.auth({ user: contributor }), { albumId: album.id }),
+      );
+      expect(memberIds).toEqual(expected);
+      await expect(ctx.get(AccessRepository).asset.checkSpaceAccess(contributor.id, memberIds)).resolves.toEqual(
+        memberIds,
+      );
+
+      const { sharedLink } = await ctx.newSharedLink({
+        userId: sharer.id,
+        type: SharedLinkType.Album,
+        albumId: album.id,
+        spaceId: space.id,
+      });
+      const linkIds = manifestIds(
+        await sut.getDownloadInfo(
+          factory.auth({ user: sharer, sharedLink: { id: sharedLink.id, albumId: album.id, spaceId: space.id } }),
+          { albumId: album.id },
+        ),
+      );
+      expect(linkIds).toEqual(expected);
+      await expect(ctx.get(AccessRepository).asset.checkSharedLinkAccess(sharedLink.id, linkIds)).resolves.toEqual(
+        linkIds,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // An album may be linked to several spaces at once. A contribution is only
+  // ever reachable through the ONE space it was made to (#764), so what you get
+  // depends on which of those spaces you are actually a member of.
+  // -------------------------------------------------------------------------
+  describe('album linked to two spaces', () => {
+    it("gives a member of only one space that space's contributions, not the other's", async () => {
+      const { sut, contributor, album, ownAsset, contributed, otherContribution } = await seedTwoSpaces();
+
+      const ids = manifestIds(await sut.getDownloadInfo(factory.auth({ user: contributor }), { albumId: album.id }));
+
+      expect(ids).toEqual(new Set([ownAsset.id, contributed.id]));
+      expect(ids.has(otherContribution.id)).toBe(false);
+    });
+
+    it('gives a member of both spaces both sets', async () => {
+      const { sut, sharer, album, ownAsset, contributed, otherContribution } = await seedTwoSpaces();
+
+      const ids = manifestIds(await sut.getDownloadInfo(factory.auth({ user: sharer }), { albumId: album.id }));
+
+      expect(ids).toEqual(new Set([ownAsset.id, contributed.id, otherContribution.id]));
+    });
+
+    it("scopes a link made from one space to that space alone, never the album's other space", async () => {
+      const { sut, ctx, sharer, space, album, ownAsset, contributed, otherContribution } = await seedTwoSpaces();
+      const { sharedLink } = await ctx.newSharedLink({
+        userId: sharer.id,
+        type: SharedLinkType.Album,
+        albumId: album.id,
+        spaceId: space.id,
+      });
+
+      const ids = manifestIds(
+        await sut.getDownloadInfo(
+          factory.auth({ user: sharer, sharedLink: { id: sharedLink.id, albumId: album.id, spaceId: space.id } }),
+          { albumId: album.id },
+        ),
+      );
+
+      expect(ids).toEqual(new Set([ownAsset.id, contributed.id]));
+      expect(ids.has(otherContribution.id)).toBe(false);
+    });
   });
 });

--- a/server/test/medium/specs/services/download.service.spec.ts
+++ b/server/test/medium/specs/services/download.service.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * Medium tests for `DownloadService.getDownloadInfo` on a space-linked album — issue #1048.
+ *
+ * A share link created from inside a Space (#1018) shows every member's photos, and so does the
+ * album page for a member browsing it. "Download all" must ship exactly what was shown: the album
+ * owner's own `album_asset` rows AND the cross-owner `album_space_asset` contributions (#764).
+ *
+ * These run the real service against the real DB so both halves of the download are covered — the
+ * archive manifest built here, and the `AssetDownload` gate `downloadArchive` applies to the ids it
+ * returns. A manifest listing an asset the gate then rejects would 400 the whole download, so the
+ * two are asserted together.
+ */
+import { Kysely } from 'kysely';
+import { SharedLinkType, SharedSpaceRole } from 'src/enum';
+import { AccessRepository } from 'src/repositories/access.repository';
+import { AlbumRepository } from 'src/repositories/album.repository';
+import { DownloadRepository } from 'src/repositories/download.repository';
+import { LoggingRepository } from 'src/repositories/logging.repository';
+import { SharedLinkRepository } from 'src/repositories/shared-link.repository';
+import { SharedSpaceRepository } from 'src/repositories/shared-space.repository';
+import { UserRepository } from 'src/repositories/user.repository';
+import { DB } from 'src/schema';
+import { DownloadService } from 'src/services/download.service';
+import { newMediumService } from 'test/medium.factory';
+import { factory } from 'test/small.factory';
+import { getKyselyDB } from 'test/utils';
+
+let defaultDatabase: Kysely<DB>;
+
+const setup = () =>
+  newMediumService(DownloadService, {
+    database: defaultDatabase,
+    real: [
+      AccessRepository,
+      AlbumRepository,
+      DownloadRepository,
+      SharedLinkRepository,
+      SharedSpaceRepository,
+      UserRepository,
+    ],
+    mock: [LoggingRepository],
+  });
+
+beforeAll(async () => {
+  defaultDatabase = await getKyselyDB();
+});
+
+/**
+ * A space whose owner (`sharer`) owns the linked album, plus an Editor (`contributor`) who owns one
+ * photo contributed to it. `contributed` is never owned by the sharer — that is the whole point.
+ */
+const seedSpaceAlbum = async () => {
+  const { sut, ctx } = setup();
+  const { user: sharer } = await ctx.newUser();
+  const { user: contributor } = await ctx.newUser();
+  const { space } = await ctx.newSharedSpace({ createdById: sharer.id });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: sharer.id, role: SharedSpaceRole.Owner });
+  await ctx.newSharedSpaceMember({ spaceId: space.id, userId: contributor.id, role: SharedSpaceRole.Editor });
+
+  const { asset: ownAsset } = await ctx.newAsset({ ownerId: sharer.id });
+  await ctx.newExif({ assetId: ownAsset.id, fileSizeInByte: 1024 });
+  const { result: album } = await ctx.newAlbum({ ownerId: sharer.id, albumName: 'Trip' }, [ownAsset.id]);
+  await ctx.get(SharedSpaceRepository).addAlbum({ spaceId: space.id, albumId: album.id, addedById: sharer.id });
+
+  const { asset: contributed } = await ctx.newAsset({ ownerId: contributor.id });
+  await ctx.newExif({ assetId: contributed.id, fileSizeInByte: 2048 });
+  await ctx.newAlbumSpaceAsset({
+    albumId: album.id,
+    assetId: contributed.id,
+    spaceId: space.id,
+    addedById: contributor.id,
+  });
+
+  return { sut, ctx, sharer, contributor, space, album, ownAsset, contributed };
+};
+
+const manifestIds = (response: { archives: { assetIds: string[] }[] }) =>
+  new Set(response.archives.flatMap((archive) => archive.assetIds));
+
+describe(`${DownloadService.name} — space-linked album (#1048)`, () => {
+  it("includes another member's contribution in a share link's album download", async () => {
+    const { sut, ctx, sharer, space, album, ownAsset, contributed } = await seedSpaceAlbum();
+    const { sharedLink } = await ctx.newSharedLink({
+      userId: sharer.id,
+      type: SharedLinkType.Album,
+      albumId: album.id,
+      spaceId: space.id,
+    });
+    const auth = factory.auth({
+      user: sharer,
+      sharedLink: { id: sharedLink.id, albumId: album.id, spaceId: space.id },
+    });
+
+    const ids = manifestIds(await sut.getDownloadInfo(auth, { albumId: album.id }));
+
+    expect(ids).toEqual(new Set([ownAsset.id, contributed.id]));
+    // The archive step re-checks every id under AssetDownload; a manifest the gate rejects 400s.
+    await expect(ctx.get(AccessRepository).asset.checkSharedLinkAccess(sharedLink.id, ids)).resolves.toEqual(ids);
+  });
+
+  it('stops including it once the contributor pulls the photo out of the space', async () => {
+    const { sut, ctx, sharer, space, album, ownAsset, contributed } = await seedSpaceAlbum();
+    const { sharedLink } = await ctx.newSharedLink({
+      userId: sharer.id,
+      type: SharedLinkType.Album,
+      albumId: album.id,
+      spaceId: space.id,
+    });
+    const auth = factory.auth({
+      user: sharer,
+      sharedLink: { id: sharedLink.id, albumId: album.id, spaceId: space.id },
+    });
+
+    await ctx.database.deleteFrom('album_space_asset').where('assetId', '=', contributed.id).execute();
+
+    const ids = manifestIds(await sut.getDownloadInfo(auth, { albumId: album.id }));
+
+    expect(ids).toEqual(new Set([ownAsset.id]));
+  });
+
+  it('serves only the album owner once the link creator is demoted to Viewer', async () => {
+    const { sut, ctx, sharer, space, album, ownAsset } = await seedSpaceAlbum();
+    const { sharedLink } = await ctx.newSharedLink({
+      userId: sharer.id,
+      type: SharedLinkType.Album,
+      albumId: album.id,
+      spaceId: space.id,
+    });
+    const auth = factory.auth({
+      user: sharer,
+      sharedLink: { id: sharedLink.id, albumId: album.id, spaceId: space.id },
+    });
+
+    await ctx.database
+      .updateTable('shared_space_member')
+      .set({ role: SharedSpaceRole.Viewer })
+      .where('spaceId', '=', space.id)
+      .where('userId', '=', sharer.id)
+      .execute();
+
+    const ids = manifestIds(await sut.getDownloadInfo(auth, { albumId: album.id }));
+
+    expect(ids).toEqual(new Set([ownAsset.id]));
+  });
+
+  it('includes the contribution for a signed-in member downloading the album', async () => {
+    const { sut, ctx, contributor, ownAsset, album, contributed } = await seedSpaceAlbum();
+    const auth = factory.auth({ user: contributor });
+
+    const ids = manifestIds(await sut.getDownloadInfo(auth, { albumId: album.id }));
+
+    expect(ids).toEqual(new Set([ownAsset.id, contributed.id]));
+    await expect(ctx.get(AccessRepository).asset.checkSpaceAccess(contributor.id, ids)).resolves.toEqual(ids);
+  });
+
+  it('serves only the album owner to a plain album share with no space behind it', async () => {
+    const { sut, ctx, sharer, album, ownAsset } = await seedSpaceAlbum();
+    const { sharedLink } = await ctx.newSharedLink({
+      userId: sharer.id,
+      type: SharedLinkType.Album,
+      albumId: album.id,
+    });
+    const auth = factory.auth({ user: sharer, sharedLink: { id: sharedLink.id, albumId: album.id } });
+
+    const ids = manifestIds(await sut.getDownloadInfo(auth, { albumId: album.id }));
+
+    expect(ids).toEqual(new Set([ownAsset.id]));
+  });
+});


### PR DESCRIPTION
Fixes #1048.

## The bug

`DownloadRepository.downloadAlbumId` read `album_asset` only. Cross-owner contributions in a Space-linked album live in `album_space_asset` (#764), so the album grid — and a share link created from the Space (#1018) — showed every member's photos while the download icon shipped an archive containing only the album owner's own.

The access gate was never the problem: `checkSharedLinkAccess` already covers contributions. Only the archive manifest was wrong.

## The fix

- **`server/src/utils/album-space-ids.ts`** (new) — `getAlbumSpaceIds`, extracted from `timeline.service.ts`, which carried this resolution inline. A shared link resolves at most the ONE space it was created from, publisher-role gated; an authenticated viewer resolves their live member-spaces linking the album. One copy, so the grid and the download cannot drift apart about what an album contains.
- **`download.service.ts`** — resolves those ids for the `albumId` branch and passes them down.
- **`download.repository.ts`** — `downloadAlbumId(albumId, albumSpaceIds?)` unions the contributed arm when ids resolve (UNION, not ALL, so the P1-6 coexistence window doesn't list an asset twice). With no ids it reads `album_asset` alone, exactly as before, so a personal album, an `album_user` share and a pre-#1018 spaceless link are unchanged. `downloadSpaceId` was missing the same arm, so a whole-space download gets it too.

No client change: the shared-link download button already calls `handleDownloadAlbum` → `{ albumId }`.

## Tests

Written red first.

- `test/medium/specs/services/download.service.spec.ts` (new) — the real service against the real DB through a Space album share link. 2 of 5 cases were red before the fix; the other 3 are the guards that must keep returning owner-only (contributor pulls the photo out of the space, link creator demoted to Viewer, plain album share with no space). Each positive case also asserts the `AssetDownload` gate accepts the manifest — a manifest the gate rejects would 400 the whole download, so the two halves are pinned together.
- `test/medium/specs/repositories/download.repository.spec.ts` — 3 of the new cases were red; covers the different-space, Hidden, soft-deleted, dedupe and unlinked-album guards.
- `src/services/download.service.spec.ts` — 5 unit cases for the scoping decision itself.

## Verification

- server unit: `184 passed | 1 skipped` (185 files), 6094 tests
- medium: `download.repository` + `download.service` 23/23; timeline, shared-link, shared-space-album and contribution-permission specs 159/159
- `tsc --noEmit`, `eslint --max-warnings 0`, `prettier --check` clean on the touched files

https://claude.ai/code/session_0173LgoLQXW1rrKq1xSVaoSo
