### PR TITLE
fix(web): apply the persisted People/Pets filter on the first load

### DIFF
--- a/web/src/lib/components/spaces/space-people-page.spec.ts
+++ b/web/src/lib/components/spaces/space-people-page.spec.ts
@@ -164,7 +164,7 @@ function renderPage({
       members,
       people,
       peopleStatistics,
-      hasSpacePeople: hasSpacePeople ?? ((peopleStatistics?.total ?? people.length) > 0),
+      hasSpacePeople: hasSpacePeople ?? (peopleStatistics?.total ?? people.length) > 0,
       meta: { title: `${space.name} - People` },
     },
   };

--- a/web/src/lib/components/spaces/space-people-page.spec.ts
+++ b/web/src/lib/components/spaces/space-people-page.spec.ts
@@ -144,12 +144,15 @@ function renderPage({
     detectedFaceCount: 0,
   },
   userId = 'current-user-id',
+  hasSpacePeople,
 }: {
   space?: SharedSpaceResponseDto;
   members?: SharedSpaceMemberResponseDto[];
   people?: SharedSpacePersonResponseDto[];
   peopleStatistics?: SharedSpacePeopleStatisticsResponseDto | null;
   userId?: string;
+  /** Whether the space has any people at all, ignoring the filter, as `load` resolves it. */
+  hasSpacePeople?: boolean;
 } = {}) {
   const currentUser = userAdminFactory.build({ id: userId });
   authManager.setUser(currentUser);
@@ -161,6 +164,7 @@ function renderPage({
       members,
       people,
       peopleStatistics,
+      hasSpacePeople: hasSpacePeople ?? ((peopleStatistics?.total ?? people.length) > 0),
       meta: { title: `${space.name} - People` },
     },
   };
@@ -1073,11 +1077,12 @@ describe('Spaces people page', () => {
       vi.stubGlobal('IntersectionObserver', VisibleObserver);
       const pets = Array.from({ length: PAGE_SIZE }, (_, i) => makePerson({ id: `pet-${i}`, type: 'pet' }));
       peopleViewSettings.set({ sortBy: PeopleSortBy.PhotoCount, filterBy: PeopleFilterBy.Pets });
-      sdkMock.getSpacePeople.mockImplementation(({ offset }) => Promise.resolve(offset ? [] : pets));
+      sdkMock.getSpacePeople.mockResolvedValue([]);
       sdkMock.getSpacePeopleStatistics.mockResolvedValue({ total: PAGE_SIZE, hidden: 0, detectedFaceCount: 0 });
 
-      // The SSR-loaded data is unfiltered; the mount effect reapplies the persisted Pets filter.
-      renderPage({ people: [], peopleStatistics: { total: 0, hidden: 0, detectedFaceCount: 0 } });
+      // `load` now delivers the filtered first page, so a full page means there is a second one to
+      // fetch — and that request has to carry the same filter, or paging widens the list.
+      renderPage({ people: pets, peopleStatistics: { total: PAGE_SIZE, hidden: 0, detectedFaceCount: 0 } });
 
       await waitFor(() => {
         expect(sdkMock.getSpacePeople).toHaveBeenCalledWith(
@@ -1148,18 +1153,37 @@ describe('Spaces people page', () => {
       });
     });
 
-    it('reapplies a persisted non-All filter on mount, since SSR loads unfiltered', async () => {
+    // Regression: the page used to re-apply a persisted filter in onMount, so a refresh under Pets
+    // painted the unfiltered list for one round trip before narrowing. `load` now fetches the
+    // filtered list, so mounting must issue no request at all — no request, no flash.
+    it('issues no request on mount under a persisted non-All filter', async () => {
       peopleViewSettings.set({ sortBy: PeopleSortBy.PhotoCount, filterBy: PeopleFilterBy.Pets });
-      sdkMock.getSpacePeople.mockResolvedValue([makePerson({ id: 'p1', type: 'pet' })]);
-      sdkMock.getSpacePeopleStatistics.mockResolvedValue({ total: 1, hidden: 0, detectedFaceCount: 0 });
 
-      // SSR-loaded data (passed to renderPage) is always unfiltered.
-      renderPage({ people: [makePerson({ id: 'p0' })] });
+      renderPage({
+        people: [makePerson({ id: 'pet-1', type: 'pet' })],
+        peopleStatistics: { total: 1, hidden: 0, detectedFaceCount: 0 },
+        hasSpacePeople: true,
+      });
 
       await waitFor(() => {
-        expect(sdkMock.getSpacePeople).toHaveBeenCalledWith(expect.objectContaining({ $type: 'pet' }));
+        expect(screen.getByTestId('space-people-heading-description')).toBeInTheDocument();
       });
-      expect(sdkMock.getSpacePeopleStatistics).toHaveBeenCalledWith(expect.objectContaining({ $type: 'pet' }));
+      expect(sdkMock.getSpacePeople).not.toHaveBeenCalled();
+      expect(sdkMock.getSpacePeopleStatistics).not.toHaveBeenCalled();
+    });
+
+    // The show/hide screen is the only place a misdetected species bucket can be corrected, so a
+    // Pets filter matching nothing must not hide it. `load` hands over the unfiltered total for it.
+    it('keeps show/hide reachable when the active filter matches nothing', () => {
+      peopleViewSettings.set({ sortBy: PeopleSortBy.PhotoCount, filterBy: PeopleFilterBy.Pets });
+
+      renderPage({
+        people: [],
+        peopleStatistics: { total: 0, hidden: 0, detectedFaceCount: 0 },
+        hasSpacePeople: true,
+      });
+
+      expect(screen.getByRole('button', { name: 'show_and_hide_people' })).toBeInTheDocument();
     });
 
     it('does not send the filter to the face-statistics endpoint', async () => {

--- a/web/src/lib/utils/people-filter.ts
+++ b/web/src/lib/utils/people-filter.ts
@@ -1,0 +1,45 @@
+import { get } from 'svelte/store';
+import { PeopleFilterBy, peopleViewSettings } from '$lib/stores/preferences.store';
+
+/**
+ * The People/Pets type filter, shared by the global People page, the space People tab, and both of
+ * their `load` functions.
+ *
+ * Deliberately a module of its own rather than part of `people-utils`: that module reaches the
+ * asset-viewer manager and the SDK URL helpers, and a SvelteKit `load` has no business pulling those
+ * in just to read one persisted enum.
+ */
+
+/** The `type` query param a filter maps to; `All` sends none. */
+export type PeopleTypeParam = 'person' | 'pet' | undefined;
+
+export const peopleFilterToTypeParam = (filterBy: PeopleFilterBy): PeopleTypeParam => {
+  switch (filterBy) {
+    case PeopleFilterBy.People: {
+      return 'person';
+    }
+    case PeopleFilterBy.Pets: {
+      return 'pet';
+    }
+    default: {
+      return undefined;
+    }
+  }
+};
+
+/** The persisted choice, falling back to `All` for an absent or corrupt localStorage value. */
+export const resolvePeopleFilterBy = (value: unknown): PeopleFilterBy =>
+  Object.values(PeopleFilterBy).includes(value as PeopleFilterBy) ? (value as PeopleFilterBy) : PeopleFilterBy.All;
+
+/**
+ * The persisted People/Pets choice, for callers outside a component — the `load` functions.
+ *
+ * Both People pages used to load unfiltered and re-apply the persisted filter in `onMount`, so a
+ * saved Pets choice painted the whole people list for one round trip before narrowing to pets.
+ * Reading the setting here — the root layout sets `ssr = false`, so `load` runs in the browser with
+ * localStorage available — makes the first request the already-filtered one.
+ */
+export const getPersistedPeopleFilterBy = (): PeopleFilterBy => resolvePeopleFilterBy(get(peopleViewSettings).filterBy);
+
+/** The `type` param for the persisted choice. */
+export const getPersistedPeopleTypeParam = (): PeopleTypeParam => peopleFilterToTypeParam(getPersistedPeopleFilterBy());

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -25,6 +25,7 @@
   import { getGlobalPersonHref, getGlobalPersonThumbnailUrl } from '$lib/utils/global-person-route';
   import { handleError } from '$lib/utils/handle-error';
   import { clearQueryParam } from '$lib/utils/navigation';
+  import { peopleFilterToTypeParam as filterToTypeParam, resolvePeopleFilterBy } from '$lib/utils/people-filter';
   import { appendUniqueById, sortPeople } from '$lib/utils/people-utils';
   import { formatPeopleHeaderDescription } from '$lib/utils/people-statistics';
   import {
@@ -75,10 +76,11 @@
   // re-check), and both are gated on the `loading` prop below. Without it the same page is fetched
   // concurrently and appended twice.
   let loadingPage = $state(false);
-  // Totals for the currently applied type filter. The SSR load and the overview-statistics endpoint
-  // are both unfiltered, so once a filter is active the header has to read the filtered list's own
-  // total instead, or it reports the whole library above a filtered grid.
-  let listTotals = $state<{ total: number; hidden: number } | null>(null);
+  // Totals for the currently applied type filter. The overview-statistics endpoint is unfiltered, so
+  // once a filter is active the header has to read the filtered list's own total instead, or it
+  // reports the whole library above a filtered grid. `load` already applied the persisted filter, so
+  // seed this from its response rather than leaving the header wrong until the first filter change.
+  let listTotals = $state<{ total: number; hidden: number } | null>(data.peopleListTotals ?? null);
 
   onMount(() => {
     const getSearchedPeople = $page.url.searchParams.get(QueryParameter.SEARCHED_PEOPLE);
@@ -87,10 +89,6 @@
       if (searchPeopleElement) {
         handlePromiseError(searchPeopleElement.searchPeople(true, searchName));
       }
-    }
-
-    if (peopleFilterBy !== PeopleFilterBy.All) {
-      handlePromiseError(handleFilterChange(peopleFilterBy));
     }
 
     return websocketEvents.on('on_person_thumbnail', (personId: string) => {
@@ -120,6 +118,9 @@
                   withSharedSpaces: true,
                   page: startingPage + i,
                   size: PEOPLE_PAGE_SIZE,
+                  // Restoring scroll must page over the SAME filtered list the first page came
+                  // from; without this, returning to a filtered grid appends unfiltered people.
+                  $type: filterToTypeParam(peopleFilterBy),
                 });
               }),
             )
@@ -329,24 +330,7 @@
     [PeopleFilterBy.People]: $t('people'),
     [PeopleFilterBy.Pets]: $t('pets'),
   });
-  let peopleFilterBy = $derived(
-    Object.values(PeopleFilterBy).includes($peopleViewSettings.filterBy as PeopleFilterBy)
-      ? ($peopleViewSettings.filterBy as PeopleFilterBy)
-      : PeopleFilterBy.All,
-  );
-  const filterToTypeParam = (filterBy: PeopleFilterBy) => {
-    switch (filterBy) {
-      case PeopleFilterBy.People: {
-        return 'person' as const;
-      }
-      case PeopleFilterBy.Pets: {
-        return 'pet' as const;
-      }
-      default: {
-        return undefined;
-      }
-    }
-  };
+  let peopleFilterBy = $derived(resolvePeopleFilterBy($peopleViewSettings.filterBy));
 
   const handleFilterChange = async (filterBy: PeopleFilterBy) => {
     $peopleViewSettings.filterBy = filterBy;

--- a/web/src/routes/(user)/people/+page.ts
+++ b/web/src/routes/(user)/people/+page.ts
@@ -3,15 +3,27 @@ import { PEOPLE_PAGE_SIZE } from '$lib/constants';
 import { featureFlagsManager } from '$lib/managers/feature-flags-manager.svelte';
 import { authenticate } from '$lib/utils/auth';
 import { getFormatter } from '$lib/utils/i18n';
+import { getPersistedPeopleFilterBy, peopleFilterToTypeParam } from '$lib/utils/people-filter';
 import type { PageLoad } from './$types';
 
 export const load = (async ({ parent, url }) => {
   await authenticate(url);
 
+  // Apply the persisted People/Pets choice to the FIRST request. The page used to load unfiltered
+  // and re-fetch in onMount, so refreshing under a Pets filter painted the full people list for one
+  // round trip before narrowing to pets.
+  const filterBy = getPersistedPeopleFilterBy();
+  const type = peopleFilterToTypeParam(filterBy);
+
   // Fire the (heavy) people query up front so it overlaps the root layout's init() instead of
   // serializing behind await parent(). ssr=false, so the SDK's global fetch works even before
   // init() assigns defaults.fetch. It is awaited below via Promise.all.
-  const peoplePromise = getAllPeople({ withHidden: true, withSharedSpaces: true, size: PEOPLE_PAGE_SIZE });
+  const peoplePromise = getAllPeople({
+    withHidden: true,
+    withSharedSpaces: true,
+    size: PEOPLE_PAGE_SIZE,
+    $type: type,
+  });
 
   // parent() resolves once the root layout's init() has populated the feature-flags manager.
   await parent();
@@ -31,6 +43,11 @@ export const load = (async ({ parent, url }) => {
   return {
     people,
     peopleStatistics,
+    // Header totals for an active filter. The overview-statistics endpoint is unfiltered, so under a
+    // filter the header has to read the filtered list's own totals; handing them over here saves the
+    // page a round trip to discover what it already fetched. Null under `All`, where the unfiltered
+    // overview statistics are the right source.
+    peopleListTotals: type ? { total: people.total, hidden: people.hidden } : null,
     meta: {
       title: $t('people'),
     },

--- a/web/src/routes/(user)/people/page-load.spec.ts
+++ b/web/src/routes/(user)/people/page-load.spec.ts
@@ -1,5 +1,6 @@
 import { sdkMock } from '$lib/__mocks__/sdk.mock';
 import { PEOPLE_PAGE_SIZE } from '$lib/constants';
+import { PeopleFilterBy, PeopleSortBy, peopleViewSettings } from '$lib/stores/preferences.store';
 import { load } from './+page';
 
 const { authenticate, getFormatter, featureFlagsMock } = vi.hoisted(() => ({
@@ -11,7 +12,13 @@ const { authenticate, getFormatter, featureFlagsMock } = vi.hoisted(() => ({
 }));
 
 vi.mock('$lib/utils/auth', () => ({ authenticate }));
-vi.mock('$lib/utils/i18n', () => ({ getFormatter }));
+// preferences.store (reached via people-filter, for the persisted People/Pets choice) pulls the
+// locale helpers out of this module at import time, so the mock has to carry them too.
+vi.mock('$lib/utils/i18n', () => ({
+  getFormatter,
+  getPreferredLocale: () => 'en',
+  convertBCP47: (value: string) => value,
+}));
 vi.mock('$lib/managers/feature-flags-manager.svelte', () => ({ featureFlagsManager: featureFlagsMock }));
 
 describe('people page load', () => {
@@ -39,6 +46,7 @@ describe('people page load', () => {
     sdkMock.getPeopleStatistics.mockResolvedValue(statisticsResponse);
     parent = vi.fn().mockResolvedValue({});
     featureFlagsMock.valueOrUndefined = { peopleStatistics: true };
+    peopleViewSettings.set({ sortBy: PeopleSortBy.PhotoCount, filterBy: PeopleFilterBy.All });
   });
 
   it('authenticates, awaits parent, and loads a bounded first page with overview statistics when enabled', async () => {
@@ -47,6 +55,7 @@ describe('people page load', () => {
     await expect(runLoad(url)).resolves.toEqual({
       people: peopleResponse,
       peopleStatistics: statisticsResponse,
+      peopleListTotals: null,
       meta: { title: 'people' },
     });
 
@@ -63,6 +72,48 @@ describe('people page load', () => {
     expect(sdkMock.getPeopleFaceStatistics).not.toHaveBeenCalled();
   });
 
+  // The page used to load unfiltered and re-apply the persisted filter in onMount, so refreshing
+  // under a Pets filter painted the whole people list for one round trip before narrowing to pets.
+  it('applies a persisted Pets filter to the first request', async () => {
+    peopleViewSettings.set({ sortBy: PeopleSortBy.PhotoCount, filterBy: PeopleFilterBy.Pets });
+
+    const result = await runLoad(new URL('https://gallery.test/people'));
+
+    expect(sdkMock.getAllPeople).toHaveBeenCalledWith({
+      withHidden: true,
+      withSharedSpaces: true,
+      size: PEOPLE_PAGE_SIZE,
+      $type: 'pet',
+    });
+    // Header totals come back with the list, so the page needs no second request to correct them.
+    expect(result.peopleListTotals).toEqual({ total: peopleResponse.total, hidden: peopleResponse.hidden });
+  });
+
+  it('applies a persisted People filter to the first request', async () => {
+    peopleViewSettings.set({ sortBy: PeopleSortBy.PhotoCount, filterBy: PeopleFilterBy.People });
+
+    await runLoad(new URL('https://gallery.test/people'));
+
+    expect(sdkMock.getAllPeople).toHaveBeenCalledWith(expect.objectContaining({ $type: 'person' }));
+  });
+
+  it('sends no type and no list totals under the All filter', async () => {
+    const result = await runLoad(new URL('https://gallery.test/people'));
+
+    expect(sdkMock.getAllPeople).toHaveBeenCalledWith(expect.objectContaining({ $type: undefined }));
+    // Null, so the header keeps reading the unfiltered overview statistics.
+    expect(result.peopleListTotals).toBeNull();
+  });
+
+  it('falls back to All when the persisted filter is corrupt', async () => {
+    peopleViewSettings.set({ sortBy: PeopleSortBy.PhotoCount, filterBy: 'Nonsense' as never });
+
+    const result = await runLoad(new URL('https://gallery.test/people'));
+
+    expect(sdkMock.getAllPeople).toHaveBeenCalledWith(expect.objectContaining({ $type: undefined }));
+    expect(result.peopleListTotals).toBeNull();
+  });
+
   it('skips the overview statistics query when the peopleStatistics flag is disabled', async () => {
     featureFlagsMock.valueOrUndefined = { peopleStatistics: false };
     const url = new URL('https://gallery.test/people');
@@ -70,6 +121,7 @@ describe('people page load', () => {
     await expect(runLoad(url)).resolves.toEqual({
       people: peopleResponse,
       peopleStatistics: null,
+      peopleListTotals: null,
       meta: { title: 'people' },
     });
 
@@ -110,6 +162,7 @@ describe('people page load', () => {
     await expect(runLoad(url)).resolves.toEqual({
       people: peopleResponse,
       peopleStatistics: null,
+      peopleListTotals: null,
       meta: { title: 'people' },
     });
   });

--- a/web/src/routes/(user)/people/people-page.spec.ts
+++ b/web/src/routes/(user)/people/people-page.spec.ts
@@ -18,7 +18,7 @@ import { sdkMock } from '$lib/__mocks__/sdk.mock';
 import { clearPeopleFaceStatisticsInfoCache } from '$lib/components/people/people-face-statistics-info-cache';
 import { PEOPLE_PAGE_SIZE } from '$lib/constants';
 import { authManager } from '$lib/managers/auth-manager.svelte';
-import { PeopleSortBy, peopleViewSettings } from '$lib/stores/preferences.store';
+import { PeopleFilterBy, PeopleSortBy, peopleViewSettings } from '$lib/stores/preferences.store';
 import { personFactory } from '@test-data/factories/person-factory';
 import { preferencesFactory } from '@test-data/factories/preferences-factory';
 import { userAdminFactory } from '@test-data/factories/user-factory';
@@ -119,6 +119,9 @@ function renderPage(
   people: PersonResponseDto[] = [makePerson()],
   peopleStatistics: PeopleStatisticsResponseDto | null = getDefaultPeopleStatistics(people),
   hasNextPage = false,
+  // Header totals for a filtered load, as `load` resolves them. Null under All, where the
+  // unfiltered overview statistics are the right source.
+  peopleListTotals: { total: number; hidden: number } | null = null,
 ) {
   return render(PeoplePage, {
     props: {
@@ -130,6 +133,7 @@ function renderPage(
           hasNextPage,
         },
         peopleStatistics,
+        peopleListTotals,
         meta: { title: 'People' },
       },
     },
@@ -179,7 +183,7 @@ function renderPaginatedPage() {
 describe('Global people page', () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    peopleViewSettings.set({ sortBy: PeopleSortBy.PhotoCount });
+    peopleViewSettings.set({ sortBy: PeopleSortBy.PhotoCount, filterBy: PeopleFilterBy.All });
     clearPeopleFaceStatisticsInfoCache();
     authManager.setUser(userAdminFactory.build({ id: 'current-user-id' }));
     authManager.setPreferences(preferencesFactory.build());
@@ -305,6 +309,34 @@ describe('Global people page', () => {
         'Alice',
       ]);
     });
+  });
+
+  // Regression: the page used to re-apply a persisted filter in onMount, so refreshing under Pets
+  // painted the unfiltered list for one round trip before narrowing. `load` now fetches the filtered
+  // list, so mounting must issue no request at all — no request, no flash.
+  it('issues no request on mount under a persisted non-All filter', async () => {
+    peopleViewSettings.set({ sortBy: PeopleSortBy.PhotoCount, filterBy: PeopleFilterBy.Pets });
+
+    renderPage([makePerson({ id: 'pet-1', name: 'Rex' })], { total: 1, hidden: 0, detectedFaceCount: 0 }, false, {
+      total: 1,
+      hidden: 0,
+    });
+
+    await waitFor(() => expect(screen.getByTestId('user-page-layout')).toBeInTheDocument());
+    expect(sdkMock.getAllPeople).not.toHaveBeenCalled();
+  });
+
+  // Under a filter the unfiltered overview statistics would report the whole library above a
+  // filtered grid, so the header has to read the totals `load` returned with the filtered list.
+  it('reads the header totals from the filtered load rather than the overview statistics', () => {
+    peopleViewSettings.set({ sortBy: PeopleSortBy.PhotoCount, filterBy: PeopleFilterBy.Pets });
+
+    renderPage([makePerson({ id: 'pet-1', name: 'Rex' })], { total: 120, hidden: 20, detectedFaceCount: 2901 }, false, {
+      total: 4,
+      hidden: 1,
+    });
+
+    expect(screen.getByTestId('user-page-layout')).toHaveAttribute('data-description', '(3) \u{B7} 2,901 faces');
   });
 
   it('shows visible people and detected faces in the heading', () => {

--- a/web/src/routes/(user)/spaces/[spaceId]/people/+page.svelte
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/+page.svelte
@@ -19,6 +19,7 @@
   import { createCrossOwnerMergeHandlers, runMergeWithCrossOwnerConfirmation } from '$lib/utils/cross-owner-merge';
   import { handleError } from '$lib/utils/handle-error';
   import { clearQueryParam } from '$lib/utils/navigation';
+  import { peopleFilterToTypeParam as filterToTypeParam, resolvePeopleFilterBy } from '$lib/utils/people-filter';
   import { sortPeople } from '$lib/utils/people-utils';
   import { formatPeopleHeaderDescription } from '$lib/utils/people-statistics';
   import {
@@ -103,24 +104,7 @@
     [PeopleFilterBy.People]: $t('people'),
     [PeopleFilterBy.Pets]: $t('pets'),
   });
-  let peopleFilterBy = $derived(
-    Object.values(PeopleFilterBy).includes($peopleViewSettings.filterBy as PeopleFilterBy)
-      ? ($peopleViewSettings.filterBy as PeopleFilterBy)
-      : PeopleFilterBy.All,
-  );
-  const filterToTypeParam = (filterBy: PeopleFilterBy) => {
-    switch (filterBy) {
-      case PeopleFilterBy.People: {
-        return 'person' as const;
-      }
-      case PeopleFilterBy.Pets: {
-        return 'pet' as const;
-      }
-      default: {
-        return undefined;
-      }
-    }
-  };
+  let peopleFilterBy = $derived(resolvePeopleFilterBy($peopleViewSettings.filterBy));
 
   const visiblePeople = $derived(
     sortPeople(
@@ -167,12 +151,13 @@
   );
   let allPeople = $state<SharedSpacePersonResponseDto[]>([]);
   let mergingPerson = $state<SharedSpacePersonResponseDto>();
-  // Unfiltered-by-type total, used only to gate show/hide access (canManageVisibility below).
-  // `peopleStatistics` gets re-fetched WITH the active type filter on every filter/search change, so
-  // it legitimately reads 0 under a Pets filter with no pets — that must not take the show/hide
-  // screen with it, since it's the one place a misdetected species bucket can be hidden. The SSR load
-  // (+page.ts) never passes a type, so this is set once here and left alone by refreshPeople/searchPeople.
-  let spacePeopleTotal = $state(0);
+  // Whether the space has any people at all, ignoring the type filter — it gates show/hide access
+  // (canManageVisibility below). `peopleStatistics` gets re-fetched WITH the active type filter on
+  // every filter/search change, so it legitimately reads 0 under a Pets filter with no pets; that
+  // must not take the show/hide screen with it, since it's the one place a misdetected species
+  // bucket can be corrected. `load` resolves this, so it is set once and left alone by
+  // refreshPeople/searchPeople.
+  let hasSpacePeople = $state(false);
 
   $effect(() => {
     if (data.space.id === loadedSpaceId) {
@@ -181,7 +166,7 @@
 
     people = data.people;
     peopleStatistics = data.peopleStatistics;
-    spacePeopleTotal = data.peopleStatistics?.total ?? data.people.length;
+    hasSpacePeople = data.hasSpacePeople;
     statisticsSearchName = null;
     hasMore = data.people.length >= PAGE_SIZE;
     mergingPerson = undefined;
@@ -191,19 +176,13 @@
   const currentMember = $derived(members.find((m) => m.userId === authManager.user.id));
   const isOwner = $derived(currentMember?.role === SharedSpaceRole.Owner);
   const isEditor = $derived(isOwner || currentMember?.role === SharedSpaceRole.Editor);
-  const canManageVisibility = $derived(isEditor && spacePeopleTotal > 0);
+  const canManageVisibility = $derived(isEditor && hasSpacePeople);
 
   onMount(() => {
     const searchedPeople = $page.url.searchParams.get(QueryParameter.SEARCHED_PEOPLE);
     if (searchedPeople) {
       searchName = searchedPeople;
       handlePromiseError(searchPeople(searchedPeople));
-    }
-
-    // The SSR load (+page.ts) is always unfiltered, so a persisted non-All choice has to trigger
-    // a refetch here, same as the global people page.
-    if (peopleFilterBy !== PeopleFilterBy.All) {
-      handlePromiseError(handleFilterChange(peopleFilterBy));
     }
   });
 

--- a/web/src/routes/(user)/spaces/[spaceId]/people/+page.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/+page.ts
@@ -1,6 +1,7 @@
 import { getSpacePeople, getSpacePeopleStatistics } from '@immich/sdk';
 import { redirect } from '@sveltejs/kit';
 import { authenticate } from '$lib/utils/auth';
+import { getPersistedPeopleTypeParam } from '$lib/utils/people-filter';
 import type { PageLoad } from './$types';
 
 export const load = (async ({ url, params, parent }) => {
@@ -10,9 +11,27 @@ export const load = (async ({ url, params, parent }) => {
   if (!space.faceRecognitionEnabled) {
     redirect(307, `/spaces/${params.spaceId}`);
   }
+
+  // Apply the persisted People/Pets choice to the FIRST request. The tab used to load unfiltered and
+  // re-fetch in onMount, so refreshing under a Pets filter painted the full people list for one
+  // round trip before narrowing to pets.
+  const type = getPersistedPeopleTypeParam();
+
   const [people, peopleStatistics] = await Promise.all([
-    getSpacePeople({ id: params.spaceId, limit: 100 }),
-    getSpacePeopleStatistics({ id: params.spaceId }).catch(() => null),
+    getSpacePeople({ id: params.spaceId, limit: 100, ...(type && { $type: type }) }),
+    getSpacePeopleStatistics({ id: params.spaceId, ...(type && { $type: type }) }).catch(() => null),
   ]);
-  return { people, peopleStatistics };
+
+  // Whether the space has ANY people, ignoring the active type filter. The show/hide screen is the
+  // one place a misdetected species bucket can be corrected, so a Pets filter matching nothing must
+  // not hide it (see `hasSpacePeople` in +page.svelte). Anything the filtered queries already found
+  // answers this, so the extra unfiltered request is spent only when the filter matched nothing —
+  // never on an unfiltered load, and never on a filtered one that returned rows.
+  let hasSpacePeople = people.length > 0 || (peopleStatistics?.total ?? 0) > 0;
+  if (!hasSpacePeople && type) {
+    const unfiltered = await getSpacePeopleStatistics({ id: params.spaceId }).catch(() => null);
+    hasSpacePeople = (unfiltered?.total ?? 0) > 0;
+  }
+
+  return { people, peopleStatistics, hasSpacePeople };
 }) satisfies PageLoad;

--- a/web/src/routes/(user)/spaces/[spaceId]/people/page-load.spec.ts
+++ b/web/src/routes/(user)/spaces/[spaceId]/people/page-load.spec.ts
@@ -1,5 +1,6 @@
 import { SharedSpaceRole } from '@immich/sdk';
 import { sdkMock } from '$lib/__mocks__/sdk.mock';
+import { PeopleFilterBy, PeopleSortBy, peopleViewSettings } from '$lib/stores/preferences.store';
 import { load } from './+page';
 
 const { authenticate } = vi.hoisted(() => ({
@@ -75,6 +76,7 @@ describe('space people page load', () => {
     vi.resetAllMocks();
     sdkMock.getSpacePeople.mockResolvedValue(people as never);
     sdkMock.getSpacePeopleStatistics.mockResolvedValue(peopleStatistics);
+    peopleViewSettings.set({ sortBy: PeopleSortBy.PhotoCount, filterBy: PeopleFilterBy.All });
   });
 
   it('authenticates and loads space people with overview statistics', async () => {
@@ -82,6 +84,7 @@ describe('space people page load', () => {
     await expect(load(event as never)).resolves.toEqual({
       people,
       peopleStatistics,
+      hasSpacePeople: true,
     });
 
     expect(authenticate).toHaveBeenCalledWith(event.url);
@@ -100,7 +103,61 @@ describe('space people page load', () => {
     await expect(load(makeEvent() as never)).resolves.toEqual({
       people,
       peopleStatistics: null,
+      hasSpacePeople: true,
     });
+  });
+
+  // The tab used to load unfiltered and re-apply the persisted filter in onMount, so refreshing
+  // under a Pets filter painted the whole people list for one round trip before narrowing to pets.
+  it('applies a persisted Pets filter to the first request', async () => {
+    peopleViewSettings.set({ sortBy: PeopleSortBy.PhotoCount, filterBy: PeopleFilterBy.Pets });
+    const filtered = { total: 3, hidden: 0, detectedFaceCount: 40 };
+    sdkMock.getSpacePeopleStatistics.mockImplementation((query: { $type?: string }) =>
+      Promise.resolve(query.$type ? filtered : peopleStatistics),
+    );
+
+    const result = await load(makeEvent() as never);
+
+    expect(sdkMock.getSpacePeople).toHaveBeenCalledWith({ id: 'space-1', limit: 100, $type: 'pet' });
+    expect(sdkMock.getSpacePeopleStatistics).toHaveBeenCalledWith({ id: 'space-1', $type: 'pet' });
+    expect(result.peopleStatistics).toEqual(filtered);
+    // The filtered queries already found people, so the gate is answered without a second request.
+    expect(result.hasSpacePeople).toBe(true);
+    expect(sdkMock.getSpacePeopleStatistics).toHaveBeenCalledTimes(1);
+  });
+
+  // The show/hide screen is the one place a misdetected species bucket can be corrected, so a Pets
+  // filter matching nothing must not hide it — that, and only that, is worth a second request.
+  it('spends one extra statistics request only when the active filter matches nothing', async () => {
+    peopleViewSettings.set({ sortBy: PeopleSortBy.PhotoCount, filterBy: PeopleFilterBy.Pets });
+    sdkMock.getSpacePeople.mockResolvedValue([] as never);
+    sdkMock.getSpacePeopleStatistics.mockImplementation((query: { $type?: string }) =>
+      Promise.resolve(query.$type ? { total: 0, hidden: 0, detectedFaceCount: 0 } : peopleStatistics),
+    );
+
+    const result = await load(makeEvent() as never);
+
+    expect(result.hasSpacePeople).toBe(true);
+    expect(sdkMock.getSpacePeopleStatistics).toHaveBeenCalledWith({ id: 'space-1' });
+    expect(sdkMock.getSpacePeopleStatistics).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports no people when the space is genuinely empty', async () => {
+    sdkMock.getSpacePeople.mockResolvedValue([] as never);
+    sdkMock.getSpacePeopleStatistics.mockResolvedValue({ total: 0, hidden: 0, detectedFaceCount: 0 });
+
+    const result = await load(makeEvent() as never);
+
+    expect(result.hasSpacePeople).toBe(false);
+    // No filter is active, so the single statistics call already answered the gate.
+    expect(sdkMock.getSpacePeopleStatistics).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not spend a second statistics request under the All filter', async () => {
+    await load(makeEvent() as never);
+
+    expect(sdkMock.getSpacePeopleStatistics).toHaveBeenCalledTimes(1);
+    expect(sdkMock.getSpacePeople).toHaveBeenCalledWith({ id: 'space-1', limit: 100 });
   });
 
   it('still rejects when the people list fails', async () => {


### PR DESCRIPTION
Refreshing either People page with a saved **Pets** filter showed the full, unfiltered people list for a moment before narrowing to pets.

Both `+page.ts` loaders fetched unfiltered, and the component re-applied the persisted choice in `onMount` — so the corrected list was always one round trip behind first paint:

```js
// The SSR load (+page.ts) is always unfiltered, so a persisted non-All choice has to trigger
// a refetch here, same as the global people page.
if (peopleFilterBy !== PeopleFilterBy.All) {
  handlePromiseError(handleFilterChange(peopleFilterBy));
}
```

## The fix

Read the setting in `load` instead — the root layout sets `ssr = false`, so it runs in the browser with localStorage available — and drop the mount refetch. The first request is now the filtered one: no second request, no flash.

Two things the loaders have to carry over as a result:

- **Global page header totals.** The overview-statistics endpoint is unfiltered, so under a filter the header has to read the filtered list's own totals. `load` returns them rather than making the page re-fetch to discover what it just loaded. Null under `All`, where the overview stats are the right source.
- **Space tab show/hide gate**, which must stay *unfiltered*: a Pets filter matching nothing must not hide the one screen where a misdetected species bucket can be corrected. Reduced to the boolean it was always used as (`hasSpacePeople`), and resolved **without extra traffic** — anything the filtered queries already found answers it, so the extra unfiltered request is spent only when the filter matched nothing. Never on an unfiltered load, never on a filtered one that returned rows.

Also fixes the global page's scroll restore, which paged with no `$type` and so appended unfiltered people onto a filtered grid.

The filter helpers move to `$lib/utils/people-filter`, deliberately apart from `people-utils`: that module reaches the asset-viewer manager and SDK URL helpers, which a `load` has no business importing to read one persisted enum.

## Testing

Full web suite green (`6327 passed`). New coverage, each proven to fail without the fix:

- loaders send `$type` for a persisted People/Pets choice, and fall back to `All` on a corrupt value
- both pages issue **no request on mount** under a persisted filter — the direct regression guard for the flash
- the global header reads the filtered load's totals rather than the unfiltered overview stats
- the space loader spends its second statistics request only when the filter matched nothing
- show/hide stays reachable when the active filter matches nothing

## Base

Stacked on `feat/people-pets-filter-parity` (#1070): the global-page half of this bug is on `main`, but the space-page half only exists on that branch, so fixing both together needs it as the base. Retarget to `main` once #1070 merges.

https://claude.ai/code/session_017Z9KkjH2EZ43A4kE4bzMa8