### PR TITLE
fix(server): accept the midnight-UTC timeBucket form upstream clients send

### DIFF
--- a/server/src/utils/timeline-bucket.spec.ts
+++ b/server/src/utils/timeline-bucket.spec.ts
@@ -30,6 +30,25 @@ describe('normalizeTimeBucketForBucketSize', () => {
   it('preserves five-digit years used by existing timeline bucket calls', () => {
     expect(normalizeTimeBucketForBucketSize('012345-01-01', TimeBucketSize.Month)).toBe('012345-01-01');
   });
+
+  it('accepts the midnight-UTC timestamp form upstream clients send and normalises it to a date', () => {
+    expect(normalizeTimeBucketForBucketSize('2024-02-01T00:00:00.000Z', TimeBucketSize.Month)).toBe('2024-02-01');
+    expect(normalizeTimeBucketForBucketSize('2024-02-01T00:00:00Z', TimeBucketSize.Month)).toBe('2024-02-01');
+    expect(normalizeTimeBucketForBucketSize('2024-01-01T00:00:00.000Z', TimeBucketSize.Year)).toBe('2024-01-01');
+    expect(normalizeTimeBucketForBucketSize('2024-02-29T00:00:00.000Z', TimeBucketSize.Day)).toBe('2024-02-29');
+  });
+
+  it('rejects timestamps that are not midnight UTC', () => {
+    expect(() => normalizeTimeBucketForBucketSize('2024-02-01T01:00:00.000Z', TimeBucketSize.Month)).toThrow(
+      BadRequestException,
+    );
+    expect(() => normalizeTimeBucketForBucketSize('2024-02-01T00:00:00.000+02:00', TimeBucketSize.Month)).toThrow(
+      BadRequestException,
+    );
+    expect(() => normalizeTimeBucketForBucketSize('2024-02-01T00:00:00', TimeBucketSize.Month)).toThrow(
+      BadRequestException,
+    );
+  });
 });
 
 describe('dateTruncUnitForTimeBucketSize', () => {

--- a/server/src/utils/timeline-bucket.ts
+++ b/server/src/utils/timeline-bucket.ts
@@ -1,7 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
 import { TimeBucketSize } from 'src/enum';
 
-const TIME_BUCKET_PATTERN = /^([+]?\d{4,6})-(\d{2})-(\d{2})$/;
+const TIME_BUCKET_PATTERN = /^([+]?\d{4,6})-(\d{2})-(\d{2})(?:T00:00:00(?:\.000)?Z)?$/;
 
 export function dateTruncUnitForTimeBucketSize(bucketSize: TimeBucketSize) {
   return {


### PR DESCRIPTION
## What

`GET /timeline/bucket` returns `400 Invalid time bucket format` when `timeBucket` is `YYYY-MM-DDT00:00:00.000Z`. Upstream Immich expects this form, and its own web client sends in this format. Third-party clients that follow upstream, such as [immich-public-proxy](https://github.com/alangrainger/immich-public-proxy), fail against Gallery but work against Immich. Reported at alangrainger/immich-public-proxy issue 291.

As part of this issue I submitted a PR to Immich to correctly document their format in Immich's API docs, which has been approved: immich-31421.

## Why

#625 introduced `normalizeTimeBucketForBucketSize` with a pattern that only matches a bare date, and changed the fork web client to send bare dates. That is self-consistent inside the fork but drops compatibility with the upstream client format.

Upstream sends the `Z` suffix on purpose. `getTimeBucket` compares the string against a timestamptz, so a bare date is cast in the Postgres session timezone. On a non-UTC database that lands in the previous month and the bucket is empty (upstream issue immich-22672).

## Change

Extend `TIME_BUCKET_PATTERN` with an optional `T00:00:00(.000)?Z` suffix. The function still returns the bare date, so the service and repository are untouched. Non-midnight times, offsets, and timestamps without `Z` are still rejected.

## Tests

- `server/src/utils/timeline-bucket.spec.ts`: new cases for the timestamp form across year, month and day buckets, and for rejected non-midnight or offset timestamps. All existing cases pass unchanged.
- Manually: `GET /timeline/bucket?albumId=...&timeBucket=2026-09-01T00:00:00.000Z&key=...` returns assets instead of 400.

## Out of scope

Because the fork web client now sends bare dates, `getTimeBucket` in `asset.repository.ts` has the same non-UTC session-timezone problem as upstream immich-22672 for Gallery's own UI. `getTimeBucketCovers` already pins its comparison to UTC, so there is precedent.

## LLM use

Claude was used to trace the fork and open-noodle code paths and to draft the tests and this description.