### PR TITLE
test(medium): raise the medium-test Postgres to max_connections=200

### DIFF
--- a/server/test/medium/globalSetup.ts
+++ b/server/test/medium/globalSetup.ts
@@ -31,6 +31,13 @@ const globalSetup = async () => {
       'full_page_writes=off',
       '-c',
       'synchronous_commit=off',
+      // Each medium spec opens its own pool of up to 10 connections via getKyselyDB(), and most
+      // never destroy it, so pools accumulate for the lifetime of a file. At the image default of
+      // 100 (97 usable after superuser_reserved_connections) the suite sits close enough to the
+      // ceiling that crossing it depends on the runner rather than the code, surfacing as
+      // PostgresError 53300 "sorry, too many clients already" in whichever specs happen to run last.
+      '-c',
+      'max_connections=200',
       '-c',
       'config_file=/var/lib/postgresql/data/postgresql.conf',
     ])


### PR DESCRIPTION
## What

One line in `server/test/medium/globalSetup.ts`: start the medium-test Postgres with `-c max_connections=200` instead of leaving it at the image default.

## Why

`Medium Tests (Server)` fails intermittently with:

```
PostgresError: sorry, too many clients already
  code: '53300', routine: 'InitProcess', severity: FATAL
```

Three things mark this as contention rather than a regression:

- every failure is a **connection-acquisition error**, never a product assertion;
- the **failing set wanders** between runs (a real break repeats);
- the failing specs pass **in isolation on the exact tree CI failed on**.

### Mechanism

Already documented in-repo, at `server/test/medium/specs/services/memory.service.spec.ts:118`:

> Each test opens its own connection pool (up to 10 conns) via `getKyselyDB()` and nothing previously closed it, so pools accumulated for the lifetime of the whole file. With enough tests in one file that exhausts Postgres's `max_connections`.

Only **5 of ~172** medium specs currently destroy their pool. `globalSetup.ts` already tunes `shared_buffers`, `fsync`, `max_wal_size` and `synchronous_commit`, but leaves `max_connections` at the image default — measured at **100**, so **97 usable** after `superuser_reserved_connections=3`.

At 172 spec files the suite runs close enough to that ceiling that crossing it depends on the runner rather than the code. The spec count only goes up (upstream 64 → this repo 172), so the margin keeps shrinking.

## Why raise the ceiling rather than fix the leak

The leak is **systemic and shared with upstream** — most leaking files are upstream's own specs, so closing them here means touching ~167 files and re-diverging from upstream in every one. This is the cheapest change that stops the bleeding: no spec churn, no behaviour change, no upstream divergence beyond a single flag.

Worth doing later, in rough order:

1. `afterEach(() => db.destroy())` in the highest-pool files (`face-identity.repository.spec.ts` alone opens 29).
2. Bound `poolOptions.threads.maxThreads` in `server/test/vitest.config.medium.mjs` so concurrent files are capped.

## Verification

**That the setting actually applies** — worth checking, because the same command also passes `-c config_file=...`, which could plausibly have won:

```
$ docker run ... <pinned image> postgres <current flags>
show max_connections -> 100

$ docker run ... <pinned image> postgres <current flags> -c max_connections=200
show max_connections -> 200
```

**That nothing breaks** — full medium suite locally on this branch:

```
Test Files  172 passed (172)
Tests       2976 passed (2976)
```

(The first local attempt showed 6 failures in three `exif/` specs; those were `ffprobe exited with code 1` from a missing `e2e/test-assets` symlink in a fresh worktree, unrelated to this change, and all three pass once the assets are present.)

**Scope of the claim:** this run proves the container still boots, migrations still run, and the whole suite passes with the flag. It does **not** by itself demonstrate the failure disappearing, because the local run sits under the ceiling either way — the argument for the fix is the measured headroom (97 → 197 usable connections against pools of up to 10 per spec).

https://claude.ai/code/session_01SpdrQLGt3siWDMBUZHv9Ev
