### PR TITLE
fix(web): keep the People filter reachable when it matches nobody

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -2830,6 +2830,7 @@
   "search_no_more_result": "Keine weiteren Ergebnisse",
   "search_no_people": "Keine Personen",
   "search_no_people_named": "Keine Person mit dem Namen \"{name}\"",
+  "search_no_pets": "Keine Haustiere",
   "search_no_result": "Keine Ergebnisse gefunden, probiere eine andere Kombination oder einen anderen Suchbegriff",
   "search_open_palette": "Palette öffnen",
   "search_options": "Suchoptionen",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2833,6 +2833,7 @@
   "search_no_more_result": "No more results",
   "search_no_people": "No people",
   "search_no_people_named": "No people named \"{name}\"",
+  "search_no_pets": "No pets",
   "search_no_result": "No results found, try a different search term or combination",
   "search_open_palette": "Open palette",
   "search_options": "Search options",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -2830,6 +2830,7 @@
   "search_no_more_result": "No hay más resultados",
   "search_no_people": "Ninguna persona",
   "search_no_people_named": "Ninguna persona llamada \"{name}\"",
+  "search_no_pets": "Ninguna mascota",
   "search_no_result": "No se encontraron resultados, prueba con un término o combinación de búsqueda diferente",
   "search_open_palette": "Abrir la paleta",
   "search_options": "Opciones de búsqueda",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -2830,6 +2830,7 @@
   "search_no_more_result": "Plus de résultats",
   "search_no_people": "Aucune personne",
   "search_no_people_named": "Aucune personne nommée « {name} »",
+  "search_no_pets": "Aucun animal",
   "search_no_result": "Aucun résultat trouvé, essayez un autre terme de recherche ou une autre combinaison",
   "search_open_palette": "Ouvrir la palette",
   "search_options": "Options de recherche",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -2830,6 +2830,7 @@
   "search_no_more_result": "Non ci sono altri risultati",
   "search_no_people": "Nessuna persona",
   "search_no_people_named": "Nessuna persona chiamate \"{name}\"",
+  "search_no_pets": "Nessun animale domestico",
   "search_no_result": "Nessun risultato trovato, prova con un termine o combinazione diversi",
   "search_open_palette": "Apri la palette",
   "search_options": "Opzioni di ricerca",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -2830,6 +2830,7 @@
   "search_no_more_result": "Geen resultaten meer",
   "search_no_people": "Geen mensen",
   "search_no_people_named": "Geen mensen genaamd \"{name}\"",
+  "search_no_pets": "Geen huisdieren",
   "search_no_result": "Geen resultaten gevonden, probeer een andere zoekterm of combinatie",
   "search_open_palette": "Palet openen",
   "search_options": "Zoekopties",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -2848,6 +2848,7 @@
   "search_no_more_result": "Brak dalszych wyników",
   "search_no_people": "Brak osób",
   "search_no_people_named": "Brak osób nazwanych \"{name}\"",
+  "search_no_pets": "Brak zwierząt",
   "search_no_result": "Nie znaleziono wyników, spróbuj innego terminu wyszukiwania lub kombinacji",
   "search_open_palette": "Otwórz paletę",
   "search_options": "Opcje wyszukiwania",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -2832,6 +2832,7 @@
   "search_no_more_result": "Больше результатов нет",
   "search_no_people": "Нет людей",
   "search_no_people_named": "Нет людей с именем \"{name}\"",
+  "search_no_pets": "Нет питомцев",
   "search_no_result": "Ничего не найдено, попробуйте изменить поисковый запрос",
   "search_open_palette": "Открыть палитру",
   "search_options": "Параметры поиска",

--- a/i18n/zh_Hans.json
+++ b/i18n/zh_Hans.json
@@ -2830,6 +2830,7 @@
   "search_no_more_result": "无更多结果",
   "search_no_people": "找不到人物",
   "search_no_people_named": "人物“{name}”不存在",
+  "search_no_pets": "找不到宠物",
   "search_no_result": "未找到结果，请尝试不同的搜索词或搜索组合",
   "search_open_palette": "打开命令面板",
   "search_options": "搜索选项",

--- a/i18n/zh_Hant.json
+++ b/i18n/zh_Hant.json
@@ -2830,6 +2830,7 @@
   "search_no_more_result": "無更多結果",
   "search_no_people": "沒有人找到",
   "search_no_people_named": "沒有名為「{name}」的人物",
+  "search_no_pets": "沒有寵物",
   "search_no_result": "找不到結果，請嘗試其他搜尋字詞或組合",
   "search_open_palette": "開啟命令面板",
   "search_options": "搜尋選項",

--- a/web/src/routes/(user)/people/+page.svelte
+++ b/web/src/routes/(user)/people/+page.svelte
@@ -331,6 +331,20 @@
     [PeopleFilterBy.Pets]: $t('pets'),
   });
   let peopleFilterBy = $derived(resolvePeopleFilterBy($peopleViewSettings.filterBy));
+  // "No people" under an empty Pets filter reads as a claim about the whole library, which is
+  // exactly backwards: the library still has people, it just has no pets.
+  let emptyStateMessageKey: 'search_no_people' | 'search_no_people_named' | 'search_no_pets' = $derived(
+    searchName
+      ? 'search_no_people_named'
+      : peopleFilterBy === PeopleFilterBy.Pets
+        ? 'search_no_pets'
+        : 'search_no_people',
+  );
+  // A type filter that matches nothing — Pets after a pet-detection reset, say — legitimately
+  // empties `people` without meaning the library has none. Gating the toolbar on the loaded rows
+  // alone takes the filter dropdown down with them, stranding the user on the empty view with no
+  // control to get back to All.
+  let hasPeopleControls = $derived(people.length > 0 || peopleFilterBy !== PeopleFilterBy.All);
 
   const handleFilterChange = async (filterBy: PeopleFilterBy) => {
     $peopleViewSettings.filterBy = filterBy;
@@ -493,7 +507,7 @@
   {/snippet}
 
   {#snippet buttons()}
-    {#if people.length > 0}
+    {#if hasPeopleControls}
       <div class="flex items-center justify-center gap-2">
         <div class="hidden sm:block">
           <div class="h-10 w-40 lg:w-80">
@@ -575,7 +589,7 @@
       <div class="flex flex-col content-center items-center text-center">
         <Icon icon={mdiAccountOff} size="3.5em" />
         <p class="mt-5 line-clamp-2 max-w-lg overflow-hidden text-3xl font-medium">
-          {$t(searchName ? 'search_no_people_named' : 'search_no_people', { values: { name: searchName } })}
+          {$t(emptyStateMessageKey, { values: { name: searchName } })}
         </p>
       </div>
     </div>

--- a/web/src/routes/(user)/people/people-page.spec.ts
+++ b/web/src/routes/(user)/people/people-page.spec.ts
@@ -280,6 +280,55 @@ describe('Global people page', () => {
     expect(screen.queryByRole('button', { name: 'sort_people_most_photos' })).toBeNull();
   });
 
+  // A library with people but no pets, loaded under a persisted Pets filter — what a user is left
+  // with after resetting pet detection. `load` applies the filter, so the page is handed an empty
+  // list and zeroed filtered totals while the unfiltered overview statistics still count people.
+  const renderEmptyPetFilter = () => {
+    peopleViewSettings.set({ sortBy: PeopleSortBy.PhotoCount, filterBy: PeopleFilterBy.Pets });
+    return renderPage([], { total: 12, hidden: 0, detectedFaceCount: 340 }, false, { total: 0, hidden: 0 });
+  };
+
+  it('keeps the type filter reachable when the active filter matches nobody', () => {
+    // An empty filtered list says nothing about whether the library has people. Gating the toolbar
+    // on the loaded rows takes the filter dropdown down with them, stranding the user on the empty
+    // view with no control to get back to All.
+    renderEmptyPetFilter();
+
+    expect(screen.getByRole('button', { name: 'pets' })).toBeInTheDocument();
+  });
+
+  it('names pets, not people, in the empty state under the Pets filter', () => {
+    renderEmptyPetFilter();
+
+    // "No people" under an empty Pets filter reads as a claim about the whole library, which is
+    // exactly backwards: the library still has people, it just has no pets.
+    expect(screen.getByText('search_no_pets')).toBeInTheDocument();
+    expect(screen.queryByText('search_no_people')).toBeNull();
+  });
+
+  it('reloads the unfiltered people when an empty pet filter is switched back to All', async () => {
+    const user = userEvent.setup();
+    renderEmptyPetFilter();
+    sdkMock.getAllPeople.mockResolvedValue({
+      people: [makePerson({ id: 'p1', name: 'Alice' })],
+      total: 1,
+      hidden: 0,
+      hasNextPage: false,
+    });
+
+    await user.click(screen.getByRole('button', { name: 'pets' }));
+    await user.click(screen.getByRole('button', { name: 'all' }));
+
+    await waitFor(() => expect(screen.getByDisplayValue('Alice')).toBeInTheDocument());
+    expect(sdkMock.getAllPeople).toHaveBeenLastCalledWith({
+      withHidden: true,
+      withSharedSpaces: true,
+      page: 1,
+      size: PEOPLE_PAGE_SIZE,
+      $type: undefined,
+    });
+  });
+
   it('falls back to the default order when the stored preference is corrupt', () => {
     peopleViewSettings.set({ sortBy: 'garbage' as PeopleSortBy });
     renderPage([


### PR DESCRIPTION
Reset pet detection while the People page is filtered to Pets and the page becomes a dead end: the filtered list is empty, the toolbar is gated on the loaded rows, so the filter dropdown disappears along with the grid. There is no control left to switch back to All, and no way to reach your people again short of clearing site data. With the filter now applied in `load` (#1072) this happens on first paint rather than after a round trip.

## The fix

An empty filtered list says nothing about whether the library has people, so the toolbar is gated on `people.length > 0 || filter !== All` instead. This is the rule the space People tab already applies. A genuinely empty library — no rows, no filter — still gets no toolbar, which the existing `hides the sort control when there are no people` test pins down.

The empty state was also claiming "No people" under a Pets filter, which is the opposite of what is true: the library has people, it has no pets. It now names what was actually filtered for (`search_no_pets`, added across the nine maintained locales).

## Verification

- Three new tests in `people-page.spec.ts`, each watched failing against the pre-fix page: the filter dropdown survives an empty filtered load, the empty state names pets, and switching back to All refetches unfiltered and repopulates the grid.
- Mutating the gate to always-true is caught by the pre-existing empty-library test, so the fix is not over-broad.
- `web`: 6330 unit tests pass, `svelte-check` 0 errors, `tsc --noEmit` clean, eslint clean, prettier clean.

Mobile is unaffected — its People filter button lives in the app bar and is never gated on the list.

https://claude.ai/code/session_01UeqQne7pM9mBLrqwSngMN3
