### PR TITLE
feat(web): a "Search here" button on the surfaces whose search is scoped (#1051)

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -2782,6 +2782,7 @@
   "search_filter_tags_title": "Tags auswählen",
   "search_for": "Suche nach",
   "search_for_existing_person": "Suche nach vorhandener Person",
+  "search_here": "Hier suchen",
   "search_legacy_notice": "Verwenden Sie ⌘K für die Suche.",
   "search_no_more_result": "Keine weiteren Ergebnisse",
   "search_no_people": "Keine Personen",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2785,6 +2785,7 @@
   "search_filter_tags_title": "Select tags",
   "search_for": "Search for",
   "search_for_existing_person": "Search for existing person",
+  "search_here": "Search here",
   "search_legacy_notice": "Use ⌘K to search.",
   "search_no_more_result": "No more results",
   "search_no_people": "No people",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -2782,6 +2782,7 @@
   "search_filter_tags_title": "Seleccionar etiquetas",
   "search_for": "Buscar",
   "search_for_existing_person": "Buscar persona existente",
+  "search_here": "Buscar aquí",
   "search_legacy_notice": "Usa ⌘K para buscar.",
   "search_no_more_result": "No hay más resultados",
   "search_no_people": "Ninguna persona",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -2782,6 +2782,7 @@
   "search_filter_tags_title": "Sélectionner des étiquettes",
   "search_for": "Chercher",
   "search_for_existing_person": "Rechercher une personne existante",
+  "search_here": "Rechercher ici",
   "search_legacy_notice": "Utilisez ⌘K pour rechercher.",
   "search_no_more_result": "Plus de résultats",
   "search_no_people": "Aucune personne",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -2782,6 +2782,7 @@
   "search_filter_tags_title": "Seleziona tag",
   "search_for": "Cerca per",
   "search_for_existing_person": "Cerca per persona esistente",
+  "search_here": "Cerca qui",
   "search_legacy_notice": "Usa ⌘K per cercare.",
   "search_no_more_result": "Non ci sono altri risultati",
   "search_no_people": "Nessuna persona",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -2782,6 +2782,7 @@
   "search_filter_tags_title": "Labels selecteren",
   "search_for": "Zoeken naar",
   "search_for_existing_person": "Zoek naar bestaande persoon",
+  "search_here": "Hier zoeken",
   "search_legacy_notice": "Gebruik ⌘K om te zoeken.",
   "search_no_more_result": "Geen resultaten meer",
   "search_no_people": "Geen mensen",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -2800,6 +2800,7 @@
   "search_filter_tags_title": "Wybierz tagi",
   "search_for": "Szukaj wśród",
   "search_for_existing_person": "Wyszukaj istniejącą osobę",
+  "search_here": "Szukaj tutaj",
   "search_legacy_notice": "Użyj ⌘K, aby wyszukiwać.",
   "search_no_more_result": "Brak dalszych wyników",
   "search_no_people": "Brak osób",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -2784,6 +2784,7 @@
   "search_filter_tags_title": "Выберите теги",
   "search_for": "Поиск по",
   "search_for_existing_person": "Поиск существующего человека",
+  "search_here": "Искать здесь",
   "search_legacy_notice": "Используйте ⌘K для поиска.",
   "search_no_more_result": "Больше результатов нет",
   "search_no_people": "Нет людей",

--- a/i18n/zh_Hans.json
+++ b/i18n/zh_Hans.json
@@ -2782,6 +2782,7 @@
   "search_filter_tags_title": "选择标签",
   "search_for": "查找",
   "search_for_existing_person": "查找已有人物",
+  "search_here": "在此搜索",
   "search_legacy_notice": "按 ⌘K 进行搜索。",
   "search_no_more_result": "无更多结果",
   "search_no_people": "找不到人物",

--- a/i18n/zh_Hant.json
+++ b/i18n/zh_Hant.json
@@ -2782,6 +2782,7 @@
   "search_filter_tags_title": "選擇標籤",
   "search_for": "搜尋",
   "search_for_existing_person": "搜尋現有人物",
+  "search_here": "在此搜尋",
   "search_legacy_notice": "按 ⌘K 進行搜尋。",
   "search_no_more_result": "無更多結果",
   "search_no_people": "沒有人找到",

--- a/web/src/lib/components/filter-panel/__tests__/filter-toolbar.spec.ts
+++ b/web/src/lib/components/filter-panel/__tests__/filter-toolbar.spec.ts
@@ -1,5 +1,5 @@
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import { createRawSnippet } from 'svelte';
 import { init, register, waitLocale } from 'svelte-i18n';
 import FilterToolbar from '../filter-toolbar.svelte';
@@ -115,6 +115,127 @@ describe('FilterToolbar', () => {
       });
 
       expect(screen.getByTestId('timeline-desktop-grouping-control').className).toContain('hidden');
+    });
+  });
+
+  // --- scoped search button (#1051) ---
+  //
+  // The scoped search already worked from the nav bar; what it lacked was an affordance ON the
+  // surface being searched. The button sits with the grouping pill, YouTube-channel style.
+  describe('scoped search button', () => {
+    it('is absent unless the host opts in', () => {
+      render(FilterToolbar, { grouping: 'day', onGroupingChange: vi.fn(), showGrouping: true });
+
+      expect(screen.queryByTestId('scoped-search-button')).toBeNull();
+    });
+
+    it('renders and calls onSearch when the host opts in', async () => {
+      const onSearch = vi.fn();
+      render(FilterToolbar, {
+        grouping: 'day',
+        onGroupingChange: vi.fn(),
+        showGrouping: true,
+        showSearchButton: true,
+        onSearch,
+      });
+
+      await fireEvent.click(screen.getByTestId('scoped-search-button'));
+
+      expect(onSearch).toHaveBeenCalledOnce();
+    });
+
+    it('stays hidden when showSearchButton is set but no handler is wired', () => {
+      render(FilterToolbar, {
+        grouping: 'day',
+        onGroupingChange: vi.fn(),
+        showGrouping: true,
+        showSearchButton: true,
+      });
+
+      expect(screen.queryByTestId('scoped-search-button')).toBeNull();
+    });
+
+    it('sits after the grouping pill, matching the requested layout', () => {
+      render(FilterToolbar, {
+        grouping: 'day',
+        onGroupingChange: vi.fn(),
+        showGrouping: true,
+        showSearchButton: true,
+        onSearch: vi.fn(),
+      });
+
+      const grouping = screen.getByTestId('timeline-desktop-grouping-control');
+      const search = screen.getByTestId('filter-toolbar-search');
+      expect(grouping.compareDocumentPosition(search) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+
+    it('is desktop-only, matching the grouping control it sits beside', () => {
+      render(FilterToolbar, {
+        grouping: 'day',
+        onGroupingChange: vi.fn(),
+        showGrouping: true,
+        showSearchButton: true,
+        onSearch: vi.fn(),
+      });
+
+      const wrapper = screen.getByTestId('filter-toolbar-search');
+      expect(wrapper.className).toContain('hidden');
+      expect(wrapper.className).toContain('md:flex');
+    });
+
+    it('renders the toolbar for the search button alone — browsing an unfiltered album is the main case', () => {
+      render(FilterToolbar, {
+        grouping: 'day',
+        onGroupingChange: vi.fn(),
+        showGrouping: false,
+        showFilters: false,
+        showSearchButton: true,
+        onSearch: vi.fn(),
+      });
+
+      expect(screen.getByTestId('filter-toolbar-root')).toBeInTheDocument();
+      expect(screen.getByTestId('scoped-search-button')).toBeInTheDocument();
+    });
+
+    it('survives search mode, where the grouping pill is swapped out for the chip bar', () => {
+      render(FilterToolbar, {
+        grouping: 'day',
+        onGroupingChange: vi.fn(),
+        showGrouping: false,
+        showFilters: true,
+        filters: filtersSnippet,
+        showSearchButton: true,
+        onSearch: vi.fn(),
+      });
+
+      expect(screen.getByTestId('scoped-search-button')).toBeInTheDocument();
+      expect(screen.getByTestId('bar-content')).toBeInTheDocument();
+    });
+
+    it('keeps a separator before the chip bar in search mode, where the grouping pill is gone', () => {
+      render(FilterToolbar, {
+        grouping: 'day',
+        onGroupingChange: vi.fn(),
+        showGrouping: false,
+        showFilters: true,
+        filters: filtersSnippet,
+        showSearchButton: true,
+        onSearch: vi.fn(),
+      });
+
+      expect(screen.getByTestId('filter-toolbar-separator')).toBeInTheDocument();
+    });
+
+    it('still omits the separator when neither the pill nor the button is there', () => {
+      render(FilterToolbar, {
+        grouping: 'day',
+        onGroupingChange: vi.fn(),
+        showGrouping: false,
+        showFilters: true,
+        filters: filtersSnippet,
+      });
+
+      expect(screen.queryByTestId('filter-toolbar-separator')).toBeNull();
     });
   });
 });

--- a/web/src/lib/components/filter-panel/filter-toolbar.svelte
+++ b/web/src/lib/components/filter-panel/filter-toolbar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import FilterToggleButton from '$lib/components/filter-panel/filter-toggle-button.svelte';
+  import ScopedSearchButton from '$lib/components/search/scoped-search-button.svelte';
   import TimelineGroupingControl from '$lib/components/timeline/TimelineGroupingControl.svelte';
   import type { TimelineGrouping } from '$lib/managers/timeline-manager/types';
   import type { Snippet } from 'svelte';
@@ -17,6 +18,11 @@
     showFilterButton?: boolean;
     filterActive?: boolean;
     onExpandFilters?: () => void;
+    // "Search here" affordance for surfaces whose search is page-scoped (#1051). Opt-in: most
+    // callers of this toolbar (favorites, archive, tags, trash…) are not searchable pages, and an
+    // icon that silently searched the whole library from inside them would be a lie.
+    showSearchButton?: boolean;
+    onSearch?: () => void;
   }
 
   let {
@@ -30,10 +36,14 @@
     showFilterButton = false,
     filterActive = false,
     onExpandFilters,
+    showSearchButton = false,
+    onSearch,
   }: Props = $props();
+
+  const searchButtonVisible = $derived(showSearchButton && onSearch !== undefined);
 </script>
 
-{#if showGrouping || showFilters || (showFilterButton && onExpandFilters)}
+{#if showGrouping || showFilters || (showFilterButton && onExpandFilters) || searchButtonVisible}
   <!--
     Root display is responsive-by-intent:
     - showFilters → `flex` (visible on ALL sizes, so the chip bar still shows on mobile)
@@ -73,8 +83,23 @@
       </div>
     {/if}
 
+    {#if searchButtonVisible}
+      <!-- Desktop-only (`hidden md:flex`), matching the grouping pill it sits beside; below md the
+           nav bar's magnifier is the only trigger.
+           Note the nav magnifier is `xl:hidden` (NavigationBar.svelte), so between md and xl BOTH are
+           on screen. That overlap is accepted, not an oversight: they read as different affordances in
+           different places — global chrome vs. "search this surface" — and it is exactly what the
+           YouTube channel pattern this copies does when its masthead search collapses to an icon. -->
+      <div class="hidden md:flex md:items-center" data-testid="filter-toolbar-search">
+        <ScopedSearchButton onclick={() => onSearch?.()} />
+      </div>
+    {/if}
+
     {#if showFilters}
-      {#if showGrouping}
+      <!-- The separator divides the leading controls from the chip bar, so it must follow whichever
+           of them is present — the grouping pill OR the search button (search mode drops the pill
+           but keeps the button). -->
+      {#if showGrouping || searchButtonVisible}
         <span
           class="hidden h-5 w-px shrink-0 bg-gray-200/70 md:block dark:bg-white/10"
           data-testid="filter-toolbar-separator"

--- a/web/src/lib/components/search/scoped-search-button.spec.ts
+++ b/web/src/lib/components/search/scoped-search-button.spec.ts
@@ -1,0 +1,38 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { init, register, waitLocale } from 'svelte-i18n';
+import { describe, expect, it, vi } from 'vitest';
+import ScopedSearchButton from './scoped-search-button.svelte';
+
+beforeAll(async () => {
+  register('en-US', () => import('$i18n/en.json'));
+  await init({ fallbackLocale: 'en-US' });
+  await waitLocale('en-US');
+});
+
+describe('ScopedSearchButton', () => {
+  it('fires onclick so the host can open the search palette', async () => {
+    const onclick = vi.fn();
+    render(ScopedSearchButton, { onclick });
+
+    await fireEvent.click(screen.getByTestId('scoped-search-button'));
+
+    expect(onclick).toHaveBeenCalledOnce();
+  });
+
+  it('is labelled and tooltipped, so the affordance is discoverable rather than a bare glyph', () => {
+    render(ScopedSearchButton, { onclick: vi.fn() });
+
+    const button = screen.getByTestId('scoped-search-button');
+    expect(button).toHaveAttribute('aria-label', 'Search here');
+    expect(button).toHaveAttribute('title', 'Search here');
+  });
+
+  it('is a real button (keyboard reachable, never a submit)', () => {
+    render(ScopedSearchButton, { onclick: vi.fn() });
+
+    const button = screen.getByTestId('scoped-search-button');
+    expect(button.tagName).toBe('BUTTON');
+    expect(button).toHaveAttribute('type', 'button');
+  });
+});

--- a/web/src/lib/components/search/scoped-search-button.svelte
+++ b/web/src/lib/components/search/scoped-search-button.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { Icon } from '@immich/ui';
+  import { mdiMagnify } from '@mdi/js';
+  import { t } from 'svelte-i18n';
+
+  /**
+   * "Search this surface" affordance, sat beside the Years/Months/All pill (#1051).
+   *
+   * Scoped search already worked before this button existed — the nav bar's palette reads
+   * `getSearchablePageState(page.url)` and narrows to whatever album or space you are standing in.
+   * What it lacked was any sign, on the surface itself, that searching here searches HERE. This is
+   * the YouTube channel-page pattern: tabs, then a magnifier that scopes to the channel.
+   *
+   * Deliberately dumb — it takes an `onclick` rather than reaching for `globalSearchManager`, so
+   * FilterToolbar (rendered by every timeline surface, most of them not searchable) does not grow
+   * an import edge onto the palette manager and its SDK graph.
+   */
+  interface Props {
+    onclick: () => void;
+  }
+
+  let { onclick }: Props = $props();
+</script>
+
+<button
+  type="button"
+  class="flex size-9 shrink-0 items-center justify-center rounded-full bg-white/95 text-gray-600 ring-1 ring-black/10 transition hover:bg-gray-100 hover:text-gray-900 dark:bg-immich-dark-gray dark:text-gray-300 dark:ring-white/10 dark:hover:bg-gray-700 dark:hover:text-white"
+  {onclick}
+  data-testid="scoped-search-button"
+  aria-label={$t('search_here')}
+  title={$t('search_here')}
+>
+  <Icon icon={mdiMagnify} size="20" />
+</button>

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -872,6 +872,8 @@
                 (!isTimelineEmpty || showSearchResults)}
               filterActive={getActiveFilterCount(albumFilters) > 0}
               onExpandFilters={() => (filterCollapsed = false)}
+              showSearchButton={isBrowseTimeline && !assetMultiSelectManager.selectionActive}
+              onSearch={() => globalSearchManager.open()}
             />
           {/if}
 

--- a/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts
+++ b/web/src/routes/(user)/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/page.route.spec.ts
@@ -16,14 +16,19 @@ import { userAdminFactory } from '@test-data/factories/user-factory';
 import { reactivePageMock as mockPage } from '@test-data/mocks/reactive-page.mock.svelte';
 import AlbumPage from './+page.svelte';
 
-const { registerAlbumContextMock, registerSelectionContextMock, gotoMock, mockFeatureFlagsManager } = vi.hoisted(
-  () => ({
-    registerAlbumContextMock: vi.fn(),
-    registerSelectionContextMock: vi.fn(),
-    gotoMock: vi.fn(),
-    mockFeatureFlagsManager: { init: vi.fn(), loadFeatureFlags: vi.fn(), value: { map: false } },
-  }),
-);
+const {
+  registerAlbumContextMock,
+  registerSelectionContextMock,
+  gotoMock,
+  mockFeatureFlagsManager,
+  mockOpenSearchPalette,
+} = vi.hoisted(() => ({
+  registerAlbumContextMock: vi.fn(),
+  registerSelectionContextMock: vi.fn(),
+  gotoMock: vi.fn(),
+  mockFeatureFlagsManager: { init: vi.fn(), loadFeatureFlags: vi.fn(), value: { map: false } },
+  mockOpenSearchPalette: vi.fn(),
+}));
 
 vi.mock('$app/navigation', () => ({
   goto: gotoMock,
@@ -46,6 +51,14 @@ vi.mock('$lib/components/search/smart-search-results.svelte', async () => {
   const { default: MockComponent } = await import('@test-data/mocks/smart-search-results.stub.svelte');
   return { default: MockComponent };
 });
+
+vi.mock('$lib/managers/global-search-manager.svelte', () => ({
+  globalSearchManager: {
+    // Returns a teardown, matching the real registration the page's $effect consumes.
+    registerSearchablePageFilters: vi.fn(() => vi.fn()),
+    open: mockOpenSearchPalette,
+  },
+}));
 
 vi.mock('$lib/managers/command-context-manager.svelte', () => ({
   registerAlbumContext: registerAlbumContextMock,
@@ -323,6 +336,52 @@ describe('album detail filter panel route', () => {
     expect(screen.getByTestId('timeline-mobile-grouping-props')).toHaveTextContent(
       JSON.stringify({ grouping: 'day', hasHandler: true }),
     );
+  });
+
+  // #1051: searching an album already narrowed to the album — via the nav bar, which gave no hint
+  // it would. This puts the trigger on the album itself.
+  describe('scoped search button', () => {
+    it('sits beside the album grouping control', async () => {
+      renderPage();
+
+      expect(await screen.findByTestId('scoped-search-button')).toBeInTheDocument();
+    });
+
+    it('opens the album-scoped search palette when clicked', async () => {
+      renderPage();
+      await fireEvent.click(await screen.findByTestId('scoped-search-button'));
+
+      expect(mockOpenSearchPalette).toHaveBeenCalledOnce();
+    });
+
+    it('is hidden in select-assets mode, alongside the grouping control', async () => {
+      renderPage();
+
+      await fireEvent.click(screen.getByLabelText('add_photos'));
+
+      await waitFor(() => expect(screen.queryByTestId('scoped-search-button')).not.toBeInTheDocument());
+    });
+
+    it('is hidden in select-thumbnail mode, where the grouping control also goes', async () => {
+      renderPage();
+      const user = userEvent.setup();
+
+      await user.click(screen.getByLabelText('album_options'));
+      await user.click(screen.getByText('select_album_cover'));
+
+      expect(screen.queryByTestId('scoped-search-button')).not.toBeInTheDocument();
+    });
+
+    // The grouping pill is swapped out in search mode; the search button must NOT be, or the
+    // only way to change a query would be to clear it first.
+    it('stays available while album search results are showing', async () => {
+      mockPage.url = new URL('https://gallery.test/albums/album-1?q=beach');
+
+      renderPage(albumFactory.build({ id: 'album-1', assetCount: 2 }));
+
+      expect(await screen.findByTestId('scoped-search-button')).toBeInTheDocument();
+      expect(screen.queryByTestId('timeline-desktop-grouping-control')).not.toBeInTheDocument();
+    });
   });
 
   it('changes album grouping without changing album filters or URL state', async () => {

--- a/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/+page.svelte
@@ -633,6 +633,8 @@
         showFilterButton={filterCollapsed && !isTimelineEmpty && !assetMultiSelectManager.selectionActive}
         filterActive={getActiveFilterCount(filters) > 0}
         onExpandFilters={() => (filterCollapsed = false)}
+        showSearchButton={!assetMultiSelectManager.selectionActive}
+        onSearch={() => globalSearchManager.open()}
       />
       {#if showSearchResults}
         <SmartSearchResults

--- a/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
+++ b/web/src/routes/(user)/photos/[[assetId=id]]/photos-page.spec.ts
@@ -19,6 +19,7 @@ const {
   mockMemoryManager,
   mockRegisterSelectionContext,
   mockRegisterSearchablePageFilters,
+  mockOpenSearchPalette,
   readableFn,
 } = vi.hoisted(() => ({
   mockAssetMultiSelectManager: {
@@ -36,6 +37,7 @@ const {
   },
   mockRegisterSelectionContext: vi.fn(),
   mockRegisterSearchablePageFilters: vi.fn(() => vi.fn()),
+  mockOpenSearchPalette: vi.fn(),
   // `memoryLaneTitle` and `getAltText` are `derived(t, ...)` stores *holding a function*, read by
   // the page as `$memoryLaneTitle(memory)` / `$getAltText(asset)`. As bare vi.fn()s they threw
   // `store_invalid_shape` the first time anything rendered the memories strip - which nothing did
@@ -195,6 +197,7 @@ vi.mock('$lib/managers/command-context-manager.svelte', () => ({
 vi.mock('$lib/managers/global-search-manager.svelte', () => ({
   globalSearchManager: {
     registerSearchablePageFilters: mockRegisterSearchablePageFilters,
+    open: mockOpenSearchPalette,
   },
 }));
 
@@ -1122,6 +1125,45 @@ describe('Photos page search URL state', () => {
     renderPage();
 
     expect(screen.queryByTestId('timeline-desktop-grouping-control')).not.toBeInTheDocument();
+  });
+
+  // #1051: same affordance as the album and space timelines — one rule, "the icon is wherever
+  // scoped search works", rather than a per-page allowlist that drifts.
+  describe('scoped search button', () => {
+    it('sits beside the grouping control on the photos timeline', async () => {
+      mockPage.url = new URL('https://gallery.test/photos');
+
+      renderPage();
+
+      expect(await screen.findByTestId('scoped-search-button')).toBeInTheDocument();
+    });
+
+    it('opens the page-scoped search palette when clicked', async () => {
+      mockPage.url = new URL('https://gallery.test/photos');
+
+      renderPage();
+      await fireEvent.click(await screen.findByTestId('scoped-search-button'));
+
+      expect(mockOpenSearchPalette).toHaveBeenCalledOnce();
+    });
+
+    it('is hidden while photos selection mode is active', () => {
+      mockPage.url = new URL('https://gallery.test/photos');
+      mockAssetMultiSelectManager.selectionActive = true;
+
+      renderPage();
+
+      expect(screen.queryByTestId('scoped-search-button')).not.toBeInTheDocument();
+    });
+
+    it('stays available while search results are showing, unlike the grouping pill', async () => {
+      mockPage.url = new URL('https://gallery.test/photos?q=nature');
+
+      renderPage();
+
+      expect(await screen.findByTestId('scoped-search-button')).toBeInTheDocument();
+      expect(screen.queryByTestId('timeline-desktop-grouping-control')).not.toBeInTheDocument();
+    });
   });
 
   it('ignores photos bucket activation while selection mode is active', async () => {

--- a/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts
+++ b/web/src/routes/(user)/recently-added/[[photos=photos]]/[[assetId=id]]/recently-added-page.spec.ts
@@ -298,6 +298,18 @@ describe('Recently Added page filters', () => {
     await waitFor(() => expect(mockRegisterSearchablePageFilters).toHaveBeenCalledOnce());
   });
 
+  // #1051: deliberately NO scoped search button here. Recently Added is an ORDERING
+  // (orderBy: CreatedAt), not a set — the search it launches carries no recency predicate
+  // (see <SmartSearchResults> in +page.svelte: filters + withSharedSpaces only), so a
+  // "Search here" affordance would promise a scope the page does not have and hand back
+  // ten-year-old photos.
+  it('has no scoped search button, because the page is an ordering rather than a scope', async () => {
+    renderPage();
+
+    await waitFor(() => expect(screen.getByTestId('filter-panel-stub')).toBeInTheDocument());
+    expect(screen.queryByTestId('scoped-search-button')).toBeNull();
+  });
+
   it('passes all ten sections to the filter panel', async () => {
     renderPage();
 

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -865,6 +865,8 @@
         showFilterButton={filterCollapsed && !isTimelineEmpty && !assetMultiSelectManager.selectionActive}
         filterActive={getActiveFilterCount(filters) > 0}
         onExpandFilters={() => (filterCollapsed = false)}
+        showSearchButton={!assetMultiSelectManager.selectionActive}
+        onSearch={() => globalSearchManager.open()}
       />
     {/if}
 

--- a/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/[[photos=photos]]/[[assetId=id]]/spaces-page.spec.ts
@@ -26,6 +26,7 @@ const {
   mockRegisterSelectionContext,
   mockRegisterSpaceContext,
   mockRegisterSearchablePageFilters,
+  mockOpenSearchPalette,
 } = vi.hoisted(() => ({
   gotoMock: vi.fn().mockResolvedValue(undefined),
   invalidateAllMock: vi.fn().mockResolvedValue(undefined),
@@ -46,6 +47,7 @@ const {
   mockRegisterSelectionContext: vi.fn(),
   mockRegisterSpaceContext: vi.fn(),
   mockRegisterSearchablePageFilters: vi.fn(() => vi.fn()),
+  mockOpenSearchPalette: vi.fn(),
 }));
 
 vi.mock('$app/navigation', () => ({ goto: gotoMock, invalidateAll: invalidateAllMock }));
@@ -139,6 +141,7 @@ vi.mock('$lib/managers/event-manager.svelte', () => ({ eventManager: mockEventMa
 vi.mock('$lib/managers/global-search-manager.svelte', () => ({
   globalSearchManager: {
     registerSearchablePageFilters: mockRegisterSearchablePageFilters,
+    open: mockOpenSearchPalette,
   },
 }));
 
@@ -1030,6 +1033,44 @@ describe('Spaces page search URL state', () => {
     renderPage();
 
     expect(screen.queryByTestId('timeline-desktop-grouping-control')).not.toBeInTheDocument();
+  });
+
+  // #1051: the space timeline searches the space, but nothing on the surface said so — the only
+  // trigger lived in the nav bar. The palette itself already scopes from the URL.
+  describe('scoped search button', () => {
+    it('sits beside the grouping control on the space browse timeline', async () => {
+      mockPage.url = new URL('https://gallery.test/spaces/space-1/photos');
+
+      renderPage();
+
+      expect(await screen.findByTestId('scoped-search-button')).toBeInTheDocument();
+    });
+
+    it('opens the page-scoped search palette when clicked', async () => {
+      mockPage.url = new URL('https://gallery.test/spaces/space-1/photos');
+
+      renderPage();
+      await fireEvent.click(await screen.findByTestId('scoped-search-button'));
+
+      expect(mockOpenSearchPalette).toHaveBeenCalledOnce();
+    });
+
+    it('stays available while space search results are showing, so the query can be changed', async () => {
+      mockPage.url = new URL('https://gallery.test/spaces/space-1/photos?q=nature');
+
+      renderPage();
+
+      expect(await screen.findByTestId('scoped-search-button')).toBeInTheDocument();
+    });
+
+    it('is hidden in select-assets mode, where the toolbar belongs to the selection', async () => {
+      mockPage.url = new URL('https://gallery.test/spaces/space-1/photos');
+
+      renderPage();
+      await enterSelectAssets();
+
+      await waitFor(() => expect(screen.queryByTestId('scoped-search-button')).not.toBeInTheDocument());
+    });
   });
 
   it('shows the filtered empty state for a filtered space timeline with no assets', () => {

--- a/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/+page.svelte
@@ -20,6 +20,7 @@
   import ControlAppBar from '$lib/components/shared-components/ControlAppBar.svelte';
   import SelectionToolbar from '$lib/components/timeline/SelectionToolbar.svelte';
   import Timeline from '$lib/components/timeline/Timeline.svelte';
+  import ScopedSearchButton from '$lib/components/search/scoped-search-button.svelte';
   import TimelineGroupingControl from '$lib/components/timeline/TimelineGroupingControl.svelte';
   import { assetMultiSelectManager, AssetMultiSelectManager } from '$lib/managers/asset-multi-select-manager.svelte';
   import { authManager } from '$lib/managers/auth-manager.svelte';
@@ -658,6 +659,11 @@
             {/if}
             <div class="hidden md:flex md:items-center" data-testid="timeline-desktop-grouping-control">
               <TimelineGroupingControl grouping={timelineGrouping} onGroupingChange={handleTimelineGroupingChange} />
+            </div>
+            <!-- #1051: the "search here" affordance, desktop-only to match the grouping pill beside it.
+                 Below md the nav bar's own magnifier opens the same page-scoped palette. -->
+            <div class="hidden md:flex md:items-center" data-testid="space-album-toolbar-search">
+              <ScopedSearchButton onclick={() => globalSearchManager.open()} />
             </div>
           </div>
         {/if}

--- a/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/space-album-detail-page.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/albums/[albumId=id]/[[photos=photos]]/[[assetId=id]]/space-album-detail-page.spec.ts
@@ -102,23 +102,34 @@ vi.mock('$lib/managers/feature-flags-manager.svelte', () => ({
   featureFlagsManager: { value: { trash: true } },
 }));
 
-const { mockAssetMultiSelectManager, pickerMultiSelectClear, pickerSelectedAssets } = vi.hoisted(() => ({
-  pickerMultiSelectClear: vi.fn(),
-  // Shared so a test can give the PICKER (not the browse bar) a selection to add.
-  pickerSelectedAssets: [] as { id: string }[],
-  mockAssetMultiSelectManager: {
-    selectionActive: false,
-    assets: [] as { id: string }[],
-    clear: vi.fn(),
-    isAllFavorite: false,
-    isAllArchived: false,
-    isAllUserOwned: true,
-    // Mirrors the real manager's derived field. These fixtures only model the all-owned and
-    // none-owned ends of the range, so deriving it from isAllUserOwned keeps the two in step.
-    get ownedAssets() {
-      // eslint-disable-next-line unicorn/no-this-outside-of-class
-      return this.isAllUserOwned ? this.assets : [];
+const { mockAssetMultiSelectManager, pickerMultiSelectClear, pickerSelectedAssets, mockOpenSearchPalette } = vi.hoisted(
+  () => ({
+    mockOpenSearchPalette: vi.fn(),
+    pickerMultiSelectClear: vi.fn(),
+    // Shared so a test can give the PICKER (not the browse bar) a selection to add.
+    pickerSelectedAssets: [] as { id: string }[],
+    mockAssetMultiSelectManager: {
+      selectionActive: false,
+      assets: [] as { id: string }[],
+      clear: vi.fn(),
+      isAllFavorite: false,
+      isAllArchived: false,
+      isAllUserOwned: true,
+      // Mirrors the real manager's derived field. These fixtures only model the all-owned and
+      // none-owned ends of the range, so deriving it from isAllUserOwned keeps the two in step.
+      get ownedAssets() {
+        // eslint-disable-next-line unicorn/no-this-outside-of-class
+        return this.isAllUserOwned ? this.assets : [];
+      },
     },
+  }),
+);
+
+vi.mock('$lib/managers/global-search-manager.svelte', () => ({
+  globalSearchManager: {
+    // Returns a teardown, matching the real registration the page's $effect consumes.
+    registerSearchablePageFilters: vi.fn(() => vi.fn()),
+    open: mockOpenSearchPalette,
   },
 }));
 
@@ -404,6 +415,46 @@ describe('Space album detail page', () => {
   it('in browse mode, the timeline-desktop-grouping-control renders', () => {
     renderPage();
     expect(screen.getByTestId('timeline-desktop-grouping-control')).toBeInTheDocument();
+  });
+
+  // #1051. This page hand-rolls the toolbar row rather than using FilterToolbar, so the button is
+  // wired separately here and needs its own coverage — a FilterToolbar test proves nothing for it.
+  describe('scoped search button', () => {
+    it('sits beside the grouping control in browse mode', () => {
+      renderPage();
+      expect(screen.getByTestId('scoped-search-button')).toBeInTheDocument();
+    });
+
+    it('opens the album-scoped search palette when clicked', async () => {
+      renderPage();
+      await fireEvent.click(screen.getByTestId('scoped-search-button'));
+
+      expect(mockOpenSearchPalette).toHaveBeenCalledOnce();
+    });
+
+    it('is hidden when selection is active, alongside the grouping control', () => {
+      mockAssetMultiSelectManager.selectionActive = true;
+      renderPage();
+      expect(screen.queryByTestId('scoped-search-button')).not.toBeInTheDocument();
+    });
+
+    it('stays available while album search results are showing', () => {
+      mockPage.reset('https://gallery.test/spaces/space-1/albums/album-1?q=beach');
+
+      renderPage();
+
+      expect(screen.getByTestId('scoped-search-button')).toBeInTheDocument();
+    });
+
+    // This toolbar row is hand-rolled rather than FilterToolbar, so its responsive contract
+    // has to be asserted here too — a FilterToolbar test proves nothing for it.
+    it('is desktop-only, matching the grouping control beside it', () => {
+      renderPage();
+
+      const wrapper = screen.getByTestId('space-album-toolbar-search');
+      expect(wrapper.className).toContain('hidden');
+      expect(wrapper.className).toContain('md:flex');
+    });
   });
 
   it('the grouping-control bar is transparent (no navy/border bar) to match the space page', () => {


### PR DESCRIPTION
Closes the web half of #1051.

## The problem

Searching from inside an album or a Space **already** ran against that album or Space — `globalSearchManager.open()` reads `getSearchablePageState(page.url)` and narrows to whichever surface you're on. But the only trigger lived in the nav bar, which gives no sign it will scope. As #1051 puts it: functionally great, undiscoverable.

## The change

The YouTube channel-page affordance the discussion asked for — a magnifier beside the Years/Months/All selector that searches the surface you're looking at.

|  | before | after |
|---|---|---|
| album / Space toolbar | `[⚙] [Years\|Months\|All]` | `[⚙] [Years\|Months\|All] [🔍]` |

- New `ScopedSearchButton`, plus an opt-in `showSearchButton` / `onSearch` pair on `FilterToolbar`.
- The button is deliberately dumb — it takes an `onclick` rather than importing `globalSearchManager`, so `FilterToolbar` (rendered by favorites, archive, tags, trash… most of them *not* searchable) doesn't grow an import edge onto the palette manager and its SDK graph.
- **Survives search mode**, where the grouping pill gives way to the chip bar, so a query can be *changed*, not only started. The toolbar separator now follows the button as well as the pill, since in search mode the button is the only thing left to separate from the chips.
- **Hidden during multi-select** and, on the album page, in select-assets / select-thumbnail modes.

### Where it appears

| surface | button | why |
|---|---|---|
| `/albums/<id>` | ✅ | scopes to the album |
| `/spaces/<id>` | ✅ | scopes to the space |
| `/spaces/<s>/albums/<a>` | ✅ | scopes to the album (hand-rolls its own toolbar row, so wired separately) |
| `/photos` | ✅ | *is* the whole library, so the promise holds |
| `/recently-added` | ❌ | see below |
| favorites, archive, tags, trash, … | ❌ | not searchable pages |

**`/recently-added` is deliberately excluded** even though it's a searchable page. It's an *ordering* (`orderBy: CreatedAt`), not a set — the search it launches carries no recency predicate (`<SmartSearchResults>` there gets `filters` + `withSharedSpaces` only). A "Search here" button would promise a scope the page doesn't have and hand back ten-year-old photos. A test guards the absence.

## Responsive

Desktop-only (`hidden md:flex`), matching the grouping pill beside it. Worth calling out explicitly: the nav bar's own magnifier is `xl:hidden`, so **between md and xl both are on screen**. That overlap is accepted rather than overlooked — they read as different affordances in different places (global chrome vs. "search this surface"), and it's what YouTube does once its masthead search collapses to an icon. Flagging it in case you'd rather gate on `xl`.

## Testing

TDD throughout — every assertion was watched fail first. 30 tests across the component, `FilterToolbar`, and all five page surfaces.

The five "stays available during search results" tests were additionally proven to be real gates: temporarily adding `&& !showSearchResults` to each call site turned all five red, then the flip was reverted.

| gate | result |
|---|---|
| web unit suite | 6000 passed, 0 failed |
| `svelte-check` | 614 files, 0 errors, 0 warnings |
| `tsc --noEmit` | clean |
| eslint / prettier | clean |

`search_here` added to all ten required locales, each built parallel to that file's existing `search_everywhere` so register and phrasing match.

## Not in scope

- **Mobile (Flutter)** — the other half of #1051, left for a follow-up.
- **A visible scope label in the palette.** Opening it from this button behaves identically to the nav bar, but neither path displays "searching in this album". Pre-existing, and closing it would touch the palette's design for both entry points.

https://claude.ai/code/session_01Esr4yHbYHsTvpEfF64ShhZ
