### PR TITLE
fix(web): give the content panel its chrome gutter when the sidebar is collapsed

### DIFF
--- a/web/src/lib/styles/gallery-theme.spec.ts
+++ b/web/src/lib/styles/gallery-theme.spec.ts
@@ -82,3 +82,26 @@ describe('L3 typography', () => {
     expect(theme![0]).toMatch(/--font-display:\s*['"]Bricolage Grotesque Variable['"]/);
   });
 });
+
+describe('content panel chrome gutter', () => {
+  const css = readFileSync(resolve(process.cwd(), 'src/styles/gallery-theme.css'), 'utf8');
+  const panelRule = (prefix: string) =>
+    css.match(new RegExp(String.raw`${prefix}main:has\(> div\.absolute\.overflow-y-auto\)\s*\{[\s\S]*?\n\}`));
+
+  it('omits the inline-start gutter while a sidebar is rendered', () => {
+    // Desktop intent: the chrome-tinted sidebar IS the panel's left boundary, so a gutter there
+    // would widen the chrome band past the sidebar itself and de-centre the rail's icons.
+    const rule = panelRule(String.raw`\n`);
+    expect(rule, 'content panel rule present').not.toBeNull();
+    expect(rule![0]).toMatch(/margin-inline:\s*0\s+8px/);
+  });
+
+  it('restores the inline-start gutter when the sidebar column is collapsed', () => {
+    // Below 850px `sidebarModeStore.layout` is 'overlay', so UserPageLayout renders
+    // --sidebar-width: 0px / data-sidebar-width="0" and no sidebar is left to stand in for the
+    // gutter — the panel butts against the window edge with its left corners squared off.
+    const rule = panelRule(String.raw`\[data-sidebar-width=['"]0['"]\]\s*`);
+    expect(rule, 'collapsed-sidebar panel rule present').not.toBeNull();
+    expect(rule![0]).toMatch(/margin-inline-start:\s*8px/);
+  });
+});

--- a/web/src/styles/gallery-theme.css
+++ b/web/src/styles/gallery-theme.css
@@ -209,6 +209,19 @@ main:has(> div.absolute.overflow-y-auto) {
   margin-block: 0 8px;
   margin-inline: 0 8px;
 }
+/* ...but the start gutter is only safe to omit while a sidebar is actually rendered. Below
+ * 850px `sidebarModeStore.layout` is 'overlay', so UserPageLayout collapses the grid's first
+ * column to --sidebar-width: 0px and the boundary the rule above relies on is simply not
+ * there: the panel butts against the window edge, its left rounded corners squared off
+ * against it while the other three sides keep their chrome band. Restore the gutter for
+ * exactly that case, keyed on the same data-sidebar-width the layout already exposes (and
+ * user-page-layout.spec.ts already asserts) rather than a second copy of the 850px query -
+ * '0' means "no sidebar column", which is the condition that actually matters here. The
+ * rail and expanded layouts are untouched, so the chrome band stays the width of the
+ * sidebar itself and the rail's icons stay centred. */
+[data-sidebar-width='0'] main:has(> div.absolute.overflow-y-auto) {
+  margin-inline-start: 8px;
+}
 /* Inset ONLY the page header row (title + actions: Albums, Settings, …) so it
  * clears the panel's rounded corners. Keyed on the stable page-header-title-row
  * testid; the timeline/content keeps its tighter gutter untouched. */


### PR DESCRIPTION
## The bug

At viewport widths with no left sidebar, the rounded content panel runs flush into the window edge: the chrome band shows along the top, right and bottom but not the left, and the panel's left rounded corners are squared off against the edge.

## Cause

`web/src/styles/gallery-theme.css` gives the panel a gutter on three sides only:

```css
main:has(> div.absolute.overflow-y-auto) {
  border-radius: 16px;
  margin-block: 0 8px;
  margin-inline: 0 8px;   /* start: 0 */
}
```

The omission is deliberate, and the rule's comment says why: the chrome-tinted sidebar already supplies that boundary, and adding a gutter there widens the chrome band past the sidebar itself, leaving the rail's icons — centred in their 5rem column — sitting left of centre in the grey the user actually sees.

That assumption only holds while a sidebar is rendered. Below 850px `sidebarModeStore.layout` returns `'overlay'`, so `UserPageLayout` collapses the grid's first column to `--sidebar-width: 0px` and nothing is left to stand in for the gutter.

## Fix

One rule, keyed on the `data-sidebar-width` attribute `UserPageLayout` already exposes (and `user-page-layout.spec.ts` already asserts on) rather than a second copy of the 850px breakpoint:

```css
[data-sidebar-width='0'] main:has(> div.absolute.overflow-y-auto) {
  margin-inline-start: 8px;
}
```

`'0'` means "no sidebar column" — the condition that actually matters — so the rail and expanded layouts are untouched by construction, and the icon-centring regression the original comment warns about cannot occur.

Considered and rejected: a `@media (max-width: 849px)` block. It would duplicate the sidebar's own breakpoint in a second place that can silently drift apart from it.

## Verification

Checked against a local stack at four widths, spanning the 850px layout boundary in both directions:

| Width | Sidebar | Result |
| --- | --- | --- |
| 435px | none (overlay) | gutter on all four sides, corners rounded |
| 840px | none (overlay) | gutter on all four sides |
| 860px | rail | unchanged, rail icons still centred |
| 1440px | expanded | unchanged |

## Tests

Added two cases to `web/src/lib/styles/gallery-theme.spec.ts`. The new one fails red on the unfixed tree (`expected null not to be null`); its sibling pins the desktop intent so the base rule can't quietly gain a start gutter.

These are source-level guards over the CSS — the established pattern in that spec file — rather than computed-style proofs. Their value is catching deletion of a fork-owned theme rule during an upstream rebase; the behavioural proof is the browser check above.

## Gates

| Gate | Result |
| --- | --- |
| `pnpm test` (full web unit suite) | 388 files, 6329 tests, rc 0 |
| `pnpm run check:typescript` | rc 0 |
| `pnpm run check:svelte` | rc 0, 625 files, 0 errors |
| eslint (changed files) | rc 0 |
| prettier (changed files) | rc 0 |

Branched off `origin/main` at `7ceb53bb54b`; no overlap with #1075.

https://claude.ai/code/session_017SbUD52Bkr94DiEKdeBTJS
