### PR TITLE
feat(web): make the search mode visible and tappable next to the search bar

### DIFF
--- a/web/src/lib/components/global-search/__tests__/global-search-footer.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search-footer.spec.ts
@@ -1,84 +1,36 @@
 import { modalManager } from '@immich/ui';
 import { render, screen } from '@testing-library/svelte';
-import userEvent from '@testing-library/user-event';
 import { init, register, waitLocale } from 'svelte-i18n';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { GlobalSearchManager } from '$lib/managers/global-search-manager.svelte';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 import ShortcutsModal from '$lib/modals/ShortcutsModal.svelte';
 import GlobalSearchFooter from '../global-search-footer.svelte';
 
-vi.mock('@immich/sdk', async () => {
-  const actual = await vi.importActual<typeof import('@immich/sdk')>('@immich/sdk');
-  return {
-    ...actual,
-    searchSmart: vi.fn().mockResolvedValue({ assets: { items: [], nextPage: null } }),
-    searchAssets: vi.fn().mockResolvedValue({ assets: { items: [], nextPage: null } }),
-    searchPerson: vi.fn().mockResolvedValue([]),
-    searchPlaces: vi.fn().mockResolvedValue([]),
-    getAllTags: vi.fn().mockResolvedValue([]),
-  };
-});
-
 describe('global-search-footer', () => {
-  beforeEach(() => {
-    localStorage.clear();
+  // The mode segmented control moved out of the footer and into `SearchModeControl`,
+  // which renders as a rail under the palette input and as a chip in the inline search
+  // field. Leaving a copy down here would be duplicate UI, and on a phone the extra
+  // items overflowed this `justify-between` row.
+  it('no longer renders the mode segmented control', () => {
+    render(GlobalSearchFooter);
+    expect(screen.queryAllByRole('radio')).toHaveLength(0);
   });
 
-  it('renders four segmented-control radios', () => {
-    const manager = new GlobalSearchManager();
-    render(GlobalSearchFooter, { props: { manager } });
-    for (const label of ['cmdk_mode_smart', 'cmdk_mode_filename', 'cmdk_mode_description', 'cmdk_mode_ocr']) {
-      expect(screen.getByRole('radio', { name: new RegExp(label, 'i') })).toBeInTheDocument();
-    }
-  });
-
-  it('reflects manager.mode as the checked radio', () => {
-    const manager = new GlobalSearchManager();
-    manager.setMode('metadata');
-    render(GlobalSearchFooter, { props: { manager } });
-    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
-    const filenameRadio = radios.find((r) => r.value === 'metadata');
-    expect(filenameRadio?.checked).toBe(true);
-  });
-
-  it('clicking a segment calls manager.setMode with the right value', async () => {
-    const user = userEvent.setup({ pointerEventsCheck: 0 });
-    const manager = new GlobalSearchManager();
-    const spy = vi.spyOn(manager, 'setMode');
-    render(GlobalSearchFooter, { props: { manager } });
-    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
-    const descriptionRadio = radios.find((r) => r.value === 'description');
-    await user.click(descriptionRadio!);
-    expect(spy).toHaveBeenCalledWith('description');
-  });
-
-  it('displays the Ctrl+/ keybind hint', () => {
-    const manager = new GlobalSearchManager();
-    render(GlobalSearchFooter, { props: { manager } });
-    expect(screen.getByText(/ctrl\+\//i)).toBeInTheDocument();
+  it('no longer advertises Ctrl+/, now that the control itself is on screen', () => {
+    render(GlobalSearchFooter);
+    expect(screen.queryByText(/ctrl\+\//i)).not.toBeInTheDocument();
   });
 });
 
 describe('prefix scoping — footer chrome', () => {
-  let manager: GlobalSearchManager;
-
-  // Load en so `$t('cmdk_scope_hint_footer')` resolves to "@ # / >" rather than
-  // the raw key. Other blocks in this file use raw-key assertions and don't need
-  // locale setup — this scoped beforeAll keeps the change localized.
+  // Load en so `$t('cmdk_scope_hint_footer')` resolves to "@ # / >" rather than the raw key.
   beforeAll(async () => {
     register('en-US', () => import('$i18n/en.json'));
     await init({ fallbackLocale: 'en-US' });
     await waitLocale('en-US');
   });
 
-  beforeEach(() => {
-    localStorage.clear();
-    manager = new GlobalSearchManager();
-  });
-
-  it('renders both kbd groups (Ctrl+/ cycle and @ # / > scope)', () => {
-    const { getByText } = render(GlobalSearchFooter, { props: { manager } });
-    expect(getByText('Ctrl+/')).toBeInTheDocument();
+  it('keeps the @ # / > scope hint', () => {
+    const { getByText } = render(GlobalSearchFooter);
     expect(getByText('@ # / >')).toBeInTheDocument();
     // The label next to the kbd is translated (cmdk_scope_hint_footer_label); beforeAll
     // loads en-US so it must resolve to "scope" and stay rendered — guards against
@@ -87,14 +39,14 @@ describe('prefix scoping — footer chrome', () => {
   });
 
   it('? icon button hidden below sm breakpoint (carries sm:block class)', () => {
-    const { container } = render(GlobalSearchFooter, { props: { manager } });
+    const { container } = render(GlobalSearchFooter);
     const btn = container.querySelector('[data-cmdk-shortcuts-trigger]');
     expect(btn?.className).toMatch(/sm:block|sm:flex|sm:inline-flex/);
   });
 
   it('clicking ? calls modalManager.show(ShortcutsModal, {})', () => {
     const showSpy = vi.spyOn(modalManager, 'show');
-    const { container } = render(GlobalSearchFooter, { props: { manager } });
+    const { container } = render(GlobalSearchFooter);
     const btn = container.querySelector('[data-cmdk-shortcuts-trigger]') as HTMLButtonElement;
     btn.click();
     expect(showSpy).toHaveBeenCalledWith(ShortcutsModal, {});

--- a/web/src/lib/components/global-search/__tests__/global-search.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search.spec.ts
@@ -2143,6 +2143,26 @@ describe('search mode control placement', () => {
     expect(m.mode).toBe('description');
   });
 
+  // Both the menu and the results panel are absolutely positioned under the field and
+  // overlap, and clicking the chip does not close the dropdown (the chip is inside the
+  // field's clickOutside wrapper). The panel is the later sibling, so at equal z-index it
+  // wins the paint and swallows the menu. Assert the menu outranks it.
+  it('paints the chip menu above the open results panel', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const m = new GlobalSearchManager();
+    m.open('dropdown');
+    const { container } = render(GlobalSearch, { props: { manager: m, variant: 'dropdown' } });
+
+    await user.click(container.querySelector('[data-testid="search-mode-chip-trigger"]') as HTMLButtonElement);
+
+    const zIndexOf = (element: Element | null) => Number(/z-(\d+)/.exec(element?.className ?? '')?.[1] ?? 0);
+    const panel = container.querySelector('[data-cmdk-dropdown-panel]');
+    const menu = container.querySelector(':scope [data-testid="search-mode-chip"] [role="menu"]');
+    expect(panel).not.toBeNull();
+    expect(menu).not.toBeNull();
+    expect(zIndexOf(menu)).toBeGreaterThan(zIndexOf(panel));
+  });
+
   it('keeps the chip out of the modal, where the rail already carries the mode', () => {
     const m = new GlobalSearchManager();
     m.open();

--- a/web/src/lib/components/global-search/__tests__/global-search.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search.spec.ts
@@ -2143,6 +2143,14 @@ describe('search mode control placement', () => {
     expect(m.mode).toBe('description');
   });
 
+  it('keeps the chip out of the modal, where the rail already carries the mode', () => {
+    const m = new GlobalSearchManager();
+    m.open();
+    render(GlobalSearch, { props: { manager: m } });
+
+    expect(document.querySelector('[data-testid="search-mode-chip"]')).toBeNull();
+  });
+
   it('keeps the rail out of the inline dropdown, where the chip already carries the mode', () => {
     const m = new GlobalSearchManager();
     const { container } = render(GlobalSearch, { props: { manager: m, variant: 'dropdown' } });

--- a/web/src/lib/components/global-search/__tests__/global-search.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/global-search.spec.ts
@@ -1883,16 +1883,16 @@ describe('prefix scoping — scoped rendering', () => {
     const manager = makeWithScope('@alice');
     render(GlobalSearch, { props: { manager } });
     // Modal portals its content to document.body, not the render container.
-    const radioGroup = document.querySelector('[role="radiogroup"]');
+    const radioGroup = document.querySelector('[data-testid="search-mode-rail"]');
     expect(radioGroup).not.toBeNull();
-    expect(radioGroup?.className).toMatch(/opacity-50/);
+    expect(radioGroup).toHaveAttribute('data-scoped', 'true');
     // The radiogroup + every radio input inside it must not carry aria-disabled —
     // they stay focusable so users can still preset a mode for when they clear
     // the prefix. Scoping to the radiogroup subtree avoids coincidental
     // `aria-disabled` from unrelated portal content (Modal chrome, etc.).
     expect(radioGroup?.hasAttribute('aria-disabled')).toBe(false);
     expect(radioGroup?.querySelectorAll('[aria-disabled]').length).toBe(0);
-    const radios = document.querySelectorAll('input[type="radio"][name="cmdk-mode"]');
+    const radios = document.querySelectorAll('input[type="radio"][name="search-mode-rail"]');
     expect(radios.length).toBeGreaterThan(0);
     // Radio inputs default to tabindex=0; confirm none are tabindex=-1.
     for (const r of radios) {
@@ -2095,5 +2095,58 @@ describe('prefix scoping — scoped rendering', () => {
     expect(document.querySelector('[data-cmdk-nav-section]')).not.toBeNull();
     const rows = document.querySelectorAll('[data-command-item]');
     expect(rows.length).toBeGreaterThan(0);
+  });
+});
+
+describe('search mode control placement', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('puts the rail in the modal palette', () => {
+    const m = new GlobalSearchManager();
+    m.open();
+    render(GlobalSearch, { props: { manager: m } });
+
+    expect(document.querySelector('[data-testid="search-mode-rail"]')).not.toBeNull();
+  });
+
+  it('changes the manager mode from the modal rail', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const m = new GlobalSearchManager();
+    m.open();
+    render(GlobalSearch, { props: { manager: m } });
+
+    const radios = [...document.querySelectorAll('[data-testid="search-mode-rail"] input')] as HTMLInputElement[];
+    await user.click(radios.find((radio) => radio.value === 'ocr')!);
+
+    expect(m.mode).toBe('ocr');
+  });
+
+  it('puts the chip inside the inline search field, where the Cmd-K hint lives', () => {
+    const m = new GlobalSearchManager();
+    const { container } = render(GlobalSearch, { props: { manager: m, variant: 'dropdown' } });
+
+    expect(
+      container.querySelector(':scope [data-testid="cmdk-input-trigger"] [data-testid="search-mode-chip"]'),
+    ).not.toBeNull();
+  });
+
+  it('changes the manager mode from the inline chip', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const m = new GlobalSearchManager();
+    const { container } = render(GlobalSearch, { props: { manager: m, variant: 'dropdown' } });
+
+    await user.click(container.querySelector('[data-testid="search-mode-chip-trigger"]') as HTMLButtonElement);
+    await user.click(container.querySelector('[data-testid="search-mode-option-description"]') as HTMLButtonElement);
+
+    expect(m.mode).toBe('description');
+  });
+
+  it('keeps the rail out of the inline dropdown, where the chip already carries the mode', () => {
+    const m = new GlobalSearchManager();
+    const { container } = render(GlobalSearch, { props: { manager: m, variant: 'dropdown' } });
+
+    expect(container.querySelector('[data-testid="search-mode-rail"]')).toBeNull();
   });
 });

--- a/web/src/lib/components/global-search/__tests__/search-mode-control.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/search-mode-control.spec.ts
@@ -1,0 +1,233 @@
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import { init, register, waitLocale } from 'svelte-i18n';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import SearchModeControl from '../search-mode-control.svelte';
+
+beforeAll(async () => {
+  register('en-US', () => import('$i18n/en.json'));
+  await init({ fallbackLocale: 'en-US' });
+  await waitLocale('en-US');
+});
+
+describe('search-mode-control — rail variant', () => {
+  it('renders one radio per search mode', () => {
+    render(SearchModeControl, { props: { variant: 'rail', mode: 'smart', onSelect: vi.fn() } });
+
+    const values = (screen.getAllByRole('radio') as HTMLInputElement[]).map((radio) => radio.value);
+    expect(values).toEqual(['smart', 'metadata', 'description', 'ocr']);
+  });
+
+  it('checks the radio matching the active mode', () => {
+    render(SearchModeControl, { props: { variant: 'rail', mode: 'description', onSelect: vi.fn() } });
+
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    expect(radios.find((radio) => radio.checked)?.value).toBe('description');
+  });
+
+  it('calls onSelect with the clicked mode', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const onSelect = vi.fn();
+    render(SearchModeControl, { props: { variant: 'rail', mode: 'smart', onSelect } });
+
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    await user.click(radios.find((radio) => radio.value === 'ocr')!);
+
+    expect(onSelect).toHaveBeenCalledWith('ocr');
+  });
+
+  it('labels the group so the control is identifiable without sighted context', () => {
+    render(SearchModeControl, { props: { variant: 'rail', mode: 'smart', onSelect: vi.fn() } });
+
+    expect(screen.getByRole('radiogroup', { name: 'Search mode' })).toBeInTheDocument();
+  });
+});
+
+describe('search-mode-control — chip variant', () => {
+  it('names the active mode on the trigger, so the mode is legible while the menu is shut', () => {
+    render(SearchModeControl, { props: { variant: 'chip', mode: 'ocr', onSelect: vi.fn() } });
+
+    expect(screen.getByRole('button', { name: 'Search mode: OCR' })).toBeInTheDocument();
+  });
+
+  it('keeps the menu shut until the trigger is clicked', () => {
+    render(SearchModeControl, { props: { variant: 'chip', mode: 'smart', onSelect: vi.fn() } });
+
+    expect(screen.queryByRole('menuitemradio')).not.toBeInTheDocument();
+  });
+
+  it('opens a menu with one item per search mode', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(SearchModeControl, { props: { variant: 'chip', mode: 'smart', onSelect: vi.fn() } });
+
+    await user.click(screen.getByRole('button', { name: 'Search mode: Smart' }));
+
+    expect(screen.getAllByRole('menuitemradio').map((item) => item.textContent?.trim())).toEqual([
+      'Smart',
+      'Filename',
+      'Description',
+      'OCR',
+    ]);
+  });
+
+  it('marks the active mode as checked in the open menu', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(SearchModeControl, { props: { variant: 'chip', mode: 'metadata', onSelect: vi.fn() } });
+
+    await user.click(screen.getByRole('button', { name: 'Search mode: Filename' }));
+
+    const checked = screen.getAllByRole('menuitemradio').filter((item) => item.getAttribute('aria-checked') === 'true');
+    expect(checked.map((item) => item.textContent?.trim())).toEqual(['Filename']);
+  });
+
+  it('calls onSelect with the chosen mode', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const onSelect = vi.fn();
+    render(SearchModeControl, { props: { variant: 'chip', mode: 'smart', onSelect } });
+
+    await user.click(screen.getByRole('button', { name: 'Search mode: Smart' }));
+    await user.click(screen.getByRole('menuitemradio', { name: 'Description' }));
+
+    expect(onSelect).toHaveBeenCalledWith('description');
+  });
+
+  it('closes the menu once a mode is chosen', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(SearchModeControl, { props: { variant: 'chip', mode: 'smart', onSelect: vi.fn() } });
+
+    await user.click(screen.getByRole('button', { name: 'Search mode: Smart' }));
+    await user.click(screen.getByRole('menuitemradio', { name: 'Description' }));
+
+    expect(screen.queryByRole('menuitemradio')).not.toBeInTheDocument();
+  });
+});
+
+describe('search-mode-control — chip menu dismissal', () => {
+  const openMenu = async (user: ReturnType<typeof userEvent.setup>) => {
+    render(SearchModeControl, { props: { variant: 'chip', mode: 'smart', onSelect: vi.fn() } });
+    await user.click(screen.getByRole('button', { name: 'Search mode: Smart' }));
+    expect(screen.queryByRole('menu')).toBeInTheDocument();
+  };
+
+  it('closes when a click lands outside the control', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    await openMenu(user);
+
+    await user.click(document.body);
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('closes on Escape', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    await openMenu(user);
+
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  // The chip sits inside the search field, which is wrapped in a `clickOutside` action
+  // whose `onEscape` closes the whole palette. Without stopping propagation, dismissing
+  // the menu would tear down the search around it.
+  it('keeps Escape from reaching the surrounding palette', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const onEscapeOutside = vi.fn();
+    document.addEventListener('keydown', onEscapeOutside);
+
+    try {
+      await openMenu(user);
+      await user.keyboard('{Escape}');
+
+      expect(onEscapeOutside).not.toHaveBeenCalled();
+    } finally {
+      document.removeEventListener('keydown', onEscapeOutside);
+    }
+  });
+
+  it('lets Escape through when the menu is already closed', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const onEscapeOutside = vi.fn();
+    document.addEventListener('keydown', onEscapeOutside);
+
+    try {
+      render(SearchModeControl, { props: { variant: 'chip', mode: 'smart', onSelect: vi.fn() } });
+      screen.getByRole('button', { name: 'Search mode: Smart' }).focus();
+      await user.keyboard('{Escape}');
+
+      expect(onEscapeOutside).toHaveBeenCalled();
+    } finally {
+      document.removeEventListener('keydown', onEscapeOutside);
+    }
+  });
+});
+
+describe('search-mode-control — prefix scope', () => {
+  // `GlobalSearchManager.setMode` short-circuits under a prefix scope, so the control
+  // has to say so. It must NOT disable the inputs though: the footer this replaces
+  // deliberately kept them focusable so a keyboard user can still queue up a mode for
+  // once the prefix is cleared.
+  it('marks the rail as scoped', () => {
+    render(SearchModeControl, { props: { variant: 'rail', mode: 'smart', onSelect: vi.fn(), scoped: true } });
+
+    expect(screen.getByTestId('search-mode-rail')).toHaveAttribute('data-scoped', 'true');
+  });
+
+  it('marks the chip as scoped', () => {
+    render(SearchModeControl, { props: { variant: 'chip', mode: 'smart', onSelect: vi.fn(), scoped: true } });
+
+    expect(screen.getByTestId('search-mode-chip-trigger')).toHaveAttribute('data-scoped', 'true');
+  });
+
+  it('leaves every mode operable while scoped', () => {
+    render(SearchModeControl, { props: { variant: 'rail', mode: 'smart', onSelect: vi.fn(), scoped: true } });
+
+    for (const radio of screen.getAllByRole('radio') as HTMLInputElement[]) {
+      expect(radio.disabled).toBe(false);
+      expect(radio).not.toHaveAttribute('aria-disabled');
+    }
+  });
+
+  it('is unscoped by default', () => {
+    render(SearchModeControl, { props: { variant: 'rail', mode: 'smart', onSelect: vi.fn() } });
+
+    expect(screen.getByTestId('search-mode-rail')).toHaveAttribute('data-scoped', 'false');
+  });
+});
+
+describe('search-mode-control — smart search unavailable', () => {
+  it('flags the smart option in the rail when machine learning is down', () => {
+    render(SearchModeControl, {
+      props: { variant: 'rail', mode: 'metadata', onSelect: vi.fn(), smartUnavailable: true },
+    });
+
+    expect(screen.getByTestId('search-mode-option-smart')).toHaveAttribute('title', 'Smart search is unavailable');
+  });
+
+  it('flags the smart option in the chip menu when machine learning is down', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(SearchModeControl, {
+      props: { variant: 'chip', mode: 'metadata', onSelect: vi.fn(), smartUnavailable: true },
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Search mode: Filename' }));
+
+    expect(screen.getByTestId('search-mode-option-smart')).toHaveAttribute('title', 'Smart search is unavailable');
+  });
+
+  it('leaves the other modes unflagged', () => {
+    render(SearchModeControl, {
+      props: { variant: 'rail', mode: 'metadata', onSelect: vi.fn(), smartUnavailable: true },
+    });
+
+    for (const value of ['metadata', 'description', 'ocr']) {
+      expect(screen.getByTestId(`search-mode-option-${value}`)).not.toHaveAttribute('title');
+    }
+  });
+
+  it('flags nothing while smart search is healthy', () => {
+    render(SearchModeControl, { props: { variant: 'rail', mode: 'smart', onSelect: vi.fn() } });
+
+    expect(screen.getByTestId('search-mode-option-smart')).not.toHaveAttribute('title');
+  });
+});

--- a/web/src/lib/components/global-search/__tests__/search-mode-control.spec.ts
+++ b/web/src/lib/components/global-search/__tests__/search-mode-control.spec.ts
@@ -145,6 +145,59 @@ describe('search-mode-control — chip menu dismissal', () => {
     }
   });
 
+  // Same reasoning as Escape, for the rest of the keys the palette acts on. `Command.Root`'s
+  // onKeyDown treats Enter as "run the top search" and the arrows as "move the result
+  // selection", so a key aimed at this menu must not reach it — pressing Enter to pick a
+  // mode would otherwise also fire activateSearch and navigate away.
+  it.each(['{Enter}', '{ArrowDown}', '{ArrowUp}', '{Home}', '{End}'])(
+    'keeps %s from reaching the surrounding palette',
+    async (key) => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
+      const onKeyOutside = vi.fn();
+      document.addEventListener('keydown', onKeyOutside);
+
+      try {
+        await openMenu(user);
+        await user.keyboard(key);
+
+        expect(onKeyOutside).not.toHaveBeenCalled();
+      } finally {
+        document.removeEventListener('keydown', onKeyOutside);
+      }
+    },
+  );
+
+  it('still selects a mode when Enter activates a menu item', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const onSelect = vi.fn();
+    render(SearchModeControl, { props: { variant: 'chip', mode: 'smart', onSelect } });
+
+    await user.click(screen.getByRole('button', { name: 'Search mode: Smart' }));
+    screen.getByRole('menuitemradio', { name: 'OCR' }).focus();
+    await user.keyboard('{Enter}');
+
+    expect(onSelect).toHaveBeenCalledWith('ocr');
+  });
+
+  it('moves focus down the menu with ArrowDown', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    await openMenu(user);
+
+    await user.keyboard('{ArrowDown}');
+
+    expect(document.activeElement).toBe(screen.getByRole('menuitemradio', { name: 'Smart' }));
+  });
+
+  it('wraps from the last item back to the first', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    await openMenu(user);
+
+    screen.getByRole('menuitemradio', { name: 'OCR' }).focus();
+    await user.keyboard('{ArrowDown}');
+
+    expect(document.activeElement).toBe(screen.getByRole('menuitemradio', { name: 'Smart' }));
+  });
+
   it('lets Escape through when the menu is already closed', async () => {
     const user = userEvent.setup({ pointerEventsCheck: 0 });
     const onEscapeOutside = vi.fn();

--- a/web/src/lib/components/global-search/global-search-footer.svelte
+++ b/web/src/lib/components/global-search/global-search-footer.svelte
@@ -1,97 +1,22 @@
 <script lang="ts">
-  import type { GlobalSearchManager, SearchMode } from '$lib/managers/global-search-manager.svelte';
   import ShortcutsModal from '$lib/modals/ShortcutsModal.svelte';
   import { Icon, modalManager } from '@immich/ui';
   import { mdiHelpCircleOutline } from '@mdi/js';
-  import { t, type Translations } from 'svelte-i18n';
+  import { t } from 'svelte-i18n';
 
-  interface Props {
-    manager: GlobalSearchManager;
-  }
-  let { manager }: Props = $props();
-
-  const options: Array<{ value: SearchMode; labelKey: Translations }> = [
-    { value: 'smart', labelKey: 'cmdk_mode_smart' as Translations },
-    { value: 'metadata', labelKey: 'cmdk_mode_filename' as Translations },
-    { value: 'description', labelKey: 'cmdk_mode_description' as Translations },
-    { value: 'ocr', labelKey: 'cmdk_mode_ocr' as Translations },
-  ];
-
-  // Sliding pill indicator — tracks the currently selected label's bounding box
-  // so the pill actually moves (per design spec line 409: "Selected pill slides
-  // between positions" over 180 ms ease-out). Color-only transitions look static.
-  const labelRefs: HTMLLabelElement[] = $state([]);
-  let pillLeft = $state(0);
-  let pillWidth = $state(0);
-  let pillReady = $state(false);
-
-  // Under a prefix scope the mode pills are informational — setMode is a no-op
-  // (see GlobalSearchManager.setMode's `scope !== 'all'` short-circuit). Visually
-  // communicate this with a 50 % opacity dim. Intentionally NO aria-disabled: the
-  // radios stay focusable and keyboard-reachable so users can still cycle the
-  // pending mode for when they clear the prefix.
-  const isScoped = $derived(manager.scope !== 'all');
-
-  // Shared class for footer kbd chips. Extracted so both kbd tags fit on a
-  // single line — otherwise prettier breaks `</kbd\n>` across lines, which
-  // causes Svelte to merge adjacent text nodes into the kbd. A cosmetic but
-  // test-visible bug.
+  // Shared class for footer kbd chips. Extracted so the kbd tag fits on a single
+  // line — otherwise prettier breaks `</kbd\n>` across lines, which causes Svelte
+  // to merge adjacent text nodes into the kbd. A cosmetic but test-visible bug.
   const kbdClass = 'rounded-sm border border-gray-200 bg-subtle/60 px-1.5 py-0.5 dark:border-gray-700';
-
-  $effect(() => {
-    const idx = options.findIndex((o) => o.value === manager.mode);
-    const el = labelRefs[idx];
-    if (el) {
-      pillLeft = el.offsetLeft;
-      pillWidth = el.offsetWidth;
-      pillReady = true;
-    }
-  });
 </script>
 
-<div class="flex items-center justify-between border-t border-gray-200 px-4 py-2 dark:border-gray-700">
-  <div
-    role="radiogroup"
-    aria-label={$t('cmdk_search_mode')}
-    class="relative flex gap-0 rounded-md bg-subtle/40 p-0.5 font-mono text-[11px] font-medium uppercase {isScoped
-      ? 'opacity-50'
-      : ''}"
-  >
-    {#if pillReady}
-      <div
-        aria-hidden="true"
-        class="absolute inset-y-0.5 rounded-sm bg-primary/10 transition-all duration-180 ease-out"
-        style:left="{pillLeft}px"
-        style:width="{pillWidth}px"
-      ></div>
-    {/if}
-    {#each options as opt, idx (opt.value)}
-      <label class="relative" bind:this={labelRefs[idx]}>
-        <input
-          type="radio"
-          name="cmdk-mode"
-          value={opt.value}
-          checked={manager.mode === opt.value}
-          onchange={() => manager.setMode(opt.value)}
-          class="sr-only"
-        />
-        <span
-          class="block cursor-pointer rounded-sm px-2.5 py-1 tabular-nums transition-colors duration-180 ease-out {manager.mode ===
-          opt.value
-            ? 'text-primary'
-            : 'text-gray-500 dark:text-gray-400'}"
-        >
-          {$t(opt.labelKey)}
-        </span>
-      </label>
-    {/each}
-  </div>
-
+<!-- The search-mode segmented control used to live here. It moved to `SearchModeControl`,
+     which renders as a rail under the palette input and as a chip inside the inline search
+     field, so the mode is reachable by touch and visible without opening the footer. The
+     `Ctrl+/` hint went with it: the control is on screen now, and dropping both items stops
+     this `justify-between` row from overflowing on a phone. -->
+<div class="flex items-center justify-end border-t border-gray-200 px-4 py-2 dark:border-gray-700">
   <div class="flex items-center gap-4 font-mono text-[11px] text-gray-500 dark:text-gray-400">
-    <span class="flex items-center gap-1.5">
-      <kbd class={kbdClass}>Ctrl+/</kbd>
-      <span>{$t('cmdk_cycle_mode_hint')}</span>
-    </span>
     <span class="flex items-center gap-1.5">
       <kbd class={kbdClass}>{$t('cmdk_scope_hint_footer')}</kbd>
       <span>{$t('cmdk_scope_hint_footer_label')}</span>

--- a/web/src/lib/components/global-search/global-search.svelte
+++ b/web/src/lib/components/global-search/global-search.svelte
@@ -20,6 +20,7 @@
   import CommandRow from './rows/command-row.svelte';
   import GlobalSearchFooter from './global-search-footer.svelte';
   import GlobalSearchPreview from './global-search-preview.svelte';
+  import SearchModeControl from '$lib/components/global-search/search-mode-control.svelte';
   import ShortcutsModal from '$lib/modals/ShortcutsModal.svelte';
   import { mediaQueryManager } from '$lib/stores/media-query-manager.svelte';
   import { getEntries, type RecentEntry } from '$lib/stores/cmdk-recent';
@@ -669,6 +670,13 @@
           }}
           class="min-w-0 flex-1 bg-transparent text-sm text-gray-800 placeholder:text-gray-500 focus:outline-none dark:text-gray-100 dark:placeholder:text-gray-300"
         />
+        <SearchModeControl
+          variant="chip"
+          mode={manager.mode}
+          onSelect={(next) => manager.setMode(next)}
+          scoped={manager.scope !== 'all'}
+          smartUnavailable={!manager.mlHealthy}
+        />
         {#if !mediaQueryManager.pointerCoarse}
           <kbd
             class="hidden shrink-0 rounded-lg border border-gray-300 bg-white px-2 py-1 font-mono text-[11px] font-semibold tracking-wide text-gray-500 sm:inline-block dark:border-immich-dark-gray dark:bg-immich-dark-bg dark:text-gray-300"
@@ -1051,6 +1059,13 @@
             aria-label={inputValue === '' ? $t('close') : $t('clear')}
           />
         </div>
+        <SearchModeControl
+          variant="rail"
+          mode={manager.mode}
+          onSelect={(next) => manager.setMode(next)}
+          scoped={manager.scope !== 'all'}
+          smartUnavailable={!manager.mlHealthy}
+        />
         <TypedSearchTokenRail tokens={manager.typedSearchDisplayTokens} />
         {#if showProgressStripe}
           <div
@@ -1427,7 +1442,7 @@
         </div>
 
         <div aria-live="polite" aria-atomic="true" class="sr-only">{manager.announcementText}</div>
-        <GlobalSearchFooter {manager} />
+        <GlobalSearchFooter />
       </Command.Root>
     </ModalBody>
   </Modal>

--- a/web/src/lib/components/global-search/search-mode-control.svelte
+++ b/web/src/lib/components/global-search/search-mode-control.svelte
@@ -76,7 +76,7 @@
       return;
     }
     // -1 while focus is still on the trigger, which is why the two arrows enter the list
-    // from opposite ends rather than sharing one wrap-around expression.
+    // from opposite ends rather than sharing one modulo expression.
     const current = items.indexOf(document.activeElement as HTMLButtonElement);
     let next: number;
     switch (event.key) {

--- a/web/src/lib/components/global-search/search-mode-control.svelte
+++ b/web/src/lib/components/global-search/search-mode-control.svelte
@@ -46,15 +46,57 @@
     }
   }
 
-  // Escape dismisses the menu and stops there. The chip sits inside the search field,
-  // whose `clickOutside` action closes the whole palette on Escape — letting the key
-  // through would tear down the search around the menu the user meant to dismiss.
-  function closeOnEscape(event: KeyboardEvent) {
-    if (!open || event.key !== 'Escape') {
+  let menuElement = $state<HTMLElement | null>(null);
+
+  const MENU_KEYS = new Set(['Escape', 'Enter', 'ArrowDown', 'ArrowUp', 'Home', 'End']);
+
+  // The chip renders inside `Command.Root`, whose onKeyDown runs the top search on Enter,
+  // moves the result selection on the arrows, and jumps it on Home/End — and the field's
+  // `clickOutside` action closes the whole palette on Escape. Every key this menu owns has
+  // to stop there, or picking a mode with the keyboard would also fire a search and
+  // navigate away.
+  function onMenuKeydown(event: KeyboardEvent) {
+    if (!open || !MENU_KEYS.has(event.key)) {
       return;
     }
-    open = false;
     event.stopPropagation();
+
+    if (event.key === 'Escape') {
+      open = false;
+      event.preventDefault();
+      return;
+    }
+    // Enter falls through to the button's own activation.
+    if (event.key === 'Enter') {
+      return;
+    }
+
+    const items = [...(menuElement?.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]') ?? [])];
+    if (items.length === 0) {
+      return;
+    }
+    // -1 while focus is still on the trigger, which is why the two arrows enter the list
+    // from opposite ends rather than sharing one wrap-around expression.
+    const current = items.indexOf(document.activeElement as HTMLButtonElement);
+    let next: number;
+    switch (event.key) {
+      case 'Home': {
+        next = 0;
+        break;
+      }
+      case 'End': {
+        next = items.length - 1;
+        break;
+      }
+      case 'ArrowDown': {
+        next = current === -1 ? 0 : (current + 1) % items.length;
+        break;
+      }
+      default: {
+        next = current === -1 ? items.length - 1 : (current - 1 + items.length) % items.length;
+      }
+    }
+    items[next]?.focus();
     event.preventDefault();
   }
 
@@ -88,7 +130,7 @@
       data-testid="search-mode-chip-trigger"
       data-scoped={scoped}
       onclick={() => (open = !open)}
-      onkeydown={closeOnEscape}
+      onkeydown={onMenuKeydown}
       class="flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-2 py-1 text-[11px] font-semibold tracking-wide text-gray-600 transition-colors duration-150 hover:border-primary/50 hover:text-primary dark:border-immich-dark-gray dark:bg-immich-dark-bg dark:text-gray-300 dark:hover:text-primary {scoped
         ? 'opacity-50'
         : ''}"
@@ -103,7 +145,8 @@
         role="menu"
         aria-label={$t('cmdk_search_mode')}
         tabindex="-1"
-        onkeydown={closeOnEscape}
+        bind:this={menuElement}
+        onkeydown={onMenuKeydown}
         class="absolute inset-e-0 top-full z-50 mt-1.5 min-w-[180px] overflow-hidden rounded-xl border border-gray-200 bg-white py-1 shadow-[0_18px_48px_rgba(15,23,42,0.18)] dark:border-gray-700 dark:bg-immich-dark-bg"
       >
         {#each options as option (option.value)}

--- a/web/src/lib/components/global-search/search-mode-control.svelte
+++ b/web/src/lib/components/global-search/search-mode-control.svelte
@@ -147,7 +147,7 @@
         tabindex="-1"
         bind:this={menuElement}
         onkeydown={onMenuKeydown}
-        class="absolute inset-e-0 top-full z-50 mt-1.5 min-w-[180px] overflow-hidden rounded-xl border border-gray-200 bg-white py-1 shadow-[0_18px_48px_rgba(15,23,42,0.18)] dark:border-gray-700 dark:bg-immich-dark-bg"
+        class="absolute inset-e-0 top-full z-60 mt-1.5 min-w-[180px] overflow-hidden rounded-xl border border-gray-200 bg-white py-1 shadow-[0_18px_48px_rgba(15,23,42,0.18)] dark:border-gray-700 dark:bg-immich-dark-bg"
       >
         {#each options as option (option.value)}
           <button

--- a/web/src/lib/components/global-search/search-mode-control.svelte
+++ b/web/src/lib/components/global-search/search-mode-control.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+  import type { SearchMode } from '$lib/managers/global-search-manager.svelte';
+  import { Icon } from '@immich/ui';
+  import { mdiChevronDown, mdiCreation, mdiFormatTitle, mdiOcr, mdiTextBoxOutline } from '@mdi/js';
+  import { t, type Translations } from 'svelte-i18n';
+
+  interface Props {
+    variant: 'chip' | 'rail';
+    mode: SearchMode;
+    onSelect: (mode: SearchMode) => void;
+    /**
+     * True while a prefix scope (@person, #tag, …) is active. `setMode` is a no-op then,
+     * so the control dims — but the inputs stay operable on purpose, so a keyboard user
+     * can still queue a mode up for when the prefix is cleared. Deliberately no
+     * `aria-disabled`; this mirrors the segmented control it replaces.
+     */
+    scoped?: boolean;
+    /** True when the ML service is down, which makes smart search return nothing. */
+    smartUnavailable?: boolean;
+  }
+
+  let { variant, mode, onSelect, scoped = false, smartUnavailable = false }: Props = $props();
+
+  const options: Array<{ value: SearchMode; labelKey: Translations; icon: string }> = [
+    { value: 'smart', labelKey: 'cmdk_mode_smart' as Translations, icon: mdiCreation },
+    { value: 'metadata', labelKey: 'cmdk_mode_filename' as Translations, icon: mdiFormatTitle },
+    { value: 'description', labelKey: 'cmdk_mode_description' as Translations, icon: mdiTextBoxOutline },
+    { value: 'ocr', labelKey: 'cmdk_mode_ocr' as Translations, icon: mdiOcr },
+  ];
+
+  let open = $state(false);
+
+  const activeOption = $derived(options.find((option) => option.value === mode) ?? options[0]);
+
+  const unavailableTitle = (value: SearchMode) =>
+    smartUnavailable && value === 'smart' ? $t('cmdk_smart_unavailable') : undefined;
+
+  function select(value: SearchMode) {
+    open = false;
+    onSelect(value);
+  }
+
+  function closeOnOutsideClick(event: MouseEvent) {
+    if (open && !(event.target as HTMLElement | null)?.closest('[data-testid="search-mode-chip"]')) {
+      open = false;
+    }
+  }
+
+  // Escape dismisses the menu and stops there. The chip sits inside the search field,
+  // whose `clickOutside` action closes the whole palette on Escape — letting the key
+  // through would tear down the search around the menu the user meant to dismiss.
+  function closeOnEscape(event: KeyboardEvent) {
+    if (!open || event.key !== 'Escape') {
+      return;
+    }
+    open = false;
+    event.stopPropagation();
+    event.preventDefault();
+  }
+
+  // Sliding pill indicator, carried over from the footer segmented control this
+  // replaces: track the selected label's box so the highlight actually travels
+  // between positions. A colour-only transition reads as static.
+  const labelRefs: HTMLLabelElement[] = $state([]);
+  let pillLeft = $state(0);
+  let pillWidth = $state(0);
+  let pillReady = $state(false);
+
+  $effect(() => {
+    const element = labelRefs[options.findIndex((option) => option.value === mode)];
+    if (element) {
+      pillLeft = element.offsetLeft;
+      pillWidth = element.offsetWidth;
+      pillReady = true;
+    }
+  });
+</script>
+
+<svelte:window onclick={closeOnOutsideClick} />
+
+{#if variant === 'chip'}
+  <div class="relative shrink-0" data-testid="search-mode-chip">
+    <button
+      type="button"
+      aria-label="{$t('cmdk_search_mode')}: {$t(activeOption.labelKey)}"
+      aria-haspopup="menu"
+      aria-expanded={open}
+      data-testid="search-mode-chip-trigger"
+      data-scoped={scoped}
+      onclick={() => (open = !open)}
+      onkeydown={closeOnEscape}
+      class="flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-2 py-1 text-[11px] font-semibold tracking-wide text-gray-600 transition-colors duration-150 hover:border-primary/50 hover:text-primary dark:border-immich-dark-gray dark:bg-immich-dark-bg dark:text-gray-300 dark:hover:text-primary {scoped
+        ? 'opacity-50'
+        : ''}"
+    >
+      <Icon icon={activeOption.icon} size="1em" aria-hidden />
+      <span>{$t(activeOption.labelKey)}</span>
+      <Icon icon={mdiChevronDown} size="0.9em" aria-hidden />
+    </button>
+
+    {#if open}
+      <div
+        role="menu"
+        aria-label={$t('cmdk_search_mode')}
+        tabindex="-1"
+        onkeydown={closeOnEscape}
+        class="absolute inset-e-0 top-full z-50 mt-1.5 min-w-[180px] overflow-hidden rounded-xl border border-gray-200 bg-white py-1 shadow-[0_18px_48px_rgba(15,23,42,0.18)] dark:border-gray-700 dark:bg-immich-dark-bg"
+      >
+        {#each options as option (option.value)}
+          <button
+            type="button"
+            role="menuitemradio"
+            aria-checked={mode === option.value}
+            data-testid="search-mode-option-{option.value}"
+            title={unavailableTitle(option.value)}
+            onclick={() => select(option.value)}
+            class="flex w-full items-center gap-2.5 px-3 py-2 text-start text-sm transition-colors duration-80 hover:bg-subtle {mode ===
+            option.value
+              ? 'font-semibold text-primary'
+              : 'text-gray-700 dark:text-gray-200'} {unavailableTitle(option.value) ? 'opacity-50' : ''}"
+          >
+            <Icon icon={option.icon} size="1.05em" aria-hidden />
+            <span>{$t(option.labelKey)}</span>
+          </button>
+        {/each}
+      </div>
+    {/if}
+  </div>
+{/if}
+
+{#if variant === 'rail'}
+  <div
+    role="radiogroup"
+    aria-label={$t('cmdk_search_mode')}
+    data-testid="search-mode-rail"
+    data-scoped={scoped}
+    class="relative mx-4 my-2 flex w-fit max-w-full items-center gap-0 overflow-x-auto rounded-lg bg-subtle/50 p-0.5 font-mono text-[11px] font-medium uppercase {scoped
+      ? 'opacity-50'
+      : ''}"
+  >
+    {#if pillReady}
+      <div
+        aria-hidden="true"
+        class="absolute inset-y-0.5 rounded-md bg-primary/10 transition-all duration-180 ease-out"
+        style:left="{pillLeft}px"
+        style:width="{pillWidth}px"
+      ></div>
+    {/if}
+    {#each options as option, index (option.value)}
+      <label
+        class="relative shrink-0"
+        data-testid="search-mode-option-{option.value}"
+        title={unavailableTitle(option.value)}
+        bind:this={labelRefs[index]}
+      >
+        <input
+          type="radio"
+          name="search-mode-rail"
+          value={option.value}
+          checked={mode === option.value}
+          onchange={() => onSelect(option.value)}
+          class="sr-only"
+        />
+        <span
+          class="block cursor-pointer rounded-md px-3 py-1.5 transition-colors duration-180 ease-out {mode ===
+          option.value
+            ? 'text-primary'
+            : 'text-gray-500 dark:text-gray-400'} {unavailableTitle(option.value) ? 'opacity-60' : ''}"
+        >
+          {$t(option.labelKey)}
+        </span>
+      </label>
+    {/each}
+  </div>
+{/if}


### PR DESCRIPTION
## The problem

Switching search mode had exactly two entry points: `Ctrl+/`, and clicking a pill in the palette footer. Looking at how that lands on a small screen turned up more than the reported issue:

- **Below `xl` (1279px) there is no search bar at all.** `NavigationBar.svelte` renders the trigger `hidden … xl:block`; everything narrower gets a magnifier that opens the modal. So the palette *is* the search surface on mobile.
- **The footer put the control at the bottom of a full-height modal**, in a `justify-between` row alongside `Ctrl+/ cycle mode` and `@ # / > scope` — two keyboard-only hints that overflow the row at 375px.
- **The desktop inline dropdown had no mode UI whatsoever.** `GlobalSearchFooter` is rendered only in the modal branch, so a user typing in the bar at xl+ could not see which mode was active, or change it without the keyboard.

## The change

`SearchModeControl` — one component, two presentations, the same split `SearchSortDropdown` already uses next door:

| | where | why |
|---|---|---|
| **chip** | inside the inline search field, beside the `⌘K` hint | the field is `max-w-5xl` at xl+, so both fit; the `⌘K` affordance stays |
| **rail** | directly under the modal input | the surface every sub-xl user reaches from the magnifier; one tap per mode, all four visible |

The footer loses the pills and the `Ctrl+/` hint — with the control on screen they were duplicate UI, and dropping both is what stops the row overflowing on a phone. It also loses its now-unused `manager` prop. Both `Ctrl+/` handlers are untouched and `ShortcutsModal` still documents the shortcut.

Two behaviours moved across with the control:

- Under a prefix scope `setMode` short-circuits, so the control dims — but stays focusable with **no** `aria-disabled`, which is the footer's deliberate choice preserved (a keyboard user can still queue a mode for once the prefix clears).
- When the ML service is down, the Smart option is flagged with the existing `cmdk_smart_unavailable` string.

**No new i18n keys.** `cmdk_search_mode`, `cmdk_mode_*` and `cmdk_smart_unavailable` all already existed, so no nine-locale sweep. `cmdk_cycle_mode_hint` is now unused; left in place rather than churning the locale files.

## Testing

Built test-first. 22 tests for the control, 5 integration tests for placement and wiring, each watched failing before the code existed.

Four of those tests could have passed vacuously, so each was mutation-checked against the production change it claims to catch — un-gating `{#if open}`, adding `disabled={scoped}`, making the Escape interception unconditional, and swapping the dropdown's `variant="chip"` for `"rail"`. All four went red.

The pre-existing `mode pills under scope` test was moved to the new control rather than deleted, and now asserts a `data-scoped` attribute instead of matching an `opacity-50` Tailwind class.

Local: full web suite 6352 passed / exit 0 · `check:svelte` 626 files, 0 errors 0 warnings · `check:typescript` clean · eslint and prettier clean on the changed files.

## Not covered

The mode is still invisible below `xl` once you leave the palette and look at results, since there is no bar there to hang it off. Fixing that means adding an item to a mobile navbar already carrying magnifier, upload and avatar — deliberately out of scope here.

https://claude.ai/code/session_012rVXwhubzQ4D98PuYNu3f1
