### PR TITLE
fix(server): keep expanded-year timeline buckets out of JS Date

### DIFF
--- a/server/src/repositories/asset.repository.ts
+++ b/server/src/repositories/asset.repository.ts
@@ -321,7 +321,10 @@ const withBoundingBox = <T>(qb: SelectQueryBuilder<DB, 'asset' | 'asset_exif', T
   );
 };
 
-const formatUtcDate = (date: Date) => date.toISOString().slice(0, 10);
+// Postgres writes years past 9999 unsigned (`12345-01-01`), while `toISOString()` uses the ISO 8601
+// expanded-year form (`+012346-01-01`) — six digits plus a sign, so a fixed 10-character slice cuts
+// the day off. Take the whole date part and drop the sign to land back on Postgres's own spelling.
+const formatUtcDate = (date: Date) => date.toISOString().split('T', 1)[0].replace(/^\+0*/, '');
 
 // Advance a YYYY-MM-DD bucket-start date by one bucket interval (the exclusive
 // upper bound of the requested range).
@@ -1708,9 +1711,12 @@ export class AssetRepository {
     const maxStart = sorted.at(-1)!;
     const maxEnd = addBucketInterval(maxStart, bucketSize);
 
-    // The CTE `timeBucket` is the truncated timestamptz at UTC midnight; the
-    // requested YYYY-MM-DD strings correspond to those exact values.
-    const requestedBucketDates = requestedBuckets.map((tb) => new Date(`${tb}T00:00:00Z`));
+    // The CTE `timeBucket` is the truncated timestamptz at UTC midnight; the requested YYYY-MM-DD
+    // strings correspond to those exact values. Bound as text and cast in SQL, never as a `Date`: a bucket
+    // past year 9999 is unparseable by `Date` in Postgres's unsigned spelling, and the signed
+    // spelling `Date` does emit is rejected by Postgres as a timezone displacement — so the
+    // round-trip is lossy in both directions. The explicit `Z` keeps the comparison pinned to UTC.
+    const requestedBucketStarts = requestedBuckets.map((tb) => sql<Date>`${`${tb}T00:00:00Z`}::timestamptz`);
 
     // Narrow on the same column the buckets are derived from (createdAt for the
     // "date added" timeline, localDateTime otherwise) so createdAt-grouped covers
@@ -1750,7 +1756,7 @@ export class AssetRepository {
       )
       .selectFrom('asset')
       .distinctOn('timeBucket')
-      .where('timeBucket', 'in', requestedBucketDates)
+      .where('timeBucket', 'in', requestedBucketStarts)
       .select([
         sql<string>`("timeBucket" AT TIME ZONE 'UTC')::date::text`.as('timeBucket'),
         'id as representativeAssetId',

--- a/server/test/medium/specs/repositories/asset.repository.spec.ts
+++ b/server/test/medium/specs/repositories/asset.repository.spec.ts
@@ -1,4 +1,4 @@
-import { Insertable, Kysely } from 'kysely';
+import { Insertable, Kysely, sql } from 'kysely';
 import {
   AssetFileType,
   AssetOrder,
@@ -812,6 +812,51 @@ describe(AssetRepository.name, () => {
           timeBuckets: ['2023-12-01'],
         }),
       ).resolves.toEqual([expect.objectContaining({ timeBucket: '2023-12-01', representativeAssetId: decAsset.id })]);
+    });
+
+    // A corrupt EXIF date puts an asset past year 9999 — Postgres timestamps run to 294276, and
+    // getTimeBuckets hands the client that bucket as `12345-01-01`, UNSIGNED, because that is how
+    // Postgres renders it. The web then asks for its cover with the same string. JS is the odd one
+    // out: `Date` demands the ISO 8601 expanded-year sign to parse it and emits that sign back,
+    // which Postgres reads as a timezone displacement and rejects. So nothing on this path may
+    // round-trip a bucket start through `Date`.
+    // Every bucket size, because each takes a different branch of addBucketInterval to build the
+    // range bound and they must all come back through formatUtcDate intact.
+    it.each([
+      [TimeBucketSize.Year, '12345-01-01'],
+      [TimeBucketSize.Month, '12345-06-01'],
+      [TimeBucketSize.Day, '12345-06-01'],
+    ])('resolves %s covers for expanded-year buckets, which Postgres renders unsigned', async (bucketSize, bucket) => {
+      const { ctx, sut } = setup();
+      const { user } = await ctx.newUser();
+
+      const asset = await createTimelineAsset(ctx, user.id, new Date('2024-06-01T12:00:00.000Z'), {
+        thumbhash: Buffer.from('far-future'),
+      });
+      // Seeded through SQL on purpose: passing a year-12345 `Date` to the driver would fail here
+      // too, for the very reason this test pins.
+      await defaultDatabase
+        .updateTable('asset')
+        .set({ localDateTime: sql<Date>`timestamptz '12345-06-01 12:00:00+00'` })
+        .where('id', '=', asset.id)
+        .execute();
+
+      await expect(
+        sut.getTimeBucketCovers({
+          userIds: [user.id],
+          visibility: AssetVisibility.Timeline,
+          bucketSize,
+          order: AssetOrder.Desc,
+          timeBuckets: [bucket],
+        }),
+      ).resolves.toEqual([
+        {
+          timeBucket: bucket,
+          representativeAssetId: asset.id,
+          representativeThumbhash: Buffer.from('far-future').toString('base64'),
+          representativeRatio: 2,
+        },
+      ]);
     });
   });
 

--- a/server/test/medium/specs/services/timeline.service.spec.ts
+++ b/server/test/medium/specs/services/timeline.service.spec.ts
@@ -426,6 +426,27 @@ describe(TimelineService.name, () => {
       expect(response).toEqual(expect.objectContaining({ id: [] }));
     });
 
+    // Upstream has no format validator at all, so its clients — and third parties mirroring them,
+    // such as immich-public-proxy — send the bucket start as a full midnight-UTC timestamp. The
+    // fork validates, so the timestamp form has to be accepted explicitly and resolve to the very
+    // same bucket as the bare date; the unit test pins the grammar, this pins the whole path
+    // through to SQL.
+    it.each(['2024-02-01', '2024-02-01T00:00:00.000Z', '2024-02-01T00:00:00Z'])(
+      'resolves timeBucket=%s to the same month bucket',
+      async (timeBucket) => {
+        const { sut, ctx } = setup();
+        const { user } = await ctx.newUser();
+        const auth = factory.auth({ user });
+
+        const inBucket = await createTimelineAsset(ctx, user.id, new Date('2024-02-15T12:00:00.000Z'));
+        await createTimelineAsset(ctx, user.id, new Date('2024-03-01T00:00:00.000Z')); // must be excluded
+
+        const rawResponse = await sut.getTimeBucket(auth, { timeBucket, bucketSize: TimeBucketSize.Month });
+
+        expect(JSON.parse(rawResponse)).toEqual(expect.objectContaining({ id: [inBucket.id] }));
+      },
+    );
+
     it('should return time bucket in trash', async () => {
       const { sut, ctx } = setup();
       const { user } = await ctx.newUser();


### PR DESCRIPTION
## What

Two things that came out of reviewing #1093:

1. **A reachable 500 in `/timeline/bucket-covers`** for any bucket past year 9999.
2. **The end-to-end test #1093 was missing** — its fix is covered only by a unit test on the regex; the PR description says the real check was manual.

> [!NOTE]
> Stacked on #1093 — the guard test in the second commit needs that PR's widened pattern, so this branch currently carries its commit as well. I'll rebase it away once #1093 merges.

## The bug

A corrupt EXIF date puts an asset past year 9999 (Postgres timestamps run to 294276). `getTimeBuckets` hands the client that bucket as `12345-01-01` — **unsigned**, because that is how Postgres renders a date — and the web echoes the string straight back to `/timeline/bucket-covers` via `loadCoversForBuckets`. `getTimeBucketCovers` then round-trips it through `Date` twice and loses it both ways:

```
new Date('12345-01-01T00:00:00Z')  ->  Invalid Date
'+012346-01-01'.slice(0, 10)       ->  '+012346-01'
```

`Date` requires the ISO 8601 expanded-year sign to parse those years, so the requested bucket became an `Invalid Date` whose serialisation threw `RangeError: Invalid time value` before the query even left the process. The range bound from `addBucketInterval` fared no better: `toISOString()` emits six digits plus a sign, so the fixed 10-character slice cut the day off and produced `+012346-01`, which Postgres rejects as a timezone displacement. Either path is a 500.

Both defects are visible at once in the bound parameters the failing test prints:

```
parameters: [ '12345-01-01', '+012346-01', 'timeline', '{...}', null ]
                              ^^^^^^^^^^^^                      ^^^^
                    truncated formatUtcDate        Invalid Date -> RangeError
```

## Why not just sign the dates

That was the obvious fix and it does not work — Postgres rejects the signed spelling too:

```sql
SELECT '+012345-06-01T12:00:00.000Z'::timestamptz;  -- ERROR: time zone displacement out of range
SELECT  '12345-06-01T12:00:00.000Z'::timestamptz;   -- 12345-06-01 12:00:00+00
```

Postgres writes these years unsigned and refuses to read them signed; JS does the exact opposite. The value cannot survive a `Date` in either direction, so the fix is to keep it out of one: bind the bucket start as text with an explicit `::timestamptz` cast — the same shape `getTimeBucket` already uses — and take the whole date part in `formatUtcDate` instead of a fixed slice.

## Scope

`getTimeBucketCovers` is fork-only (`bucket-covers` does not exist upstream), so this is not an upstream backport candidate.

## Tests

- `asset.repository.spec.ts` — a year-12345 cover, seeded through SQL on purpose: passing a year-12345 `Date` to the driver would fail for the very reason the test pins. Red before the fix with `RangeError: Invalid time value`.
- `timeline.service.spec.ts` — the #1093 guard, parameterised over the bare date and both accepted timestamp spellings, asserting all three resolve to the *same* bucket. Asserting merely "not rejected" would still pass if the suffix changed the bucket. Verified red by reverting #1093's pattern underneath it: the bare date passes, both timestamp forms fail with `Invalid time bucket format`.

No `@GenerateSql` decorator on `getTimeBucketCovers` and no mention of it in the generated `.sql`, so there is no SQL-doc drift to regenerate.

https://claude.ai/code/session_019T2EcuCAmBifjPTRC8awnJ
