### PR TITLE
fix(web): dedupe folder cover asset ids in Space Albums preview

### DIFF
--- a/web/src/lib/utils/space-album-folders.spec.ts
+++ b/web/src/lib/utils/space-album-folders.spec.ts
@@ -231,6 +231,22 @@ describe('space-album-folders', () => {
 
       expect(getFolderPreviewAssetIds(tripsTree(), albums, 'trips')).toEqual(['asset-a2']);
     });
+
+    // 1091: getLinkedAlbums resolves a null cover to the newest space-visible asset in the
+    // album, so two different albums can legitimately resolve to the same cover asset (e.g. a
+    // photo added to both). SpaceCollage keys its `{#each}` on asset id — emitting that id twice
+    // throws Svelte's each_key_duplicate and aborts the whole tab render.
+    it('1091: does not repeat a cover asset id when two albums resolve to the same cover', () => {
+      const albums = [
+        album('a1', 'One', 'trips', { albumThumbnailAssetId: 'shared-asset', endDate: '2026-01-01T00:00:00.000Z' }),
+        album('a2', 'Two', 'trips', { albumThumbnailAssetId: 'shared-asset', endDate: '2026-02-01T00:00:00.000Z' }),
+        album('a3', 'Three', 'trips', { endDate: '2026-03-01T00:00:00.000Z' }),
+      ];
+
+      const previewAssetIds = getFolderPreviewAssetIds(tripsTree(), albums, 'trips');
+
+      expect(previewAssetIds).toEqual(['asset-a3', 'shared-asset']);
+    });
   });
 
   describe('isDescendant', () => {
@@ -371,6 +387,21 @@ describe('space-album-folders', () => {
       // Exactly one bucketing pass, one read per album. The per-card shape this replaced read
       // folderId once per album PER FOLDER, twice over (count + previews) — 200 x 200 x 2.
       expect(folderIdReads).toBe(albums.length);
+    });
+
+    // 1091: same case as getFolderPreviewAssetIds above, against the batch pass the components
+    // actually call.
+    it('1091: does not repeat a cover asset id when two albums resolve to the same cover', () => {
+      const folders = [folder('trips', 'Trips')];
+      const albums = [
+        album('a1', 'One', 'trips', { albumThumbnailAssetId: 'shared-asset', endDate: '2026-01-01T00:00:00.000Z' }),
+        album('a2', 'Two', 'trips', { albumThumbnailAssetId: 'shared-asset', endDate: '2026-02-01T00:00:00.000Z' }),
+        album('a3', 'Three', 'trips', { endDate: '2026-03-01T00:00:00.000Z' }),
+      ];
+
+      const summaries = buildFolderSummaries(folders, albums);
+
+      expect(summaries.get('trips')?.previewAssetIds).toEqual(['asset-a3', 'shared-asset']);
     });
   });
 });

--- a/web/src/lib/utils/space-album-folders.ts
+++ b/web/src/lib/utils/space-album-folders.ts
@@ -181,16 +181,36 @@ const recencyOf = (album: SharedSpaceLinkedAlbumDto): number =>
 const byRecencyThenId = (a: SharedSpaceLinkedAlbumDto, b: SharedSpaceLinkedAlbumDto): number =>
   recencyOf(b) - recencyOf(a) || a.id.localeCompare(b.id);
 
+// Two different albums can legitimately resolve to the same cover asset — getLinkedAlbums
+// falls back to the newest space-visible asset in the album, so a photo added to two albums
+// makes both covers identical. SpaceCollage keys its `{#each}` on asset id, so a repeated id
+// throws Svelte's each_key_duplicate and aborts the whole tab render (1091).
+const dedupeByAssetId = (albums: SharedSpaceLinkedAlbumDto[]): SharedSpaceLinkedAlbumDto[] => {
+  const seen = new Set<string>();
+  const result: SharedSpaceLinkedAlbumDto[] = [];
+  for (const album of albums) {
+    const assetId = album.albumThumbnailAssetId as string;
+    if (seen.has(assetId)) {
+      continue;
+    }
+    seen.add(assetId);
+    result.push(album);
+  }
+  return result;
+};
+
 export const getFolderPreviewAssetIds = (
   folders: SharedSpaceAlbumFolderDto[],
   albums: SharedSpaceLinkedAlbumDto[],
   folderId: string,
 ): string[] =>
-  albumsInSubtree(folders, albums, folderId)
-    // A null cover means getLinkedAlbums found no space-visible asset. Emitting it would
-    // render a broken tile, which is the exact bug the server-side COALESCE prevents.
-    .filter((a) => a.albumThumbnailAssetId !== null)
-    .sort(byRecencyThenId)
+  dedupeByAssetId(
+    albumsInSubtree(folders, albums, folderId)
+      // A null cover means getLinkedAlbums found no space-visible asset. Emitting it would
+      // render a broken tile, which is the exact bug the server-side COALESCE prevents.
+      .filter((a) => a.albumThumbnailAssetId !== null)
+      .sort(byRecencyThenId),
+  )
     .slice(0, FOLDER_PREVIEW_LIMIT)
     .map((a) => a.albumThumbnailAssetId as string);
 
@@ -285,8 +305,7 @@ export const buildFolderSummaries = (
 
     summaries.set(folder.id, {
       albumCount,
-      previewAssetIds: withCovers
-        .sort(byRecencyThenId)
+      previewAssetIds: dedupeByAssetId(withCovers.sort(byRecencyThenId))
         .slice(0, FOLDER_PREVIEW_LIMIT)
         .map((a) => a.albumThumbnailAssetId as string),
     });


### PR DESCRIPTION
## Summary

- Fixes #1091 — clicking into a Space's Albums tab threw Svelte's `each_key_duplicate` and aborted the tab render (the previous tab's content stayed on screen), reported on a space with ~25 albums / ~20k photos.
- Root cause: `getLinkedAlbums` resolves an album's cover to the newest space-visible asset when the album has no thumbnail of its own, so two different albums can legitimately resolve to the *same* cover asset (a photo shared across albums). `previewAssetIds` (built by `getFolderPreviewAssetIds` / `buildFolderSummaries` in `web/src/lib/utils/space-album-folders.ts`) fed that repeated asset id straight into `SpaceCollage`'s `{#each assets as asset (asset.id)}`, which throws on the duplicate key.
- Fix: de-duplicate by asset id, after the recency sort and before slicing to the four-cover limit, in both functions (the batch `buildFolderSummaries` pass is what the components actually call; `getFolderPreviewAssetIds` is the per-folder reference implementation the tests pin against it).

## Test plan

- [x] Added a failing-first regression test to `space-album-folders.spec.ts` for both `getFolderPreviewAssetIds` and `buildFolderSummaries`, reproducing two albums resolving to the same cover asset — watched both fail with the duplicated id before the fix.
- [x] `pnpm test -- --run` in `web/`: 6392 passed, 0 failed (up from the 6390-passing baseline).
- [x] `eslint --max-warnings 0`, `tsc --noEmit`, and `prettier --check` on the changed files: all clean.