### PR TITLE
fix(server): show contributed albums in the asset info panel (#1095)

### DIFF
--- a/server/src/queries/album.repository.sql
+++ b/server/src/queries/album.repository.sql
@@ -130,41 +130,77 @@ select
   ) as "albumUsers"
 from
   "album"
-  inner join "album_asset" on "album_asset"."albumId" = "album"."id"
 where
   (
-    exists (
-      select
-      from
-        "album_user"
-      where
-        "album_user"."albumId" = "album"."id"
-        and "album_user"."userId" = $2
+    (
+      exists (
+        select
+          1 as "exists"
+        from
+          "album_asset"
+        where
+          "album_asset"."albumId" = "album"."id"
+          and "album_asset"."assetId" = $2::uuid
+      )
+      and (
+        exists (
+          select
+          from
+            "album_user"
+          where
+            "album_user"."albumId" = "album"."id"
+            and "album_user"."userId" = $3
+        )
+        or (
+          "album"."id" in (
+            select
+              "shared_space_album"."albumId" as "id"
+            from
+              "shared_space_album"
+              inner join "album" on "album"."id" = "shared_space_album"."albumId"
+            where
+              "album"."deletedAt" is null
+              and "shared_space_album"."spaceId" in (
+                select
+                  "shared_space"."id"
+                from
+                  "shared_space"
+                where
+                  "shared_space"."createdById" = $4
+                union
+                select
+                  "shared_space_member"."spaceId" as "id"
+                from
+                  "shared_space_member"
+                where
+                  "shared_space_member"."userId" = $5
+              )
+          )
+          and exists (
+            select
+              1 as "exists"
+            from
+              "asset"
+            where
+              "asset"."id" = $6::uuid
+              and "asset"."visibility" in ($7, $8)
+          )
+        )
+      )
     )
     or (
-      "album"."id" in (
+      exists (
         select
-          "shared_space_album"."albumId" as "id"
+          1 as "exists"
         from
           "shared_space_album"
-          inner join "album" on "album"."id" = "shared_space_album"."albumId"
+          inner join "album_space_asset" on "album_space_asset"."albumId" = "shared_space_album"."albumId"
+          and "album_space_asset"."spaceId" = "shared_space_album"."spaceId"
+          inner join "shared_space_member" on "shared_space_member"."spaceId" = "shared_space_album"."spaceId"
+          and "shared_space_member"."userId" = $9::uuid
         where
-          "album"."deletedAt" is null
-          and "shared_space_album"."spaceId" in (
-            select
-              "shared_space"."id"
-            from
-              "shared_space"
-            where
-              "shared_space"."createdById" = $3
-            union
-            select
-              "shared_space_member"."spaceId" as "id"
-            from
-              "shared_space_member"
-            where
-              "shared_space_member"."userId" = $4
-          )
+          "shared_space_album"."albumId" = "album"."id"
+          and "album_space_asset"."assetId" = $10::uuid
       )
       and exists (
         select
@@ -172,12 +208,11 @@ where
         from
           "asset"
         where
-          "asset"."id" = "album_asset"."assetId"
-          and "asset"."visibility" in ($5, $6)
+          "asset"."id" = $11::uuid
+          and "asset"."visibility" in ($12, $13)
       )
     )
   )
-  and "album_asset"."assetId" = $7
   and "album"."deletedAt" is null
 order by
   "album"."createdAt" desc

--- a/server/src/repositories/album.repository.ts
+++ b/server/src/repositories/album.repository.ts
@@ -110,43 +110,89 @@ export class AlbumRepository {
    * Deliberately NOT every album containing the asset: album names are user-authored and a space
    * member must not learn the owner's private album titles. Callers do not separately authorize
    * `assetId` (see AlbumService.getAll) — this scoping IS the access check.
+   *
+   * An asset reaches an album through EITHER membership table, so both are checked (#1095): the
+   * owner's own `album_asset` row, or a cross-owner `album_space_asset` contribution (#764). The
+   * previous `innerJoin('album_asset')` dropped every contribution-only album, so a member who
+   * added someone else's space asset saw it in the album grid but never in "Contained in" — the
+   * count from `getMetadataForIds` already unions both arms, and this now agrees with it.
    */
   @GenerateSql({ params: [DummyValue.UUID, DummyValue.UUID] })
   getByAssetId(ownerId: string, assetId: string) {
-    return this.db
-      .selectFrom('album')
-      .selectAll('album')
-      .innerJoin('album_asset', 'album_asset.albumId', 'album.id')
-      .where((eb) =>
-        eb.or([
-          eb.exists(
-            eb
-              .selectFrom('album_user')
-              .whereRef('album_user.albumId', '=', 'album.id')
-              .where('album_user.userId', '=', ownerId),
-          ),
-          eb.and([
-            eb('album.id', 'in', (e) => accessibleSpaceAlbums(e, ownerId)),
-            // A space member must never learn that another member's Hidden/Locked asset sits in a
-            // linked album, so the space arm carries the space-shareable visibility gate
-            // (Archive/Timeline). The album_user arm above is deliberately NOT gated: an album
-            // member — including the owner, who always has an album_user row — keeps seeing
-            // "Contained in" for their own Hidden/Locked assets.
-            eb.exists(
-              eb
-                .selectFrom('asset')
-                .select(eb.lit(1).as('exists'))
-                .whereRef('asset.id', '=', 'album_asset.assetId')
-                .where((e) => spaceVisibilityGate(e)),
-            ),
+    // A space member must never learn that another member's Hidden/Locked asset sits in a linked
+    // album, so both space-reached arms below carry the space-shareable visibility gate
+    // (Archive/Timeline). The album_user arm is deliberately NOT gated: an album member — including
+    // the owner, who always has an album_user row — keeps seeing "Contained in" for their own
+    // Hidden/Locked assets.
+    const isSpaceShareable = (eb: ExpressionBuilder<DB, 'album'>) =>
+      eb.exists(
+        eb
+          .selectFrom('asset')
+          .select(eb.lit(1).as('exists'))
+          .where('asset.id', '=', asUuid(assetId))
+          .where((e) => spaceVisibilityGate(e)),
+      );
+
+    return (
+      this.db
+        .selectFrom('album')
+        .selectAll('album')
+        .where((eb) =>
+          eb.or([
+            // The owner's own `album_asset` row, reached either by a direct album share or by the
+            // album being linked into a space the caller can access.
+            eb.and([
+              eb.exists(
+                eb
+                  .selectFrom('album_asset')
+                  .select(eb.lit(1).as('exists'))
+                  .whereRef('album_asset.albumId', '=', 'album.id')
+                  .where('album_asset.assetId', '=', asUuid(assetId)),
+              ),
+              eb.or([
+                eb.exists(
+                  eb
+                    .selectFrom('album_user')
+                    .whereRef('album_user.albumId', '=', 'album.id')
+                    .where('album_user.userId', '=', ownerId),
+                ),
+                eb.and([eb('album.id', 'in', (e) => accessibleSpaceAlbums(e, ownerId)), isSpaceShareable(eb)]),
+              ]),
+            ]),
+            // A cross-owner contribution (#764) is only ever reachable through the ONE space it was
+            // contributed to, so membership and the live album↔space link are correlated to that
+            // space — the same scoping `getMetadataForIds` applies to its contributed arm. Written
+            // inline rather than via `spaceContributedAssetExists`, whose subquery correlates on the
+            // asset only: that helper answers "can I reach this asset through any linked album", and
+            // here the question is album-centric ("is THIS album's link to the asset valid for me").
+            eb.and([
+              eb.exists(
+                eb
+                  .selectFrom('shared_space_album')
+                  .innerJoin('album_space_asset', (join) =>
+                    join
+                      .onRef('album_space_asset.albumId', '=', 'shared_space_album.albumId')
+                      .onRef('album_space_asset.spaceId', '=', 'shared_space_album.spaceId'),
+                  )
+                  .innerJoin('shared_space_member', (join) =>
+                    join
+                      .onRef('shared_space_member.spaceId', '=', 'shared_space_album.spaceId')
+                      .on('shared_space_member.userId', '=', asUuid(ownerId)),
+                  )
+                  .select(eb.lit(1).as('exists'))
+                  .whereRef('shared_space_album.albumId', '=', 'album.id')
+                  .where('album_space_asset.assetId', '=', asUuid(assetId)),
+              ),
+              isSpaceShareable(eb),
+            ]),
           ]),
-        ]),
-      )
-      .where('album_asset.assetId', '=', assetId)
-      .where('album.deletedAt', 'is', null)
-      .select(withAlbumUsers(ownerId))
-      .orderBy('album.createdAt', 'desc')
-      .execute();
+        )
+        // The A1 invariant, covering both arms above — a soft-deleted album is never returned.
+        .where('album.deletedAt', 'is', null)
+        .select(withAlbumUsers(ownerId))
+        .orderBy('album.createdAt', 'desc')
+        .execute()
+    );
   }
 
   @GenerateSql({ params: [DummyValue.UUID, [DummyValue.UUID]] })

--- a/server/test/medium/specs/repositories/album.repository.spec.ts
+++ b/server/test/medium/specs/repositories/album.repository.spec.ts
@@ -1,5 +1,5 @@
 import { Kysely } from 'kysely';
-import { AssetVisibility } from 'src/enum';
+import { AssetVisibility, SharedSpaceRole } from 'src/enum';
 import { AlbumRepository } from 'src/repositories/album.repository';
 import { LoggingRepository } from 'src/repositories/logging.repository';
 import { DB } from 'src/schema';
@@ -508,6 +508,113 @@ describe(AlbumRepository.name, () => {
       const rows = await sut.getByAssetId(viewer.id, asset.id);
 
       expect(rows).toEqual([]);
+    });
+
+    it('stops surfacing a contributed asset album once the user leaves the space', async () => {
+      const { ctx, sut } = setup();
+      const { user: albumOwner } = await ctx.newUser();
+      const { user: contributor } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: contributor.id });
+      const { album } = await ctx.newAlbum({ ownerId: albumOwner.id, albumName: 'Departed Contribution Album' });
+
+      const { space } = await ctx.newSharedSpace({ createdById: albumOwner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: contributor.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+      await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+      expect(await sut.getByAssetId(contributor.id, asset.id)).toHaveLength(1);
+
+      // Membership is the whole grant on this arm — revoking it must close the album title too.
+      await ctx.database.deleteFrom('shared_space_member').where('userId', '=', contributor.id).execute();
+
+      expect(await sut.getByAssetId(contributor.id, asset.id)).toEqual([]);
+    });
+
+    it('surfaces a contributed asset album to a space Viewer, not only to editors', async () => {
+      const { ctx, sut } = setup();
+      const { user: albumOwner } = await ctx.newUser();
+      const { user: contributor } = await ctx.newUser();
+      const { user: spaceViewer } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: contributor.id });
+      const { album } = await ctx.newAlbum({ ownerId: albumOwner.id, albumName: 'Viewer Role Album' });
+
+      const { space } = await ctx.newSharedSpace({ createdById: albumOwner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: contributor.id, role: SharedSpaceRole.Editor });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: spaceViewer.id, role: SharedSpaceRole.Viewer });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+      await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+      // Any-role membership is deliberate: a Viewer can already open the linked album, so the read
+      // arm must not be narrowed to write-capable roles.
+      const rows = await sut.getByAssetId(spaceViewer.id, asset.id);
+
+      expect(rows.map((row) => row.id)).toEqual([album.id]);
+    });
+
+    it('does not surface a sibling album in the same space that lacks the asset', async () => {
+      const { ctx, sut } = setup();
+      const { user: albumOwner } = await ctx.newUser();
+      const { user: contributor } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: contributor.id });
+      const { album: withAsset } = await ctx.newAlbum({ ownerId: albumOwner.id, albumName: 'Holds The Asset' });
+      const { album: sibling } = await ctx.newAlbum({ ownerId: albumOwner.id, albumName: 'Unrelated Sibling' });
+
+      const { space } = await ctx.newSharedSpace({ createdById: albumOwner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: contributor.id });
+      // BOTH albums are linked into the space the viewer belongs to; only one holds the asset.
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: withAsset.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: sibling.id });
+      await ctx.newAlbumSpaceAsset({ albumId: withAsset.id, assetId: asset.id, spaceId: space.id });
+
+      const rows = await sut.getByAssetId(contributor.id, asset.id);
+
+      // The sibling's user-authored title must not ride along on an accessible-space match.
+      expect(rows.map((row) => row.id)).toEqual([withAsset.id]);
+      expect(rows.map((row) => row.id)).not.toContain(sibling.id);
+    });
+
+    it('does not surface a contributed asset album to a partner of the asset owner', async () => {
+      const { ctx, sut } = setup();
+      const { user: albumOwner } = await ctx.newUser();
+      const { user: assetOwner } = await ctx.newUser();
+      const { user: partner } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: assetOwner.id });
+      const { album } = await ctx.newAlbum({ ownerId: albumOwner.id, albumName: 'Partner Blind Album' });
+
+      // A partner can view the asset itself, but partnership is not an album or space grant — it
+      // must not reveal where someone else filed the photo.
+      await ctx.newPartner({ sharedById: assetOwner.id, sharedWithId: partner.id });
+
+      const { space } = await ctx.newSharedSpace({ createdById: albumOwner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: assetOwner.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+      await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+      const rows = await sut.getByAssetId(partner.id, asset.id);
+
+      expect(rows).toEqual([]);
+    });
+
+    it('does not surface a contributed asset album to the album owner outside the space', async () => {
+      const { ctx, sut } = setup();
+      const { user: albumOwner } = await ctx.newUser();
+      const { user: spaceOwner } = await ctx.newUser();
+      const { user: contributor } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: contributor.id });
+      const { album } = await ctx.newAlbum({ ownerId: albumOwner.id, albumName: 'Owner Outside Space Album' });
+
+      // The album owner holds an album_user row but no membership of the space the contribution
+      // came through. getMetadataForIds gates its contributed arm on membership too, so the panel
+      // and the album card agree on not counting it — pinned so neither side drifts alone.
+      const { space } = await ctx.newSharedSpace({ createdById: spaceOwner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: contributor.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+      await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+      expect(await sut.getByAssetId(albumOwner.id, asset.id)).toEqual([]);
+
+      const [metadata] = await sut.getMetadataForIds([album.id], { forUserId: albumOwner.id });
+      expect(metadata).toBeUndefined();
     });
 
     it('does not return a space-linked album that has been soft-deleted', async () => {

--- a/server/test/medium/specs/repositories/album.repository.spec.ts
+++ b/server/test/medium/specs/repositories/album.repository.spec.ts
@@ -320,11 +320,11 @@ describe(AlbumRepository.name, () => {
       expect(rows.map((row) => row.id)).toEqual([album.id]);
     });
 
-    // Known incompleteness, pinned so it stays visible: a cross-owner contribution (#764) lives in
-    // album_space_asset, not album_asset, and this query inner-joins album_asset. A contributor
-    // therefore sees no "Contained in" for their own contributed asset. This under-reports rather
-    // than over-reports, so it is not a disclosure — but it is a gap worth closing separately.
-    it('does not yet surface a linked album for a cross-owner contributed asset', async () => {
+    // A cross-owner contribution (#764) lives in album_space_asset, not album_asset. The whole
+    // contributed group below pins that the query reaches BOTH membership tables and scopes the
+    // contributed one exactly as getMetadataForIds does — live album↔space link, live membership,
+    // album not soft-deleted — so "Contained in" agrees with the count on the album card.
+    it('surfaces a linked album for a cross-owner contributed asset', async () => {
       const { ctx, sut } = setup();
       const { user: albumOwner } = await ctx.newUser();
       const { user: contributor } = await ctx.newUser();
@@ -337,6 +337,175 @@ describe(AlbumRepository.name, () => {
       await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
 
       const rows = await sut.getByAssetId(contributor.id, asset.id);
+
+      expect(rows.map((row) => row.id)).toEqual([album.id]);
+    });
+
+    // #1095, as reported: the album owner also owns the asset, and a space member who is an album
+    // editor adds it. The adder holds no AssetShare on someone else's asset, so the add lands in
+    // album_space_asset even though the album owner owns the asset — and the album vanished from
+    // the adder's "Contained in" panel while still showing in the album grid.
+    it('surfaces a linked album for an asset the album owner owns but a member contributed', async () => {
+      const { ctx, sut } = setup();
+      const { user: albumOwner } = await ctx.newUser();
+      const { user: member } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: albumOwner.id });
+      const { album } = await ctx.newAlbum({ ownerId: albumOwner.id, albumName: 'Party Album' });
+      await ctx.newAlbumUser({ albumId: album.id, userId: member.id });
+
+      const { space } = await ctx.newSharedSpace({ createdById: albumOwner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: member.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+      await ctx.newAlbumSpaceAsset({
+        albumId: album.id,
+        assetId: asset.id,
+        spaceId: space.id,
+        addedById: member.id,
+      });
+
+      const rows = await sut.getByAssetId(member.id, asset.id);
+
+      expect(rows.map((row) => row.id)).toEqual([album.id]);
+    });
+
+    it('returns a contributed asset album once when an album_asset row also exists', async () => {
+      const { ctx, sut } = setup();
+      const { user: albumOwner } = await ctx.newUser();
+      const { user: contributor } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: contributor.id });
+      const { album } = await ctx.newAlbum({ ownerId: albumOwner.id, albumName: 'Coexistence Album' });
+      await ctx.newAlbumUser({ albumId: album.id, userId: contributor.id });
+
+      const { space } = await ctx.newSharedSpace({ createdById: albumOwner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: contributor.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+      // The P1-6 coexistence window: both membership rows exist for the same (album, asset) pair.
+      await ctx.newAlbumAsset({ albumId: album.id, assetId: asset.id });
+      await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+      const rows = await sut.getByAssetId(contributor.id, asset.id);
+
+      expect(rows.map((row) => row.id)).toEqual([album.id]);
+    });
+
+    it('does not surface a contributed asset album to a non-member of the space', async () => {
+      const { ctx, sut } = setup();
+      const { user: albumOwner } = await ctx.newUser();
+      const { user: contributor } = await ctx.newUser();
+      const { user: outsider } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: contributor.id });
+      const { album } = await ctx.newAlbum({ ownerId: albumOwner.id, albumName: 'Member Only Album' });
+      // The outsider is shared into the ALBUM but not into the space the contribution came through.
+      await ctx.newAlbumUser({ albumId: album.id, userId: outsider.id });
+
+      const { space } = await ctx.newSharedSpace({ createdById: albumOwner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: contributor.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+      await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+      const rows = await sut.getByAssetId(outsider.id, asset.id);
+
+      expect(rows).toEqual([]);
+    });
+
+    it('does not leak a contribution to members of a different space the album is linked to', async () => {
+      const { ctx, sut } = setup();
+      const { user: albumOwner } = await ctx.newUser();
+      const { user: contributor } = await ctx.newUser();
+      const { user: otherSpaceMember } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: contributor.id });
+      const { album } = await ctx.newAlbum({ ownerId: albumOwner.id, albumName: 'Two Space Album' });
+
+      const { space: spaceA } = await ctx.newSharedSpace({ createdById: albumOwner.id });
+      await ctx.newSharedSpaceMember({ spaceId: spaceA.id, userId: contributor.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: spaceA.id, albumId: album.id });
+
+      const { space: spaceB } = await ctx.newSharedSpace({ createdById: albumOwner.id });
+      await ctx.newSharedSpaceMember({ spaceId: spaceB.id, userId: otherSpaceMember.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: spaceB.id, albumId: album.id });
+
+      // Contributed through space A only.
+      await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: spaceA.id });
+
+      expect(await sut.getByAssetId(contributor.id, asset.id)).toHaveLength(1);
+      expect(await sut.getByAssetId(otherSpaceMember.id, asset.id)).toEqual([]);
+    });
+
+    it('stops surfacing a contributed asset album once the album is unlinked from the space', async () => {
+      const { ctx, sut } = setup();
+      const { user: albumOwner } = await ctx.newUser();
+      const { user: contributor } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: contributor.id });
+      const { album } = await ctx.newAlbum({ ownerId: albumOwner.id, albumName: 'Unlinked Contribution Album' });
+
+      const { space } = await ctx.newSharedSpace({ createdById: albumOwner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: contributor.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+      await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+      expect(await sut.getByAssetId(contributor.id, asset.id)).toHaveLength(1);
+
+      // D1-b: the retained album_space_asset row of an unlinked album is inert.
+      await ctx.database.deleteFrom('shared_space_album').where('albumId', '=', album.id).execute();
+
+      expect(await sut.getByAssetId(contributor.id, asset.id)).toEqual([]);
+    });
+
+    it('does not surface a soft-deleted album for a contributed asset', async () => {
+      const { ctx, sut } = setup();
+      const { user: albumOwner } = await ctx.newUser();
+      const { user: contributor } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: contributor.id });
+      const { album } = await ctx.newAlbum({
+        ownerId: albumOwner.id,
+        albumName: 'Deleted Contribution Album',
+        deletedAt: new Date(),
+      });
+
+      const { space } = await ctx.newSharedSpace({ createdById: albumOwner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: contributor.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+      await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+      const rows = await sut.getByAssetId(contributor.id, asset.id);
+
+      expect(rows).toEqual([]);
+    });
+
+    it('does not reveal a contributed album for another member Hidden asset', async () => {
+      const { ctx, sut } = setup();
+      const { user: albumOwner } = await ctx.newUser();
+      const { user: assetOwner } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: assetOwner.id, visibility: AssetVisibility.Hidden });
+      const { album } = await ctx.newAlbum({ ownerId: albumOwner.id, albumName: 'Hidden Contribution Album' });
+
+      const { space } = await ctx.newSharedSpace({ createdById: albumOwner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: assetOwner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+      await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+      const rows = await sut.getByAssetId(viewer.id, asset.id);
+
+      expect(rows).toEqual([]);
+    });
+
+    it('does not reveal a contributed album for another member Locked asset', async () => {
+      const { ctx, sut } = setup();
+      const { user: albumOwner } = await ctx.newUser();
+      const { user: assetOwner } = await ctx.newUser();
+      const { user: viewer } = await ctx.newUser();
+      const { asset } = await ctx.newAsset({ ownerId: assetOwner.id, visibility: AssetVisibility.Locked });
+      const { album } = await ctx.newAlbum({ ownerId: albumOwner.id, albumName: 'Locked Contribution Album' });
+
+      const { space } = await ctx.newSharedSpace({ createdById: albumOwner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: assetOwner.id });
+      await ctx.newSharedSpaceMember({ spaceId: space.id, userId: viewer.id });
+      await ctx.newSharedSpaceAlbum({ spaceId: space.id, albumId: album.id });
+      await ctx.newAlbumSpaceAsset({ albumId: album.id, assetId: asset.id, spaceId: space.id });
+
+      const rows = await sut.getByAssetId(viewer.id, asset.id);
 
       expect(rows).toEqual([]);
     });


### PR DESCRIPTION
Fixes #1095.

## What was wrong

An asset belongs to an album through one of two tables: the owner's own `album_asset` row, or a cross-owner `album_space_asset` contribution (#764), written when a space member adds an asset they don't own.

`Permission.AssetShare` resolves to owner ∪ partner only (`server/src/utils/access.ts:127`), so when a space member adds another member's photo the add is denied on the ordinary path and `tryContributeDeniedAssets` re-routes it into `album_space_asset` — even when the album owner happens to own the asset, which is the shape reported.

`AlbumRepository.getByAssetId`, the query behind the asset-viewer's "Contained in" panel, inner-joined `album_asset` only. An album reached solely by a contribution was dropped for every viewer. The album card's count comes from `getMetadataForIds`, which already unions both arms — which is exactly why the reporter saw the photo in the album, the album counting it, and the info panel listing a different album instead.

The gap was already pinned in the medium suite as a known incompleteness worth closing separately; this is that gap being hit in the wild.

## The fix

Check both membership tables. The contributed arm is correlated to the one space the contribution came through and requires a live album↔space link plus live membership of that space — the same scoping `getMetadataForIds` applies — so the panel and the card stay consistent. Both space-reached arms keep the Archive/Timeline visibility gate; the `album_user` arm stays ungated so an album member still sees their own Hidden/Locked assets.

Server-only. The web panel renders whatever the endpoint returns.

## Access matrix

`getByAssetId` is its own access check — nothing authorizes the asset id before it (see `AlbumService.getAll`) and album titles are user-authored — so the grant arms are covered as a matrix:

| Viewer | Expected | |
| --- | --- | --- |
| Contributor, space member | album shown | ✅ |
| Space member, album owner owns the asset (the reported shape) | album shown | ✅ |
| Space **Viewer** role | album shown — any-role membership is deliberate | ✅ |
| Album member, not in the space | absent | ✅ |
| Member of a different space the album is also linked to | absent | ✅ |
| Partner of the asset owner | absent | ✅ |
| Album owner outside the contribution's space | absent, asserted against `getMetadataForIds` | ✅ |
| After the album is unlinked from the space | absent | ✅ |
| After membership is revoked | absent | ✅ |
| Soft-deleted album | absent | ✅ |
| Another member's Hidden / Locked asset | absent | ✅ |
| Sibling album in the same space without the asset | absent | ✅ |
| Both membership rows present for one pair | returned once | ✅ |

Two things worth noting for review: `@Authenticated` defaults to `sharedLink: false`, so an anonymous shared-link session cannot reach this endpoint at all; and `AlbumRepository.create` throws unless an `album_user` row with role Owner exists, so the `album_user` arm's "the owner always has a row" assumption is a real invariant rather than a test-factory artifact.

## Verification

Red first — the four positive assertions failed with the reported symptom before the change. Because the negative guards pass vacuously while the bug exists, each was re-checked against a deliberately weakened query: dropping the membership join, the album↔space correlation, the album correlation, or the visibility gate, and narrowing to write-capable roles, each turns the matching tests red.

- `album.repository.spec.ts` 31/31; all 43 medium repository files pass
- server unit suite 6418 passed across 201 files
- `tsc`, `eslint --max-warnings 0`, `prettier` clean
- `album.repository.sql` regenerated; only that query changed

Out of scope: `getByAssetIds` (plural) has the same `album_asset`-only shape, but it feeds the duplicates UI and is scoped to `album_user` albums with no space arm at all — a separate design question.

https://claude.ai/code/session_014bE5dBBCKb2tgN4EpNby7c
